### PR TITLE
M2-04 (Phase A): TranslationSystem Primitives + Domain + ReadModels — GameVersion aggregate

### DIFF
--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -29,12 +29,16 @@
     <Project Path="src/Utilities/LotroKoniecDev.Hateoas.Abstractions/LotroKoniecDev.Hateoas.Abstractions.csproj" />
     <Project Path="src/Utilities/LotroKoniecDev.Logging/LotroKoniecDev.Logging.csproj" />
     <Project Path="src/Utilities/LotroKoniecDev.Options/LotroKoniecDev.Options.csproj" />
+    <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/LotroKoniecDev.TranslationSystem.Primitives.csproj" />
+    <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/LotroKoniecDev.TranslationSystem.Domain.csproj" />
+    <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/LotroKoniecDev.TranslationSystem.ReadModels.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <File Path="tests/README.md" />
     <Project Path="tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj" />
     <Project Path="tests/LotroKoniecDev.SharedKernel.Tests.Unit/LotroKoniecDev.SharedKernel.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.E2E/LotroKoniecDev.Tests.E2E.csproj" />
+    <Project Path="tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Infrastructure/LotroKoniecDev.Tests.Infrastructure.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj" />
   </Folder>

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -38,8 +38,8 @@
     <Project Path="tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj" />
     <Project Path="tests/LotroKoniecDev.SharedKernel.Tests.Unit/LotroKoniecDev.SharedKernel.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.E2E/LotroKoniecDev.Tests.E2E.csproj" />
-    <Project Path="tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Infrastructure/LotroKoniecDev.Tests.Infrastructure.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj" />
+    <Project Path="tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj" />
   </Folder>
 </Solution>

--- a/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
+++ b/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
@@ -113,6 +113,10 @@ player's patcher downloads a translation file that never shows outdated text in 
   versions are marked superseded/skipped — they will never receive an upload.
 - Re-upload to an already processed version is allowed and **idempotent** (admin uploaded a wrong
   file and corrects it; same guarantee #97 already demands).
+- *(Amendment 2026-06-12, M2-04 Phase A)*: `IsProcessed` + the superseded/skipped marker are
+  realized in code as a single `GameVersionStatus` enum (`Unprocessed | Processed | Superseded`) —
+  the same no-parallel-bool philosophy as the Translation status model below, making
+  processed-and-superseded unrepresentable.
 
 ### Diff semantics (runs only on upload, over the full file)
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
@@ -21,13 +21,13 @@ public sealed class GameVersion : AggregateRoot<GameVersionId>
 
         if (string.IsNullOrWhiteSpace(version))
         {
-            return Result.Failure<GameVersion>(DomainErrors.GameVersionEntity.VersionRequired);
+            return Result.Failure<GameVersion>(DomainErrors.GameVersionEntity.VersionProperty.NullOrEmpty);
         }
 
         string trimmedVersion = version.Trim();
         if (trimmedVersion.Length > VersionMaxLength)
         {
-            return Result.Failure<GameVersion>(DomainErrors.GameVersionEntity.VersionTooLong(VersionMaxLength));
+            return Result.Failure<GameVersion>(DomainErrors.GameVersionEntity.VersionProperty.LongerThanAllowed);
         }
 
         GameVersion instance = new(GameVersionId.Create(), trimmedVersion, detectedAt);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
@@ -1,0 +1,80 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Guards;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+
+public sealed class GameVersion : AggregateRoot<GameVersionId>
+{
+    public const int VersionMaxLength = 50;
+
+    public string Version { get; }
+    public DateTimeOffset DetectedAt { get; }
+    public GameVersionStatus Status { get; private set; }
+
+    public static Result<GameVersion> Create(string version, DateTimeOffset detectedAt)
+    {
+        Ensure.NotEmpty(detectedAt);
+
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return Result.Failure<GameVersion>(DomainErrors.GameVersionEntity.VersionRequired);
+        }
+
+        string trimmedVersion = version.Trim();
+        if (trimmedVersion.Length > VersionMaxLength)
+        {
+            return Result.Failure<GameVersion>(DomainErrors.GameVersionEntity.VersionTooLong(VersionMaxLength));
+        }
+
+        GameVersion instance = new(GameVersionId.Create(), trimmedVersion, detectedAt);
+
+        return Result.Success(instance);
+    }
+
+    // Re-upload to an already processed version is allowed and idempotent (spec 0001,
+    // GameVersion lifecycle) — only a superseded version can never be processed.
+    public Result MarkProcessed()
+    {
+        if (Status is GameVersionStatus.Superseded)
+        {
+            return Result.Failure(DomainErrors.GameVersionEntity.SupersededCannotBeProcessed(Id));
+        }
+
+        Status = GameVersionStatus.Processed;
+
+        return Result.Success();
+    }
+
+    // Stacked unprocessed versions are mass-marked when a newer one is processed (spec 0001),
+    // so re-marking an already superseded version is a no-op — processed work is never undone.
+    public Result MarkSuperseded()
+    {
+        if (Status is GameVersionStatus.Processed)
+        {
+            return Result.Failure(DomainErrors.GameVersionEntity.ProcessedCannotBeSuperseded(Id));
+        }
+
+        Status = GameVersionStatus.Superseded;
+
+        return Result.Success();
+    }
+
+    private GameVersion(
+        GameVersionId id,
+        string version,
+        DateTimeOffset detectedAt) : base(id)
+    {
+        Version = version;
+        DetectedAt = detectedAt;
+        Status = GameVersionStatus.Unprocessed;
+    }
+
+    private GameVersion()
+    {
+        Version = null!;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Repositories/IGameVersionRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Repositories/IGameVersionRepository.cs
@@ -1,0 +1,10 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
+
+public interface IGameVersionRepository : IRepository<GameVersion, GameVersionId>
+{
+    Task<bool> ExistsByVersionAsync(string version, CancellationToken cancellationToken);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/BaseDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/BaseDomainErrors.cs
@@ -1,0 +1,38 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+
+public static partial class DomainErrors
+{
+    private static Error HasNotBeenFound(string entity, Guid id, string? additionalMessage = null)
+    {
+        string message = $"The {entity.ToLowerInvariant()} with id: {id} has not been found.";
+        if (!string.IsNullOrWhiteSpace(additionalMessage))
+        {
+            message += $" {additionalMessage}";
+        }
+
+        return new Error($"{entity}.NotFound",
+            message,
+            TypeOfError.NotFound);
+    }
+
+    private static Error Required(string entity, string property)
+        => new($"{entity}.{property}.NullOrEmpty",
+            $"The {property.ToLowerInvariant()} is required.",
+            TypeOfError.Validation);
+
+    private static Error AlreadyHasBeenTaken(string entity, string property, object alreadyTakenValue)
+        => new($"{entity}.{property}.AlreadyTaken",
+            $"The {property.ToLowerInvariant()} value '{alreadyTakenValue}' is already taken.",
+            TypeOfError.DataConflict);
+
+    private static Error TooManyCharacters(string entity, string property, int maxLength)
+        => new($"{entity}.{property}.LongerThanAllowed",
+            $"The {property.ToLowerInvariant()} exceeds maximum length of {maxLength}.",
+            TypeOfError.Validation);
+
+    private static Error InvalidOperation(string entity, string message, string code)
+        => new($"{entity}.{code}", message, TypeOfError.DataConflict);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
@@ -1,4 +1,5 @@
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 
 namespace LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
@@ -10,14 +11,8 @@ public static partial class DomainErrors
         public static Error NotFound(GameVersionId id)
             => HasNotBeenFound(nameof(GameVersionEntity), id.Value);
 
-        public static Error VersionRequired
-            => Required(nameof(GameVersionEntity), "Version");
-
-        public static Error VersionTooLong(int maxLength)
-            => TooManyCharacters(nameof(GameVersionEntity), "Version", maxLength);
-
         public static Error VersionAlreadyRegistered(string version)
-            => AlreadyHasBeenTaken(nameof(GameVersionEntity), "Version", version);
+            => AlreadyHasBeenTaken(nameof(GameVersionEntity), nameof(GameVersion.Version), version);
 
         public static Error SupersededCannotBeProcessed(GameVersionId id)
             => InvalidOperation(
@@ -30,5 +25,14 @@ public static partial class DomainErrors
                 nameof(GameVersionEntity),
                 $"Game version with ID '{id.Value}' is already processed and cannot be superseded.",
                 "ProcessedCannotBeSuperseded");
+
+        public static class VersionProperty
+        {
+            public static Error NullOrEmpty
+                => Required(nameof(GameVersionEntity), nameof(GameVersion.Version));
+
+            public static Error LongerThanAllowed
+                => TooManyCharacters(nameof(GameVersionEntity), nameof(GameVersion.Version), GameVersion.VersionMaxLength);
+        }
     }
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
@@ -1,0 +1,34 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+
+public static partial class DomainErrors
+{
+    public static class GameVersionEntity
+    {
+        public static Error NotFound(GameVersionId id)
+            => HasNotBeenFound(nameof(GameVersionEntity), id.Value);
+
+        public static Error VersionRequired
+            => Required(nameof(GameVersionEntity), "Version");
+
+        public static Error VersionTooLong(int maxLength)
+            => TooManyCharacters(nameof(GameVersionEntity), "Version", maxLength);
+
+        public static Error VersionAlreadyRegistered(string version)
+            => AlreadyHasBeenTaken(nameof(GameVersionEntity), "Version", version);
+
+        public static Error SupersededCannotBeProcessed(GameVersionId id)
+            => InvalidOperation(
+                nameof(GameVersionEntity),
+                $"Game version with ID '{id.Value}' is superseded and can never be processed.",
+                "SupersededCannotBeProcessed");
+
+        public static Error ProcessedCannotBeSuperseded(GameVersionId id)
+            => InvalidOperation(
+                nameof(GameVersionEntity),
+                $"Game version with ID '{id.Value}' is already processed and cannot be superseded.",
+                "ProcessedCannotBeSuperseded");
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/LotroKoniecDev.TranslationSystem.Domain.csproj
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/LotroKoniecDev.TranslationSystem.Domain.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="LotroKoniecDev.TranslationSystem.Domain.Tests.Unit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\LotroKoniecDev.TranslationSystem.Primitives\LotroKoniecDev.TranslationSystem.Primitives.csproj" />
+        <ProjectReference Include="..\..\SharedKernel\LotroKoniecDev.SharedKernel\LotroKoniecDev.SharedKernel.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/GameVersionAggregate/Enums/GameVersionStatus.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/GameVersionAggregate/Enums/GameVersionStatus.cs
@@ -1,0 +1,9 @@
+namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+
+public enum GameVersionStatus
+{
+    Unset,
+    Unprocessed,
+    Processed,
+    Superseded
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/GameVersionAggregate/GameVersionId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/GameVersionAggregate/GameVersionId.cs
@@ -1,0 +1,15 @@
+using LotroKoniecDev.SharedKernel.Guards;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+
+namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+
+[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]
+public partial struct GameVersionId : IStronglyTypedId<GameVersionId>
+{
+    public static GameVersionId Create() => new(Guid.CreateVersion7());
+    public static GameVersionId Create(Guid id)
+    {
+        Ensure.NotEmpty(id);
+        return new GameVersionId(id);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/LotroKoniecDev.TranslationSystem.Primitives.csproj
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/LotroKoniecDev.TranslationSystem.Primitives.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="StronglyTypedId" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\SharedKernel\LotroKoniecDev.SharedKernel\LotroKoniecDev.SharedKernel.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Aggregates/GameVersionAggregate/GameVersionReadModel.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Aggregates/GameVersionAggregate/GameVersionReadModel.cs
@@ -1,0 +1,16 @@
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.ReadModels.Core.BuildingBlocks;
+
+namespace LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.GameVersionAggregate;
+
+public sealed record GameVersionReadModel(
+    GameVersionId Id,
+    string Version,
+    DateTimeOffset DetectedAt,
+    GameVersionStatus Status) : IReadOnlyEntity<GameVersionId>
+{
+    // A GameVersion row is created the moment the version is detected, so detection time
+    // is the row's creation time — kept unmapped to avoid a duplicate column.
+    public DateTimeOffset CreatedAt => DetectedAt;
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Core/BuildingBlocks/ReadOnlyEntity.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Core/BuildingBlocks/ReadOnlyEntity.cs
@@ -1,0 +1,9 @@
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+
+namespace LotroKoniecDev.TranslationSystem.ReadModels.Core.BuildingBlocks;
+
+public interface IReadOnlyEntity<out T> where T : struct, IStronglyTypedId<T>
+{
+    public T Id { get; }
+    public DateTimeOffset CreatedAt { get; }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/LotroKoniecDev.TranslationSystem.ReadModels.csproj
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/LotroKoniecDev.TranslationSystem.ReadModels.csproj
@@ -6,11 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\LotroKoniecDev.TranslationSystem.Primitives\LotroKoniecDev.TranslationSystem.Primitives.csproj" />
     </ItemGroup>
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/LotroKoniecDev.TranslationSystem.ReadModels.csproj
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/LotroKoniecDev.TranslationSystem.ReadModels.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\LotroKoniecDev.TranslationSystem.Primitives\LotroKoniecDev.TranslationSystem.Primitives.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>LotroKoniecDev.TranslationSystem.Domain.Tests.Unit</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+        <Using Include="Shouldly"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.Domain\LotroKoniecDev.TranslationSystem.Domain.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/GameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/GameVersionTests.cs
@@ -3,18 +3,14 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.En
 using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
 
-namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates;
+namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates.GameVersionAggregate;
 
 public sealed class GameVersionTests
 {
     private static readonly DateTimeOffset DetectedAt = new(2026, 6, 12, 12, 0, 0, TimeSpan.Zero);
 
     private static GameVersion CreateGameVersion(string version = "48.0")
-    {
-        Result<GameVersion> result = GameVersion.Create(version, DetectedAt);
-        result.IsSuccess.ShouldBeTrue();
-        return result.Value;
-    }
+        => GameVersion.Create(version, DetectedAt).Value;
 
     [Fact]
     public void Create_WithValidVersion_ShouldSucceedAsUnprocessed()
@@ -52,7 +48,7 @@ public sealed class GameVersionTests
 
         // Assert
         result.IsFailure.ShouldBeTrue();
-        result.Error.ShouldBe(DomainErrors.GameVersionEntity.VersionRequired);
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.VersionProperty.NullOrEmpty);
     }
 
     [Fact]
@@ -66,7 +62,7 @@ public sealed class GameVersionTests
 
         // Assert
         result.IsFailure.ShouldBeTrue();
-        result.Error.ShouldBe(DomainErrors.GameVersionEntity.VersionTooLong(GameVersion.VersionMaxLength));
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.VersionProperty.LongerThanAllowed);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionTests.cs
@@ -1,0 +1,181 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates;
+
+public sealed class GameVersionTests
+{
+    private static readonly DateTimeOffset DetectedAt = new(2026, 6, 12, 12, 0, 0, TimeSpan.Zero);
+
+    private static GameVersion CreateGameVersion(string version = "48.0")
+    {
+        Result<GameVersion> result = GameVersion.Create(version, DetectedAt);
+        result.IsSuccess.ShouldBeTrue();
+        return result.Value;
+    }
+
+    [Fact]
+    public void Create_WithValidVersion_ShouldSucceedAsUnprocessed()
+    {
+        // Act
+        Result<GameVersion> result = GameVersion.Create("48.0", DetectedAt);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Version.ShouldBe("48.0");
+        result.Value.DetectedAt.ShouldBe(DetectedAt);
+        result.Value.Status.ShouldBe(GameVersionStatus.Unprocessed);
+        result.Value.Id.Value.ShouldNotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public void Create_WithSurroundingWhitespace_ShouldTrimVersion()
+    {
+        // Act
+        Result<GameVersion> result = GameVersion.Create("  47.1.1  ", DetectedAt);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Version.ShouldBe("47.1.1");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithNullOrWhitespaceVersion_ShouldReturnVersionRequired(string? version)
+    {
+        // Act
+        Result<GameVersion> result = GameVersion.Create(version!, DetectedAt);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.VersionRequired);
+    }
+
+    [Fact]
+    public void Create_WithTooLongVersion_ShouldReturnVersionTooLong()
+    {
+        // Arrange
+        string version = new('1', GameVersion.VersionMaxLength + 1);
+
+        // Act
+        Result<GameVersion> result = GameVersion.Create(version, DetectedAt);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.VersionTooLong(GameVersion.VersionMaxLength));
+    }
+
+    [Fact]
+    public void Create_WithVersionAtMaxLength_ShouldSucceed()
+    {
+        // Arrange
+        string version = new('1', GameVersion.VersionMaxLength);
+
+        // Act
+        Result<GameVersion> result = GameVersion.Create(version, DetectedAt);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Create_WithDefaultDetectedAt_ShouldThrowArgumentException()
+    {
+        // Assert
+        Should.Throw<ArgumentException>(() => GameVersion.Create("48.0", default));
+    }
+
+    [Fact]
+    public void MarkProcessed_WhenUnprocessed_ShouldTransitionToProcessed()
+    {
+        // Arrange
+        GameVersion gameVersion = CreateGameVersion();
+
+        // Act
+        Result result = gameVersion.MarkProcessed();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        gameVersion.Status.ShouldBe(GameVersionStatus.Processed);
+    }
+
+    [Fact]
+    public void MarkProcessed_WhenAlreadyProcessed_ShouldSucceedIdempotently()
+    {
+        // Arrange
+        GameVersion gameVersion = CreateGameVersion();
+        gameVersion.MarkProcessed();
+
+        // Act
+        Result result = gameVersion.MarkProcessed();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        gameVersion.Status.ShouldBe(GameVersionStatus.Processed);
+    }
+
+    [Fact]
+    public void MarkProcessed_WhenSuperseded_ShouldReturnFailure()
+    {
+        // Arrange
+        GameVersion gameVersion = CreateGameVersion();
+        gameVersion.MarkSuperseded();
+
+        // Act
+        Result result = gameVersion.MarkProcessed();
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.SupersededCannotBeProcessed(gameVersion.Id));
+        gameVersion.Status.ShouldBe(GameVersionStatus.Superseded);
+    }
+
+    [Fact]
+    public void MarkSuperseded_WhenUnprocessed_ShouldTransitionToSuperseded()
+    {
+        // Arrange
+        GameVersion gameVersion = CreateGameVersion();
+
+        // Act
+        Result result = gameVersion.MarkSuperseded();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        gameVersion.Status.ShouldBe(GameVersionStatus.Superseded);
+    }
+
+    [Fact]
+    public void MarkSuperseded_WhenAlreadySuperseded_ShouldSucceedIdempotently()
+    {
+        // Arrange
+        GameVersion gameVersion = CreateGameVersion();
+        gameVersion.MarkSuperseded();
+
+        // Act
+        Result result = gameVersion.MarkSuperseded();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        gameVersion.Status.ShouldBe(GameVersionStatus.Superseded);
+    }
+
+    [Fact]
+    public void MarkSuperseded_WhenProcessed_ShouldReturnFailure()
+    {
+        // Arrange
+        GameVersion gameVersion = CreateGameVersion();
+        gameVersion.MarkProcessed();
+
+        // Act
+        Result result = gameVersion.MarkSuperseded();
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.ProcessedCannotBeSuperseded(gameVersion.Id));
+        gameVersion.Status.ShouldBe(GameVersionStatus.Processed);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Primitives/GameVersionIdTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Primitives/GameVersionIdTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Primitives;
+
+public sealed class GameVersionIdTests
+{
+    [Fact]
+    public void Create_ShouldGenerateVersion7Guid()
+    {
+        // Act
+        GameVersionId id = GameVersionId.Create();
+
+        // Assert
+        id.Value.ShouldNotBe(Guid.Empty);
+        id.Value.Version.ShouldBe(7);
+    }
+
+    [Fact]
+    public void Create_CalledTwice_ShouldGenerateUniqueIds()
+    {
+        // Act
+        GameVersionId first = GameVersionId.Create();
+        GameVersionId second = GameVersionId.Create();
+
+        // Assert
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void Create_WithGuid_ShouldWrapProvidedGuid()
+    {
+        // Arrange
+        Guid guid = Guid.NewGuid();
+
+        // Act
+        GameVersionId id = GameVersionId.Create(guid);
+
+        // Assert
+        id.Value.ShouldBe(guid);
+    }
+
+    [Fact]
+    public void Create_WithEmptyGuid_ShouldThrowArgumentException()
+    {
+        // Assert
+        Should.Throw<ArgumentException>(() => GameVersionId.Create(Guid.Empty));
+    }
+
+    [Fact]
+    public void Equality_SameGuid_ShouldBeEqual()
+    {
+        // Arrange
+        Guid guid = Guid.NewGuid();
+
+        // Act
+        GameVersionId first = GameVersionId.Create(guid);
+        GameVersionId second = GameVersionId.Create(guid);
+
+        // Assert
+        first.ShouldBe(second);
+        (first == second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void JsonSerialization_ShouldRoundTripAsPlainGuid()
+    {
+        // Arrange
+        GameVersionId id = GameVersionId.Create();
+
+        // Act
+        string json = JsonSerializer.Serialize(id);
+        GameVersionId deserialized = JsonSerializer.Deserialize<GameVersionId>(json);
+
+        // Assert
+        json.ShouldBe($"\"{id.Value}\"");
+        deserialized.ShouldBe(id);
+    }
+}


### PR DESCRIPTION
Part of #93 (Phase A — the boilerplate vehicle; Phase B adds the Translation aggregate after the maintainer's domain-design session and will close the ticket).

## What
First three TranslationSystem projects, mirroring AdoptionSystem 1:1 (ADR-0002 amendment: ReadModels + per-system Primitives are lifted from day 1):
- **`TranslationSystem.Primitives`** — `GameVersionId` (StronglyTypedId, v7 guids, `Ensure.NotEmpty` guard — CatId pattern verbatim) + `GameVersionStatus` enum (`Unset/Unprocessed/Processed/Superseded`).
- **`TranslationSystem.Domain`** — `GameVersion` AR per spec 0001 "GameVersion lifecycle": raw forum version string (trimmed, max 50), `DetectedAt` ordering, no semver parsing; transitions: `MarkProcessed` idempotent when already processed (spec: re-upload is idempotent), fails for superseded ("will never receive an upload"); `MarkSuperseded` idempotent, fails for processed. `DomainErrors` partials with the mirror's per-property nested factories (`VersionProperty.NullOrEmpty/LongerThanAllowed`, `nameof`-parametrized). `IGameVersionRepository : IRepository<,>` + `ExistsByVersionAsync` (present need: M2-18 watcher dedup, M2-19 duplicate-register guard).
- **`TranslationSystem.ReadModels`** — `IReadOnlyEntity<T>` + `GameVersionReadModel` (POCO record; `CreatedAt` is an unmapped computed alias of `DetectedAt` — a row is born at detection, no duplicate column). EF configurations land in M2-05 (`ReadModels.EntityFramework`).

## Modeling note
Single `GameVersionStatus` enum replaces the ticket's literal "IsProcessed bool + superseded marker" — the spec's own no-parallel-bool philosophy; processed-and-superseded is unrepresentable. Spec 0001 carries a dated amendment recording this.

## Tests
New `tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit`: **20 pure unit tests** — creation boundary matrix (null/empty/whitespace Theory, max-length both sides, trim, programmer-error guard) + every status transition incl. state-unchanged-after-failure + GameVersionIdTests (v7, uniqueness, empty-guid guard, JSON round-trip). Full solution: 0 warnings; 223 patcher + 57 SharedKernel tests untouched and green.

## Review
code-reviewer agent: REQUEST CHANGES → all findings fixed in the follow-up commit (GameVersionId tests, mirror-shaped nested error factories as the Phase B template, helper-assertion cleanup, dead EF refs dropped from ReadModels, slnx ordering, spec amendment). Modeling decisions explicitly verified against spec 0001 lines and the KittySaver mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)