### PR TITLE
M1-14: Defensive parsing of || separator in content (patcher + TMS)

### DIFF
--- a/src/LotroKoniecDev.Application/Parsers/TranslationFileParser.cs
+++ b/src/LotroKoniecDev.Application/Parsers/TranslationFileParser.cs
@@ -76,14 +76,18 @@ public sealed class TranslationFileParser : ITranslationParser
 
         try
         {
+            // Anchor from both ends: file_id, gossip_id lead; args_order, args_id, approved trail.
+            // Everything between is content re-joined with the separator, so content may contain "||".
+            string content = string.Join(FieldSeparator, parts[2..^3]);
+
             Translation translation = new()
             {
                 FileId = int.Parse(parts[0]),
                 GossipId = int.Parse(parts[1]),
-                Content = UnescapeContent(parts[2]),
-                ArgsOrder = ParseArgsArray(parts[3]),
-                ArgsId = ParseArgsArray(parts[4]),
-                IsApproved = parts[5] == "1"
+                Content = UnescapeContent(content),
+                ArgsOrder = ParseArgsArray(parts[^3]),
+                ArgsId = ParseArgsArray(parts[^2]),
+                IsApproved = parts[^1] == "1"
             };
 
             return Result.Success(translation);

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserTests.cs
@@ -265,6 +265,71 @@ public sealed class TranslationFileParserTests : IDisposable
     }
 
     [Fact]
+    public void ParseLine_ContentContainsSeparator_ShouldPreserveFullContent()
+    {
+        // Act
+        Result<Translation> result = _parser.ParseLine("100||200||Left||Right||NULL||NULL||1");
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.FileId.ShouldBe(100);
+        result.Value.GossipId.ShouldBe(200);
+        result.Value.Content.ShouldBe("Left||Right");
+        result.Value.ArgsOrder.ShouldBeNull();
+        result.Value.ArgsId.ShouldBeNull();
+        result.Value.IsApproved.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("100||200||a||b||NULL||NULL||1", "a||b")]              // separator inside content
+    [InlineData("100||200||||trailing||NULL||NULL||1", "||trailing")] // content starts with separator
+    [InlineData("100||200||leading||||NULL||NULL||1", "leading||")]   // content ends with separator
+    [InlineData("100||200||a||b||c||NULL||NULL||1", "a||b||c")]       // multiple separators
+    [InlineData("100||200||||NULL||NULL||1", "")]                     // empty content, minimum field count
+    public void ParseLine_ContentWithSeparators_ShouldRecoverExactContent(string line, string expectedContent)
+    {
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(expectedContent);
+    }
+
+    [Fact]
+    public void ParseLine_ContentContainsSeparatorWithArgs_ShouldKeepContentAndArgsSeparate()
+    {
+        // Act
+        Result<Translation> result = _parser.ParseLine("100||200||Tekst||z argumentem||1-2||3-4||0");
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe("Tekst||z argumentem");
+        result.Value.ArgsOrder.ShouldBe(new[] { 0, 1 });
+        result.Value.ArgsId.ShouldBe(new[] { 2, 3 });
+        result.Value.IsApproved.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("Left||Right")]
+    [InlineData("||leading")]
+    [InlineData("trailing||")]
+    [InlineData("a||b||c")]
+    [InlineData("Witaj||w Srodziemiu||przyjacielu")]
+    public void ParseLine_ContentWithSeparators_ShouldRoundTripToIdenticalContent(string content)
+    {
+        // Arrange — serialize via the canonical export line format (file_id||gossip_id||content||args_order||args_id||approved)
+        string serializedLine = $"100||200||{content}||NULL||NULL||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(serializedLine);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(content);
+    }
+
+    [Fact]
     public void ParseFile_WithInvalidLines_ShouldSkipAndContinue()
     {
         // Arrange


### PR DESCRIPTION
## What
`TranslationFileParser.ParseLine` split on `||` and read fixed indexes (`parts[2]` content, `parts[3..5]` trailing fields). Content that itself contained `||` was truncated and the trailing fields (`args_order`/`args_id`/`approved`) were read from the wrong positions. `MinimumFieldCount = 6` did not catch this — it only rejects too-few fields.

## Fix
Anchor from both ends: first two fields = `file_id`/`gossip_id`, last three = `args_order`/`args_id`/`approved`, everything between = content re-joined with `||`. The `MinimumFieldCount = 6` invariant still holds (2 front + ≥1 content + 3 back).

The serializer (`ExportTextsQueryHandler`) needed **no change**: it writes content verbatim and the five boundary fields are numbers / `NULL` / `-`-joined args / literal `1`, none of which can contain `||`, so the anchored parser recovers `||`-bearing content losslessly.

## Tests
+12 pure unit cases in `TranslationFileParserTests` (separator inside/leading/trailing content, multiple separators, empty content at the 6-field minimum, content+args separation, and a `||` round-trip Theory). Existing assertions untouched. Build green, 0 warnings; 223 unit tests pass.

## TMS side
The TMS parser/serializer (#97 import / #102 export) does not exist yet (M2). The same both-ends anchoring rule is cross-referenced into both tickets.

Closes #29