### PR TITLE
M2-07: TranslationSystem.API scaffold — endpoints infra + auth + observability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Scalar.AspNetCore" Version="2.13.14" />
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <!-- Authentication & Identity -->
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageVersion Include="OpenIddict.AspNetCore" Version="7.4.0" />
     <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -35,11 +35,13 @@
     <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework/LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework.csproj" />
     <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/LotroKoniecDev.TranslationSystem.Persistence.csproj" />
     <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/LotroKoniecDev.TranslationSystem.Contracts.csproj" />
+    <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <File Path="tests/README.md" />
     <Project Path="tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj" />
     <Project Path="tests/LotroKoniecDev.SharedKernel.Tests.Unit/LotroKoniecDev.SharedKernel.Tests.Unit.csproj" />
+    <Project Path="tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.E2E/LotroKoniecDev.Tests.E2E.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Infrastructure/LotroKoniecDev.Tests.Infrastructure.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj" />

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -1,0 +1,146 @@
+using System.Text.Json.Serialization;
+using FluentValidation;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using LotroKoniecDev.Hateoas;
+using LotroKoniecDev.Options;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
+using LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
+
+namespace LotroKoniecDev.TranslationSystem.API;
+
+internal static class ApiDependencyInjection
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddApi()
+        {
+            services.AddTransient<IDiscoveryLinkFactory, DiscoveryLinkFactory>();
+
+            services.AddExceptionHandler<BadHttpRequestExceptionHandler>();
+            services.AddExceptionHandler<FluentValidationExceptionHandler>();
+            services.AddExceptionHandler<ArgumentExceptionHandler>();
+            services.AddExceptionHandler<DbUpdateConcurrencyExceptionHandler>();
+            services.AddExceptionHandler<GlobalExceptionHandler>();
+            services.AddProblemDetails();
+
+            services.ConfigureHttpJsonOptions(jsonOptions =>
+            {
+                jsonOptions.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+            });
+            // Registers ILinkFactory, IHttpContextAccessor, the fallback IProblemDetailsWriter
+            // for the HATEOAS vendor media type, and the JsonTypeInfo modifier that strips
+            // empty 'links' arrays from plain-JSON responses. Must follow AddProblemDetails()
+            // so ASP.NET Core's default writer handles plain JSON / RFC 7807 Accept values first.
+            services.AddHateoasInfrastructure();
+
+            return services;
+        }
+
+        public IServiceCollection AddJwtBearerAuthentication(IWebHostEnvironment environment)
+        {
+            services.AddSingleton<IValidator<AuthSettings>, AuthSettingsValidator>();
+            services.AddOptionsWithFluentValidation<AuthSettings>(AuthSettings.ConfigurationSection);
+
+            // Standard JWT Bearer authentication against the AuthSystem (OpenIddict) issuer —
+            // avoids OpenIddict's scope permission validation which is hard to configure.
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer();
+
+            services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+                .Configure<IOptions<AuthSettings>>((options, authSettingsAccessor) =>
+                {
+                    AuthSettings settings = authSettingsAccessor.Value;
+
+                    // In containerized environments, internal service-to-service communication uses HTTP.
+                    // HTTPS is terminated at the ingress/load balancer level.
+                    bool requireHttps = !environment.IsDevelopment()
+                                        && !environment.IsTesting()
+                                        && settings.Issuer.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+
+                    options.Authority = settings.EffectiveAuthority;
+                    options.Audience = settings.Audience;
+                    options.RequireHttpsMetadata = requireHttps;
+
+                    // Disable default claim type mapping so OpenIddict claim types
+                    // (sub, name, role) are preserved as-is in the ClaimsPrincipal.
+                    options.MapInboundClaims = false;
+
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuer = true,
+                        ValidIssuer = settings.Issuer,
+                        ValidateAudience = true,
+                        ValidAudience = settings.Audience,
+                        ValidateLifetime = true,
+                        ValidateIssuerSigningKey = true,
+                        NameClaimType = "name",
+                        RoleClaimType = "role"
+                    };
+
+                    // Fetch signing keys from JWKS endpoint
+                    options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                        $"{settings.EffectiveAuthority.TrimEnd('/')}/.well-known/openid-configuration",
+                        new OpenIdConnectConfigurationRetriever(),
+                        new HttpDocumentRetriever { RequireHttps = requireHttps });
+                });
+
+            services.AddAuthorizationPolicies();
+
+            services.AddHttpContextAccessor();
+            services.AddScoped<ICurrentUserAccessor, CurrentUserAccessor>();
+
+            return services;
+        }
+
+        private void AddAuthorizationPolicies()
+        {
+            // Endpoints are authorized by default (house rule): any endpoint without explicit
+            // authorization metadata requires an authenticated user. Public endpoints opt out
+            // explicitly with AllowAnonymous (health checks, future export download).
+            services.AddAuthorizationBuilder()
+                .SetFallbackPolicy(new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .Build())
+                .AddPolicy(AuthorizationPolicies.RequireAuthenticatedUser, policy =>
+                    policy.RequireAuthenticatedUser())
+                .AddPolicy(AuthorizationPolicies.RequireAdminRole, policy =>
+                    policy.RequireRole(AuthConstants.Roles.Admin))
+                .AddPolicy(AuthorizationPolicies.RequireTranslatorRole, policy =>
+                    policy.RequireRole(AuthConstants.Roles.Admin, AuthConstants.Roles.Translator))
+                .AddPolicy(AuthorizationPolicies.ApiScope, policy =>
+                    policy.RequireAssertion(context =>
+                        HasScope(context.User, AuthConstants.Scopes.Api)))
+                .AddPolicy(AuthorizationPolicies.RequireServiceScope, policy =>
+                    policy.RequireAssertion(context =>
+                        HasScope(context.User, AuthConstants.Scopes.Service)));
+        }
+
+        private static bool HasScope(System.Security.Claims.ClaimsPrincipal user, string requiredScope)
+        {
+            // OAuth2 scopes can be:
+            // 1. Space-separated in a single "scope" claim (OAuth2 standard)
+            // 2. Multiple individual "scope" claims (some identity providers)
+            IEnumerable<System.Security.Claims.Claim> scopeClaims = user.FindAll("scope");
+
+            foreach (System.Security.Claims.Claim claim in scopeClaims)
+            {
+                string[] scopes = claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (scopes.Contains(requiredScope))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/AuthSettings.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/AuthSettings.cs
@@ -1,0 +1,19 @@
+namespace LotroKoniecDev.TranslationSystem.API.Auth;
+
+internal sealed class AuthSettings
+{
+    public const string ConfigurationSection = "Auth";
+
+    public required string Issuer { get; init; }
+    public required string Audience { get; init; }
+
+    /// <summary>
+    /// Authority URL for OIDC metadata discovery (signing keys, endpoints).
+    /// If not set, falls back to <see cref="Issuer"/>.
+    /// Useful in Docker environments where the metadata endpoint is on an internal network address
+    /// while the Issuer must match the browser-facing URL in tokens.
+    /// </summary>
+    public string? Authority { get; init; }
+
+    public string EffectiveAuthority => Authority ?? Issuer;
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/AuthSettingsValidator.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/AuthSettingsValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+
+namespace LotroKoniecDev.TranslationSystem.API.Auth;
+
+internal sealed class AuthSettingsValidator : AbstractValidator<AuthSettings>
+{
+    public AuthSettingsValidator()
+    {
+        RuleFor(x => x.Issuer)
+            .NotEmpty()
+            .Must(BeAbsoluteHttpUrl)
+            .WithMessage("Issuer must be an absolute http(s) URL.");
+
+        RuleFor(x => x.Audience)
+            .NotEmpty();
+
+        RuleFor(x => x.Authority!)
+            .Must(BeAbsoluteHttpUrl)
+            .When(x => !string.IsNullOrWhiteSpace(x.Authority))
+            .WithMessage("Authority must be an absolute http(s) URL.");
+    }
+
+    private static bool BeAbsoluteHttpUrl(string value)
+    {
+        return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+               && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/AuthorizationPolicies.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/AuthorizationPolicies.cs
@@ -1,0 +1,10 @@
+namespace LotroKoniecDev.TranslationSystem.API.Auth;
+
+internal static class AuthorizationPolicies
+{
+    public const string RequireAuthenticatedUser = nameof(RequireAuthenticatedUser);
+    public const string RequireAdminRole = nameof(RequireAdminRole);
+    public const string RequireTranslatorRole = nameof(RequireTranslatorRole);
+    public const string ApiScope = nameof(ApiScope);
+    public const string RequireServiceScope = nameof(RequireServiceScope);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/CurrentUserAccessing/CurrentUserAccessor.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/CurrentUserAccessing/CurrentUserAccessor.cs
@@ -1,0 +1,58 @@
+using System.Security.Claims;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
+
+internal sealed class CurrentUserAccessor : ICurrentUserAccessor
+{
+    // OpenIddict standard claim types — MapInboundClaims is disabled, so they arrive as-is.
+    private const string SubjectClaimType = "sub";
+    private const string EmailClaimType = "email";
+    private const string NameClaimType = "name";
+    private const string RoleClaimType = "role";
+
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CurrentUserAccessor(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    private ClaimsPrincipal? User => _httpContextAccessor.HttpContext?.User;
+
+    public bool IsAuthenticated => User?.Identity?.IsAuthenticated ?? false;
+
+    public ValueMaybe<IdentityId> MaybeIdentityId
+    {
+        get
+        {
+            string? subject = User?.FindFirstValue(SubjectClaimType);
+            IdentityId? result = Guid.TryParse(subject, out Guid userId) ? new IdentityId(userId) : null;
+            return ValueMaybe<IdentityId>.From(result);
+        }
+    }
+
+    public string? Email => User?.FindFirstValue(EmailClaimType);
+
+    public string? Username => User?.FindFirstValue(NameClaimType);
+
+    public IEnumerable<string> Roles => User?
+        .FindAll(RoleClaimType)
+        .Select(claim => claim.Value) ?? [];
+
+    public bool IsInRole(string role) => User?.IsInRole(role) ?? false;
+
+    public bool HasOnlyRegularUserPrivileges()
+    {
+        if (User is null)
+        {
+            return true;
+        }
+
+        bool isUserAdmin = User.IsInRole(AuthConstants.Roles.Admin);
+
+        return !isUserAdmin;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/CurrentUserAccessing/ICurrentUserAccessor.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/CurrentUserAccessing/ICurrentUserAccessor.cs
@@ -1,0 +1,19 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
+
+internal interface ICurrentUserAccessor
+{
+    ValueMaybe<IdentityId> MaybeIdentityId { get; }
+    string? Email { get; }
+    string? Username { get; }
+    IEnumerable<string> Roles { get; }
+    bool IsAuthenticated { get; }
+    bool IsInRole(string role);
+
+    /// <summary>
+    /// Currently only the Admin role can bypass every kind of privileges validation.
+    /// </summary>
+    bool HasOnlyRegularUserPrivileges();
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Common/IEndpoint.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Common/IEndpoint.cs
@@ -1,0 +1,6 @@
+namespace LotroKoniecDev.TranslationSystem.API.Common;
+
+internal interface IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/EventIds.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/EventIds.cs
@@ -1,0 +1,18 @@
+namespace LotroKoniecDev.TranslationSystem.API;
+
+/// <summary>
+/// Event ID ranges: TranslationSystem 1000–1999, AuthSystem 2000–2999, Shared 3000–3999.
+/// </summary>
+internal static class EventIds
+{
+    // Exception Handlers (1100–1199)
+    public const int ArgumentException = 1100;
+    public const int BadHttpRequest = 1110;
+    public const int ConcurrencyConflict = 1120;
+    public const int ValidationFailure = 1140;
+    public const int UnhandledException = 1150;
+
+    // Middleware (1300–1399)
+    public const int UnauthorizedAccessAttempt = 1300;
+    public const int ForbiddenAccessAttempt = 1301;
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/ArgumentExceptionHandler.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/ArgumentExceptionHandler.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+
+namespace LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
+
+internal sealed partial class ArgumentExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<ArgumentExceptionHandler> _logger;
+    private readonly IHostEnvironment _environment;
+    private readonly IProblemDetailsService _problemDetailsService;
+
+    public ArgumentExceptionHandler(
+        ILogger<ArgumentExceptionHandler> logger,
+        IHostEnvironment environment,
+        IProblemDetailsService problemDetailsService)
+    {
+        _logger = logger;
+        _environment = environment;
+        _problemDetailsService = problemDetailsService;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not ArgumentException argumentException)
+        {
+            return false;
+        }
+
+        ProblemDetails problemDetails = new()
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Type = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+            Title = "Bad Request",
+            Detail = "One or more arguments provided are invalid.",
+            Extensions = { ["errorCode"] = "Http.InvalidArgument" }
+        };
+
+        if (_environment.IsDevelopment() || _environment.IsTesting())
+        {
+            problemDetails.Detail = argumentException.Message;
+        }
+
+        LogArgumentException(_logger, argumentException, argumentException.GetType().Name, "ArgumentException", argumentException.Message);
+
+        httpContext.Response.StatusCode = problemDetails.Status!.Value;
+
+        await _problemDetailsService.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            ProblemDetails = problemDetails
+        });
+
+        return true;
+    }
+
+    [LoggerMessage(EventId = EventIds.ArgumentException, Level = LogLevel.Warning, Message = "Argument exception: {ErrorCode} ({ErrorType}) — {ErrorMessage}")]
+    private static partial void LogArgumentException(ILogger logger, Exception exception, string errorCode, string errorType, string errorMessage);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/BadHttpRequestExceptionHandler.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/BadHttpRequestExceptionHandler.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+
+namespace LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
+
+internal sealed partial class BadHttpRequestExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<BadHttpRequestExceptionHandler> _logger;
+    private readonly IHostEnvironment _environment;
+    private readonly IProblemDetailsService _problemDetailsService;
+
+    public BadHttpRequestExceptionHandler(
+        ILogger<BadHttpRequestExceptionHandler> logger,
+        IHostEnvironment environment,
+        IProblemDetailsService problemDetailsService)
+    {
+        _logger = logger;
+        _environment = environment;
+        _problemDetailsService = problemDetailsService;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not BadHttpRequestException badHttpRequestException)
+        {
+            return false;
+        }
+
+        ProblemDetails problemDetails = new()
+        {
+            Status = badHttpRequestException.StatusCode,
+            Type = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+            Title = "Bad Request",
+            Extensions = { ["errorCode"] = "Http.BadRequest" }
+        };
+
+        if (_environment.IsTesting() || _environment.IsDevelopment())
+        {
+            problemDetails.Detail = badHttpRequestException.Message;
+            problemDetails.Extensions["exceptionType"] = badHttpRequestException.GetType().Name;
+            problemDetails.Extensions["stackTrace"] = badHttpRequestException.StackTrace;
+        }
+
+        LogBadHttpRequest(_logger, badHttpRequestException, badHttpRequestException.GetType().Name, "BadHttpRequestException", badHttpRequestException.Message);
+
+        httpContext.Response.StatusCode = problemDetails.Status!.Value;
+
+        await _problemDetailsService.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            ProblemDetails = problemDetails
+        });
+
+        return true;
+    }
+
+    [LoggerMessage(EventId = EventIds.BadHttpRequest, Level = LogLevel.Warning, Message = "Bad HTTP request: {ErrorCode} ({ErrorType}) — {ErrorMessage}")]
+    private static partial void LogBadHttpRequest(ILogger logger, Exception exception, string errorCode, string errorType, string errorMessage);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/DbUpdateConcurrencyExceptionHandler.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/DbUpdateConcurrencyExceptionHandler.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+
+namespace LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
+
+internal sealed partial class DbUpdateConcurrencyExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<DbUpdateConcurrencyExceptionHandler> _logger;
+    private readonly IHostEnvironment _environment;
+    private readonly IProblemDetailsService _problemDetailsService;
+
+    public DbUpdateConcurrencyExceptionHandler(
+        ILogger<DbUpdateConcurrencyExceptionHandler> logger,
+        IHostEnvironment environment,
+        IProblemDetailsService problemDetailsService)
+    {
+        _logger = logger;
+        _environment = environment;
+        _problemDetailsService = problemDetailsService;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not DbUpdateConcurrencyException concurrencyException)
+        {
+            return false;
+        }
+
+        ProblemDetails problemDetails = new()
+        {
+            Status = StatusCodes.Status409Conflict,
+            Type = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409",
+            Title = "Concurrency conflict",
+            Detail = "The resource was modified by another request. Please refresh and try again.",
+            Extensions = { ["errorCode"] = "Db.ConcurrencyConflict" }
+        };
+
+        if (_environment.IsDevelopment() || _environment.IsTesting())
+        {
+            problemDetails.Detail = concurrencyException.Message;
+        }
+
+        LogConcurrencyConflict(_logger, concurrencyException, concurrencyException.Message);
+
+        httpContext.Response.StatusCode = problemDetails.Status!.Value;
+
+        await _problemDetailsService.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            ProblemDetails = problemDetails
+        });
+
+        return true;
+    }
+
+    [LoggerMessage(EventId = EventIds.ConcurrencyConflict, Level = LogLevel.Warning, Message = "Concurrency conflict: {Message}")]
+    private static partial void LogConcurrencyConflict(ILogger logger, Exception exception, string message);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/FluentValidationExceptionHandler.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/FluentValidationExceptionHandler.cs
@@ -1,0 +1,59 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
+
+internal sealed partial class FluentValidationExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<FluentValidationExceptionHandler> _logger;
+    private readonly IProblemDetailsService _problemDetailsService;
+
+    public FluentValidationExceptionHandler(
+        ILogger<FluentValidationExceptionHandler> logger,
+        IProblemDetailsService problemDetailsService)
+    {
+        _logger = logger;
+        _problemDetailsService = problemDetailsService;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not ValidationException validationException)
+        {
+            return false;
+        }
+
+        Dictionary<string, string[]> errors = validationException.Errors
+            .GroupBy(error => error.PropertyName)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(error => error.ErrorMessage).ToArray());
+
+        ValidationProblemDetails problemDetails = new(errors)
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Type = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+            Title = "Validation Error",
+            Extensions = { ["errorCode"] = "Validation.FluentValidation" }
+        };
+
+        LogValidationException(_logger, validationException, validationException.GetType().Name, "ValidationException", validationException.Message);
+
+        httpContext.Response.StatusCode = problemDetails.Status!.Value;
+
+        await _problemDetailsService.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            ProblemDetails = problemDetails
+        });
+
+        return true;
+    }
+
+    [LoggerMessage(EventId = EventIds.ValidationFailure, Level = LogLevel.Warning, Message = "Validation failure: {ErrorCode} ({ErrorType}) — {ErrorMessage}")]
+    private static partial void LogValidationException(ILogger logger, Exception exception, string errorCode, string errorType, string errorMessage);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/GlobalExceptionHandler.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/GlobalExceptionHandler.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+
+namespace LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
+
+internal sealed partial class GlobalExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<GlobalExceptionHandler> _logger;
+    private readonly IHostEnvironment _environment;
+
+    private readonly IProblemDetailsService _problemDetailsService;
+
+    public GlobalExceptionHandler(
+        ILogger<GlobalExceptionHandler> logger,
+        IHostEnvironment environment,
+        IProblemDetailsService problemDetailsService)
+    {
+        _logger = logger;
+        _environment = environment;
+        _problemDetailsService = problemDetailsService;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        ProblemDetails problemDetails = new()
+        {
+            Status = StatusCodes.Status500InternalServerError,
+            Type = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500",
+            Title = "Sorry, an internal server error has occurred, there is nothing You can do.",
+            Extensions = { ["errorCode"] = "Internal.UnhandledException" }
+        };
+
+        if (_environment.IsTesting() || _environment.IsDevelopment())
+        {
+            problemDetails.Detail = exception.Message;
+            problemDetails.Extensions["exceptionType"] = exception.GetType().Name;
+            problemDetails.Extensions["stackTrace"] = exception.StackTrace;
+        }
+
+        LogGlobalException(_logger, exception, exception.GetType().Name, "Exception", exception.Message);
+
+        httpContext.Response.StatusCode = problemDetails.Status!.Value;
+
+        await _problemDetailsService.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            ProblemDetails = problemDetails
+        });
+
+        return true;
+    }
+
+    [LoggerMessage(EventId = EventIds.UnhandledException, Level = LogLevel.Error, Message = "Unhandled exception: {ErrorCode} ({ErrorType}) — {ErrorMessage}")]
+    private static partial void LogGlobalException(ILogger logger, Exception exception, string errorCode, string errorType, string errorMessage);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/EndpointExtensions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/EndpointExtensions.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using LotroKoniecDev.TranslationSystem.API.Common;
+
+namespace LotroKoniecDev.TranslationSystem.API.Extensions;
+
+internal static class EndpointExtensions
+{
+    public static IServiceCollection AddEndpoints(this IServiceCollection services, Assembly assembly)
+    {
+        ServiceDescriptor[] endpointServiceDescriptors = [.. assembly
+            .DefinedTypes
+            .Where(type =>
+                type is { IsAbstract: false, IsInterface: false }
+                && type.IsAssignableTo(typeof(IEndpoint)))
+            .Select(type => ServiceDescriptor.Transient(typeof(IEndpoint), type))];
+
+        services.TryAddEnumerable(endpointServiceDescriptors);
+
+        return services;
+    }
+
+    public static IApplicationBuilder MapEndpoints(this WebApplication app, RouteGroupBuilder? routeGroupBuilder = null)
+    {
+        IEnumerable<IEndpoint> endpoints = app.Services.GetRequiredService<IEnumerable<IEndpoint>>();
+
+        IEndpointRouteBuilder builder = routeGroupBuilder is null ? app : routeGroupBuilder;
+
+        foreach (IEndpoint endpoint in endpoints)
+        {
+            endpoint.MapEndpoint(builder);
+        }
+        return app;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/EnvironmentsExtensions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/EnvironmentsExtensions.cs
@@ -1,0 +1,13 @@
+namespace LotroKoniecDev.TranslationSystem.API.Extensions;
+
+internal static class EnvironmentsExtensions
+{
+    public const string DevelopmentName = "Development";
+    public const string TestingName = "Testing";
+    public const string ProductionName = "Production";
+    extension(Environments)
+    {
+        public static string Development => DevelopmentName;
+        public static string Testing => TestingName;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/ErrorExtensions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/ErrorExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.API.Extensions;
+
+internal static class ErrorExtensions
+{
+    extension(Error error)
+    {
+        public ProblemDetails ToProblemDetails()
+        {
+            ProblemDetails response = error.Type switch
+            {
+                TypeOfError.NotFound => error.CreateProblemDetails(StatusCodes.Status404NotFound),
+                TypeOfError.Validation => error.CreateProblemDetails(StatusCodes.Status400BadRequest),
+                TypeOfError.Forbidden => error.CreateProblemDetails(StatusCodes.Status403Forbidden),
+                TypeOfError.DataConflict => error.CreateProblemDetails(StatusCodes.Status422UnprocessableEntity),
+                _ => error.CreateProblemDetails(StatusCodes.Status500InternalServerError)
+            };
+            return response;
+        }
+
+        private ProblemDetails CreateProblemDetails(int statusCode) =>
+            new()
+            {
+                Status = statusCode,
+                Type = $"https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{statusCode}",
+                Title = Error.GetTitle(error.Type),
+                Detail = error.Message,
+                Extensions = { ["errorCode"] = error.Code }
+            };
+
+        private static string GetTitle(TypeOfError type) =>
+            type switch
+            {
+                TypeOfError.NotFound => "Not Found",
+                TypeOfError.Validation => "Validation Error",
+                TypeOfError.DataConflict => "Data Conflict",
+                TypeOfError.Forbidden => "Forbidden",
+                TypeOfError.Failure => "Internal Server Error",
+                _ => "Error"
+            };
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/IHostEnvironmentExtensions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/IHostEnvironmentExtensions.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.TranslationSystem.API.Extensions;
+
+internal static class IHostEnvironmentExtensions
+{
+    extension(IHostEnvironment hostEnvironment)
+    {
+        public bool IsTesting()
+        {
+            ArgumentNullException.ThrowIfNull(hostEnvironment);
+
+            return hostEnvironment.IsEnvironment(Environments.Testing);
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Discovery/Discovery.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Discovery/Discovery.cs
@@ -1,0 +1,25 @@
+using LotroKoniecDev.Hateoas.ContentNegotiation;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
+using LotroKoniecDev.TranslationSystem.Contracts.Discovery;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.Discovery;
+
+internal sealed class Discovery : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        // No explicit authorization metadata — the fallback policy applies, which makes this
+        // the canonical authorized-by-default endpoint (anonymous requests get 401).
+        endpointRouteBuilder.MapGet("", (IDiscoveryLinkFactory discoveryLinkFactory) =>
+            {
+                DiscoveryResponse response = new("LotroKoniecDev.TranslationSystem");
+
+                return HateoasResults.Ok(response, r =>
+                    r.Links = discoveryLinkFactory.CreateDiscoveryLinks());
+            })
+            .WithName(nameof(Discovery))
+            .WithTags("Discovery")
+            .Produces<DiscoveryResponse>(StatusCodes.Status200OK);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/DiscoveryFactories/DiscoveryLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/DiscoveryFactories/DiscoveryLinkFactory.cs
@@ -1,0 +1,27 @@
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.Hateoas.LinkFactories;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+
+namespace LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
+
+internal sealed class DiscoveryLinkFactory : IDiscoveryLinkFactory
+{
+    private readonly ILinkFactory _linkFactory;
+
+    public DiscoveryLinkFactory(ILinkFactory linkFactory)
+    {
+        _linkFactory = linkFactory;
+    }
+
+    public List<LinkDto> CreateDiscoveryLinks()
+    {
+        List<LinkDto> links = [];
+
+        links.AddIfPresent(_linkFactory.Create(
+            endpoint: nameof(Features.Discovery.Discovery),
+            rel: Rels.Self,
+            method: HttpMethods.Get));
+
+        return links;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/DiscoveryFactories/IDiscoveryLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/DiscoveryFactories/IDiscoveryLinkFactory.cs
@@ -1,0 +1,8 @@
+using LotroKoniecDev.Hateoas.Abstractions;
+
+namespace LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
+
+internal interface IDiscoveryLinkFactory
+{
+    List<LinkDto> CreateDiscoveryLinks();
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Health/HealthCheckResponseWriter.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Health/HealthCheckResponseWriter.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace LotroKoniecDev.TranslationSystem.API.Health;
+
+internal static class HealthCheckResponseWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public static async Task WriteResponse(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+
+        var response = new
+        {
+            status = report.Status.ToString(),
+            totalDuration = report.TotalDuration.ToString(),
+            checks = report.Entries.Select(entry => new
+            {
+                name = entry.Key,
+                status = entry.Value.Status.ToString(),
+                duration = entry.Value.Duration.ToString(),
+                description = entry.Value.Description,
+                exception = entry.Value.Exception?.Message,
+                data = entry.Value.Data.Count > 0 ? entry.Value.Data : null
+            })
+        };
+
+        await context.Response.WriteAsJsonAsync(response, JsonOptions);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>lotrokoniecdev-translationsystem-api</UserSecretsId>
+        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentValidation" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Scalar.AspNetCore" />
+        <PackageReference Include="Serilog.AspNetCore" />
+        <PackageReference Include="Serilog.Enrichers.Environment" />
+        <PackageReference Include="Serilog.Enrichers.Thread" />
+        <PackageReference Include="Serilog.Formatting.Compact" />
+        <PackageReference Include="Serilog.Sinks.Console" />
+        <PackageReference Include="Serilog.Sinks.File" />
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry" />
+        <PackageReference Include="Serilog.Enrichers.CorrelationId" />
+        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Hateoas\LotroKoniecDev.Hateoas.csproj" />
+        <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Logging\LotroKoniecDev.Logging.csproj" />
+        <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Options\LotroKoniecDev.Options.csproj" />
+        <ProjectReference Include="..\LotroKoniecDev.TranslationSystem.Contracts\LotroKoniecDev.TranslationSystem.Contracts.csproj" />
+        <ProjectReference Include="..\LotroKoniecDev.TranslationSystem.Persistence\LotroKoniecDev.TranslationSystem.Persistence.csproj" />
+        <ProjectReference Include="..\..\SharedKernel\LotroKoniecDev.SharedKernel\LotroKoniecDev.SharedKernel.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="LotroKoniecDev.TranslationSystem.API.Tests.Integration" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Content Include="..\..\..\.dockerignore">
+        <Link>.dockerignore</Link>
+      </Content>
+    </ItemGroup>
+
+</Project>

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Middleware/AuthorizationLoggingMiddleware.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Middleware/AuthorizationLoggingMiddleware.cs
@@ -1,0 +1,37 @@
+namespace LotroKoniecDev.TranslationSystem.API.Middleware;
+
+internal sealed partial class AuthorizationLoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<AuthorizationLoggingMiddleware> _logger;
+
+    public AuthorizationLoggingMiddleware(RequestDelegate next, ILogger<AuthorizationLoggingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        await _next(context);
+
+        switch (context.Response.StatusCode)
+        {
+            case StatusCodes.Status401Unauthorized:
+                LogUnauthorizedAccess(_logger,
+                    context.Request.Method,
+                    context.Request.Path,
+                    context.Connection.RemoteIpAddress);
+                break;
+            case StatusCodes.Status403Forbidden:
+                LogForbiddenAccess(_logger, context.Request.Method, context.Request.Path, context.Connection.RemoteIpAddress, context.User.Identity?.Name ?? "anonymous");
+                break;
+        }
+    }
+
+    [LoggerMessage(EventId = EventIds.UnauthorizedAccessAttempt, Level = LogLevel.Warning, Message = "Unauthorized access attempt: {Method} {Path} from {IP}")]
+    private static partial void LogUnauthorizedAccess(ILogger logger, string method, PathString path, System.Net.IPAddress? ip);
+
+    [LoggerMessage(EventId = EventIds.ForbiddenAccessAttempt, Level = LogLevel.Warning, Message = "Forbidden access attempt: {Method} {Path} from {IP} by {User}")]
+    private static partial void LogForbiddenAccess(ILogger logger, string method, PathString path, System.Net.IPAddress? ip, string user);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Middleware/GlobalNoCacheMiddleware.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Middleware/GlobalNoCacheMiddleware.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Net.Http.Headers;
+
+namespace LotroKoniecDev.TranslationSystem.API.Middleware;
+
+public sealed class GlobalNoCacheMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public GlobalNoCacheMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        context.Response.OnStarting(() =>
+        {
+            IHeaderDictionary responseHeaders = context.Response.Headers;
+
+            if (responseHeaders.ContainsKey(HeaderNames.CacheControl))
+            {
+                return Task.CompletedTask;
+            }
+
+            Endpoint? endpoint = context.GetEndpoint();
+
+            bool hasOutputCache = endpoint?.Metadata.GetMetadata<IOutputCachePolicy>() is not null;
+
+            if (hasOutputCache)
+            {
+                return Task.CompletedTask;
+            }
+
+            responseHeaders[HeaderNames.CacheControl] = "no-store, no-cache, max-age=0, must-revalidate";
+            responseHeaders[HeaderNames.Pragma] = "no-cache";
+            responseHeaders[HeaderNames.Expires] = "0";
+
+            return Task.CompletedTask;
+        });
+
+        await _next(context);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Middleware/MiddlewareDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Middleware/MiddlewareDependencyInjection.cs
@@ -1,0 +1,25 @@
+namespace LotroKoniecDev.TranslationSystem.API.Middleware;
+
+public static class MiddlewareDependencyInjection
+{
+    extension(IApplicationBuilder app)
+    {
+        public IApplicationBuilder UseRequestContextLogging()
+        {
+            app.UseMiddleware<RequestContextLoggingMiddleware>();
+            return app;
+        }
+
+        public IApplicationBuilder UseGlobalNoCache()
+        {
+            app.UseMiddleware<GlobalNoCacheMiddleware>();
+            return app;
+        }
+
+        public IApplicationBuilder UseAuthorizationLogging()
+        {
+            app.UseMiddleware<AuthorizationLoggingMiddleware>();
+            return app;
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Middleware/RequestContextLoggingMiddleware.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Middleware/RequestContextLoggingMiddleware.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Primitives;
+using Serilog.Context;
+
+namespace LotroKoniecDev.TranslationSystem.API.Middleware;
+
+internal sealed class RequestContextLoggingMiddleware
+{
+    private const string CorrelationIdHeaderName = "X-Correlation-ID";
+    private const string CorrelationIdItemName = "CorrelationId";
+    private readonly RequestDelegate _next;
+
+    public RequestContextLoggingMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        string correlationId = GetOrCreateCorrelationId(context);
+
+        context.Items[CorrelationIdItemName] = correlationId;
+        context.Response.Headers.TryAdd(CorrelationIdHeaderName, correlationId);
+
+        using (LogContext.PushProperty(CorrelationIdItemName, correlationId))
+        {
+            await _next(context);
+        }
+    }
+
+    private static string GetOrCreateCorrelationId(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(CorrelationIdHeaderName, out StringValues existingId)
+            && !string.IsNullOrWhiteSpace(existingId))
+        {
+            return existingId.ToString();
+        }
+
+        return context.TraceIdentifier;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
@@ -1,0 +1,221 @@
+using System.Globalization;
+using System.Reflection;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Options;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Scalar.AspNetCore;
+using Serilog;
+using Serilog.Sinks.OpenTelemetry;
+using LotroKoniecDev.TranslationSystem.API;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.API.Health;
+using LotroKoniecDev.TranslationSystem.API.Middleware;
+using LotroKoniecDev.TranslationSystem.Persistence.Settings;
+
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
+    .CreateBootstrapLogger();
+
+try
+{
+    Log.Information("Starting TranslationSystem");
+
+    WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+    builder.Services.AddSerilog((services, lc) =>
+    {
+        lc.ReadFrom.Configuration(builder.Configuration)
+          .ReadFrom.Services(services);
+
+        string? otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+        if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+        {
+            lc.WriteTo.OpenTelemetry(opts =>
+            {
+                opts.Endpoint = otlpEndpoint;
+                opts.Protocol = string.Equals(
+                    builder.Configuration["OTEL_EXPORTER_OTLP_PROTOCOL"],
+                    "http/protobuf",
+                    StringComparison.OrdinalIgnoreCase)
+                    ? OtlpProtocol.HttpProtobuf
+                    : OtlpProtocol.Grpc;
+                opts.ResourceAttributes = new Dictionary<string, object>
+                {
+                    ["service.name"] = builder.Environment.ApplicationName
+                };
+            });
+        }
+    });
+
+    builder.Services.AddTranslationSystem();
+    builder.Services.AddJwtBearerAuthentication(builder.Environment);
+
+    builder.Services.AddEndpointsApiExplorer();
+    builder.Services.AddOpenApi();
+
+    builder.Services.AddOpenTelemetry()
+        .ConfigureResource(resource => resource.AddService(builder.Environment.ApplicationName))
+        .WithTracing(tracing => tracing
+            .AddHttpClientInstrumentation()
+            .AddAspNetCoreInstrumentation()
+            .AddSource("Npgsql"))
+        .WithMetrics(metrics => metrics
+            .AddHttpClientInstrumentation()
+            .AddAspNetCoreInstrumentation()
+            .AddRuntimeInstrumentation()
+            .AddMeter("Microsoft.EntityFrameworkCore")
+            .AddMeter("Npgsql"))
+        .UseOtlpExporter();
+
+    builder.Services.AddResponseCompression(options =>
+    {
+        options.EnableForHttps = true;
+        options.Providers.Add<BrotliCompressionProvider>();
+        options.Providers.Add<GzipCompressionProvider>();
+        options.MimeTypes = ResponseCompressionDefaults.MimeTypes;
+    });
+
+    builder.Services.Configure<RouteHandlerOptions>(options =>
+    {
+        options.ThrowOnBadRequest = true;
+    });
+
+    const string localCorsPolicy = "DevelopmentPolicy";
+    const string productionCorsPolicy = "ProductionPolicy";
+
+    builder.Services.AddCors(options =>
+    {
+        options.AddPolicy(localCorsPolicy, corsBuilder =>
+        {
+            corsBuilder
+                .AllowAnyOrigin()
+                .AllowAnyHeader()
+                .AllowAnyMethod();
+        });
+        options.AddPolicy(productionCorsPolicy, corsBuilder =>
+        {
+            corsBuilder
+                .WithOrigins("https://lotro.koniec.dev")
+                .WithHeaders("Authorization", "Content-Type", "X-Requested-With", "Accept")
+                .WithMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+        });
+    });
+
+    builder.Services.AddEndpoints(Assembly.GetExecutingAssembly());
+
+    builder.Services
+        .AddHealthChecks()
+        .AddNpgSql(
+            connectionStringFactory: sp => sp.GetRequiredService<IOptions<ConnectionStringSettings>>().Value.TranslationDatabase,
+            name: "translationdb",
+            tags: ["db", "postgres", "ready"]);
+
+    const string rateLimitPolicy = "fixed-by-ip";
+
+    builder.Services.AddRateLimiter(options =>
+    {
+        options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+        options.AddPolicy(rateLimitPolicy, httpContext =>
+            RateLimitPartition.GetFixedWindowLimiter(
+                partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                factory: _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = 100,
+                    Window = TimeSpan.FromMinutes(1)
+                }));
+    });
+
+    WebApplication app = builder.Build();
+
+    app.UseRequestContextLogging();
+
+    app.UseSerilogRequestLogging(options =>
+    {
+        options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+        {
+            if (httpContext.Items.TryGetValue("CorrelationId", out object? correlationId))
+            {
+                diagnosticContext.Set("CorrelationId", correlationId);
+            }
+        };
+    });
+
+    app.UseExceptionHandler();
+    app.UseStatusCodePages();
+    if (!app.Environment.IsDevelopment() && !app.Environment.IsTesting())
+    {
+        app.UseHsts();
+        app.UseHttpsRedirection();
+    }
+    app.UseResponseCompression();
+    app.UseRouting();
+    app.UseGlobalNoCache();
+
+    string corsPolicy = app.Environment.EnvironmentName switch
+    {
+        EnvironmentsExtensions.ProductionName => productionCorsPolicy,
+        _ => localCorsPolicy
+    };
+    app.UseCors(corsPolicy);
+
+    app.UseAuthentication();
+    app.UseAuthorization();
+
+    app.UseAuthorizationLogging();
+
+    if (!app.Environment.IsDevelopment() && !app.Environment.IsTesting())
+    {
+        app.UseRateLimiter();
+    }
+
+    if (app.Environment.IsDevelopment())
+    {
+        app.MapOpenApi().AllowAnonymous();
+        app.MapScalarApiReference().AllowAnonymous();
+    }
+
+    app.MapHealthChecks("/health", new HealthCheckOptions
+    {
+        ResponseWriter = HealthCheckResponseWriter.WriteResponse
+    }).AllowAnonymous();
+
+    app.MapHealthChecks("/health/live", new HealthCheckOptions
+    {
+        Predicate = _ => false,
+        ResponseWriter = HealthCheckResponseWriter.WriteResponse
+    }).AllowAnonymous();
+
+    app.MapHealthChecks("/health/ready", new HealthCheckOptions
+    {
+        Predicate = check => check.Tags.Contains("ready"),
+        ResponseWriter = HealthCheckResponseWriter.WriteResponse
+    }).AllowAnonymous();
+
+    RouteGroupBuilder endpointsGroup = app.MapGroup("");
+
+    if (!app.Environment.IsDevelopment() && !app.Environment.IsTesting())
+    {
+        endpointsGroup.RequireRateLimiting(rateLimitPolicy);
+    }
+
+    app.MapEndpoints(endpointsGroup);
+
+    await app.RunAsync();
+}
+#pragma warning disable S2139
+catch (Exception ex)
+{
+    Log.Fatal(ex, "TranslationSystem terminated unexpectedly");
+    throw;
+}
+#pragma warning restore S2139
+finally
+{
+    await Log.CloseAndFlushAsync();
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Properties/launchSettings.json
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5504",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5004",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"
+      }
+    }
+  }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/RootDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/RootDependencyInjection.cs
@@ -1,0 +1,14 @@
+using LotroKoniecDev.TranslationSystem.Persistence;
+
+namespace LotroKoniecDev.TranslationSystem.API;
+
+internal static class RootDependencyInjection
+{
+    public static IServiceCollection AddTranslationSystem(this IServiceCollection services)
+    {
+        services.AddTranslationPersistence();
+        services.AddApi();
+
+        return services;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/appsettings.Development.json
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/appsettings.Development.json
@@ -1,0 +1,35 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "TranslationDatabase": "Host=localhost;Port=5432;Database=lotro_translation;Username=postgres"
+  },
+  "Auth": {
+    "Issuer": "https://localhost:5003",
+    "Audience": "lotrokoniecdev-api"
+  },
+  "Serilog": {
+    "Using": ["Serilog.Sinks.Console"],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}"
+        }
+      }
+    ],
+    "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"]
+  }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/appsettings.json
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/appsettings.json
@@ -1,0 +1,36 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "TranslationDatabase": ""
+  },
+  "Auth": {
+    "Issuer": "https://auth.lotro.koniec.dev",
+    "Audience": "lotrokoniecdev-api"
+  },
+  "Serilog": {
+    "Using": ["Serilog.Sinks.Console", "Serilog.Enrichers.CorrelationId"],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.EntityFrameworkCore": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ],
+    "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId", "WithCorrelationId", "WithCorrelationIdHeader"]
+  }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Discovery/DiscoveryResponse.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Discovery/DiscoveryResponse.cs
@@ -1,0 +1,8 @@
+using LotroKoniecDev.Hateoas.Abstractions;
+
+namespace LotroKoniecDev.TranslationSystem.Contracts.Discovery;
+
+public sealed record DiscoveryResponse(string Name) : ILinksResponse
+{
+    public IReadOnlyCollection<LinkDto> Links { get; set; } = [];
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
@@ -1,0 +1,6 @@
+namespace LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+
+public static class Rels
+{
+    public const string Self = "self";
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="Testcontainers" />
+        <PackageReference Include="Testcontainers.PostgreSql"/>
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.API\LotroKoniecDev.TranslationSystem.API.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TestCollection.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TestCollection.cs
@@ -1,0 +1,6 @@
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration;
+
+[CollectionDefinition("TranslationApi")]
+#pragma warning disable CA1515
+public class TestCollection : ICollectionFixture<TranslationSystemApiFactory>;
+#pragma warning restore CA1515

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Auth/AuthorizationDefaultsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Auth/AuthorizationDefaultsTests.cs
@@ -1,0 +1,106 @@
+using System.Net.Http.Headers;
+using LotroKoniecDev.TranslationSystem.Contracts.Discovery;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Auth;
+
+[Collection("TranslationApi")]
+public sealed class AuthorizationDefaultsTests
+{
+    private readonly TranslationSystemApiFactory _factory;
+
+    public AuthorizationDefaultsTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetDiscovery_WithoutToken_ShouldReturn401()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetDiscovery_WithValidToken_ShouldReturn200AndDiscoveryResponse()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", TranslationSystemApiFactory.CreateAccessToken());
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/");
+        DiscoveryResponse? body = await response.Content.ReadFromJsonAsync<DiscoveryResponse>();
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        body.ShouldNotBeNull();
+        body.Name.ShouldBe("LotroKoniecDev.TranslationSystem");
+    }
+
+    [Fact]
+    public async Task GetDiscovery_WithTokenSignedByUnknownKey_ShouldReturn401()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", TranslationSystemApiFactory.CreateTokenSignedWithUnknownKey());
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetDiscovery_WithExpiredToken_ShouldReturn401()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", TranslationSystemApiFactory.CreateExpiredAccessToken());
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetUnknownRoute_WithoutToken_ShouldReturn401()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/does-not-exist");
+
+        // Assert
+        // The fallback policy covers even unmatched paths — anonymous requests cannot
+        // enumerate routes by distinguishing 401 from 404.
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetUnknownRoute_WithValidToken_ShouldReturn404()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", TranslationSystemApiFactory.CreateAccessToken());
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/does-not-exist");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Health/HealthEndpointsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Health/HealthEndpointsTests.cs
@@ -1,0 +1,56 @@
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Health;
+
+[Collection("TranslationApi")]
+public sealed class HealthEndpointsTests
+{
+    private readonly TranslationSystemApiFactory _factory;
+
+    public HealthEndpointsTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetHealth_WithoutToken_ShouldReturn200AndHealthy()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/health");
+        string body = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        body.ShouldContain("Healthy");
+    }
+
+    [Fact]
+    public async Task GetHealthLive_WithoutToken_ShouldReturn200()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/health/live");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetHealthReady_WithoutToken_ShouldReturn200AndHealthyPostgres()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/health/ready");
+        string body = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        body.ShouldContain("translationdb");
+        body.ShouldContain("Healthy");
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
@@ -1,0 +1,124 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Testcontainers.PostgreSql;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration;
+
+#pragma warning disable CA1515
+// ReSharper disable once ClassNeverInstantiated.Global
+public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifetime
+#pragma warning restore CA1515
+{
+    public const string TestIssuer = "https://localhost:5003";
+    public const string TestAudience = "lotrokoniecdev-api";
+
+    private static readonly SymmetricSecurityKey TestSigningKey =
+        new("integration-test-signing-key-32-bytes!!"u8.ToArray());
+
+    private readonly PostgreSqlContainer _postgresContainer =
+        new PostgreSqlBuilder("postgres:17-alpine")
+            .WithDatabase("LotroKoniecDevTranslation")
+            .Build();
+
+    private string _connectionString = string.Empty;
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((_, configBuilder) =>
+        {
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ConnectionStrings:TranslationDatabase", _connectionString },
+                { "Auth:Issuer", TestIssuer },
+                { "Auth:Audience", TestAudience },
+            });
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            // The AuthSystem issuer is not running in these tests — validate tokens against
+            // a local symmetric key instead of fetching signing keys from the JWKS endpoint.
+            services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+            {
+                options.ConfigurationManager = null;
+                options.TokenValidationParameters.IssuerSigningKey = TestSigningKey;
+            });
+        });
+
+        builder.ConfigureLogging(logging =>
+        {
+            logging.SetMinimumLevel(LogLevel.Warning);
+        });
+    }
+
+    public static string CreateAccessToken(
+        string role = AuthConstants.Roles.Translator,
+        string scope = AuthConstants.Scopes.Api)
+        => CreateToken(TestSigningKey, DateTime.UtcNow.AddMinutes(30), role, scope);
+
+    public static string CreateExpiredAccessToken()
+        => CreateToken(TestSigningKey, DateTime.UtcNow.AddMinutes(-20));
+
+    public static string CreateTokenSignedWithUnknownKey()
+        => CreateToken(
+            new SymmetricSecurityKey("some-other-unknown-key-32-bytes-long!!!!"u8.ToArray()),
+            DateTime.UtcNow.AddMinutes(30));
+
+    private static string CreateToken(
+        SymmetricSecurityKey signingKey,
+        DateTime expires,
+        string role = AuthConstants.Roles.Translator,
+        string scope = AuthConstants.Scopes.Api)
+    {
+        JsonWebTokenHandler handler = new();
+
+        SecurityTokenDescriptor descriptor = new()
+        {
+            Issuer = TestIssuer,
+            Audience = TestAudience,
+            IssuedAt = expires.AddMinutes(-30),
+            NotBefore = expires.AddMinutes(-30),
+            Expires = expires,
+            SigningCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256),
+            Claims = new Dictionary<string, object>
+            {
+                ["sub"] = Guid.NewGuid().ToString(),
+                ["name"] = "integration-test-user",
+                ["email"] = "translator@lotro.koniec.dev",
+                ["role"] = role,
+                ["scope"] = scope
+            }
+        };
+
+        return handler.CreateToken(descriptor);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _postgresContainer.StartAsync();
+        _connectionString = _postgresContainer.GetConnectionString();
+
+        // Accessing Services triggers host startup; the compose migrator owns migrations in
+        // deployed environments, so tests apply them explicitly against the container.
+        using IServiceScope scope = Services.CreateScope();
+        ApplicationWriteDbContext writeDbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await writeDbContext.Database.MigrateAsync();
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await _postgresContainer.DisposeAsync();
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Usings.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Usings.cs
@@ -1,0 +1,3 @@
+global using System.Net;
+global using System.Net.Http.Json;
+global using Shouldly;


### PR DESCRIPTION
Closes #96

## M2-07: TranslationSystem.API scaffold — endpoints infra + auth + observability

Mirrors TheKittySaver `AdoptionSystem.API` bootstrap, de-mediatorized (ADR-0001).

### What's in
- **Endpoints infra:** `IEndpoint` + assembly-scan `AddEndpoints`/`MapEndpoints`; slices in `Features/<Area>/`. First slice = `Discovery`.
- **Auth (day-1, house rule):** JwtBearer against the AuthSystem issuer (JWKS metadata), policies (Admin/Translator roles, api/service scopes) + `CurrentUserAccessor`. **Authorized-by-default** via `SetFallbackPolicy` — public endpoints opt out explicitly (health checks `AllowAnonymous`). Ownership guards deferred until the first owned resource exists.
- **ExceptionHandlers:** BadHttpRequest / FluentValidation / Argument / DbUpdateConcurrency / Global, + ProblemDetails + HATEOAS infra. Internals (message/stack) gated to Dev/Testing only.
- **Observability:** Serilog + OpenTelemetry bootstrap, health checks (aggregate `/health` + `/health/live` + `/health/ready` w/ NpgSql), CORS, rate limiting, response compression.

### Acceptance criteria
- [x] API starts; `/health` returns 200
- [x] Unauthorized → 401 on protected endpoints by default (incl. unmatched paths)
- [x] Assembly-scan endpoint registration works
- [x] Serilog + OTel emit; zero warnings

### Tests
9 integration tests (Testcontainers Postgres + local symmetric signing key instead of live JWKS): health 200 (aggregate/live/ready), 401-by-default incl. unmatched paths, valid/expired/forged-key token matrix, 404 only when authenticated.

### Reviews
- `code-reviewer`: APPROVE, no blockers (actioned the one should-fix: added aggregate `/health`).
- `security-review`: no HIGH/MEDIUM findings ≥ confidence 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)