### PR TITLE
M2-02: SharedKernel lift (de-mediatorized messaging + monads)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,8 @@
   <ItemGroup>
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+    <!-- Strongly-typed IDs (source generator) -->
+    <PackageVersion Include="StronglyTypedId" Version="0.2.1" />
     <!-- DI -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -19,9 +19,11 @@
     <Project Path="src/LotroKoniecDev.Application/LotroKoniecDev.Application.csproj" />
     <Project Path="src/LotroKoniecDev.Infrastructure/LotroKoniecDev.Infrastructure.csproj" />
     <Project Path="src/LotroKoniecDev.Cli/LotroKoniecDev.Cli.csproj" />
+    <Project Path="src/SharedKernel/LotroKoniecDev.SharedKernel/LotroKoniecDev.SharedKernel.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <File Path="tests/README.md" />
+    <Project Path="tests/LotroKoniecDev.SharedKernel.Tests.Unit/LotroKoniecDev.SharedKernel.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.E2E/LotroKoniecDev.Tests.E2E.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Infrastructure/LotroKoniecDev.Tests.Infrastructure.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj" />

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/AggregateRoot.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/AggregateRoot.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.SharedKernel.BuildingBlocks;
+
+public interface IAggregateRoot;
+
+public abstract class AggregateRoot<TId> : Entity<TId>, IAggregateRoot where TId : struct
+{
+    protected AggregateRoot(TId id) : base(id)
+    {
+    }
+
+    protected AggregateRoot()
+    {
+    }
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/Entity.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/Entity.cs
@@ -1,0 +1,72 @@
+namespace LotroKoniecDev.SharedKernel.BuildingBlocks;
+
+public interface IEntity;
+
+public interface IEntity<TId> : IEntity, IEquatable<Entity<TId>> where TId : struct
+{
+    TId Id { get; }
+}
+
+public abstract class Entity<TId> : IEntity<TId> where TId : struct
+{
+    protected Entity()
+    {
+        Id = default;
+    }
+
+    protected Entity(TId id)
+    {
+        Id = id;
+    }
+
+    public TId Id { get; }
+
+    public static bool operator ==(Entity<TId>? a, Entity<TId>? b)
+    {
+        if (a is null && b is null)
+        {
+            return true;
+        }
+
+        if (a is null || b is null)
+        {
+            return false;
+        }
+
+        return a.Equals(b);
+    }
+
+    public static bool operator !=(Entity<TId> a, Entity<TId> b) => !(a == b);
+
+    public bool Equals(Entity<TId>? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(this, other) || Id.Equals(other.Id);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return obj is Entity<TId> other && Id.Equals(other.Id);
+    }
+
+    public override int GetHashCode() => Id.GetHashCode() * 41;
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/Error.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/Error.cs
@@ -1,0 +1,31 @@
+using LotroKoniecDev.SharedKernel.Enums;
+
+namespace LotroKoniecDev.SharedKernel.BuildingBlocks;
+
+public sealed class Error : ValueObject
+{
+    public string Code { get; }
+    public string Message { get; }
+    public TypeOfError Type { get; }
+
+    public static Error None => new(string.Empty, string.Empty);
+
+    public Error(string code, string message, TypeOfError type = TypeOfError.Failure)
+    {
+        Code = code;
+        Message = message;
+        Type = type;
+    }
+
+    public override string ToString()
+    {
+        return $"[{Type}] {Code}: {Message}";
+    }
+
+    protected override IEnumerable<object> GetAtomicValues()
+    {
+        yield return Code;
+        yield return Message;
+        yield return Type;
+    }
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/IRepository.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/IRepository.cs
@@ -1,0 +1,13 @@
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.SharedKernel.BuildingBlocks;
+
+public interface IRepository<TAggregateRoot, in TAggregateRootId>
+    where TAggregateRootId : struct
+    where TAggregateRoot : AggregateRoot<TAggregateRootId>
+{
+    Task<Maybe<TAggregateRoot>> GetByIdAsync(TAggregateRootId id, CancellationToken cancellationToken);
+    Task<bool> ExistsAsync(TAggregateRootId id, CancellationToken cancellationToken);
+    void Insert(TAggregateRoot aggregate);
+    void Remove(TAggregateRoot aggregate);
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/ValueObject.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/BuildingBlocks/ValueObject.cs
@@ -1,0 +1,37 @@
+namespace LotroKoniecDev.SharedKernel.BuildingBlocks;
+
+public abstract class ValueObject : IEquatable<ValueObject>
+{
+    public static bool operator ==(ValueObject? a, ValueObject? b)
+    {
+        if (a is null && b is null)
+        {
+            return true;
+        }
+
+        if (a is null || b is null)
+        {
+            return false;
+        }
+
+        return a.Equals(b);
+    }
+
+    public static bool operator !=(ValueObject? a, ValueObject? b) => !(a == b);
+
+    public virtual bool Equals(ValueObject? other) =>
+        other is not null && ValuesAreEqual(other);
+
+    public override bool Equals(object? obj) =>
+        obj is ValueObject valueObject && ValuesAreEqual(valueObject);
+
+    public override int GetHashCode() =>
+        GetAtomicValues().Aggregate(0,
+            (hashcode, value) =>
+                HashCode.Combine(hashcode, value.GetHashCode()));
+
+    protected abstract IEnumerable<object> GetAtomicValues();
+
+    private bool ValuesAreEqual(ValueObject valueObject) =>
+        GetAtomicValues().SequenceEqual(valueObject.GetAtomicValues());
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Enums/TypeOfError.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Enums/TypeOfError.cs
@@ -1,0 +1,10 @@
+namespace LotroKoniecDev.SharedKernel.Enums;
+
+public enum TypeOfError
+{
+    Validation,
+    NotFound,
+    DataConflict,
+    Failure,
+    Forbidden
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Guards/Ensure.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Guards/Ensure.cs
@@ -1,0 +1,75 @@
+using System.Runtime.CompilerServices;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+
+namespace LotroKoniecDev.SharedKernel.Guards;
+
+public static class Ensure
+{
+    /// <summary>
+    /// Ensures that the specified enum value is defined and not Unset (0).
+    /// </summary>
+    /// <remarks>
+    /// Do not use with <see cref="FlagsAttribute"/> enums - combined flag values will fail validation.
+    /// </remarks>
+    /// <param name="value">The enum value to check.</param>
+    /// <param name="argumentName">Automatically resolved with CallerArgumentExpression
+    /// attribute name of the argument being checked.</param>
+    /// <exception cref="ArgumentException">if the specified value is Unset (0).</exception>
+    /// <exception cref="ArgumentOutOfRangeException">if the specified value is not defined in the enum.</exception>
+    public static void IsValidNonDefaultEnum<TEnum>(
+        TEnum value,
+        [CallerArgumentExpression(nameof(value))] string argumentName = "")
+        where TEnum : struct, Enum
+    {
+        if (EqualityComparer<TEnum>.Default.Equals(value, default))
+        {
+            throw new ArgumentException($"{argumentName} cannot be default.", argumentName);
+        }
+
+        if (!Enum.IsDefined(value))
+        {
+            throw new ArgumentOutOfRangeException(argumentName, value,
+                $"{argumentName} must be a defined enum value.");
+        }
+    }
+
+    /// <summary>
+    /// Ensures that the specified strongly-typed ID value is not empty.
+    /// </summary>
+    public static void NotEmpty<T>(
+        T id,
+        [CallerArgumentExpression(nameof(id))] string argumentName = "")
+        where T : IStronglyTypedId<T>
+    {
+        if (id.Value == Guid.Empty)
+        {
+            throw new ArgumentException($"{argumentName} cannot be empty.", argumentName);
+        }
+    }
+
+    /// <summary>
+    /// Ensures that the specified strongly-typed ID value is not empty.
+    /// </summary>
+    public static void NotEmpty(
+        Guid id,
+        [CallerArgumentExpression(nameof(id))] string argumentName = "")
+    {
+        if (id == Guid.Empty)
+        {
+            throw new ArgumentException($"{argumentName} cannot be empty.", argumentName);
+        }
+    }
+
+    /// <summary>
+    /// Ensures that the specified <see cref="DateTimeOffset"/> value is not the default value.
+    /// </summary>
+    public static void NotEmpty(
+        DateTimeOffset value,
+        [CallerArgumentExpression(nameof(value))] string argumentName = "")
+    {
+        if (value == default)
+        {
+            throw new ArgumentException($"{argumentName} cannot be default.", argumentName);
+        }
+    }
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/LotroKoniecDev.SharedKernel.csproj
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/LotroKoniecDev.SharedKernel.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="StronglyTypedId" />
+    </ItemGroup>
+</Project>

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Messaging/ICommand.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Messaging/ICommand.cs
@@ -1,0 +1,3 @@
+namespace LotroKoniecDev.SharedKernel.Messaging;
+
+public interface ICommand<TResponse>;

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Messaging/ICommandHandler.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Messaging/ICommandHandler.cs
@@ -1,0 +1,7 @@
+namespace LotroKoniecDev.SharedKernel.Messaging;
+
+public interface ICommandHandler<in TCommand, TResponse>
+    where TCommand : ICommand<TResponse>
+{
+    ValueTask<TResponse> Handle(TCommand command, CancellationToken cancellationToken);
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Messaging/IQuery.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Messaging/IQuery.cs
@@ -1,0 +1,3 @@
+namespace LotroKoniecDev.SharedKernel.Messaging;
+
+public interface IQuery<TResponse>;

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Messaging/IQueryHandler.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Messaging/IQueryHandler.cs
@@ -1,0 +1,7 @@
+namespace LotroKoniecDev.SharedKernel.Messaging;
+
+public interface IQueryHandler<in TQuery, TResponse>
+    where TQuery : IQuery<TResponse>
+{
+    ValueTask<TResponse> Handle(TQuery query, CancellationToken cancellationToken);
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Monads/Maybe.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Monads/Maybe.cs
@@ -1,0 +1,58 @@
+namespace LotroKoniecDev.SharedKernel.Monads;
+
+public sealed class Maybe<T> : IEquatable<Maybe<T>> where T : class
+{
+    private readonly T? _value;
+
+    private Maybe(T? value)
+    {
+        _value = value;
+    }
+
+    public bool HasValue => !HasNoValue;
+
+    public bool HasNoValue => _value is null;
+
+    public T Value => HasValue
+        ? _value!
+        : throw new InvalidOperationException("The value can not be accessed because it does not exist.");
+
+    public static Maybe<T> None => new(null);
+
+    public static Maybe<T> From(T? value) => new(value);
+
+    public static implicit operator Maybe<T>(T value) => From(value);
+
+    public static implicit operator T?(Maybe<T> maybe) => maybe.HasValue ? maybe.Value : null;
+
+    public bool Equals(Maybe<T>? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (HasNoValue && other.HasNoValue)
+        {
+            return true;
+        }
+
+        if (HasNoValue || other.HasNoValue)
+        {
+            return false;
+        }
+
+        return Value.Equals(other.Value);
+    }
+
+    public override bool Equals(object? obj) =>
+        obj switch
+        {
+            null => false,
+            T value => Equals(new Maybe<T>(value)),
+            Maybe<T> maybe => Equals(maybe),
+            _ => false
+        };
+
+    public override int GetHashCode() => HasValue ? Value.GetHashCode() : 0;
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Monads/Result.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Monads/Result.cs
@@ -1,0 +1,46 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+
+namespace LotroKoniecDev.SharedKernel.Monads;
+
+public class Result
+{
+    protected Result(bool isSuccess, Error error)
+    {
+        if (isSuccess && error != Error.None || !isSuccess && error == Error.None)
+        {
+            throw new InvalidOperationException();
+        }
+
+        IsSuccess = isSuccess;
+        Error = error;
+    }
+
+    public bool IsSuccess { get; }
+
+    public bool IsFailure => !IsSuccess;
+
+    public Error Error { get; }
+
+    public static Result Success() => new(true, Error.None);
+
+    public static Result<TValue> Success<TValue>(TValue value) => new(value, true, Error.None);
+
+    public static Result Failure(Error error) => new(false, error);
+
+    public static Result<TValue> Failure<TValue>(Error error) => new(default!, false, error);
+}
+
+public sealed class Result<TValue> : Result
+{
+    internal Result(TValue value, bool isSuccess, Error error)
+        : base(isSuccess, error)
+    {
+        Value = value;
+    }
+
+    public static implicit operator Result<TValue>(TValue value) => Success(value);
+
+    public TValue Value => IsSuccess
+        ? field
+        : throw new InvalidOperationException("The value of a failure result can not be accessed.");
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Monads/ValueMaybe.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Monads/ValueMaybe.cs
@@ -1,0 +1,25 @@
+namespace LotroKoniecDev.SharedKernel.Monads;
+
+public readonly struct ValueMaybe<T> where T : struct
+{
+    private readonly T? _value;
+
+    private ValueMaybe(T? value)
+    {
+        _value = value;
+    }
+
+    public static ValueMaybe<T> From(T? value) => new(value);
+    public static ValueMaybe<T> None() => new(null);
+    public bool HasValue => !HasNoValue;
+    public bool HasNoValue => _value is null;
+
+    public T Value => HasValue
+        ? _value!.Value
+        : throw new InvalidOperationException("The value can not be accessed because it does not exist.");
+
+    public TOut Match<TOut>(Func<T, TOut> from, Func<TOut> none)
+        => _value.HasValue ? from(_value.Value) : none();
+
+    public static implicit operator ValueMaybe<T>(T value) => From(value);
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/Common/IStronglyTypedId.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/Common/IStronglyTypedId.cs
@@ -1,0 +1,18 @@
+namespace LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+
+/// <summary>
+/// Represents a marker interface for strongly-typed IDs.
+/// Strongly-typed IDs provide type safety and clarity over the usage of simple Guid values
+/// by associating a specific type with the ID.
+/// </summary>
+/// <typeparam name="TSelf">
+/// The strongly-typed ID type that implements this interface.
+/// This type should be a struct or a class that encapsulates a Guid value.
+/// </typeparam>
+public interface IStronglyTypedId<out TSelf> where TSelf : IStronglyTypedId<TSelf>
+{
+    public Guid Value { get; }
+
+    public static abstract TSelf Create();
+    public static abstract TSelf Create(Guid id);
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/IdentityId.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/IdentityId.cs
@@ -1,0 +1,10 @@
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+
+namespace LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]
+public partial struct IdentityId : IStronglyTypedId<IdentityId>
+{
+    public static IdentityId Create() => new(Guid.CreateVersion7());
+    public static IdentityId Create(Guid id) => new(id);
+}

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/LotroKoniecDev.SharedKernel.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/LotroKoniecDev.SharedKernel.Tests.Unit.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>LotroKoniecDev.SharedKernel.Tests.Unit</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+        <Using Include="Shouldly"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\SharedKernel\LotroKoniecDev.SharedKernel\LotroKoniecDev.SharedKernel.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/BuildingBlocks/EntityTests.cs
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/BuildingBlocks/EntityTests.cs
@@ -1,0 +1,91 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+
+namespace LotroKoniecDev.SharedKernel.Tests.Unit.Tests.BuildingBlocks;
+
+public sealed class EntityTests
+{
+    private sealed class FirstEntity : Entity<Guid>
+    {
+        public FirstEntity(Guid id) : base(id)
+        {
+        }
+    }
+
+    private sealed class SecondEntity : Entity<Guid>
+    {
+        public SecondEntity(Guid id) : base(id)
+        {
+        }
+    }
+
+    [Fact]
+    public void Equals_SameId_ShouldBeTrue()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        FirstEntity first = new(id);
+        FirstEntity second = new(id);
+
+        // Assert
+        first.Equals(second).ShouldBeTrue();
+        (first == second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentId_ShouldBeFalse()
+    {
+        // Arrange
+        FirstEntity first = new(Guid.NewGuid());
+        FirstEntity second = new(Guid.NewGuid());
+
+        // Assert
+        first.Equals(second).ShouldBeFalse();
+        (first != second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentTypeSameId_ShouldBeFalse()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        FirstEntity first = new(id);
+        SecondEntity second = new(id);
+
+        // Assert
+        first.Equals((object)second).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void OperatorEquals_BothNull_ShouldBeTrue()
+    {
+        // Arrange
+        FirstEntity? first = null;
+        FirstEntity? second = null;
+
+        // Assert
+        (first == second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OperatorEquals_OneNull_ShouldBeFalse()
+    {
+        // Arrange
+        FirstEntity first = new(Guid.NewGuid());
+        FirstEntity? second = null;
+
+        // Assert
+        (first == second).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_SameId_ShouldBeEqual()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        FirstEntity first = new(id);
+        FirstEntity second = new(id);
+
+        // Assert
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+}

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/BuildingBlocks/ErrorTests.cs
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/BuildingBlocks/ErrorTests.cs
@@ -54,6 +54,17 @@ public sealed class ErrorTests
     }
 
     [Fact]
+    public void GetHashCode_SameValues_ShouldBeEqual()
+    {
+        // Arrange
+        Error first = new("Test.Code", "Test message", TypeOfError.NotFound);
+        Error second = new("Test.Code", "Test message", TypeOfError.NotFound);
+
+        // Assert
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+
+    [Fact]
     public void ToString_ShouldFormatTypeCodeAndMessage()
     {
         // Arrange

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/BuildingBlocks/ErrorTests.cs
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/BuildingBlocks/ErrorTests.cs
@@ -1,0 +1,68 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+
+namespace LotroKoniecDev.SharedKernel.Tests.Unit.Tests.BuildingBlocks;
+
+public sealed class ErrorTests
+{
+    [Fact]
+    public void Constructor_WithoutType_ShouldDefaultToFailure()
+    {
+        // Act
+        Error error = new("Test.Code", "Test message");
+
+        // Assert
+        error.Type.ShouldBe(TypeOfError.Failure);
+    }
+
+    [Fact]
+    public void None_ShouldHaveEmptyCodeAndMessage()
+    {
+        // Act
+        Error error = Error.None;
+
+        // Assert
+        error.Code.ShouldBe(string.Empty);
+        error.Message.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Equality_SameValues_ShouldBeEqual()
+    {
+        // Arrange
+        Error first = new("Test.Code", "Test message", TypeOfError.NotFound);
+        Error second = new("Test.Code", "Test message", TypeOfError.NotFound);
+
+        // Assert
+        first.ShouldBe(second);
+        (first == second).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("Other.Code", "Test message", TypeOfError.NotFound)]
+    [InlineData("Test.Code", "Other message", TypeOfError.NotFound)]
+    [InlineData("Test.Code", "Test message", TypeOfError.Validation)]
+    public void Equality_DifferentValues_ShouldNotBeEqual(string code, string message, TypeOfError type)
+    {
+        // Arrange
+        Error first = new("Test.Code", "Test message", TypeOfError.NotFound);
+        Error second = new(code, message, type);
+
+        // Assert
+        first.ShouldNotBe(second);
+        (first != second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ToString_ShouldFormatTypeCodeAndMessage()
+    {
+        // Arrange
+        Error error = new("Test.Code", "Test message", TypeOfError.Validation);
+
+        // Act
+        string formatted = error.ToString();
+
+        // Assert
+        formatted.ShouldBe("[Validation] Test.Code: Test message");
+    }
+}

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Guards/EnsureTests.cs
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Guards/EnsureTests.cs
@@ -1,0 +1,103 @@
+using LotroKoniecDev.SharedKernel.Guards;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.SharedKernel.Tests.Unit.Tests.Guards;
+
+public sealed class EnsureTests
+{
+    public enum TestEnum
+    {
+        Unset = 0,
+        First = 1,
+        Second = 2
+    }
+
+    [Fact]
+    public void IsValidNonDefaultEnum_WithDefaultValue_ShouldThrowArgumentException()
+    {
+        // Arrange
+        TestEnum value = TestEnum.Unset;
+
+        // Assert
+        Should.Throw<ArgumentException>(() => Ensure.IsValidNonDefaultEnum(value));
+    }
+
+    [Fact]
+    public void IsValidNonDefaultEnum_WithUndefinedValue_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        TestEnum value = (TestEnum)999;
+
+        // Assert
+        Should.Throw<ArgumentOutOfRangeException>(() => Ensure.IsValidNonDefaultEnum(value));
+    }
+
+    [Theory]
+    [InlineData(TestEnum.First)]
+    [InlineData(TestEnum.Second)]
+    public void IsValidNonDefaultEnum_WithDefinedValue_ShouldNotThrow(TestEnum value)
+    {
+        // Assert
+        Should.NotThrow(() => Ensure.IsValidNonDefaultEnum(value));
+    }
+
+    [Fact]
+    public void NotEmpty_WithEmptyGuid_ShouldThrowArgumentException()
+    {
+        // Arrange
+        Guid id = Guid.Empty;
+
+        // Assert
+        Should.Throw<ArgumentException>(() => Ensure.NotEmpty(id));
+    }
+
+    [Fact]
+    public void NotEmpty_WithNonEmptyGuid_ShouldNotThrow()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+
+        // Assert
+        Should.NotThrow(() => Ensure.NotEmpty(id));
+    }
+
+    [Fact]
+    public void NotEmpty_WithEmptyStronglyTypedId_ShouldThrowArgumentException()
+    {
+        // Arrange
+        IdentityId id = IdentityId.Create(Guid.Empty);
+
+        // Assert
+        Should.Throw<ArgumentException>(() => Ensure.NotEmpty(id));
+    }
+
+    [Fact]
+    public void NotEmpty_WithNonEmptyStronglyTypedId_ShouldNotThrow()
+    {
+        // Arrange
+        IdentityId id = IdentityId.Create();
+
+        // Assert
+        Should.NotThrow(() => Ensure.NotEmpty(id));
+    }
+
+    [Fact]
+    public void NotEmpty_WithDefaultDateTimeOffset_ShouldThrowArgumentException()
+    {
+        // Arrange
+        DateTimeOffset value = default;
+
+        // Assert
+        Should.Throw<ArgumentException>(() => Ensure.NotEmpty(value));
+    }
+
+    [Fact]
+    public void NotEmpty_WithNonDefaultDateTimeOffset_ShouldNotThrow()
+    {
+        // Arrange
+        DateTimeOffset value = DateTimeOffset.UtcNow;
+
+        // Assert
+        Should.NotThrow(() => Ensure.NotEmpty(value));
+    }
+}

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Monads/MaybeTests.cs
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Monads/MaybeTests.cs
@@ -1,0 +1,151 @@
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.SharedKernel.Tests.Unit.Tests.Monads;
+
+public sealed class MaybeTests
+{
+    [Fact]
+    public void From_WithValue_ShouldHaveValue()
+    {
+        // Act
+        Maybe<string> maybe = Maybe<string>.From("value");
+
+        // Assert
+        maybe.HasValue.ShouldBeTrue();
+        maybe.HasNoValue.ShouldBeFalse();
+        maybe.Value.ShouldBe("value");
+    }
+
+    [Fact]
+    public void From_WithNull_ShouldHaveNoValue()
+    {
+        // Act
+        Maybe<string> maybe = Maybe<string>.From(null);
+
+        // Assert
+        maybe.HasValue.ShouldBeFalse();
+        maybe.HasNoValue.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void None_ShouldHaveNoValue()
+    {
+        // Act
+        Maybe<string> maybe = Maybe<string>.None;
+
+        // Assert
+        maybe.HasNoValue.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Value_WhenNone_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        Maybe<string> maybe = Maybe<string>.None;
+
+        // Assert
+        Should.Throw<InvalidOperationException>(() => _ = maybe.Value);
+    }
+
+    [Fact]
+    public void ImplicitOperator_FromValue_ShouldHaveValue()
+    {
+        // Act
+        Maybe<string> maybe = "value";
+
+        // Assert
+        maybe.HasValue.ShouldBeTrue();
+        maybe.Value.ShouldBe("value");
+    }
+
+    [Fact]
+    public void ImplicitOperator_ToNullable_WhenNone_ShouldBeNull()
+    {
+        // Arrange
+        Maybe<string> maybe = Maybe<string>.None;
+
+        // Act
+        string? value = maybe;
+
+        // Assert
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ImplicitOperator_ToNullable_WhenValue_ShouldReturnValue()
+    {
+        // Arrange
+        Maybe<string> maybe = Maybe<string>.From("value");
+
+        // Act
+        string? value = maybe;
+
+        // Assert
+        value.ShouldBe("value");
+    }
+
+    [Fact]
+    public void Equals_BothNone_ShouldBeTrue()
+    {
+        // Arrange
+        Maybe<string> first = Maybe<string>.None;
+        Maybe<string> second = Maybe<string>.None;
+
+        // Assert
+        first.Equals(second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_NoneAndValue_ShouldBeFalse()
+    {
+        // Arrange
+        Maybe<string> none = Maybe<string>.None;
+        Maybe<string> some = Maybe<string>.From("value");
+
+        // Assert
+        none.Equals(some).ShouldBeFalse();
+        some.Equals(none).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_SameValues_ShouldBeTrue()
+    {
+        // Arrange
+        Maybe<string> first = Maybe<string>.From("value");
+        Maybe<string> second = Maybe<string>.From("value");
+
+        // Assert
+        first.Equals(second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentValues_ShouldBeFalse()
+    {
+        // Arrange
+        Maybe<string> first = Maybe<string>.From("first");
+        Maybe<string> second = Maybe<string>.From("second");
+
+        // Assert
+        first.Equals(second).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_RawValue_ShouldCompareAgainstWrappedValue()
+    {
+        // Arrange
+        Maybe<string> maybe = Maybe<string>.From("value");
+
+        // Assert
+        maybe.Equals((object)"value").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_WhenNone_ShouldBeZero()
+    {
+        // Arrange
+        Maybe<string> maybe = Maybe<string>.None;
+
+        // Assert
+        maybe.GetHashCode().ShouldBe(0);
+    }
+}

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Monads/MaybeTests.cs
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Monads/MaybeTests.cs
@@ -148,4 +148,24 @@ public sealed class MaybeTests
         // Assert
         maybe.GetHashCode().ShouldBe(0);
     }
+
+    [Fact]
+    public void GetHashCode_WhenValue_ShouldBeValueHashCode()
+    {
+        // Arrange
+        Maybe<string> maybe = Maybe<string>.From("value");
+
+        // Assert
+        maybe.GetHashCode().ShouldBe("value".GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_UnrelatedType_ShouldBeFalse()
+    {
+        // Arrange
+        Maybe<string> maybe = Maybe<string>.From("value");
+
+        // Assert
+        maybe.Equals(42).ShouldBeFalse();
+    }
 }

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Monads/ResultTests.cs
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Monads/ResultTests.cs
@@ -1,0 +1,83 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.SharedKernel.Tests.Unit.Tests.Monads;
+
+public sealed class ResultTests
+{
+    [Fact]
+    public void Success_ShouldBeSuccessWithNoneError()
+    {
+        // Act
+        Result result = Result.Success();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.IsFailure.ShouldBeFalse();
+        result.Error.ShouldBe(Error.None);
+    }
+
+    [Fact]
+    public void Failure_ShouldBeFailureExposingError()
+    {
+        // Arrange
+        Error error = new("Test.Code", "Test message", TypeOfError.NotFound);
+
+        // Act
+        Result result = Result.Failure(error);
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(error);
+    }
+
+    [Fact]
+    public void SuccessGeneric_ShouldExposeValue()
+    {
+        // Act
+        Result<string> result = Result.Success("value");
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe("value");
+    }
+
+    [Fact]
+    public void FailureGeneric_AccessingValue_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        Error error = new("Test.Code", "Test message");
+        Result<string> result = Result.Failure<string>(error);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        Should.Throw<InvalidOperationException>(() => _ = result.Value);
+    }
+
+    [Fact]
+    public void ImplicitOperator_FromValue_ShouldCreateSuccessResult()
+    {
+        // Act
+        Result<int> result = 42;
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public void FailureGeneric_ShouldExposeError()
+    {
+        // Arrange
+        Error error = new("Test.Code", "Test message", TypeOfError.Validation);
+
+        // Act
+        Result<int> result = Result.Failure<int>(error);
+
+        // Assert
+        result.Error.ShouldBe(error);
+        result.Error.Type.ShouldBe(TypeOfError.Validation);
+    }
+}

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Monads/ValueMaybeTests.cs
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/Monads/ValueMaybeTests.cs
@@ -1,0 +1,85 @@
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.SharedKernel.Tests.Unit.Tests.Monads;
+
+public sealed class ValueMaybeTests
+{
+    [Fact]
+    public void From_WithValue_ShouldHaveValue()
+    {
+        // Act
+        ValueMaybe<int> maybe = ValueMaybe<int>.From(42);
+
+        // Assert
+        maybe.HasValue.ShouldBeTrue();
+        maybe.HasNoValue.ShouldBeFalse();
+        maybe.Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public void From_WithNull_ShouldHaveNoValue()
+    {
+        // Act
+        ValueMaybe<int> maybe = ValueMaybe<int>.From(null);
+
+        // Assert
+        maybe.HasNoValue.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void None_ShouldHaveNoValue()
+    {
+        // Act
+        ValueMaybe<int> maybe = ValueMaybe<int>.None();
+
+        // Assert
+        maybe.HasNoValue.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Value_WhenNone_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        ValueMaybe<int> maybe = ValueMaybe<int>.None();
+
+        // Assert
+        Should.Throw<InvalidOperationException>(() => _ = maybe.Value);
+    }
+
+    [Fact]
+    public void Match_WhenValue_ShouldInvokeFromBranch()
+    {
+        // Arrange
+        ValueMaybe<int> maybe = ValueMaybe<int>.From(42);
+
+        // Act
+        string matched = maybe.Match(value => $"value:{value}", () => "none");
+
+        // Assert
+        matched.ShouldBe("value:42");
+    }
+
+    [Fact]
+    public void Match_WhenNone_ShouldInvokeNoneBranch()
+    {
+        // Arrange
+        ValueMaybe<int> maybe = ValueMaybe<int>.None();
+
+        // Act
+        string matched = maybe.Match(value => $"value:{value}", () => "none");
+
+        // Assert
+        matched.ShouldBe("none");
+    }
+
+    [Fact]
+    public void ImplicitOperator_FromValue_ShouldHaveValue()
+    {
+        // Act
+        ValueMaybe<int> maybe = 42;
+
+        // Assert
+        maybe.HasValue.ShouldBeTrue();
+        maybe.Value.ShouldBe(42);
+    }
+}

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/StronglyTypedIds/IdentityIdTests.cs
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/Tests/StronglyTypedIds/IdentityIdTests.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.SharedKernel.Tests.Unit.Tests.StronglyTypedIds;
+
+public sealed class IdentityIdTests
+{
+    [Fact]
+    public void Create_ShouldGenerateVersion7Guid()
+    {
+        // Act
+        IdentityId id = IdentityId.Create();
+
+        // Assert
+        id.Value.ShouldNotBe(Guid.Empty);
+        id.Value.Version.ShouldBe(7);
+    }
+
+    [Fact]
+    public void Create_CalledTwice_ShouldGenerateUniqueIds()
+    {
+        // Act
+        IdentityId first = IdentityId.Create();
+        IdentityId second = IdentityId.Create();
+
+        // Assert
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void Create_WithGuid_ShouldWrapProvidedGuid()
+    {
+        // Arrange
+        Guid guid = Guid.NewGuid();
+
+        // Act
+        IdentityId id = IdentityId.Create(guid);
+
+        // Assert
+        id.Value.ShouldBe(guid);
+    }
+
+    [Fact]
+    public void Equality_SameGuid_ShouldBeEqual()
+    {
+        // Arrange
+        Guid guid = Guid.NewGuid();
+
+        // Act
+        IdentityId first = IdentityId.Create(guid);
+        IdentityId second = IdentityId.Create(guid);
+
+        // Assert
+        first.ShouldBe(second);
+        (first == second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void JsonSerialization_ShouldRoundTripAsPlainGuid()
+    {
+        // Arrange
+        IdentityId id = IdentityId.Create();
+
+        // Act
+        string json = JsonSerializer.Serialize(id);
+        IdentityId deserialized = JsonSerializer.Deserialize<IdentityId>(json);
+
+        // Assert
+        json.ShouldBe($"\"{id.Value}\"");
+        deserialized.ShouldBe(id);
+    }
+}


### PR DESCRIPTION
Closes #91

## What
1:1 lift of `TheKittySaver.SharedKernel` → `src/SharedKernel/LotroKoniecDev.SharedKernel` (namespace swap), with exactly two sanctioned deviations:
- **No Mediator** (ADR-0001): `Mediator.Abstractions` dropped; domain-event machinery (`IDomainEvent`/`DomainEvent`/aggregate event list) not lifted per ADR-0002 §5 — `IAggregateRoot` is a plain marker.
- **In-house `Messaging/`**: `ICommand`/`ICommandHandler<,>`/`IQuery`/`IQueryHandler<,>` character-identical to the patcher's `Application/Abstractions/Messaging` shapes.

Kept 1:1: `Result`/`Maybe`/`ValueMaybe` monads, `Entity`/`AggregateRoot`/`ValueObject`/`Error`/`IRepository` building blocks, `Ensure` guards, `IStronglyTypedId` + `IdentityId` (StronglyTypedId 0.2.1, same pin as KittySaver). KittySaver-specific `Authorization`/`Constants` arrive with M2-03 when first used.

## Tests
New `tests/LotroKoniecDev.SharedKernel.Tests.Unit`: 57 pure unit tests (monads, guards incl. all overload throw/no-throw matrices, IdentityId v7 + JSON round-trip, Entity/Error equality contracts). Full solution builds with 0 warnings; 223 patcher unit tests untouched and green; diff is 100% additive (patcher frozen rule respected).

## Review
code-reviewer agent: **APPROVE** — port fidelity verified file-by-file against the lift source; both coverage-gap findings fixed in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)