### PR TITLE
M2-01: ADR-0002 — record the two-bounded-context TMS pivot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ conflicts with this file (MediatR, one shared Application for all UIs, auth post
 src/
   LotroKoniecDev.{Primitives,Domain,Application,Infrastructure,Cli}                       ← PATCHER (exists, frozen)
   SharedKernel/LotroKoniecDev.SharedKernel                                                ← M2 (lift; TMS-side only)
-  TranslationSystem/LotroKoniecDev.TranslationSystem.{Domain,Persistence,Contracts,API}   ← M2 (new)
+  TranslationSystem/LotroKoniecDev.TranslationSystem.{Primitives,Domain,ReadModels,ReadModels.EntityFramework,Persistence,Contracts,API} ← M2 (new)
   AuthSystem/LotroKoniecDev.AuthSystem.{API,Domain,Infrastructure,Persistence,Contracts}  ← M2 (lift)
   Frontend/LotroKoniecDev.Frontend                                                        ← M3 (Blazor SSR, OIDC RP)
   Utilities/…                                                                             ← M2 (lift only what's used)
@@ -80,18 +80,21 @@ spec 0001): the M2-20 translation-file auto-download slice in the launch flow.
 | Building… | Mirror from `~/RiderProjects/TheKittySaver` | Lift notes |
 |---|---|---|
 | `SharedKernel` | `src/SharedKernel/TheKittySaver.SharedKernel` | Drop the `Mediator.Abstractions` package; add `Messaging/` with in-house `ICommand(Handler)`/`IQuery(Handler)` (same shapes as patcher `Application/Abstractions/Messaging/`). Keep monads, BuildingBlocks, `Ensure`, `StronglyTypedId` |
+| `TranslationSystem.Primitives` | `…AdoptionSystem.Primitives` | Strongly-typed ID types + enums per aggregate (`Aggregates/<X>Aggregate/`), shared by Domain, ReadModels and Contracts; the `StronglyTypedId` base stays in SharedKernel (ADR-0002 amendment 2026-06-12) |
 | `TranslationSystem.Domain` | `src/AdoptionSystem/…AdoptionSystem.Domain` | `Aggregates/<X>Aggregate/{Entities,ValueObjects,Repositories}` + `Core/Errors`; our aggregates are far simpler than `Cat` — don't inflate them |
-| `TranslationSystem.Persistence` | `…AdoptionSystem.Persistence` | DbContext + configurations + UoW + migrations + design-time factory; EF house rules below |
+| `TranslationSystem.ReadModels` + `…ReadModels.EntityFramework` | `…AdoptionSystem.ReadModels` + `…ReadModels.EntityFramework` | POCO read models per aggregate (`IReadOnlyEntity<TId>`) + their EF configurations; query handlers read them via `IApplicationReadDbContext` — never the write model (ADR-0002 amendment 2026-06-12) |
+| `TranslationSystem.Persistence` | `…AdoptionSystem.Persistence` | Write + read DbContexts (`ApplicationWriteDbContext` = the UoW + owns migrations; `ApplicationReadDbContext` behind `IApplicationReadDbContext`, applies the ReadModels.EntityFramework configurations) + design-time factory; EF house rules below |
 | `TranslationSystem.Contracts` | `…AdoptionSystem.Contracts` | Request/response DTOs per feature; referenced by Frontend |
 | `TranslationSystem.API` | `…AdoptionSystem.API` | `IEndpoint` + assembly-scan `AddEndpoints`/`MapEndpoints`; slices in `Features/<Area>/<Action>.cs`; `ExceptionHandlers/`, `Auth/` (JwtBearer + policies + `CurrentUserAccessor` + ownership guards), health checks, Serilog + OTel bootstrap |
 | `AuthSystem` (whole module) | `src/AuthSystem/*` | Self-hosted OpenIddict + Identity server — lift wholesale. **Do NOT lift the synchronous `RegisterUser`→`CreatePersonAsync` saga**: provision the translator profile lazily & idempotently on first authenticated TMS request (pattern: KittySaver ADR-0007 §4) |
 | `Frontend` (infra) | `src/Frontend/TheKittySaver.Frontend` | Lift `Infrastructure/` (OIDC RP, `CookieTokenRefresher`, `DiscoveryCache`, `ApiResult`, typed HttpClients, error pages); pages are written fresh for translations; reference `TranslationSystem.Contracts` directly |
 | Docker / compose | `compose.yaml`, `Dockerfile.migrator`, `Dockerfile.tests` | postgres + migrator + auth-api + tms-api (+ mailpit/aspire-dashboard in dev); Frontend joins in M3 |
 
-**Deliberate non-lifts (YAGNI — revisit only on a real, present need):** `ReadModels(+EF)`
-read/write split, `Calculators`, per-system `Primitives`, domain events (KittySaver dispatches
-them via Mediator notifications; the TMS core loop doesn't need them — if a need appears, design
-an in-house dispatcher via ADR first).
+**Deliberate non-lifts (YAGNI — revisit only on a real, present need):** `Calculators`, domain
+events (KittySaver dispatches them via Mediator notifications; the TMS core loop doesn't need
+them — if a need appears, design an in-house dispatcher via ADR first). `ReadModels(+EF)` and
+per-system `Primitives` were on this list and are now lifted from day 1 (ADR-0002 amendment
+2026-06-12).
 
 ### De-mediatorization recipe (apply to every lifted slice)
 
@@ -205,6 +208,10 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 - **No mediator — slim SRP handlers (ADR-0001), repo-wide.** One use case = one record + one
   handler implementing the in-house `ICommandHandler<,>`/`IQueryHandler<,>`. Consumers inject the
   closed handler interface directly. Lifted KittySaver code is de-mediatorized on entry.
+- **CQRS read/write split, day 1 (ADR-0002 amendment).** Query handlers read POCO `ReadModels`
+  through `IApplicationReadDbContext`; command handlers load and mutate aggregates via
+  repositories + `IUnitOfWork`. The write model never serves list/search queries; every new
+  aggregate ships with its read model + EF configuration in the same change.
 - **Patcher is frozen** (see Architecture) — never refactor it to serve the TMS.
 - **TMS ships with auth from day 1.** Endpoints are authorized by default (public ones are
   explicit); the first migration already carries user attribution (`SubmittedById`,
@@ -252,7 +259,8 @@ internal sealed class <Action> : IEndpoint
 
     internal sealed class Handler : ICommandHandler<Command, Result<TResponse>>
     {
-        // explicit ctor DI: repositories, IUnitOfWork, IValidator<Command> (commands only)…
+        // explicit ctor DI — command: repositories + IUnitOfWork + IValidator<Command>;
+        // query: IApplicationReadDbContext (read models only)
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder) { … } // injects the closed
@@ -308,8 +316,8 @@ structure.
 ## Roadmap (digest — details land as re-cut GitHub issues)
 
 - **M2 — TMS backend (core loop + update lifecycle — spec 0001).** ADR-0002 (record this pivot)
-  → SharedKernel lift → AuthSystem lift → TranslationSystem (Domain/Persistence/Contracts/API)
-  with exactly these slices: version-bound import of `exported.txt` + diff/invalidation (upload),
+  → SharedKernel lift → AuthSystem lift → TranslationSystem
+  (Primitives/Domain/ReadModels(+EF)/Persistence/Contracts/API) with exactly these slices: version-bound import of `exported.txt` + diff/invalidation (upload),
   list translations (search/filter/paginate, incl. `NeedsReview`), get one, upsert, approve
   (clears invalidation + regenerates the artifact), translation-file distribution (pre-built
   artifact + ETag/304, `GET /translation-files/{lang}`), GameVersion endpoints, forum watcher

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ forbidden — never add them back.
 
 Active development, zero production users. **Breaking changes are free** — no back-compat shims,
 no deprecation windows. M1 (patcher) is done and empirically proven. Current milestone: **M2 —
-TMS backend** (first step: write ADR-0002 recording this pivot). Live backlog: `gh issue list`,
+TMS backend** (ADR-0002 + the agreed spec 0001 record the pivot and the update-lifecycle domain).
+Live backlog: `gh issue list`,
 **but** issues are being re-cut after the 2026-06 architecture pivot — where an old issue body
 conflicts with this file (MediatR, one shared Application for all UIs, auth postponed to M5),
 **this file wins**; align the ticket before coding.
@@ -49,7 +50,9 @@ src/
 parser/serializer; **golden fixture files + round-trip tests on both sides** guard against format
 drift, and the format itself changes only via ADR. The TMS never references `datexport.dll`/DAT
 code (it runs in Linux Docker); the patcher never touches the DB (it runs on a Windows gaming
-box). WPF (M4) calls patcher handlers locally and downloads `polish.txt` from the TMS API.
+box). Distribution is HTTP, not integration: the CLI launch flow auto-downloads the current
+translation file from the TMS API (ETag-cached; M2-20, the sole freeze exception — ADR-0002
+amendment), and the WPF app (M4) is a GUI over the same patcher handlers + download.
 
 ### Patcher — frozen (do not refactor)
 
@@ -69,7 +72,8 @@ Primitives**.
 of the TMS. The TMS deliberately duplicates the few tiny building blocks it needs (Result/Maybe/
 Error shapes, messaging interfaces — they arrive inside the lifted SharedKernel); consolidating
 that duplication is at most a post-MVP ticket. Any change here must keep every existing test
-green without touching its assertions.
+green without touching its assertions. One sanctioned additive exception (ADR-0002 amendment,
+spec 0001): the M2-20 translation-file auto-download slice in the launch flow.
 
 ### TMS — the KittySaver lift map
 
@@ -114,7 +118,8 @@ A KittySaver slice is one file: `internal sealed class <Action> : IEndpoint` con
 | Work a GitHub ticket end-to-end | run **`/ticket <number>`** (mind the pivot-supersedes rule in Project status) |
 | Touch DAT binary parsing / writing / native interop | delegate to the **`dat-format-expert`** agent |
 | Re-investigate update behavior, vnum, translation survival, launch flow | **don't** — empirically settled in `docs/knowledge-base/` (start at its README) |
-| Make a non-trivial architectural/modeling decision | skim `docs/adr/`, then **write a new ADR** (`/adr`); anchors: 0001 (no mediator), 0002 (TMS pivot — to be written at M2 start) |
+| Make a non-trivial architectural/modeling decision | skim `docs/adr/`, then **write a new ADR** (`/adr`); anchors: 0001 (no mediator), 0002 (TMS pivot + freeze amendment) |
+| Touch the update lifecycle (GameVersion, import diff, invalidation, distribution, CLI sync) | `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md` — the agreed domain spec |
 | Implement a feature whose business rules are fuzzy | **`/spec`** first (seed → questions → agreed spec in `docs/specs/`) |
 | Review a finished change | the **`code-reviewer`** agent |
 | Understand the backlog / milestones | `gh issue list` (being re-cut post-pivot) + Roadmap digest below |
@@ -302,18 +307,23 @@ structure.
 
 ## Roadmap (digest — details land as re-cut GitHub issues)
 
-- **M2 — TMS backend (core loop).** ADR-0002 (record this pivot) → SharedKernel lift →
-  AuthSystem lift → TranslationSystem (Domain/Persistence/Contracts/API) with exactly these
-  slices: import `exported.txt` (upload), list translations (search/filter/paginate), get one,
-  upsert translation, approve translation, export `polish.txt` (download) → compose (postgres +
-  migrator + auth-api + tms-api) → integration tests.
-  **DoD:** the full loop works: CLI `export` → TMS import → edit/approve → TMS export → CLI
-  `patch` → texts visible in game.
+- **M2 — TMS backend (core loop + update lifecycle — spec 0001).** ADR-0002 (record this pivot)
+  → SharedKernel lift → AuthSystem lift → TranslationSystem (Domain/Persistence/Contracts/API)
+  with exactly these slices: version-bound import of `exported.txt` + diff/invalidation (upload),
+  list translations (search/filter/paginate, incl. `NeedsReview`), get one, upsert, approve
+  (clears invalidation + regenerates the artifact), translation-file distribution (pre-built
+  artifact + ETag/304, `GET /translation-files/{lang}`), GameVersion endpoints, forum watcher
+  (creates unprocessed `GameVersion`) → compose (postgres + migrator + auth-api + tms-api) →
+  integration tests → CLI auto-download (M2-20, the freeze exception).
+  **DoD:** the full loop works: CLI `export` → TMS import (diff) → edit/approve → CLI `launch`
+  auto-downloads → `patch` → texts visible in game; a simulated game update invalidates changed
+  rows and the distributed file excludes them.
 - **M3 — Frontend (Blazor SSR).** Lifted OIDC infra; pages: translation list, side-by-side
   editor with `<--DO_NOT_TOUCH!-->` placeholder validation, approve flow, import/export,
   mini-dashboard (progress counters). **DoD:** a translator completes the whole loop in the
   browser, authenticated.
-- **M4 — WPF player app** (later): patcher handlers + HTTP download of `polish.txt` from the TMS.
+- **M4 — WPF player app** (later): GUI over the patcher handlers + the same TMS auto-download
+  the CLI ships in M2-20.
 - **Post-MVP backlog (deliberately cut from MVP):** LOTRO Companion XML context import, glossary,
   quest browser, `TranslationHistory`, bulk operations, keyboard shortcuts, AI review, Discord
   notifications, public API versioning, crowdsourced game-version reports, per-language roles.

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -1,8 +1,6 @@
 <Solution>
   <Folder Name="/docs/">
-    <File Path="docs/PROJECT_PLAN.md" />
     <File Path="docs/RUSSIAN_PROJECT_RESEARCH.md" />
-    <File Path="docs/TICKETS.md" />
   </Folder>
   <Folder Name="/items/">
     <File Path=".editorconfig" />
@@ -12,7 +10,6 @@
     <File Path="Directory.Packages.props" />
     <File Path="export.bat" />
     <File Path="lotro.bat" />
-    <File Path="LotroKoniecDev.sln.DotSettings.user" />
     <File Path="patch.bat" />
     <File Path="README.md" />
   </Folder>

--- a/docs/adr/0002-two-bounded-context-tms-pivot.md
+++ b/docs/adr/0002-two-bounded-context-tms-pivot.md
@@ -58,6 +58,12 @@ duplicates the tiny building blocks it needs (Result/Maybe/Error shapes, messagi
 they arrive inside the lifted SharedKernel); consolidating that duplication is at most a
 post-MVP ticket.
 
+**Amendment (2026-06-11, spec 0001):** the freeze admits exactly one additive slice — the CLI
+translation-file auto-download in the launch flow (ticket M2-20): the patcher acts as a TMS
+distribution *consumer* over HTTP (distribution, not integration — see Alternative E). The new
+slice and its launch-flow wiring are sanctioned; refactors of existing handlers are not, and
+every pre-existing test stays green with assertions untouched.
+
 ### 3. The `||` translation file is the only contract between the contexts
 
 Each context owns its own parser/serializer. Golden fixture files + round-trip tests on both
@@ -166,7 +172,8 @@ pivot exists to avoid.
 
 Rejected. The patcher must work on a Windows gaming box with zero TMS dependency; the file
 contract already exists, is human-readable, and is proven to round-trip into the live game. (The
-M4 WPF app merely downloads `polish.txt` over HTTP — distribution, not integration.)
+CLI launch flow (M2-20, per the §2 amendment) and the M4 WPF app merely download the translation
+file over HTTP — distribution, not integration.)
 
 ### F. Follow KittySaver ADR-0007 — Entra External ID instead of the lifted OpenIddict server
 

--- a/docs/adr/0002-two-bounded-context-tms-pivot.md
+++ b/docs/adr/0002-two-bounded-context-tms-pivot.md
@@ -1,0 +1,212 @@
+# ADR-0002: Two bounded contexts — TMS lifted from TheKittySaver, patcher frozen
+
+**Status:** Accepted
+**Date:** 2026-06-11
+**Decision-makers:** Solo maintainer
+**Related:** whole-repo architecture (both contexts), ticket #90 (M2-01), PR #89 (CLAUDE.md pivot + planning-doc removal), ADR-0001 (no mediator)
+
+## Context
+
+M1 delivered the patcher: a Clean Architecture CLI (`export` / `patch` / `launch`) that is
+empirically proven in the live game — translations survive chunk-based launcher updates including
+the 47.2→48.0 major update, forum version is the reliable game-version signal, DAT vnum is useless
+(all settled in `docs/knowledge-base/`). The next goal is a Translation Management System
+(PostgreSQL + Web API + Blazor SSR + auth) so translators collaborate with a review workflow
+instead of maintaining a flat file by hand.
+
+The pre-pivot plan (`docs/PROJECT_PLAN.md`, `docs/TICKETS.md`) described a different world: one
+shared Application layer serving CLI + Web API + WPF, MediatR dispatch, auth postponed to M5.
+Facts that invalidated it:
+
+- **Runtime incompatibility.** The patcher needs `datexport.dll` (x86 Windows native interop) and
+  the local game DAT; the TMS targets Linux Docker + PostgreSQL. One shared Application layer
+  would chain a Windows-native dependency into a Linux web deployment.
+- **The integration artifact already exists.** The `||` translation file flows CLI `export` →
+  TMS import and TMS export → CLI `patch`. A file contract needs no shared code; the format is
+  round-trip-proven in the live game and its parser was just hardened against `||` inside content
+  (M1-14, PR #106 — `src/LotroKoniecDev.Application/Parsers/TranslationFileParser.cs`).
+- **The patcher is done.** Every refactor in service of the TMS risks the proven core for
+  consistency gains. The maintainer explicitly chose freezing working code over consistency
+  refactors under time pressure.
+- **The reference implementation exists.** TheKittySaver (`~/RiderProjects/TheKittySaver`,
+  closed-source) already implements every TMS building block at production grade: VSA slices in
+  the API project, DDD aggregates, Result monad, SharedKernel, a self-hosted OpenIddict +
+  ASP.NET Identity auth server (~7.3k LOC: PKCE, rolling refresh tokens, RSA key rotation, rate
+  limiting), Docker compose (postgres + migrator + auth-api + api), black-box testing discipline.
+  These are the maintainer's own patterns, ready to lift.
+- **Solo maintainer, very little time.** This is the only public portfolio repo —
+  interview-readiness, speed, and maintenance simplicity are explicit goals.
+- **ADR-0001 is already in force.** The patcher dispatches through in-house messaging interfaces
+  with direct handler injection; KittySaver slices dispatch via `Mediator.SourceGenerator`, so
+  lifted code needs a mechanical transform on entry.
+
+## Decision
+
+### 1. Two bounded contexts in one repo
+
+Patcher (`src/LotroKoniecDev.{Primitives,Domain,Application,Infrastructure,Cli}`) and TMS
+(`src/{SharedKernel,TranslationSystem,AuthSystem,Frontend,Utilities}/…`). No project references
+across the boundary, ever: the TMS never references DAT/native code (it runs in Linux Docker);
+the patcher never touches the DB (it runs on a Windows gaming box). Each context deploys to its
+natural platform.
+
+### 2. The patcher is frozen
+
+Bugfix tickets only — no renames, no extractions, no restructuring in service of the TMS. Any
+change must keep every existing test green without touching its assertions. The TMS deliberately
+duplicates the tiny building blocks it needs (Result/Maybe/Error shapes, messaging interfaces —
+they arrive inside the lifted SharedKernel); consolidating that duplication is at most a
+post-MVP ticket.
+
+### 3. The `||` translation file is the only contract between the contexts
+
+Each context owns its own parser/serializer. Golden fixture files + round-trip tests on both
+sides guard against format drift (the patcher side has `TranslationFileParserTests` today; the
+shared golden fixtures land with the TMS import/export slices). The format itself changes only
+via ADR, updating fixtures in both contexts in the same change.
+
+### 4. TheKittySaver is the canonical reference — lift 1:1, then de-mediatorize
+
+Every TMS pattern is mirrored from the nearest KittySaver sibling (lift map in CLAUDE.md →
+Architecture). One repo-wide deviation, carried over from ADR-0001: **no mediator**. Every lifted
+slice is transformed on entry per the de-mediatorization recipe — in-house
+`ICommand`/`IQuery` + closed handler interfaces, explicit DI registration, endpoints inject the
+closed handler; validation via `IValidator<TCommand>` mapped to `Result` in command handlers,
+inline in query handlers. `Mediator`/`MediatR` packages remain forbidden.
+
+### 5. Deliberate non-lifts (YAGNI — revisit only on a real, present need)
+
+- **`ReadModels(+EF)` read/write split** — the TMS query load is a translator UI list/search;
+  one EF model serves both sides until a real read-shape divergence appears.
+- **`Calculators`** — adoption-domain computation with no TMS equivalent.
+- **Per-system `Primitives` projects** — TMS constants fit in SharedKernel/Domain; a project per
+  system is structure without content.
+- **Domain events** — KittySaver dispatches them via Mediator notifications; the TMS core loop
+  (import → edit → approve → export) needs none, and if a need appears the dispatcher is designed
+  in-house via ADR first.
+
+### 6. Auth ships from day 1 — the self-hosted OpenIddict AuthSystem is lifted wholesale
+
+KittySaver's own ADR-0007 (2026-06-03) retires that server for Entra External ID, but its forces
+do not transfer here: no social/passkey demand, no Azure learning goal, no credential-risk-transfer
+mandate at this scale — while self-hosting keeps zero external SaaS dependency and the auth server
+is portfolio material in this public repo. The exit door survives regardless: the resource server
+validates standard JwtBearer over OIDC discovery, so re-pointing to a SaaS issuer later is
+configuration, not a rewrite (ADR-0007 §3's seam cuts both ways). TMS endpoints are authorized by
+default (public ones explicit); the first migration already carries user attribution
+(`SubmittedById`, `ApprovedById`). No auth-less interim state to retrofit later.
+
+### 7. No synchronous registration saga — lazy idempotent translator-profile provisioning
+
+The KittySaver `RegisterUser`→`CreatePersonAsync` saga (cross-context call + rollback + orphan
+cleanup) is **not** lifted. The translator profile is provisioned lazily and idempotently on the
+first authenticated TMS request, keyed by the identity id (pattern: KittySaver ADR-0007 §4).
+This eliminates the distributed transaction without needing an outbox.
+
+### 8. CLAUDE.md is authoritative; the superseded planning docs are gone
+
+`docs/PROJECT_PLAN.md`, `docs/TICKETS.md`, and `docs/LIVE_TEST_RESULTS.md` were deleted in PR #89
+(the empirical findings live on in `docs/knowledge-base/`). Open GitHub issues predating the
+pivot may still describe the dead world (MediatR, one shared Application, auth at M5) — where an
+issue conflicts with CLAUDE.md (the operational form) or this ADR (the decision record), the docs
+win; align the ticket before coding.
+
+## Consequences
+
+### Positive
+
+- The empirically proven patcher carries zero refactor risk while the TMS grows beside it.
+- TMS work is assembly, not design: mirror the sibling slice → de-mediatorize → wire. The fastest
+  credible path for a solo maintainer, with conventions uniform across both contexts per ADR-0001.
+- Each context deploys to its natural platform — no x86 native interop in the Linux web stack, no
+  database on the gaming box.
+- Auth and user attribution exist from the first migration; nothing to retrofit.
+- The public repo demonstrates both a native-interop CLI and a full web platform (VSA, DDD,
+  OpenIddict, Docker, integration tests against real PostgreSQL) — the portfolio goal.
+
+### Negative / Accepted Trade-offs
+
+- Duplicated building blocks (Result/Maybe/Error, messaging interfaces) between patcher
+  Application and TMS SharedKernel — accepted deliberately; freezing working code beats
+  consistency refactors under time pressure.
+- Two independent `||` parsers can drift — mitigated by golden fixtures + round-trip tests on
+  both sides and the ADR gate on format changes, not by shared code.
+- Owning the credential surface (the exact risk KittySaver shed in ADR-0007) — accepted at this
+  scale; the JwtBearer seam keeps the SaaS exit open.
+- One repo, two lifecycles: CI must keep patcher E2E Windows-skippable while TMS integration
+  tests need a real PostgreSQL.
+- Stale pre-pivot issues require manual alignment until the backlog re-cut completes.
+
+## Alternatives Considered
+
+### A. One shared Application layer for CLI + Web + WPF (the pre-pivot plan)
+
+Rejected. Chains `datexport.dll` x86 Windows interop into a Linux Docker deployment, forces
+refactors of the frozen proven patcher, and couples lifecycles that share only a file format.
+
+### B. Separate repository for the TMS
+
+Rejected. Two CIs, two issue trackers, and a cross-repo contract-versioning seam for a solo
+maintainer, with no isolation gain over project boundaries; one repo keeps both sides of the `||`
+contract honest in a single PR and tells the whole portfolio story in one place.
+
+### C. Design the TMS fresh instead of lifting
+
+Rejected. The slowest path under time pressure; KittySaver already encodes the maintainer's
+preferred production-grade answers (auth, VSA, persistence, compose, testing) — re-deriving them
+buys nothing.
+
+### D. Lift KittySaver as-is, keeping its mediator inside the TMS
+
+Rejected. ADR-0001 is repo-wide for cause (vulnerable Scriban transitive, runtime-only wiring,
+exception-based validation); two dispatch idioms in one repo is exactly the inconsistency this
+pivot exists to avoid.
+
+### E. Integrate the contexts over HTTP or a shared database instead of a file
+
+Rejected. The patcher must work on a Windows gaming box with zero TMS dependency; the file
+contract already exists, is human-readable, and is proven to round-trip into the live game. (The
+M4 WPF app merely downloads `polish.txt` over HTTP — distribution, not integration.)
+
+### F. Follow KittySaver ADR-0007 — Entra External ID instead of the lifted OpenIddict server
+
+Rejected for now. The driving forces there (passkeys/social demand, Azure skills alignment,
+credential-risk transfer) do not exist here, and the lifted server is free to operate while
+showcasing auth-server work publicly. The standards-based JwtBearer/OIDC seam preserves this as
+a future config-level swap if the forces ever materialize.
+
+## Implementation Notes
+
+*(Decision record only — implementation lands via the re-cut M2/M3 tickets.)*
+
+- New (M2): `src/SharedKernel/LotroKoniecDev.SharedKernel` (lift; `Mediator.Abstractions`
+  dropped, in-house `Messaging/` added),
+  `src/TranslationSystem/LotroKoniecDev.TranslationSystem.{Domain,Persistence,Contracts,API}`,
+  `src/AuthSystem/LotroKoniecDev.AuthSystem.{API,Domain,Infrastructure,Persistence,Contracts}`,
+  `src/Utilities/…` (only what's used), `compose.yaml` + `Dockerfile.migrator` +
+  `Dockerfile.tests`.
+- New (M3): `src/Frontend/LotroKoniecDev.Frontend` — Blazor SSR OIDC RP; `Infrastructure/`
+  lifted, pages written fresh.
+- Tests: `tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit`,
+  `tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration` (real PostgreSQL); golden `||`
+  fixture files + round-trip tests added to both the patcher unit tests and the TMS import/export
+  tests.
+- Untouched: all five patcher projects and `tests/LotroKoniecDev.Tests.{Unit,Infrastructure,E2E}`.
+- Already done (PR #89): CLAUDE.md rewritten as the operational form of this decision;
+  `docs/PROJECT_PLAN.md`, `docs/TICKETS.md`, `docs/LIVE_TEST_RESULTS.md` deleted.
+
+## References
+
+- ADR-0001 — Slim SRP handlers instead of the Mediator pipeline (the repo-wide deviation every
+  lifted slice obeys)
+- Ticket #90 (M2-01); PR #89 — CLAUDE.md pivot + planning-doc removal; PR #106 (M1-14) — `||`
+  parser hardening
+- `CLAUDE.md` — Architecture, lift map, de-mediatorization recipe, house rules (the operational
+  form of this ADR)
+- TheKittySaver (`~/RiderProjects/TheKittySaver`) — canonical reference; its
+  `docs/adr/0007-adopt-entra-external-id-retire-openiddict.md` (§3 provider-agnostic seam,
+  §4 lazy provisioning)
+- `docs/knowledge-base/` — empirical proof the patcher core is done (update survival, version
+  detection, vnum)
+- CLAUDE.md "Translation file format — THE inter-context contract" — the `||` format this ADR
+  puts behind an ADR gate

--- a/docs/adr/0002-two-bounded-context-tms-pivot.md
+++ b/docs/adr/0002-two-bounded-context-tms-pivot.md
@@ -82,14 +82,24 @@ inline in query handlers. `Mediator`/`MediatR` packages remain forbidden.
 
 ### 5. Deliberate non-lifts (YAGNI — revisit only on a real, present need)
 
-- **`ReadModels(+EF)` read/write split** — the TMS query load is a translator UI list/search;
-  one EF model serves both sides until a real read-shape divergence appears.
 - **`Calculators`** — adoption-domain computation with no TMS equivalent.
-- **Per-system `Primitives` projects** — TMS constants fit in SharedKernel/Domain; a project per
-  system is structure without content.
 - **Domain events** — KittySaver dispatches them via Mediator notifications; the TMS core loop
   (import → edit → approve → export) needs none, and if a need appears the dispatcher is designed
   in-house via ADR first.
+
+**Amendment (2026-06-12) — `ReadModels(+EF)` and per-system `Primitives` moved to lifts.** Both
+originally sat on this list. Maintainer decision: the CQRS read/write split is part of the lifted
+architectural identity this repo showcases, and retrofitting it after the first query slices ship
+would mean rewriting every list/search handler — lifting it alongside the first aggregate costs
+one thin projection instead. The shape mirrors KittySaver 1:1: `TranslationSystem.ReadModels`
+(POCO read models per aggregate) + `TranslationSystem.ReadModels.EntityFramework` (their EF
+configurations), mapped onto the same tables the write model owns; `ApplicationWriteDbContext`
+(the `IUnitOfWork`, owns migrations) serves commands, `ApplicationReadDbContext` behind
+`IApplicationReadDbContext` serves queries — query handlers never touch the write model.
+`TranslationSystem.Primitives` follows as a mechanical consequence of the mirror: read models
+must not reference the domain, yet both sides share the strongly-typed ID types and enums, and
+in KittySaver those live in the per-system Primitives project (the `StronglyTypedId` base itself
+stays in SharedKernel).
 
 ### 6. Auth ships from day 1 — the self-hosted OpenIddict AuthSystem is lifted wholesale
 
@@ -128,7 +138,8 @@ win; align the ticket before coding.
   database on the gaming box.
 - Auth and user attribution exist from the first migration; nothing to retrofit.
 - The public repo demonstrates both a native-interop CLI and a full web platform (VSA, DDD,
-  OpenIddict, Docker, integration tests against real PostgreSQL) — the portfolio goal.
+  CQRS read/write split, OpenIddict, Docker, integration tests against real PostgreSQL) — the
+  portfolio goal.
 
 ### Negative / Accepted Trade-offs
 
@@ -188,7 +199,7 @@ a future config-level swap if the forces ever materialize.
 
 - New (M2): `src/SharedKernel/LotroKoniecDev.SharedKernel` (lift; `Mediator.Abstractions`
   dropped, in-house `Messaging/` added),
-  `src/TranslationSystem/LotroKoniecDev.TranslationSystem.{Domain,Persistence,Contracts,API}`,
+  `src/TranslationSystem/LotroKoniecDev.TranslationSystem.{Primitives,Domain,ReadModels,ReadModels.EntityFramework,Persistence,Contracts,API}`,
   `src/AuthSystem/LotroKoniecDev.AuthSystem.{API,Domain,Infrastructure,Persistence,Contracts}`,
   `src/Utilities/…` (only what's used), `compose.yaml` + `Dockerfile.migrator` +
   `Dockerfile.tests`.

--- a/docs/knowledge-base/README.md
+++ b/docs/knowledge-base/README.md
@@ -62,7 +62,8 @@ Detailed analysis: [lotro-update-history.md](lotro-update-history.md)
 Detailed analysis: [update-detection-strategy.md](update-detection-strategy.md)
 - Vnum-triggered re-patch is WRONG (would never fire + would be destructive if it did)
 - Only valid local trigger: translation file hash change
-- Target model: API filters translations by forum-version compatibility
+- Target model superseded by `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md`
+  (forum-only `GameVersion` lifecycle + status-based invalidation); the core insight stands
 - Simplified flow is CORRECT as MVP — hash-based trigger naturally evolves into the API model
 
 ### VM Test Plan (Friend's 2-Year-Old LOTRO)

--- a/docs/knowledge-base/update-detection-strategy.md
+++ b/docs/knowledge-base/update-detection-strategy.md
@@ -4,6 +4,14 @@ description: How the system detects LOTRO updates, validates translations agains
 type: project
 ---
 
+> **Superseded in part (2026-06-11):** the vnum-based "Docelowy Model" (`CompatibleSinceVnum`,
+> vnum-filtered export) and the two-source crowdsource+forum detection below are superseded by
+> [`docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md`](../specs/0001-game-update-lifecycle-and-translation-invalidation.md)
+> — forum-only detection, `GameVersion` aggregate, status-based invalidation (`NeedsReview` +
+> `PreviousSourceText`), pre-built ETag-cached distribution artifact, CLI auto-download (M2-20).
+> The Core Insight below and the admin upload→diff flow remain valid and are codified there;
+> crowdsourced reports stay post-MVP (#84/#31).
+
 ## Core Insight: Re-patching After Game Update is WRONG
 
 When SSG releases an update that changes existing English texts (e.g. lore corrections, quest rewrites), blindly re-applying old translations would overwrite fresh English with stale Polish. Translations must be validated against the new game version before re-application.

--- a/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
+++ b/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
@@ -1,0 +1,324 @@
+# Spec 0001: Game-update lifecycle — GameVersion, import diff, translation invalidation, distribution
+
+- **Status:** Agreed
+- **Date:** 2026-06-11 (drafted and agreed same day — all six extracted decisions resolved by the user)
+- **Author:** Artur Koniec (domain brain dump) — structured against code + knowledge base by Claude
+- **Ticket:** re-cuts #93 (M2-04 Domain), #97 (M2-08 import), #100 (M2-11 upsert), #101 (M2-12 approve),
+  #102 (M2-13 export/download), #85 (forum cron), #28 (M2-17 bootstrap); new tickets per Impact section
+- **Related:** ADR-0002 (two bounded contexts), `docs/knowledge-base/update-detection-strategy.md`
+  (partially superseded here — vnum/crowdsource parts), `dat-export-diff-2026-03-22.md`,
+  `dat-protection.md`, `vnum-observations.md`, CLAUDE.md → Roadmap M2
+
+## Business context
+
+The whole platform exists to translate LOTRO into Polish. All game texts live in one ~2 GB DAT
+file; the CLI `export` dumps every text fragment into `exported.txt` (one row per fragment).
+Each game update (SSG patch) **adds new texts, rewords existing ones, and removes others** —
+empirically ~5k changed lines across 47.1→47.2 and +4,231 fragments at 48.0. A Polish translation
+written against the old English is **stale the moment SSG rewords the source**: re-applying it
+would mask a lore/quest correction with outdated Polish. The TMS must therefore absorb each new
+game version's export, detect exactly what changed, invalidate affected translations (falling
+back to fresh English in game), and serve patchers an always-safe translation file.
+
+## Goal
+
+After a LOTRO update, the admin uploads one fresh `exported.txt`; the system works out what SSG
+added/changed/removed, parks stale Polish for re-translation instead of shipping it, and every
+player's patcher downloads a translation file that never shows outdated text in game.
+
+## Ubiquitous language
+
+| Term | Meaning |
+|---|---|
+| **Translation** | One text fragment row of the `\|\|` contract / one DB row: identity `(FileId, GossipId)`, English source text, optional Polish content, args metadata, status. The atom of the whole domain. |
+| **GameVersion** | Aggregate root. One forum-announced LOTRO version (e.g. `48.0`). Carries detection + processing state (`IsProcessed`); the unit the admin reacts to. |
+| **Diff** | The comparison of an uploaded `exported.txt` against the last processed source state, per `(FileId, GossipId)`, over the **full** file, on **every** processed version. Outcomes: added / source-changed / removed / unchanged. |
+| **Invalidation** | Marking a Polish translation stale because its English source changed. Invalidated rows are excluded from the distributed file → game shows the fresh English (fallback-to-English). |
+| **Baseline import** | The very first `exported.txt` import: no diff partner, every row lands as untranslated English source. |
+| **Source text** | The English original of a fragment, as exported from the DAT. The thing the diff compares. |
+| **Translation file** | The distributed artifact in `polish.txt` format: Approved, non-invalidated rows only. What the CLI `patch` consumes. |
+| **`exported.txt`** | Full English dump from CLI `export`: one row per fragment, `\|\|`-separated, ~780k+ lines. |
+| **Piece separator / placeholder** | `<--DO_NOT_TOUCH!-->` — literally `DatFileConstants.PieceSeparator`. Marks argument insertion slots inside a text; never translated. |
+| **Forum version** | Version string scraped from lotro.com release notes — the **only** reliable game-version signal (DAT vnum is dead, `vnum-observations.md`). |
+
+## In scope
+
+- `GameVersion` aggregate root in `TranslationSystem.Domain` (extends #93).
+- TMS-side forum watcher (hosted service cron) that detects a new forum version and creates an
+  unprocessed `GameVersion` — the DB state change the admin reacts to (re-cuts #85: de-vnumed,
+  forum-only, no crowdsource confirmation).
+- Import slice (#97) re-shaped: upload is **bound to an unprocessed GameVersion** and triggers
+  the diff (insert added / update source + invalidate changed / handle removed / skip unchanged);
+  processing flips `IsProcessed`.
+- Invalidation state on Translation + its interplay with upsert (#100) and approve (#101).
+- Distribution endpoint (re-shapes #102): current translation file for the newest processed
+  version — anonymous, cacheable, cache-stampede-proof.
+- Baseline init flow: first import + initial GameVersion from the current forum version;
+  `polish.txt` seed (#28) layered on top as Approved.
+- CLI auto-download (decided): the end user manually downloads **only the CLI itself** — `launch`
+  fetches the current translation file from the distribution endpoint, caches it locally, and
+  refreshes it automatically whenever the artifact changes. Additive patcher slice sanctioned by
+  the ADR-0002 freeze amendment; ticket M2-20. The WPF app (M4) wraps the same flow in a GUI.
+
+## Out of scope
+
+- **Automating game updates on a VM to regenerate exports** — explicitly rejected (cost); the
+  admin's own LOTRO install + manual upload is the pipeline.
+- Crowdsourced game-version reports & two-source confirmation (#84, #31) — post-MVP as labeled;
+  the forum is the sole detection source for now.
+- `TranslationHistory` / full audit trail of content changes (#50, post-MVP). This spec stores at
+  most a single previous-source snapshot per row (Q3), not a history table.
+- Per-version snapshots of all translations — anti-bloat rule below.
+- Any change to the `||` file format itself (ADR-gated contract; this spec only *consumes* it).
+- Multi-language beyond `pl` (the shape allows it; no second language ships now).
+
+## Business rules & edge cases
+
+### Identity & the exported row (what can and cannot change)
+
+- A text fragment's identity is the pair **`(FileId, GossipId)`** — `FileId` (int) addresses the
+  DAT subfile, `GossipId` (`Fragment.FragmentId`, 8-byte unsigned) the fragment within it. This
+  is how LOTRO itself addresses texts and how the patcher writes them back. TMS stores GossipId
+  as 64-bit (`long`, already mandated by #93).
+- An exported row is exactly: `file_id||gossip_id||text||args_order||args_id||approved`
+  (`ExportTextsQueryHandler.cs:95`). On export: `text` = English pieces joined with
+  `<--DO_NOT_TOUCH!-->`, `\r`/`\n` escaped to literals; `args_order`/`args_id` = `NULL` when the
+  fragment has no arguments, otherwise the identity order `1-2-…-N`; `approved` = constant `1`.
+  There is **no other state in a row** — no hidden version, no category, no UI grouping; the DAT
+  is one undifferentiated bag of texts.
+- Across game versions, for a given `(FileId, GossipId)`: the **text may be reworded**, the
+  **argument structure may change** (placeholder count/order), the row may be **removed**; and
+  new pairs **appear**. The pair itself is stable for continuing texts — empirically proven: our
+  8 live translations were re-found at identical IDs after updates incl. major 48.0
+  (`dat-protection.md`, `live-test-2026-04-23.md`); the 47.1→47.2 window showed +7,086 added /
+  −2,319 removed lines with rewordings like `Vitals` → `Player Vitals`
+  (`dat-export-diff-2026-03-22.md`).
+- ID re-use (delete + later re-add of the same pair with different meaning) is indistinguishable
+  from a removal followed by an addition — the diff treats it as exactly that.
+
+### GameVersion lifecycle
+
+- The forum watcher polls the lotro.com release-notes page (same regex the patcher's
+  `UpdateChecking` feature uses; the TMS **duplicates** the scraping logic — bounded contexts
+  share no code, ADR-0002). A newly seen version creates `GameVersion { Version, DetectedAt,
+  IsProcessed = false }`. Detection does nothing else — no diff, no invalidation.
+- `Version` is stored as the raw forum string (`"48.0"`, `"47.1.1"`); ordering = `DetectedAt`
+  (the forum is chronological); no semver parsing.
+- The admin sees unprocessed versions and reacts: updates their own LOTRO, runs CLI `export`,
+  uploads the file **for that GameVersion**. Upload-and-diff is what processes a version —
+  `IsProcessed = true` only after the diff committed.
+- **Stacked unprocessed versions** (e.g. 48.1 detected while 48.0 still unprocessed): the admin
+  uploads only the newest; the diff is inherently cumulative (proven: the 2026-03-22 diff spanned
+  3 accumulated patches and behaved identically, `dat-export-diff-2026-03-22.md`). Intermediate
+  versions are marked superseded/skipped — they will never receive an upload.
+- Re-upload to an already processed version is allowed and **idempotent** (admin uploaded a wrong
+  file and corrects it; same guarantee #97 already demands).
+
+### Diff semantics (runs only on upload, over the full file)
+
+For every row of the uploaded export, compared against the stored source state by
+`(FileId, GossipId)`:
+
+- **Added** (pair unknown): insert as untranslated — English source only, no Polish, available
+  for translation. Stamp `IntroducedInVersion`.
+- **Source-changed** (pair known, source content differs — comparison covers text **and** args
+  columns as one unit, since a placeholder-structure change is a meaning change even if rare
+  without a text change): overwrite the stored English source with the new one; **invalidate**
+  any existing Polish translation; stamp `LastSourceChangeInVersion`.
+- **Removed** (stored pair absent from the upload): soft-mark with `RemovedInVersion` — excluded
+  from translation work and from the distributed file, never hard-deleted (pointer-only cost,
+  keeps "what did this patch kill" visible).
+- **Re-added** (a previously soft-removed pair reappears in the upload): clear `RemovedInVersion`;
+  if the incoming source is identical to the stored one, the row's previous status — including
+  `Approved` — is restored as-is (the old Polish is still valid); if it differs, the
+  source-changed rule applies.
+- **Unchanged** (pair known, source identical): no-op. *No diff = SSG touched nothing = the
+  stored state stands* — sound because `export` is a deterministic full dump of all text subfiles.
+- The diff transaction is all-or-nothing; a failed upload leaves the previous state intact.
+- **Truncation guard (both, decided):** a partially written/corrupt `exported.txt` would
+  masquerade as a mass removal (and mass invalidation), so the import defends itself twice —
+  the upload is **rejected when any line fails to parse** (stricter than the patcher's
+  warn-and-skip, because on import a skipped line is indistinguishable from a removed row), and
+  **rejected when the would-be-removed fraction exceeds a threshold** (default 20%, configurable)
+  unless the admin passes an explicit override flag (legitimate mass cuts happen — SSG removed
+  2,319 lines in one window).
+
+### Invalidation & fallback-to-English (the physics)
+
+- "Fallback to English" requires **no write of English into the Polish field**. Two mechanisms
+  compose: (1) the game launcher has *already* chunk-patched the new English into the player's
+  DAT (`dat-protection.md`); (2) the TMS excludes invalidated rows from the translation file, so
+  `patch` never re-applies stale Polish over it. This is the codified form of the knowledge-base
+  core insight "re-patching after game update is WRONG" (`update-detection-strategy.md`).
+- An invalidated translation is **explicitly visible to the admin/translators** as needing
+  re-translation; supplying and approving a new Polish text clears the invalidation (the approve
+  slice #101 gains this rule). The stale Polish is **kept** as the draft starting point, and the
+  superseded English is stored in a single `PreviousSourceText` column so the translator sees
+  old-vs-new source side by side — one column, not a history table (#50 stays post-MVP).
+- Worst case is by design: every patch may invalidate some translations; that is the system
+  working, not failing.
+
+### Storage — anti-bloat rule
+
+- **One mutable row per `(FileId, GossipId)`** — never a copy of all translations per game
+  version. Versions are referenced by pointers on the row (`IntroducedInVersion`,
+  `LastSourceChangeInVersion`, possibly `RemovedInVersion` per Q2), giving per-version grouping
+  ("what did 48.0 change?") without duplicating 780k rows each patch.
+- Status model (decided): a single status enum `Untranslated | Draft | Approved | NeedsReview` —
+  no parallel invalidation bool, so illegal combinations (`Approved` **and** invalidated) are
+  unrepresentable. Invalidation = transition to `NeedsReview` (+ `PreviousSourceText` set);
+  approve = `Draft`/`NeedsReview` → `Approved`. #93's "add states only when a slice needs them"
+  is now satisfied: this spec is the slice that needs it.
+
+### Distribution — the cacheable translation file
+
+- One endpoint serves the **current translation file for the newest processed GameVersion**:
+  Approved, non-invalidated, non-removed rows, serialized in the exact `polish.txt` contract
+  format (escaping, `NULL` args, sorted by `FileId` then `GossipId` — byte-compatible with
+  `TranslationFileParser`, #102's golden-fixture criterion stands).
+- Anonymous (players' patchers hold no accounts), **cacheable, and stampede-proof**: the file is
+  regenerated **on write** (approve/processing), never on request — the endpoint always streams a
+  pre-built artifact with an `ETag`/content-hash, so a thundering herd after an update hits static
+  bytes, and `If-None-Match` turns no-change polls into 304s. Regeneration triggers (decided):
+  every write that changes the distributed set — approve, upsert affecting an `Approved` row,
+  version processing — and nothing else; players receive newly approved translations without
+  waiting for a game patch.
+- The CLI is the end-user client (decided): on `launch` it asks the endpoint with
+  `If-None-Match` of the cached artifact's ETag — 304 → proceed with the cached file (the proven
+  255 ms skip path), 200 → save the new file, then the existing hash flow patches only on change
+  (`update-detection-strategy.md` — the hash flow "naturally evolves into the API model").
+  API unreachable/offline degrades gracefully to the cached file; launch never blocks on the
+  network.
+
+### Bootstrap (first run)
+
+- Init seeds the current forum version as the initial `GameVersion` and performs the **baseline
+  import** (no diff — everything is added/untranslated). `IsProcessed = true` once loaded.
+- The existing production `translations/polish.txt` is then seeded as Approved (#28) — it merges
+  Polish content onto baseline rows by `(FileId, GossipId)`, it does not create rows of its own.
+
+## Contract
+
+- **Detection:** TMS hosted-service cron (interval configurable) → creates unprocessed
+  `GameVersion`. No public trigger endpoint in MVP (an admin-only manual "register version"
+  endpoint is the degenerate fallback if the forum scrape breaks).
+- **Admin views pending work:** `GET /api/v1/game-versions` (authorized) — versions with
+  detection/processing state.
+- **Upload & diff:** re-shaped #97 — `POST /api/v1/game-versions/{id}/import` (multipart
+  `exported.txt`, authorized: admin). Response: `ImportSummary { Added, SourceChanged,
+  Invalidated, Removed, Unchanged, Warnings }`. Errors as ProblemDetails via `Result` failures
+  (validation → 400, unknown version → 404, truncation guard → 422).
+- **Distribution:** re-shaped #102 — `GET /api/v1/translation-files/{lang}` (anonymous, `pl`
+  only for now) → streamed translation file + `ETag`; honors `If-None-Match` → 304. (Route
+  follows the brain dump's `/translation-files/pl`; supersedes #102's
+  `/translations/export?lang=pl`.)
+- **CLI sync (M2-20, patcher context):** the launch flow gains a download step ahead of the
+  existing hash check — `GET /api/v1/translation-files/pl` with `If-None-Match`; 200 → save file
+  + ETag, 304/unreachable → keep the cached file and proceed. Configurable API base URL; the
+  manual `patch <name>` path stays untouched. Additive slice + its launch-flow wiring are the
+  sole sanctioned freeze exception (ADR-0002 amendment).
+- **Files:** the `||` format is consumed/produced unchanged — this spec triggers **no** ADR-gated
+  format change. Golden fixtures + round-trip tests on both sides stay the drift guard.
+- **Editor loop:** #98–#101 (list/get/upsert/approve) operate on the same Translation rows;
+  approve additionally clears invalidation; list gains a "needs re-translation" filter.
+
+## Acceptance criteria
+
+- [ ] New forum version ⇒ unprocessed `GameVersion` appears (cron detection; no other side effect).
+- [ ] Baseline import on empty DB loads every parseable row as untranslated English source bound
+      to the initial GameVersion.
+- [ ] Upload for an unprocessed version: added rows appear untranslated; source-changed rows get
+      the new English **and** their Polish becomes invalidated; removed rows leave the
+      distributed file; unchanged rows are byte-for-byte untouched (incl. timestamps).
+- [ ] An invalidated row never appears in the distribution endpoint output until re-approved.
+- [ ] Identical re-upload is a no-op (idempotent); the diff is all-or-nothing on failure.
+- [ ] A truncated upload does not mass-invalidate (guard per Q4) — test with a cut-off fixture.
+- [ ] Distribution output parses byte-identically with the patcher's `TranslationFileParser`
+      (golden fixture, round-trip: import → approve → download → patcher parse).
+- [ ] Distribution endpoint: anonymous, serves pre-built artifact, correct `ETag`/304 behavior,
+      no per-request regeneration (stampede-proof by construction).
+- [ ] Approving a translation makes it appear in the next download; approving an invalidated row
+      clears invalidation.
+- [ ] Skipped/superseded intermediate versions: uploading only the newest of several unprocessed
+      versions yields a correct cumulative diff (mirror of the empirically proven 3-patch case).
+- [ ] Re-adding a removed pair: identical source restores the previous status (incl. Approved);
+      changed source lands as `NeedsReview` with `PreviousSourceText` set.
+- [ ] CLI launch sync (M2-20): 304 → cached file used, no download; API unreachable → launch
+      proceeds on the cached file; 200 → new file saved and the hash flow patches.
+
+## Open questions
+
+### Empirical — answered from code/knowledge base
+
+- *What identifies a row, and what can change across updates?* Answered — see Business rules →
+  Identity (sources: `ExportTextsQueryHandler.cs:95`, `TranslationFileParser.cs`,
+  `dat-export-diff-2026-03-22.md`, `live-test-2026-04-23.md`).
+- *Is the forum really the only version source?* Yes — vnum definitively schema-only
+  (`vnum-observations.md`); nothing in game files identifies content version.
+- *Does skipping intermediate versions break the diff?* No — accumulated diffs behave identically
+  (3-patch window proven, `dat-export-diff-2026-03-22.md`).
+- *Why is exclusion enough for English fallback?* Launcher chunk-patching already delivers fresh
+  English; only re-applying stale Polish could mask it (`dat-protection.md`,
+  `update-detection-strategy.md`).
+- *Do real GossipIds exceed `int.MaxValue`?* `[needs verification]` — scan a real `exported.txt`
+  on the Windows box (`awk -F'\|\|' 'max<$2+0{max=$2+0}END{print max}'`). Export writes raw
+  8-byte `FragmentId`; the **patcher's** parser does `int.Parse` (`TranslationFileParser.cs:86`)
+  and would warn-skip larger IDs — dormant today, candidate patcher **bugfix** ticket (allowed
+  under freeze) if the scan finds large IDs. TMS uses `long` regardless (#93).
+
+### Business decisions — resolved by the user, 2026-06-11
+
+- **Q1 — Translation-file refresh trigger:** regenerate on every approve / upsert affecting an
+  `Approved` row **and** on version processing. ETag+304 keeps polling cheap; players get newly
+  approved translations without waiting for a game patch.
+- **Q2 — Removed rows:** soft-mark `RemovedInVersion`, excluded everywhere, never hard-deleted;
+  reversible when SSG re-adds the pair.
+- **Q3 — Invalidated row contents:** keep the stale Polish as the draft starting point; store the
+  superseded English in a single `PreviousSourceText` column for side-by-side context.
+- **Q4 — Corrupt/truncated upload guard:** both guards — reject on any parse error **and** on
+  removed-fraction above the configurable threshold (default 20%) without an explicit admin
+  override.
+- **Q5 — Who downloads:** the CLI is the end-user client — the only thing a player downloads
+  manually is the CLI itself; `launch` auto-downloads, caches and refreshes the translation file
+  (ETag). Additive patcher slice (M2-20) sanctioned via the ADR-0002 freeze amendment; the WPF
+  app (M4) is a GUI over the same flow.
+- **Q6 — Invalidation modeling:** single status enum `Untranslated | Draft | Approved |
+  NeedsReview`; no parallel bool.
+
+## Assumptions
+
+- The admin's own LOTRO install is the sole export source; export runs are manual (no VM/CI
+  automation — explicitly rejected on cost).
+- `export` is deterministic and complete per game state: absence of a textual diff means SSG
+  changed nothing (basis of the unchanged-rule).
+- The forum scrape (regex on release notes) keeps working; if SSG redesigns the page, detection
+  degrades gracefully to the manual fallback, never to false versions.
+- One language (`pl`) ships; identity, statuses and routes are language-scoped so a second
+  language is additive.
+- Translation volume stays in the patcher-proven envelope (~780k rows, tens of MB) — streaming +
+  pre-built artifact handles it; no pagination/chunking of the file itself.
+
+## Impact on existing docs & backlog (applied 2026-06-11)
+
+- **CLAUDE.md** — Roadmap M2 extended with the update-lifecycle slices (GameVersion + forum
+  watcher + diff-on-import + distribution artifact + CLI sync); M4 reframed as GUI over the same
+  flow; freeze wording references the amendment; routing table points at this spec.
+- **ADR-0002** — amended in place (rides the same unmerged PR #90 branch): §2 freeze admits the
+  single additive M2-20 distribution-consumer slice; Alternative E wording extended to the CLI.
+- **`docs/knowledge-base/update-detection-strategy.md`** — header supersede pointer added: the
+  vnum/crowdsource "Docelowy Model" is superseded by this spec (forum-only detection,
+  status-based invalidation); the core insight and admin-flow sections remain valid and are
+  codified here.
+- **Issues re-cut:** #93 (GameVersion aggregate + status enum + transitions), #97 (version-bound
+  upload + diff + truncation guard; route `POST /game-versions/{id}/import`), #102 (route
+  `/translation-files/{lang}`, pre-built artifact + ETag/304, regenerate-on-write), #85
+  (post-MVP M3-11 → **M2-18**: forum-only watcher creating `GameVersion`, vnum/`GameVersionReport`
+  confirmation dropped), #101 (approve clears invalidation + triggers artifact regeneration),
+  #100 (upsert on `NeedsReview` → `Draft`, `PreviousSourceText` preserved until approve), #98
+  (NeedsReview filter; removed rows hidden by default), #28 (merge-only onto baseline rows),
+  #104 (update-cycle integration scenario).
+- **New tickets:** **#107** (M2-19) GameVersion endpoints (list + manual register fallback),
+  **#108** (M2-20) CLI auto-download (launch sync; freeze amendment), **#109** (M1-15) GossipId
+  int-overflow verification/hardening `[needs verification]`.
+- **Post-MVP unchanged:** #84/#31 (crowdsource reports), #50 (TranslationHistory), #30 (XML
+  contexts), #38/#39 (glossary/UX).


### PR DESCRIPTION
Closes #90

## Summary
- **ADR-0002**: records the architecture pivot — two bounded contexts (frozen patcher + KittySaver-lifted TMS), `||` file as the only inter-context contract, auth from day 1, lazy translator-profile provisioning, freeze amendment for M2-20.
- **Spec 0001** (Agreed): game-update lifecycle — GameVersion, import diff, translation invalidation, distribution.
- **ADR-0002 amendment (2026-06-12)**: `ReadModels(+EF)` read/write split + per-system `Primitives` lifted from day 1 (maintainer decision); CLAUDE.md aligned (tree, lift map, house rule, slice anatomy, roadmap); tickets #93/#94 re-scoped.
- **slnx cleanup**: dropped stale file references (PROJECT_PLAN.md, TICKETS.md, DotSettings.user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)