### PR TITLE
M2-08: Slice — version-bound import + diff (upload exported.txt)

### DIFF
--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -42,6 +42,7 @@
     <Project Path="tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj" />
     <Project Path="tests/LotroKoniecDev.SharedKernel.Tests.Unit/LotroKoniecDev.SharedKernel.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj" />
+    <Project Path="tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.E2E/LotroKoniecDev.Tests.E2E.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Infrastructure/LotroKoniecDev.Tests.Infrastructure.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj" />

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -9,11 +9,16 @@ using Microsoft.IdentityModel.Tokens;
 using LotroKoniecDev.Hateoas;
 using LotroKoniecDev.Options;
 using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.API.Auth;
 using LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
 using LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
 using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.API.Features.Import;
 using LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+using LotroKoniecDev.TranslationSystem.Contracts.Import;
 
 namespace LotroKoniecDev.TranslationSystem.API;
 
@@ -42,7 +47,19 @@ internal static class ApiDependencyInjection
             // so ASP.NET Core's default writer handles plain JSON / RFC 7807 Accept values first.
             services.AddHateoasInfrastructure();
 
+            services.AddImportFeature();
+
             return services;
+        }
+
+        private void AddImportFeature()
+        {
+            services.AddSingleton(TimeProvider.System);
+            services.AddSingleton<ITranslationExportParser, TranslationExportParser>();
+            services.AddOptions<ImportSettings>().BindConfiguration(ImportSettings.ConfigurationSection);
+
+            services.AddScoped<IValidator<ImportExportedTexts.Command>, ImportExportedTexts.Validator>();
+            services.AddScoped<ICommandHandler<ImportExportedTexts.Command, Result<ImportSummary>>, ImportExportedTexts.Handler>();
         }
 
         public IServiceCollection AddJwtBearerAuthentication(IWebHostEnvironment environment)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportErrors.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.Import;
+
+/// <summary>
+/// Import-level failures (corrupt/truncated upload guards). Modelled as <see cref="TypeOfError.DataConflict"/>
+/// so the API maps them to 422 Unprocessable Entity (spec 0001 contract).
+/// </summary>
+internal static class ImportErrors
+{
+    public static Error ParseFailed(int errorCount, ExportParseError first)
+        => new("Import.ParseFailed",
+            $"The upload has {errorCount} unparseable line(s); the import is rejected so a truncated file "
+            + $"cannot masquerade as a mass removal. First failure — line {first.LineNumber}: {first.Message}",
+            TypeOfError.DataConflict);
+
+    public static Error InvalidRow(int fileId, long gossipId, string detail)
+        => new("Import.InvalidRow",
+            $"Row ({fileId}, {gossipId}) is invalid: {detail}",
+            TypeOfError.DataConflict);
+
+    public static Error DuplicateFragmentKey(int fileId, long gossipId)
+        => new("Import.DuplicateFragmentKey",
+            $"The upload contains more than one row for fragment ({fileId}, {gossipId}).",
+            TypeOfError.DataConflict);
+
+    public static Error MassRemovalBlocked(int removedCount, int activeCount, double threshold)
+        => new("Import.MassRemovalBlocked",
+            $"The upload would remove {removedCount} of {activeCount} active row(s) "
+            + $"({(activeCount is 0 ? 0d : (double)removedCount / activeCount).ToString("P0", CultureInfo.InvariantCulture)}), "
+            + $"exceeding the {threshold.ToString("P0", CultureInfo.InvariantCulture)} safety threshold. "
+            + "Re-upload with the override flag if this mass removal is intentional.",
+            TypeOfError.DataConflict);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportErrors.cs
@@ -27,10 +27,16 @@ internal static class ImportErrors
             $"The upload contains more than one row for fragment ({fileId}, {gossipId}).",
             TypeOfError.DataConflict);
 
-    public static Error MassRemovalBlocked(int removedCount, int activeCount, double threshold)
+    public static Error EmptyUpload()
+        => new("Import.EmptyUpload",
+            "The upload contains no translatable rows; an empty or comments-only file is rejected "
+            + "rather than marking the version processed with no content.",
+            TypeOfError.DataConflict);
+
+    public static Error MassRemovalBlocked(int removedCount, int activeCount, double removedFraction, double threshold)
         => new("Import.MassRemovalBlocked",
             $"The upload would remove {removedCount} of {activeCount} active row(s) "
-            + $"({(activeCount is 0 ? 0d : (double)removedCount / activeCount).ToString("P0", CultureInfo.InvariantCulture)}), "
+            + $"({removedFraction.ToString("P0", CultureInfo.InvariantCulture)}), "
             + $"exceeding the {threshold.ToString("P0", CultureInfo.InvariantCulture)} safety threshold. "
             + "Re-upload with the override flag if this mass removal is intentional.",
             TypeOfError.DataConflict);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
@@ -1,0 +1,230 @@
+using FluentValidation;
+using FluentValidation.Results;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+using LotroKoniecDev.TranslationSystem.Contracts.Import;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Services;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.Import;
+
+/// <summary>
+/// Version-bound import of a fresh <c>exported.txt</c> (spec 0001): parse, diff against the stored
+/// source state by <c>(FileId, GossipId)</c>, apply the five outcomes, flip the version to
+/// processed — all in a single transaction (all-or-nothing, idempotent re-upload).
+/// </summary>
+internal sealed class ImportExportedTexts : IEndpoint
+{
+    internal sealed record Command(GameVersionId GameVersionId, Stream FileStream, bool AllowMassRemoval)
+        : ICommand<Result<ImportSummary>>;
+
+    internal sealed class Validator : AbstractValidator<Command>
+    {
+        public Validator()
+        {
+            RuleFor(command => command.GameVersionId)
+                .Must(id => id.Value != Guid.Empty)
+                .WithMessage("Game version id is required.");
+
+            RuleFor(command => command.FileStream)
+                .NotNull();
+        }
+    }
+
+    internal sealed class Handler : ICommandHandler<Command, Result<ImportSummary>>
+    {
+        private readonly IValidator<Command> _validator;
+        private readonly ITranslationExportParser _parser;
+        private readonly IGameVersionRepository _gameVersionRepository;
+        private readonly ITranslationRepository _translationRepository;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly TimeProvider _timeProvider;
+        private readonly ImportSettings _settings;
+
+        public Handler(
+            IValidator<Command> validator,
+            ITranslationExportParser parser,
+            IGameVersionRepository gameVersionRepository,
+            ITranslationRepository translationRepository,
+            IUnitOfWork unitOfWork,
+            TimeProvider timeProvider,
+            IOptions<ImportSettings> settings)
+        {
+            _validator = validator;
+            _parser = parser;
+            _gameVersionRepository = gameVersionRepository;
+            _translationRepository = translationRepository;
+            _unitOfWork = unitOfWork;
+            _timeProvider = timeProvider;
+            _settings = settings.Value;
+        }
+
+        public async ValueTask<Result<ImportSummary>> Handle(Command command, CancellationToken cancellationToken)
+        {
+            ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                string message = string.Join("; ", validationResult.Errors.Select(failure => failure.ErrorMessage));
+                return Result.Failure<ImportSummary>(new Error("Import.Validation", message, TypeOfError.Validation));
+            }
+
+            Maybe<GameVersion> gameVersionMaybe = await _gameVersionRepository.GetByIdAsync(command.GameVersionId, cancellationToken);
+            if (gameVersionMaybe.HasNoValue)
+            {
+                return Result.Failure<ImportSummary>(DomainErrors.GameVersionEntity.NotFound(command.GameVersionId));
+            }
+
+            GameVersion gameVersion = gameVersionMaybe.Value;
+
+            ParsedExport parsed = await _parser.ParseAsync(command.FileStream, cancellationToken);
+            if (parsed.HasErrors)
+            {
+                return Result.Failure<ImportSummary>(ImportErrors.ParseFailed(parsed.Errors.Count, parsed.Errors[0]));
+            }
+
+            Result<IReadOnlyList<IncomingTranslation>> incomingResult = MapToIncoming(parsed.Rows);
+            if (incomingResult.IsFailure)
+            {
+                return Result.Failure<ImportSummary>(incomingResult.Error);
+            }
+
+            DateTimeOffset now = _timeProvider.GetUtcNow();
+
+            IReadOnlyList<Translation> existing = await _translationRepository.GetAllAsync(cancellationToken);
+
+            TranslationDiffPlan plan = TranslationDiffService.ComputePlan(
+                existing,
+                incomingResult.Value,
+                command.GameVersionId,
+                now);
+
+            if (!command.AllowMassRemoval && plan.RemovedFraction > _settings.MaxRemovedFractionWithoutOverride)
+            {
+                return Result.Failure<ImportSummary>(
+                    ImportErrors.MassRemovalBlocked(plan.Removed.Count, plan.ComparableExistingCount, _settings.MaxRemovedFractionWithoutOverride));
+            }
+
+            _translationRepository.InsertRange(plan.Added);
+
+            foreach (TranslationSourceChange change in plan.SourceChanges)
+            {
+                change.Existing.ApplySourceChange(change.NewSource, command.GameVersionId, now);
+            }
+
+            foreach (Translation removed in plan.Removed)
+            {
+                removed.MarkRemoved(command.GameVersionId, now);
+            }
+
+            foreach (Translation restored in plan.Restored)
+            {
+                restored.Restore(now);
+            }
+
+            // Single SaveChanges = one transaction: the row changes and the version's processed
+            // flag commit together, so IsProcessed flips only after the diff is durable (spec 0001).
+            Result markProcessedResult = gameVersion.MarkProcessed();
+            if (markProcessedResult.IsFailure)
+            {
+                return Result.Failure<ImportSummary>(markProcessedResult.Error);
+            }
+
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success(BuildSummary(plan));
+        }
+
+        private static Result<IReadOnlyList<IncomingTranslation>> MapToIncoming(IReadOnlyList<ParsedExportRow> rows)
+        {
+            List<IncomingTranslation> incoming = new(rows.Count);
+            HashSet<FragmentKey> seen = [];
+
+            foreach (ParsedExportRow row in rows)
+            {
+                Result<FragmentKey> keyResult = FragmentKey.Create(row.FileId, row.GossipId);
+                if (keyResult.IsFailure)
+                {
+                    return Result.Failure<IReadOnlyList<IncomingTranslation>>(
+                        ImportErrors.InvalidRow(row.FileId, row.GossipId, keyResult.Error.Message));
+                }
+
+                Result<TranslationSource> sourceResult = TranslationSource.Create(row.Content, row.ArgsOrder, row.ArgsId);
+                if (sourceResult.IsFailure)
+                {
+                    return Result.Failure<IReadOnlyList<IncomingTranslation>>(
+                        ImportErrors.InvalidRow(row.FileId, row.GossipId, sourceResult.Error.Message));
+                }
+
+                if (!seen.Add(keyResult.Value))
+                {
+                    return Result.Failure<IReadOnlyList<IncomingTranslation>>(
+                        ImportErrors.DuplicateFragmentKey(row.FileId, row.GossipId));
+                }
+
+                incoming.Add(new IncomingTranslation(keyResult.Value, sourceResult.Value));
+            }
+
+            return Result.Success<IReadOnlyList<IncomingTranslation>>(incoming);
+        }
+
+        private static ImportSummary BuildSummary(TranslationDiffPlan plan)
+        {
+            List<string> warnings = [];
+            if (plan.Restored.Count > 0)
+            {
+                warnings.Add($"{plan.Restored.Count} previously-removed row(s) re-added with an unchanged source and restored.");
+            }
+
+            return new ImportSummary(
+                Added: plan.Added.Count,
+                SourceChanged: plan.SourceChanges.Count,
+                Invalidated: plan.InvalidatedCount,
+                Removed: plan.Removed.Count,
+                Unchanged: plan.UnchangedCount,
+                Warnings: warnings);
+        }
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapPost("/api/v1/game-versions/{id:guid}/import", async (
+                Guid id,
+                IFormFile file,
+                ICommandHandler<Command, Result<ImportSummary>> handler,
+                CancellationToken cancellationToken,
+                [FromQuery] bool allowMassRemoval = false) =>
+            {
+                await using Stream stream = file.OpenReadStream();
+
+                Command command = new(GameVersionId.Create(id), stream, allowMassRemoval);
+
+                Result<ImportSummary> result = await handler.Handle(command, cancellationToken);
+
+                return result.IsSuccess
+                    ? Results.Ok(result.Value)
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(ImportExportedTexts))
+            .WithTags("Import")
+            .RequireAuthorization(AuthorizationPolicies.RequireAdminRole)
+            .DisableAntiforgery()
+            .Produces<ImportSummary>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
@@ -97,6 +97,11 @@ internal sealed class ImportExportedTexts : IEndpoint
                 return Result.Failure<ImportSummary>(ImportErrors.ParseFailed(parsed.Errors.Count, parsed.Errors[0]));
             }
 
+            if (parsed.Rows.Count == 0)
+            {
+                return Result.Failure<ImportSummary>(ImportErrors.EmptyUpload());
+            }
+
             Result<IReadOnlyList<IncomingTranslation>> incomingResult = MapToIncoming(parsed.Rows);
             if (incomingResult.IsFailure)
             {
@@ -116,7 +121,11 @@ internal sealed class ImportExportedTexts : IEndpoint
             if (!command.AllowMassRemoval && plan.RemovedFraction > _settings.MaxRemovedFractionWithoutOverride)
             {
                 return Result.Failure<ImportSummary>(
-                    ImportErrors.MassRemovalBlocked(plan.Removed.Count, plan.ComparableExistingCount, _settings.MaxRemovedFractionWithoutOverride));
+                    ImportErrors.MassRemovalBlocked(
+                        plan.Removed.Count,
+                        plan.ComparableExistingCount,
+                        plan.RemovedFraction,
+                        _settings.MaxRemovedFractionWithoutOverride));
             }
 
             _translationRepository.InsertRange(plan.Added);
@@ -138,6 +147,8 @@ internal sealed class ImportExportedTexts : IEndpoint
 
             // Single SaveChanges = one transaction: the row changes and the version's processed
             // flag commit together, so IsProcessed flips only after the diff is durable (spec 0001).
+            // Imports are admin-only and serial — concurrent imports of one version are out of scope,
+            // so no optimistic-concurrency token is modelled.
             Result markProcessedResult = gameVersion.MarkProcessed();
             if (markProcessedResult.IsFailure)
             {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportSettings.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportSettings.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.TranslationSystem.API.Features.Import;
+
+/// <summary>
+/// Import safety knobs. The removed-fraction guard rejects an upload that would soft-remove more
+/// than <see cref="MaxRemovedFractionWithoutOverride"/> of the active rows unless the admin passes
+/// the override flag — a partially written export would otherwise masquerade as a mass removal
+/// (spec 0001, Q4). Default 20%.
+/// </summary>
+internal sealed class ImportSettings
+{
+    public const string ConfigurationSection = "Import";
+
+    public double MaxRemovedFractionWithoutOverride { get; init; } = 0.20;
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj
@@ -41,6 +41,7 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="LotroKoniecDev.TranslationSystem.API.Tests.Integration" />
+        <InternalsVisibleTo Include="LotroKoniecDev.TranslationSystem.API.Tests.Unit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/ITranslationExportParser.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/ITranslationExportParser.cs
@@ -1,0 +1,6 @@
+namespace LotroKoniecDev.TranslationSystem.API.Parsing;
+
+internal interface ITranslationExportParser
+{
+    Task<ParsedExport> ParseAsync(Stream stream, CancellationToken cancellationToken);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/ParsedExport.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/ParsedExport.cs
@@ -1,0 +1,39 @@
+namespace LotroKoniecDev.TranslationSystem.API.Parsing;
+
+/// <summary>One parsed row of an uploaded export, in the verbatim exported representation.</summary>
+/// <remarks>
+/// Args columns are the raw <c>NULL</c>/<c>1-2-3</c> strings and <see cref="Content"/> keeps its
+/// escaped <c>\r</c>/<c>\n</c> — the TMS stores and redistributes texts byte-for-byte; only the
+/// patcher unescapes, when it injects into the DAT. <see cref="Approved"/> is retained for
+/// format symmetry but the import ignores it: the export's column is a constant and TMS approval
+/// state is owned by the editor loop, not the file.
+/// </remarks>
+public sealed record ParsedExportRow(
+    int FileId,
+    long GossipId,
+    string Content,
+    string ArgsOrder,
+    string ArgsId,
+    bool Approved);
+
+/// <summary>A line that failed to parse, with its 1-based line number for the rejection message.</summary>
+public sealed record ExportParseError(int LineNumber, string Message);
+
+/// <summary>
+/// The result of parsing an uploaded export: the well-formed rows plus every line that failed.
+/// The import rejects the whole upload when <see cref="HasErrors"/> — on import a skipped line is
+/// indistinguishable from a removed row, so partial parsing is unsafe (spec 0001, truncation guard).
+/// </summary>
+public sealed class ParsedExport
+{
+    public IReadOnlyList<ParsedExportRow> Rows { get; }
+    public IReadOnlyList<ExportParseError> Errors { get; }
+
+    public bool HasErrors => Errors.Count > 0;
+
+    public ParsedExport(IReadOnlyList<ParsedExportRow> rows, IReadOnlyList<ExportParseError> errors)
+    {
+        Rows = rows;
+        Errors = errors;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationExportParser.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationExportParser.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 
 namespace LotroKoniecDev.TranslationSystem.API.Parsing;
 
@@ -12,6 +13,14 @@ internal sealed class TranslationExportParser : ITranslationExportParser
     private const string FieldSeparator = "||";
     private const int MinimumFieldCount = 6;
 
+    /// <summary>
+    /// The patcher writes <c>exported.txt</c> as UTF-8; decode it strictly. A wrong-charset or
+    /// corrupt upload then throws instead of silently mis-decoding into garbage content that the
+    /// diff would treat as a source change and mass-invalidate every Polish row — the rejection
+    /// routes through the same truncation guard as a structural parse failure.
+    /// </summary>
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
     public async Task<ParsedExport> ParseAsync(Stream stream, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(stream);
@@ -19,26 +28,33 @@ internal sealed class TranslationExportParser : ITranslationExportParser
         List<ParsedExportRow> rows = [];
         List<ExportParseError> errors = [];
 
-        using StreamReader reader = new(stream, leaveOpen: true);
+        using StreamReader reader = new(stream, StrictUtf8, leaveOpen: true);
 
         int lineNumber = 0;
-        while (await reader.ReadLineAsync(cancellationToken) is { } line)
+        try
         {
-            lineNumber++;
+            while (await reader.ReadLineAsync(cancellationToken) is { } line)
+            {
+                lineNumber++;
 
-            if (ShouldSkipLine(line))
-            {
-                continue;
-            }
+                if (ShouldSkipLine(line))
+                {
+                    continue;
+                }
 
-            if (TryParseLine(line, out ParsedExportRow? row, out string? error))
-            {
-                rows.Add(row!);
+                if (TryParseLine(line, out ParsedExportRow? row, out string? error))
+                {
+                    rows.Add(row!);
+                }
+                else
+                {
+                    errors.Add(new ExportParseError(lineNumber, error!));
+                }
             }
-            else
-            {
-                errors.Add(new ExportParseError(lineNumber, error!));
-            }
+        }
+        catch (DecoderFallbackException exception)
+        {
+            errors.Add(new ExportParseError(lineNumber + 1, $"The upload is not valid UTF-8: {exception.Message}"));
         }
 
         return new ParsedExport(rows, errors);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationExportParser.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationExportParser.cs
@@ -1,0 +1,90 @@
+using System.Globalization;
+
+namespace LotroKoniecDev.TranslationSystem.API.Parsing;
+
+/// <summary>
+/// Parses an uploaded <c>exported.txt</c> in the LOTRO <c>||</c> contract
+/// (<c>file_id||gossip_id||content||args_order||args_id||approved</c>). The TMS owns its own
+/// parser; golden fixtures + round-trip tests guard it against drift from the patcher's parser.
+/// </summary>
+internal sealed class TranslationExportParser : ITranslationExportParser
+{
+    private const string FieldSeparator = "||";
+    private const int MinimumFieldCount = 6;
+
+    public async Task<ParsedExport> ParseAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        List<ParsedExportRow> rows = [];
+        List<ExportParseError> errors = [];
+
+        using StreamReader reader = new(stream, leaveOpen: true);
+
+        int lineNumber = 0;
+        while (await reader.ReadLineAsync(cancellationToken) is { } line)
+        {
+            lineNumber++;
+
+            if (ShouldSkipLine(line))
+            {
+                continue;
+            }
+
+            if (TryParseLine(line, out ParsedExportRow? row, out string? error))
+            {
+                rows.Add(row!);
+            }
+            else
+            {
+                errors.Add(new ExportParseError(lineNumber, error!));
+            }
+        }
+
+        return new ParsedExport(rows, errors);
+    }
+
+    private static bool TryParseLine(string line, out ParsedExportRow? row, out string? error)
+    {
+        row = null;
+
+        string[] parts = line.Split(FieldSeparator, StringSplitOptions.None);
+
+        if (parts.Length < MinimumFieldCount)
+        {
+            error = $"Expected at least {MinimumFieldCount} fields, got {parts.Length}.";
+            return false;
+        }
+
+        if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out int fileId))
+        {
+            error = $"File id '{parts[0]}' is not a valid integer.";
+            return false;
+        }
+
+        if (!long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out long gossipId))
+        {
+            error = $"Gossip id '{parts[1]}' is not a valid integer.";
+            return false;
+        }
+
+        // Anchor from both ends (matches the patcher, #29/#106): file_id, gossip_id lead;
+        // args_order, args_id, approved trail; everything between is content re-joined with the
+        // separator, so content may legally contain "||".
+        string content = string.Join(FieldSeparator, parts[2..^3]);
+
+        row = new ParsedExportRow(
+            FileId: fileId,
+            GossipId: gossipId,
+            Content: content,
+            ArgsOrder: parts[^3],
+            ArgsId: parts[^2],
+            Approved: parts[^1].Trim() == "1");
+
+        error = null;
+        return true;
+    }
+
+    private static bool ShouldSkipLine(string line)
+        => string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#');
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Import/ImportSummary.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Import/ImportSummary.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.TranslationSystem.Contracts.Import;
+
+/// <summary>
+/// The outcome of a version-bound import (spec 0001): how many rows the diff added, had their
+/// English source changed, were invalidated (source-changed rows that carried Polish), soft-removed
+/// or left untouched, plus any non-fatal notices (e.g. restored re-added rows).
+/// </summary>
+public sealed record ImportSummary(
+    int Added,
+    int SourceChanged,
+    int Invalidated,
+    int Removed,
+    int Unchanged,
+    IReadOnlyCollection<string> Warnings);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
@@ -1,0 +1,131 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Guards;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+
+/// <summary>
+/// One text-fragment row of the translation domain (spec 0001): a single mutable row per
+/// <see cref="FragmentKey"/> carrying the English source, optional Polish content and the
+/// version pointers that give per-version grouping without duplicating rows each patch.
+/// </summary>
+public sealed class Translation : AggregateRoot<TranslationId>
+{
+    public FragmentKey FragmentKey { get; }
+    public TranslationSource Source { get; private set; }
+    public string? TranslatedText { get; private set; }
+    public string? PreviousSourceText { get; private set; }
+    public TranslationStatus Status { get; private set; }
+    public GameVersionId IntroducedInVersion { get; private set; }
+    public GameVersionId? LastSourceChangeInVersion { get; private set; }
+    public GameVersionId? RemovedInVersion { get; private set; }
+    public DateTimeOffset CreatedAt { get; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    public bool IsRemoved => RemovedInVersion is not null;
+
+    /// <summary>
+    /// An <em>added</em> row (baseline or diff): English source only, no Polish, available for
+    /// translation. Stamps <see cref="IntroducedInVersion"/>.
+    /// </summary>
+    public static Result<Translation> CreateUntranslated(
+        FragmentKey fragmentKey,
+        TranslationSource source,
+        GameVersionId introducedInVersion,
+        DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(fragmentKey);
+        ArgumentNullException.ThrowIfNull(source);
+        Ensure.NotEmpty(introducedInVersion);
+        Ensure.NotEmpty(now);
+
+        Translation instance = new(TranslationId.Create(), fragmentKey, source, introducedInVersion, now);
+
+        return Result.Success(instance);
+    }
+
+    /// <summary>
+    /// Source-changed (spec 0001): overwrite the stored English; if Polish work exists it is
+    /// invalidated (parked as <see cref="TranslationStatus.NeedsReview"/>, the superseded English
+    /// kept in <see cref="PreviousSourceText"/> for side-by-side context); stamps
+    /// <see cref="LastSourceChangeInVersion"/>. Also clears any soft-removal — a re-added pair
+    /// whose source differs lands here.
+    /// </summary>
+    public void ApplySourceChange(TranslationSource newSource, GameVersionId changedInVersion, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(newSource);
+        Ensure.NotEmpty(changedInVersion);
+
+        if (Status is TranslationStatus.Draft or TranslationStatus.Approved or TranslationStatus.NeedsReview)
+        {
+            PreviousSourceText = Source.Text;
+            Status = TranslationStatus.NeedsReview;
+        }
+
+        Source = newSource;
+        LastSourceChangeInVersion = changedInVersion;
+        RemovedInVersion = null;
+        UpdatedAt = now;
+    }
+
+    /// <summary>
+    /// Removed (spec 0001): soft-mark — excluded from translation work and the distributed file,
+    /// never hard-deleted. Reversible via <see cref="Restore"/> when SSG re-adds the pair.
+    /// </summary>
+    public void MarkRemoved(GameVersionId removedInVersion, DateTimeOffset now)
+    {
+        Ensure.NotEmpty(removedInVersion);
+
+        RemovedInVersion = removedInVersion;
+        UpdatedAt = now;
+    }
+
+    /// <summary>
+    /// Re-added with an identical source (spec 0001): clear the soft-removal; the previous status
+    /// — including <see cref="TranslationStatus.Approved"/> — stands, because the old Polish is
+    /// still valid.
+    /// </summary>
+    public void Restore(DateTimeOffset now)
+    {
+        RemovedInVersion = null;
+        UpdatedAt = now;
+    }
+
+    /// <summary>
+    /// Attaches the Polish draft for this row (the upsert/seed seed; #100 enriches it with
+    /// placeholder validation). Untranslated/NeedsReview move to <see cref="TranslationStatus.Draft"/>.
+    /// </summary>
+    public void ProvideTranslation(string translatedText, DateTimeOffset now)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(translatedText);
+
+        TranslatedText = translatedText;
+        Status = TranslationStatus.Draft;
+        UpdatedAt = now;
+    }
+
+    private Translation(
+        TranslationId id,
+        FragmentKey fragmentKey,
+        TranslationSource source,
+        GameVersionId introducedInVersion,
+        DateTimeOffset now) : base(id)
+    {
+        FragmentKey = fragmentKey;
+        Source = source;
+        IntroducedInVersion = introducedInVersion;
+        Status = TranslationStatus.Untranslated;
+        CreatedAt = now;
+        UpdatedAt = now;
+    }
+
+    private Translation()
+    {
+        FragmentKey = null!;
+        Source = null!;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
@@ -96,7 +96,7 @@ public sealed class Translation : AggregateRoot<TranslationId>
     }
 
     /// <summary>
-    /// Attaches the Polish draft for this row (the upsert/seed seed; #100 enriches it with
+    /// Attaches the Polish draft for this row (the upsert/seed helper; #100 enriches it with
     /// placeholder validation). Untranslated/NeedsReview move to <see cref="TranslationStatus.Draft"/>.
     /// </summary>
     public void ProvideTranslation(string translatedText, DateTimeOffset now)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Repositories/ITranslationRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Repositories/ITranslationRepository.cs
@@ -1,0 +1,18 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+
+public interface ITranslationRepository : IRepository<Translation, TranslationId>
+{
+    /// <summary>
+    /// Loads every stored translation as tracked aggregates for the import diff, which compares
+    /// the full uploaded export against the full stored source state by <c>(FileId, GossipId)</c>
+    /// (spec 0001). Admin-only, infrequent — the whole-set load is acceptable within the
+    /// proven ~780k-row envelope; revisit only if a real perf need appears.
+    /// </summary>
+    Task<IReadOnlyList<Translation>> GetAllAsync(CancellationToken cancellationToken);
+
+    void InsertRange(IEnumerable<Translation> translations);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/IncomingTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/IncomingTranslation.cs
@@ -1,0 +1,10 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Services;
+
+/// <summary>
+/// One parsed-and-validated row of an uploaded export, ready for the diff: its identity and its
+/// English source. The API parser produces the raw rows; the import handler validates them into
+/// these value-object pairs before handing them to <see cref="TranslationDiffService"/>.
+/// </summary>
+public sealed record IncomingTranslation(FragmentKey Key, TranslationSource Source);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffPlan.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffPlan.cs
@@ -1,0 +1,52 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Services;
+
+/// <summary>An existing row whose English source the upload changed.</summary>
+public sealed record TranslationSourceChange(Translation Existing, TranslationSource NewSource);
+
+/// <summary>
+/// The outcome of diffing an upload against the stored state (spec 0001). The plan is computed
+/// without mutating anything so the import handler can enforce the truncation guard from the
+/// removed fraction <em>before</em> any change is applied; the handler then realizes the plan.
+/// </summary>
+public sealed class TranslationDiffPlan
+{
+    public IReadOnlyList<Translation> Added { get; }
+    public IReadOnlyList<TranslationSourceChange> SourceChanges { get; }
+    public IReadOnlyList<Translation> Removed { get; }
+    public IReadOnlyList<Translation> Restored { get; }
+    public int UnchangedCount { get; }
+
+    /// <summary>Source-changed rows that carried Polish work and were therefore invalidated.</summary>
+    public int InvalidatedCount { get; }
+
+    /// <summary>Active (non-removed) stored rows — the denominator of the removed-fraction guard.</summary>
+    public int ComparableExistingCount { get; }
+
+    public TranslationDiffPlan(
+        IReadOnlyList<Translation> added,
+        IReadOnlyList<TranslationSourceChange> sourceChanges,
+        IReadOnlyList<Translation> removed,
+        IReadOnlyList<Translation> restored,
+        int unchangedCount,
+        int invalidatedCount,
+        int comparableExistingCount)
+    {
+        Added = added;
+        SourceChanges = sourceChanges;
+        Removed = removed;
+        Restored = restored;
+        UnchangedCount = unchangedCount;
+        InvalidatedCount = invalidatedCount;
+        ComparableExistingCount = comparableExistingCount;
+    }
+
+    /// <summary>
+    /// The fraction of active stored rows this upload would soft-remove. Zero on a baseline import
+    /// (no active rows to remove), so the guard never trips on first load.
+    /// </summary>
+    public double RemovedFraction
+        => ComparableExistingCount is 0 ? 0d : (double)Removed.Count / ComparableExistingCount;
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffService.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffService.cs
@@ -1,0 +1,82 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Services;
+
+/// <summary>
+/// Pure diff of an uploaded export against the stored source state, keyed by
+/// <see cref="FragmentKey"/> over the full file (spec 0001). Produces a <see cref="TranslationDiffPlan"/>
+/// without touching the database — added rows are created here, existing rows are only referenced;
+/// the handler realizes the plan inside its transaction after the truncation guard passes.
+/// </summary>
+public static class TranslationDiffService
+{
+    public static TranslationDiffPlan ComputePlan(
+        IReadOnlyCollection<Translation> existing,
+        IReadOnlyCollection<IncomingTranslation> incoming,
+        GameVersionId targetVersion,
+        DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(existing);
+        ArgumentNullException.ThrowIfNull(incoming);
+
+        Dictionary<FragmentKey, Translation> existingByKey = existing.ToDictionary(translation => translation.FragmentKey);
+        HashSet<FragmentKey> incomingKeys = [.. incoming.Select(row => row.Key)];
+
+        List<Translation> added = [];
+        List<TranslationSourceChange> sourceChanges = [];
+        List<Translation> restored = [];
+        int unchangedCount = 0;
+        int invalidatedCount = 0;
+
+        foreach (IncomingTranslation row in incoming)
+        {
+            if (!existingByKey.TryGetValue(row.Key, out Translation? current))
+            {
+                added.Add(Translation.CreateUntranslated(row.Key, row.Source, targetVersion, now).Value);
+                continue;
+            }
+
+            bool sourceIdentical = current.Source == row.Source;
+
+            if (sourceIdentical)
+            {
+                if (current.IsRemoved)
+                {
+                    restored.Add(current);
+                }
+                else
+                {
+                    unchangedCount++;
+                }
+
+                continue;
+            }
+
+            sourceChanges.Add(new TranslationSourceChange(current, row.Source));
+            if (HasPolish(current))
+            {
+                invalidatedCount++;
+            }
+        }
+
+        List<Translation> removed = [.. existing
+            .Where(translation => !translation.IsRemoved && !incomingKeys.Contains(translation.FragmentKey))];
+
+        int comparableExistingCount = existing.Count(translation => !translation.IsRemoved);
+
+        return new TranslationDiffPlan(
+            added,
+            sourceChanges,
+            removed,
+            restored,
+            unchangedCount,
+            invalidatedCount,
+            comparableExistingCount);
+    }
+
+    private static bool HasPolish(Translation translation)
+        => translation.Status is TranslationStatus.Draft or TranslationStatus.Approved or TranslationStatus.NeedsReview;
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/ValueObjects/FragmentKey.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/ValueObjects/FragmentKey.cs
@@ -1,0 +1,53 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+
+/// <summary>
+/// The stable identity of a text fragment across game versions: the pair
+/// <c>(FileId, GossipId)</c> — <c>FileId</c> addresses the DAT subfile, <c>GossipId</c>
+/// (the 8-byte <c>Fragment.FragmentId</c>, stored as 64-bit) the fragment within it. This is
+/// how LOTRO itself addresses texts and the key the import diff matches on (spec 0001).
+/// </summary>
+public sealed class FragmentKey : ValueObject
+{
+    public int FileId { get; }
+    public long GossipId { get; }
+
+    public static Result<FragmentKey> Create(int fileId, long gossipId)
+    {
+        // A text FileId always has the 0x25 high byte, so it is structurally large-positive;
+        // 0 or negative signals corruption.
+        if (fileId <= 0)
+        {
+            return Result.Failure<FragmentKey>(DomainErrors.TranslationEntity.FragmentKeyProperty.InvalidFileId);
+        }
+
+        // GossipId is an 8-byte unsigned value (Fragment.FragmentId) stored as long; only a
+        // negative literal is corruption. The patcher parser applies no lower bound, so we match
+        // it — a legitimate id (including 0) must never fail the whole import.
+        if (gossipId < 0)
+        {
+            return Result.Failure<FragmentKey>(DomainErrors.TranslationEntity.FragmentKeyProperty.InvalidGossipId);
+        }
+
+        FragmentKey instance = new(fileId, gossipId);
+
+        return Result.Success(instance);
+    }
+
+    private FragmentKey(int fileId, long gossipId)
+    {
+        FileId = fileId;
+        GossipId = gossipId;
+    }
+
+    public override string ToString() => $"{FileId}/{GossipId}";
+
+    protected override IEnumerable<object> GetAtomicValues()
+    {
+        yield return FileId;
+        yield return GossipId;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/ValueObjects/TranslationSource.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/ValueObjects/TranslationSource.cs
@@ -1,0 +1,52 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+
+/// <summary>
+/// The English source of a fragment as exported from the DAT — the unit the import diff compares.
+/// Text and the two argument columns are one value (spec 0001: a placeholder-structure change is
+/// a meaning change even without a text change), so equality covers all three. Stored verbatim in
+/// the exported representation (<c>\r</c>/<c>\n</c> kept escaped, args as the raw <c>NULL</c>/<c>1-2-3</c>
+/// column) so the distributed file round-trips byte-for-byte through the patcher.
+/// </summary>
+public sealed class TranslationSource : ValueObject
+{
+    public string Text { get; }
+    public string? ArgsOrder { get; }
+    public string? ArgsId { get; }
+
+    public static Result<TranslationSource> Create(string text, string? argsOrder, string? argsId)
+    {
+        if (text is null)
+        {
+            return Result.Failure<TranslationSource>(DomainErrors.TranslationEntity.SourceProperty.TextRequired);
+        }
+
+        TranslationSource instance = new(text, NormalizeArgs(argsOrder), NormalizeArgs(argsId));
+
+        return Result.Success(instance);
+    }
+
+    private TranslationSource(string text, string? argsOrder, string? argsId)
+    {
+        Text = text;
+        ArgsOrder = argsOrder;
+        ArgsId = argsId;
+    }
+
+    // A blank or "NULL" args column carries no arguments — collapse both to null so the diff
+    // never treats an absent-vs-NULL difference as a source change.
+    private static string? NormalizeArgs(string? value)
+        => string.IsNullOrWhiteSpace(value) || string.Equals(value, "NULL", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : value;
+
+    protected override IEnumerable<object> GetAtomicValues()
+    {
+        yield return Text;
+        yield return ArgsOrder ?? string.Empty;
+        yield return ArgsId ?? string.Empty;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/TranslationAggregateDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/TranslationAggregateDomainErrors.cs
@@ -1,0 +1,33 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+
+public static partial class DomainErrors
+{
+    public static class TranslationEntity
+    {
+        public static Error NotFound(TranslationId id)
+            => HasNotBeenFound(nameof(TranslationEntity), id.Value);
+
+        public static class FragmentKeyProperty
+        {
+            public static Error InvalidFileId
+                => new($"{nameof(TranslationEntity)}.FileId.Invalid",
+                    "The file id must be a positive number.",
+                    TypeOfError.Validation);
+
+            public static Error InvalidGossipId
+                => new($"{nameof(TranslationEntity)}.GossipId.Invalid",
+                    "The gossip id must not be negative.",
+                    TypeOfError.Validation);
+        }
+
+        public static class SourceProperty
+        {
+            public static Error TextRequired
+                => Required(nameof(TranslationEntity), "SourceText");
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
@@ -1,0 +1,53 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.Consts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Configurations;
+
+internal sealed class TranslationConfiguration : IEntityTypeConfiguration<Translation>
+{
+    public void Configure(EntityTypeBuilder<Translation> builder)
+    {
+        builder.ToTable("Translations");
+
+        builder.Property(translation => translation.Id)
+            .ValueGeneratedNever();
+
+        // (FileId, GossipId) is the natural identity and needs a unique index, so the VO is mapped
+        // with OwnsOne (ComplexProperty cannot be indexed in EF Core 10).
+        builder.OwnsOne(translation => translation.FragmentKey, ownedBuilder =>
+        {
+            ownedBuilder.Property(key => key.FileId)
+                .HasColumnName(nameof(FragmentKey.FileId));
+
+            ownedBuilder.Property(key => key.GossipId)
+                .HasColumnName(nameof(FragmentKey.GossipId));
+
+            ownedBuilder.HasIndex(key => new { key.FileId, key.GossipId })
+                .IsUnique();
+        });
+
+        // The English source is a pure value compared as one unit by the diff — ComplexProperty,
+        // no index needed.
+        builder.ComplexProperty(translation => translation.Source, complexBuilder =>
+        {
+            complexBuilder.Property(source => source.Text)
+                .HasColumnName(nameof(Translation.Source) + nameof(TranslationSource.Text));
+
+            complexBuilder.Property(source => source.ArgsOrder)
+                .HasColumnName(nameof(TranslationSource.ArgsOrder));
+
+            complexBuilder.Property(source => source.ArgsId)
+                .HasColumnName(nameof(TranslationSource.ArgsId));
+        });
+
+        builder.Property(translation => translation.Status)
+            .HasConversion<string>()
+            .HasMaxLength(EnumConsts.MaxLength);
+
+        // Get-only property — EF Core convention skips it without an explicit mapping.
+        builder.Property(translation => translation.CreatedAt);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdsConverters.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdsConverters.cs
@@ -1,4 +1,5 @@
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
@@ -19,6 +20,10 @@ public static class StronglyTypedIdsConverters
             .Properties<GameVersionId>()
             .HaveConversion<GameVersionIdConverter>();
 
+        configurationBuilder
+            .Properties<TranslationId>()
+            .HaveConversion<TranslationIdConverter>();
+
         return configurationBuilder;
     }
 
@@ -29,4 +34,8 @@ public static class StronglyTypedIdsConverters
     private sealed class GameVersionIdConverter() : ValueConverter<GameVersionId, Guid>(
         id => id.Value,
         value => new GameVersionId(value));
+
+    private sealed class TranslationIdConverter() : ValueConverter<TranslationId, Guid>(
+        id => id.Value,
+        value => new TranslationId(value));
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/ReadDbContexts/ApplicationReadDbContext.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/ReadDbContexts/ApplicationReadDbContext.cs
@@ -1,5 +1,6 @@
 using LotroKoniecDev.TranslationSystem.Persistence.Converters;
 using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +13,8 @@ internal sealed class ApplicationReadDbContext : DbContext, IApplicationReadDbCo
     }
 
     public DbSet<GameVersionReadModel> GameVersions => Set<GameVersionReadModel>();
+
+    public DbSet<TranslationReadModel> Translations => Set<TranslationReadModel>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/ReadDbContexts/IApplicationReadDbContext.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/ReadDbContexts/IApplicationReadDbContext.cs
@@ -1,4 +1,5 @@
 using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
 using Microsoft.EntityFrameworkCore;
 
 namespace LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
@@ -6,4 +7,6 @@ namespace LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts
 public interface IApplicationReadDbContext
 {
     DbSet<GameVersionReadModel> GameVersions { get; }
+
+    DbSet<TranslationReadModel> Translations { get; }
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/WriteDbContexts/ApplicationWriteDbContext.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/WriteDbContexts/ApplicationWriteDbContext.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Reflection;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Persistence.Converters;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +16,8 @@ internal sealed class ApplicationWriteDbContext : DbContext, IUnitOfWork
     }
 
     public DbSet<GameVersion> GameVersions => Set<GameVersion>();
+
+    public DbSet<Translation> Translations => Set<Translation>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
@@ -1,0 +1,29 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using Microsoft.EntityFrameworkCore;
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.DomainRepositories;
+
+internal sealed class TranslationRepository : GenericRepository<Translation, TranslationId>, ITranslationRepository
+{
+    public TranslationRepository(ApplicationWriteDbContext db) : base(db)
+    {
+    }
+
+    public async Task<IReadOnlyList<Translation>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        List<Translation> translations = await DbContext.Set<Translation>()
+            .ToListAsync(cancellationToken);
+
+        return translations;
+    }
+
+    public void InsertRange(IEnumerable<Translation> translations)
+    {
+        ArgumentNullException.ThrowIfNull(translations);
+
+        DbContext.Set<Translation>().AddRange(translations);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613090456_AddTranslationAggregate.Designer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613090456_AddTranslationAggregate.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationWriteDbContext))]
-    partial class ApplicationWriteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613090456_AddTranslationAggregate")]
+    partial class AddTranslationAggregate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613090456_AddTranslationAggregate.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613090456_AddTranslationAggregate.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTranslationAggregate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Translations",
+                schema: "translation",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    FileId = table.Column<int>(type: "integer", nullable: false),
+                    GossipId = table.Column<long>(type: "bigint", nullable: false),
+                    TranslatedText = table.Column<string>(type: "text", nullable: true),
+                    PreviousSourceText = table.Column<string>(type: "text", nullable: true),
+                    Status = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    IntroducedInVersion = table.Column<Guid>(type: "uuid", nullable: false),
+                    LastSourceChangeInVersion = table.Column<Guid>(type: "uuid", nullable: true),
+                    RemovedInVersion = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ArgsId = table.Column<string>(type: "text", nullable: true),
+                    ArgsOrder = table.Column<string>(type: "text", nullable: true),
+                    SourceText = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Translations", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Translations_FileId_GossipId",
+                schema: "translation",
+                table: "Translations",
+                columns: new[] { "FileId", "GossipId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Translations",
+                schema: "translation");
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/PersistenceDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/PersistenceDependencyInjection.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using LotroKoniecDev.Options;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
@@ -54,6 +55,7 @@ public static class PersistenceDependencyInjection
                 serviceProvider.GetRequiredService<ApplicationWriteDbContext>());
 
             services.AddScoped<IGameVersionRepository, GameVersionRepository>();
+            services.AddScoped<ITranslationRepository, TranslationRepository>();
 
             return services;
         }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationAggregate/Enums/TranslationStatus.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationAggregate/Enums/TranslationStatus.cs
@@ -1,0 +1,15 @@
+namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+
+/// <summary>
+/// The lifecycle state of a single translation row. A single enum (no parallel invalidation
+/// flag) so illegal combinations — e.g. <see cref="Approved"/> while invalidated — are
+/// unrepresentable (spec 0001, Q6). Invalidation is the transition to <see cref="NeedsReview"/>.
+/// </summary>
+public enum TranslationStatus
+{
+    Unset,
+    Untranslated,
+    Draft,
+    Approved,
+    NeedsReview
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationAggregate/TranslationId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationAggregate/TranslationId.cs
@@ -1,0 +1,15 @@
+using LotroKoniecDev.SharedKernel.Guards;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+
+namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+
+[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]
+public partial struct TranslationId : IStronglyTypedId<TranslationId>
+{
+    public static TranslationId Create() => new(Guid.CreateVersion7());
+    public static TranslationId Create(Guid id)
+    {
+        Ensure.NotEmpty(id);
+        return new TranslationId(id);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework/Aggregates/TranslationAggregate/TranslationReadModelConfiguration.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework/Aggregates/TranslationAggregate/TranslationReadModelConfiguration.cs
@@ -1,0 +1,19 @@
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework.Aggregates.TranslationAggregate;
+
+public sealed class TranslationReadModelConfiguration : IEntityTypeConfiguration<TranslationReadModel>
+{
+    public void Configure(EntityTypeBuilder<TranslationReadModel> builder)
+    {
+        builder.ToTable("Translations");
+
+        builder.Property(translationReadModel => translationReadModel.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(translationReadModel => translationReadModel.Status)
+            .HasConversion<string>();
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Aggregates/TranslationAggregate/TranslationReadModel.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Aggregates/TranslationAggregate/TranslationReadModel.cs
@@ -1,0 +1,22 @@
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.ReadModels.Core.BuildingBlocks;
+
+namespace LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
+
+public sealed record TranslationReadModel(
+    TranslationId Id,
+    int FileId,
+    long GossipId,
+    string SourceText,
+    string? ArgsOrder,
+    string? ArgsId,
+    string? TranslatedText,
+    string? PreviousSourceText,
+    TranslationStatus Status,
+    GameVersionId IntroducedInVersion,
+    GameVersionId? LastSourceChangeInVersion,
+    GameVersionId? RemovedInVersion,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt) : IReadOnlyEntity<TranslationId>;

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
@@ -7,6 +7,7 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Va
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -55,6 +56,7 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         summary.Unchanged.ShouldBe(0);
         (await CountTranslationsAsync()).ShouldBe(3);
         (await GetTranslationAsync(1))!.Status.ShouldBe(TranslationStatus.Untranslated);
+        (await GetVersionStatusAsync(versionId)).ShouldBe(GameVersionStatus.Processed);
     }
 
     [Fact]
@@ -64,6 +66,7 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         GameVersionId versionId = await SeedVersionAsync("48.0");
         using HttpClient client = AdminClient();
         await client.PostAsync(ImportRoute(versionId), ExportContent(Line(1, "Alpha"), Line(2, "Beta")));
+        DateTimeOffset firstSeenAt = (await GetTranslationAsync(1))!.UpdatedAt;
 
         // Act — re-upload the identical file to the same (now processed) version.
         HttpResponseMessage response = await client.PostAsync(
@@ -77,6 +80,8 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         summary.Added.ShouldBe(0);
         summary.Unchanged.ShouldBe(2);
         (await CountTranslationsAsync()).ShouldBe(2);
+        // Unchanged rows are a byte-for-byte no-op — the timestamp must not advance on re-import.
+        (await GetTranslationAsync(1))!.UpdatedAt.ShouldBe(firstSeenAt);
     }
 
     [Fact]
@@ -131,6 +136,8 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
         (await GetTranslationAsync(2))!.IsRemoved.ShouldBeFalse();
         (await GetTranslationAsync(3))!.IsRemoved.ShouldBeFalse();
+        // A rejected import is all-or-nothing: the version must not flip to processed.
+        (await GetVersionStatusAsync(secondVersion)).ShouldBe(GameVersionStatus.Unprocessed);
     }
 
     [Fact]
@@ -251,5 +258,13 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
         return await dbContext.Translations.CountAsync();
+    }
+
+    private async Task<GameVersionStatus> GetVersionStatusAsync(GameVersionId versionId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        GameVersion version = await dbContext.GameVersions.AsNoTracking().SingleAsync(row => row.Id == versionId);
+        return version.Status;
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
@@ -1,0 +1,255 @@
+using System.Net.Http.Headers;
+using System.Text;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.Import;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Import;
+
+[Collection("TranslationApi")]
+public sealed class ImportExportedTextsTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+
+    private readonly TranslationSystemApiFactory _factory;
+
+    public ImportExportedTextsTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\" CASCADE;");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Import_AsAdminOnBaseline_ShouldReturn200AndCreateUntranslatedRows()
+    {
+        // Arrange
+        GameVersionId versionId = await SeedVersionAsync("48.0");
+        using HttpClient client = AdminClient();
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            ImportRoute(versionId),
+            ExportContent(Line(1, "Alpha"), Line(2, "Beta"), Line(3, "Gamma")));
+        ImportSummary? summary = await response.Content.ReadFromJsonAsync<ImportSummary>();
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        summary.ShouldNotBeNull();
+        summary.Added.ShouldBe(3);
+        summary.Unchanged.ShouldBe(0);
+        (await CountTranslationsAsync()).ShouldBe(3);
+        (await GetTranslationAsync(1))!.Status.ShouldBe(TranslationStatus.Untranslated);
+    }
+
+    [Fact]
+    public async Task Import_IdenticalReUpload_ShouldBeIdempotent()
+    {
+        // Arrange
+        GameVersionId versionId = await SeedVersionAsync("48.0");
+        using HttpClient client = AdminClient();
+        await client.PostAsync(ImportRoute(versionId), ExportContent(Line(1, "Alpha"), Line(2, "Beta")));
+
+        // Act — re-upload the identical file to the same (now processed) version.
+        HttpResponseMessage response = await client.PostAsync(
+            ImportRoute(versionId),
+            ExportContent(Line(1, "Alpha"), Line(2, "Beta")));
+        ImportSummary? summary = await response.Content.ReadFromJsonAsync<ImportSummary>();
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        summary.ShouldNotBeNull();
+        summary.Added.ShouldBe(0);
+        summary.Unchanged.ShouldBe(2);
+        (await CountTranslationsAsync()).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Import_SecondVersion_ShouldApplyAllDiffOutcomesAndInvalidatePolish()
+    {
+        // Arrange — baseline three rows, then attach Polish to row 1 so a source change invalidates it.
+        GameVersionId firstVersion = await SeedVersionAsync("48.0");
+        using HttpClient client = AdminClient();
+        await client.PostAsync(ImportRoute(firstVersion), ExportContent(Line(1, "Alpha"), Line(2, "Beta"), Line(3, "Gamma")));
+        await AttachPolishAsync(gossipId: 1, polish: "Alfa");
+
+        GameVersionId secondVersion = await SeedVersionAsync("48.1");
+
+        // Act — row 1 reworded, row 2 unchanged, row 3 removed, row 4 added.
+        HttpResponseMessage response = await client.PostAsync(
+            $"{ImportRoute(secondVersion)}?allowMassRemoval=true",
+            ExportContent(Line(1, "Alpha reworded"), Line(2, "Beta"), Line(4, "Delta")));
+        ImportSummary? summary = await response.Content.ReadFromJsonAsync<ImportSummary>();
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        summary.ShouldNotBeNull();
+        summary.Added.ShouldBe(1);
+        summary.SourceChanged.ShouldBe(1);
+        summary.Invalidated.ShouldBe(1);
+        summary.Removed.ShouldBe(1);
+        summary.Unchanged.ShouldBe(1);
+
+        Translation? invalidated = await GetTranslationAsync(1);
+        invalidated!.Status.ShouldBe(TranslationStatus.NeedsReview);
+        invalidated.PreviousSourceText.ShouldBe("Alpha");
+        invalidated.Source.Text.ShouldBe("Alpha reworded");
+
+        (await GetTranslationAsync(3))!.IsRemoved.ShouldBeTrue();
+        (await GetTranslationAsync(4)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Import_MassRemovalWithoutOverride_ShouldReturn422AndLeaveStateIntact()
+    {
+        // Arrange — baseline three rows, then upload that drops two of them (67% > 20%).
+        GameVersionId firstVersion = await SeedVersionAsync("48.0");
+        using HttpClient client = AdminClient();
+        await client.PostAsync(ImportRoute(firstVersion), ExportContent(Line(1, "Alpha"), Line(2, "Beta"), Line(3, "Gamma")));
+
+        GameVersionId secondVersion = await SeedVersionAsync("48.1");
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(ImportRoute(secondVersion), ExportContent(Line(1, "Alpha")));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        (await GetTranslationAsync(2))!.IsRemoved.ShouldBeFalse();
+        (await GetTranslationAsync(3))!.IsRemoved.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Import_TruncatedFile_ShouldReturn422()
+    {
+        // Arrange
+        GameVersionId versionId = await SeedVersionAsync("48.0");
+        using HttpClient client = AdminClient();
+        string truncated = string.Join('\n', Line(1, "Alpha"), "620756992||2||missing trailing fields");
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(ImportRoute(versionId), TextContent(truncated));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        (await CountTranslationsAsync()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Import_AsTranslator_ShouldReturn403()
+    {
+        // Arrange
+        GameVersionId versionId = await SeedVersionAsync("48.0");
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(ImportRoute(versionId), ExportContent(Line(1, "Alpha")));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Import_ForUnknownVersion_ShouldReturn404()
+    {
+        // Arrange
+        using HttpClient client = AdminClient();
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            ImportRoute(GameVersionId.Create()),
+            ExportContent(Line(1, "Alpha")));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Import_WithoutToken_ShouldReturn401()
+    {
+        // Arrange
+        GameVersionId versionId = await SeedVersionAsync("48.0");
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(ImportRoute(versionId), ExportContent(Line(1, "Alpha")));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private static string ImportRoute(GameVersionId versionId)
+        => $"/api/v1/game-versions/{versionId.Value}/import";
+
+    private static string Line(int gossipId, string text) => $"{FileId}||{gossipId}||{text}||NULL||NULL||1";
+
+    private static MultipartFormDataContent ExportContent(params string[] lines) => TextContent(string.Join('\n', lines));
+
+    private static MultipartFormDataContent TextContent(string export)
+    {
+        ByteArrayContent fileContent = new(Encoding.UTF8.GetBytes(export));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+
+        return new MultipartFormDataContent { { fileContent, "file", "exported.txt" } };
+    }
+
+    private HttpClient AdminClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Admin));
+        return client;
+    }
+
+    private async Task<GameVersionId> SeedVersionAsync(string version)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, DateTimeOffset.UtcNow).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+        return gameVersion.Id;
+    }
+
+    private async Task AttachPolishAsync(int gossipId, string polish)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation translation = await dbContext.Translations
+            .SingleAsync(row => row.FragmentKey.FileId == FileId && row.FragmentKey.GossipId == gossipId);
+        translation.ProvideTranslation(polish, DateTimeOffset.UtcNow);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task<Translation?> GetTranslationAsync(int gossipId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        return await dbContext.Translations
+            .AsNoTracking()
+            .SingleOrDefaultAsync(row => row.FragmentKey.FileId == FileId && row.FragmentKey.GossipId == gossipId);
+    }
+
+    private async Task<int> CountTranslationsAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        return await dbContext.Translations.CountAsync();
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj
@@ -33,6 +33,10 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.API\LotroKoniecDev.TranslationSystem.API.csproj" />
+        <!-- Test-only: the parser-parity drift guard compares the TMS parser against the patcher's
+             own parser on the same contract line. The patcher Application is net10.0/AnyCPU, so this
+             reference stays cross-platform; the two contexts remain decoupled in production. -->
+        <ProjectReference Include="..\..\src\LotroKoniecDev.Application\LotroKoniecDev.Application.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+        <Using Include="Shouldly" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="TestData\**\*.txt" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.API\LotroKoniecDev.TranslationSystem.API.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/TestData/exported-sample.txt
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/TestData/exported-sample.txt
@@ -1,0 +1,7 @@
+# Golden fixture mirroring the patcher's || contract. Guards both contexts against format drift.
+620756992||1001||Witaj w Srodziemiu!||NULL||NULL||1
+620756992||1002||Tekst z <--DO_NOT_TOUCH!--> argumentem||1||1||1
+620756992||1003||Line with || inside the content||NULL||NULL||1
+620756992||1004||Multi||arg||content||1-2||1-2||1
+
+620756992||1005||Trailing approved zero||NULL||NULL||0

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/TestData/exported-truncated.txt
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/TestData/exported-truncated.txt
@@ -1,0 +1,3 @@
+620756992||1001||Good line||NULL||NULL||1
+620756992||1002||Bad line missing trailing fields
+notanumber||1003||Bad file id||NULL||NULL||1

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
@@ -213,6 +213,22 @@ public sealed class ImportExportedTextsHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenUploadHasNoRows_ShouldRejectAndNotPersist()
+    {
+        // Arrange — a comments-and-blanks-only file parses cleanly to zero rows.
+        GivenVersion(UnprocessedVersion());
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(
+            Command(VersionId, "# only a comment\n   \n"), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Import.EmptyUpload");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_OnBaselineImport_ShouldAddEveryRowAndMarkVersionProcessed()
     {
         // Arrange

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
@@ -1,0 +1,231 @@
+using System.Text;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Features.Import;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+using LotroKoniecDev.TranslationSystem.Contracts.Import;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Import;
+
+public sealed class ImportExportedTextsHandlerTests
+{
+    private static readonly GameVersionId VersionId = GameVersionId.Create();
+
+    // The validator and parser are pure and dependency-free, so they run for real; only the
+    // genuine boundaries (repositories, unit of work) are stubbed.
+    private readonly IGameVersionRepository _gameVersionRepository = Substitute.For<IGameVersionRepository>();
+    private readonly ITranslationRepository _translationRepository = Substitute.For<ITranslationRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    public ImportExportedTextsHandlerTests()
+    {
+        _translationRepository.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Translation>());
+    }
+
+    private ImportExportedTexts.Handler CreateHandler(double maxRemovedFraction = 0.20)
+        => new(
+            new ImportExportedTexts.Validator(),
+            new TranslationExportParser(),
+            _gameVersionRepository,
+            _translationRepository,
+            _unitOfWork,
+            TimeProvider.System,
+            Microsoft.Extensions.Options.Options.Create(new ImportSettings { MaxRemovedFractionWithoutOverride = maxRemovedFraction }));
+
+    private static ImportExportedTexts.Command Command(GameVersionId versionId, string export, bool allowMassRemoval = false)
+        => new(versionId, new MemoryStream(Encoding.UTF8.GetBytes(export)), allowMassRemoval);
+
+    private static string Line(int gossipId, string text) => $"620756992||{gossipId}||{text}||NULL||NULL||1";
+
+    private static string Export(params string[] lines) => string.Join('\n', lines);
+
+    private static GameVersion UnprocessedVersion()
+        => GameVersion.Create(LotroNotationVersion.Create("48.0").Value, new DateTimeOffset(2026, 6, 13, 0, 0, 0, TimeSpan.Zero)).Value;
+
+    private static Translation ExistingRow(int gossipId, string text)
+        => Translation.CreateUntranslated(
+            FragmentKey.Create(620756992, gossipId).Value,
+            TranslationSource.Create(text, null, null).Value,
+            VersionId,
+            new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero)).Value;
+
+    private void GivenVersion(GameVersion gameVersion)
+        => _gameVersionRepository.GetByIdAsync(VersionId, Arg.Any<CancellationToken>())
+            .Returns(Maybe<GameVersion>.From(gameVersion));
+
+    private void GivenExisting(params Translation[] translations)
+        => _translationRepository.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(translations);
+
+    [Fact]
+    public async Task Handle_WhenCommandInvalid_ShouldReturnValidationError()
+    {
+        // Arrange — a default (empty) version id fails the command validator.
+        ImportExportedTexts.Command command = Command(default, Export(Line(1, "A")));
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Import.Validation");
+    }
+
+    [Fact]
+    public async Task Handle_WhenVersionNotFound_ShouldReturnNotFound()
+    {
+        // Arrange
+        _gameVersionRepository.GetByIdAsync(VersionId, Arg.Any<CancellationToken>())
+            .Returns(Maybe<GameVersion>.None);
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(Command(VersionId, Export(Line(1, "A"))), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("GameVersionEntity.NotFound");
+    }
+
+    [Fact]
+    public async Task Handle_WhenParseHasErrors_ShouldRejectAndNotPersist()
+    {
+        // Arrange — the second line is missing its trailing fields.
+        GivenVersion(UnprocessedVersion());
+        string export = Export(Line(1, "A"), "620756992||2||truncated line");
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(Command(VersionId, export), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Import.ParseFailed");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenMassRemovalExceedsThresholdWithoutOverride_ShouldBlockAndNotPersist()
+    {
+        // Arrange — five active rows, the upload keeps three (40% would be removed).
+        GivenVersion(UnprocessedVersion());
+        GivenExisting(ExistingRow(1, "A"), ExistingRow(2, "B"), ExistingRow(3, "C"), ExistingRow(4, "D"), ExistingRow(5, "E"));
+        string export = Export(Line(1, "A"), Line(2, "B"), Line(3, "C"));
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(Command(VersionId, export, allowMassRemoval: false), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Import.MassRemovalBlocked");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenMassRemovalWithOverride_ShouldPersistRemovals()
+    {
+        // Arrange
+        GivenVersion(UnprocessedVersion());
+        GivenExisting(ExistingRow(1, "A"), ExistingRow(2, "B"), ExistingRow(3, "C"), ExistingRow(4, "D"), ExistingRow(5, "E"));
+        string export = Export(Line(1, "A"), Line(2, "B"), Line(3, "C"));
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(Command(VersionId, export, allowMassRemoval: true), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Removed.ShouldBe(2);
+        result.Value.Unchanged.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRemovedFractionEqualsThreshold_ShouldSucceedWithoutOverride()
+    {
+        // Arrange — five active rows, the upload drops exactly one (20%); "exceeds" is strict.
+        GivenVersion(UnprocessedVersion());
+        GivenExisting(ExistingRow(1, "A"), ExistingRow(2, "B"), ExistingRow(3, "C"), ExistingRow(4, "D"), ExistingRow(5, "E"));
+        string export = Export(Line(1, "A"), Line(2, "B"), Line(3, "C"), Line(4, "D"));
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(Command(VersionId, export, allowMassRemoval: false), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Removed.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRowFailsValueObjectValidation_ShouldReturnInvalidRow()
+    {
+        // Arrange — file id 0 parses but fails FragmentKey validation.
+        GivenVersion(UnprocessedVersion());
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(
+            Command(VersionId, "0||1||Text||NULL||NULL||1"), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Import.InvalidRow");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenUploadHasDuplicateFragmentKey_ShouldReturnDuplicateError()
+    {
+        // Arrange — two rows share (FileId, GossipId).
+        GivenVersion(UnprocessedVersion());
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(
+            Command(VersionId, Export(Line(1, "A"), Line(1, "B"))), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Import.DuplicateFragmentKey");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenVersionIsSuperseded_ShouldRejectAndNotPersist()
+    {
+        // Arrange
+        GameVersion superseded = UnprocessedVersion();
+        superseded.MarkSuperseded();
+        GivenVersion(superseded);
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(
+            Command(VersionId, Export(Line(1, "A"))), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("GameVersionEntity.SupersededCannotBeProcessed");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_OnBaselineImport_ShouldAddEveryRowAndMarkVersionProcessed()
+    {
+        // Arrange
+        GameVersion gameVersion = UnprocessedVersion();
+        GivenVersion(gameVersion);
+        string export = Export(Line(1, "A"), Line(2, "B"));
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(Command(VersionId, export), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Added.ShouldBe(2);
+        gameVersion.Status.ShouldBe(GameVersionStatus.Processed);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/ParserContractParityTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/ParserContractParityTests.cs
@@ -1,0 +1,54 @@
+using System.Text;
+using LotroKoniecDev.Application.Parsers;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
+
+/// <summary>
+/// The two bounded contexts own independent parsers of the same <c>||</c> contract
+/// (CLAUDE.md: "share a data contract, not code"). This is the contract's drift guard: it pins that
+/// the patcher's <see cref="TranslationFileParser"/> and the TMS' <see cref="TranslationExportParser"/>
+/// carve an export line identically. They diverge only by design — the patcher unescapes content and
+/// converts the args columns to 0-indexed int arrays, the TMS keeps the verbatim exported
+/// representation — so parity is asserted at the contract-field level: file id, gossip id, the
+/// both-ends-anchored content, the args boundary, and the approved flag.
+/// </summary>
+public sealed class ParserContractParityTests
+{
+    [Theory]
+    [InlineData("620756992||1001||Witaj w Srodziemiu!||NULL||NULL||1")]
+    [InlineData("620756992||1002||Tekst z <--DO_NOT_TOUCH!--> argumentem||1||1||1")]
+    [InlineData("620756992||1003||Line with || inside the content||NULL||NULL||1")]
+    [InlineData("620756992||1004||Multi||arg||content||1-2||1-2||1")]
+    [InlineData("620756992||1005||Trailing approved zero||NULL||NULL||0")]
+    [InlineData("100||200||leading||||NULL||NULL||1")]
+    [InlineData("100||200||||trailing||NULL||NULL||1")]
+    public async Task BothParsers_OnTheSameContractLine_ShouldAgreeOnEveryField(string line)
+    {
+        // Arrange — the patcher parser is per-line; the TMS parser is per-stream.
+        LotroKoniecDev.Domain.Models.Translation patcher = new TranslationFileParser().ParseLine(line).Value;
+
+        ParsedExport tmsExport = await ParseAsync(line);
+        ParsedExportRow tms = tmsExport.Rows.ShouldHaveSingleItem();
+
+        // Assert — these lines carry no escape sequences, so the patcher's unescape is a no-op and
+        // the anchored content compares directly; the args boundary is checked by rebuilding the
+        // verbatim args string from the patcher's int arrays.
+        patcher.FileId.ShouldBe(tms.FileId);
+        ((long)patcher.GossipId).ShouldBe(tms.GossipId);
+        patcher.Content.ShouldBe(tms.Content);
+        patcher.IsApproved.ShouldBe(tms.Approved);
+        ReconstructArgs(patcher.ArgsOrder).ShouldBe(tms.ArgsOrder);
+        ReconstructArgs(patcher.ArgsId).ShouldBe(tms.ArgsId);
+    }
+
+    private static async Task<ParsedExport> ParseAsync(string content)
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(content));
+        return await new TranslationExportParser().ParseAsync(stream, CancellationToken.None);
+    }
+
+    /// <summary>Rebuilds the verbatim args string the TMS keeps from the patcher's 0-indexed int array.</summary>
+    private static string ReconstructArgs(int[]? args)
+        => args is null ? "NULL" : string.Join('-', args.Select(value => value + 1));
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationExportParserTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationExportParserTests.cs
@@ -18,6 +18,12 @@ public sealed class TranslationExportParserTests
         return await new TranslationExportParser().ParseAsync(stream, CancellationToken.None);
     }
 
+    private static async Task<ParsedExport> ParseBytesAsync(byte[] content)
+    {
+        using MemoryStream stream = new(content);
+        return await new TranslationExportParser().ParseAsync(stream, CancellationToken.None);
+    }
+
     [Fact]
     public async Task ParseAsync_WithGoldenFixture_ShouldParseEveryRowWithoutErrors()
     {
@@ -101,6 +107,52 @@ public sealed class TranslationExportParserTests
     {
         // Act
         ParsedExport result = await ParseAsync("620756992||notanumber||Text||NULL||NULL||1");
+
+        // Assert
+        result.HasErrors.ShouldBeTrue();
+        result.Rows.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithPolishDiacritics_ShouldPreserveContent()
+    {
+        // Act
+        ParsedExport result = await ParseAsync("620756992||1001||Zazolc gesla jazn: Zażółć gęślą jaźń||NULL||NULL||1");
+
+        // Assert
+        result.HasErrors.ShouldBeFalse();
+        result.Rows[0].Content.ShouldBe("Zazolc gesla jazn: Zażółć gęślą jaźń");
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithUtf8Bom_ShouldStripItAndParseTheFirstRow()
+    {
+        // Arrange — the patcher writes UTF-8, which can carry a BOM; it must not corrupt the file id.
+        byte[] content = [0xEF, 0xBB, 0xBF, .. Encoding.UTF8.GetBytes("620756992||1001||Witaj||NULL||NULL||1")];
+
+        // Act
+        ParsedExport result = await ParseBytesAsync(content);
+
+        // Assert
+        result.HasErrors.ShouldBeFalse();
+        result.Rows.Count.ShouldBe(1);
+        result.Rows[0].FileId.ShouldBe(620756992);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithInvalidUtf8Bytes_ShouldRejectTheUpload()
+    {
+        // Arrange — a stray 0xFF is never valid UTF-8. A wrong-charset/corrupt upload must be rejected,
+        // not silently mis-decoded into content the diff would then treat as a mass source change.
+        byte[] content =
+        [
+            .. Encoding.ASCII.GetBytes("620756992||1001||"),
+            0xFF,
+            .. Encoding.ASCII.GetBytes("||NULL||NULL||1"),
+        ];
+
+        // Act
+        ParsedExport result = await ParseBytesAsync(content);
 
         // Assert
         result.HasErrors.ShouldBeTrue();

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationExportParserTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationExportParserTests.cs
@@ -1,0 +1,109 @@
+using System.Text;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
+
+public sealed class TranslationExportParserTests
+{
+    private static async Task<ParsedExport> ParseAsync(string content)
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(content));
+        return await new TranslationExportParser().ParseAsync(stream, CancellationToken.None);
+    }
+
+    private static async Task<ParsedExport> ParseFixtureAsync(string fileName)
+    {
+        string path = Path.Combine(AppContext.BaseDirectory, "TestData", fileName);
+        await using FileStream stream = File.OpenRead(path);
+        return await new TranslationExportParser().ParseAsync(stream, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithGoldenFixture_ShouldParseEveryRowWithoutErrors()
+    {
+        // Act
+        ParsedExport result = await ParseFixtureAsync("exported-sample.txt");
+
+        // Assert — the comment and the blank line are skipped, five rows remain.
+        result.HasErrors.ShouldBeFalse();
+        result.Rows.Count.ShouldBe(5);
+        result.Rows[0].FileId.ShouldBe(620756992);
+        result.Rows[0].GossipId.ShouldBe(1001);
+        result.Rows[0].Content.ShouldBe("Witaj w Srodziemiu!");
+        result.Rows[0].ArgsOrder.ShouldBe("NULL");
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithSeparatorInsideContent_ShouldAnchorBothEndsAndReconstructContent()
+    {
+        // Act
+        ParsedExport result = await ParseAsync("620756992||1003||Line with || inside the content||NULL||NULL||1");
+
+        // Assert
+        result.HasErrors.ShouldBeFalse();
+        result.Rows.Count.ShouldBe(1);
+        result.Rows[0].Content.ShouldBe("Line with || inside the content");
+        result.Rows[0].ArgsOrder.ShouldBe("NULL");
+        result.Rows[0].Approved.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithSeparatorInContentAndArguments_ShouldAnchorTrailingFields()
+    {
+        // Act
+        ParsedExport result = await ParseAsync("620756992||1004||Multi||arg||content||1-2||1-2||1");
+
+        // Assert
+        result.Rows.Count.ShouldBe(1);
+        result.Rows[0].Content.ShouldBe("Multi||arg||content");
+        result.Rows[0].ArgsOrder.ShouldBe("1-2");
+        result.Rows[0].ArgsId.ShouldBe("1-2");
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithCommentAndBlankLines_ShouldSkipThem()
+    {
+        // Act
+        ParsedExport result = await ParseAsync("# a comment\n\n620756992||1001||Text||NULL||NULL||1\n   \n");
+
+        // Assert
+        result.HasErrors.ShouldBeFalse();
+        result.Rows.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithTruncatedFixture_ShouldReportEveryUnparseableLine()
+    {
+        // Act
+        ParsedExport result = await ParseFixtureAsync("exported-truncated.txt");
+
+        // Assert — one good line, two failures (too few fields, non-numeric file id).
+        result.HasErrors.ShouldBeTrue();
+        result.Rows.Count.ShouldBe(1);
+        result.Errors.Count.ShouldBe(2);
+        result.Errors[0].LineNumber.ShouldBe(2);
+        result.Errors[1].LineNumber.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithTooFewFields_ShouldReportError()
+    {
+        // Act
+        ParsedExport result = await ParseAsync("620756992||1001||only three fields");
+
+        // Assert
+        result.HasErrors.ShouldBeTrue();
+        result.Rows.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithNonNumericGossipId_ShouldReportError()
+    {
+        // Act
+        ParsedExport result = await ParseAsync("620756992||notanumber||Text||NULL||NULL||1");
+
+        // Assert
+        result.HasErrors.ShouldBeTrue();
+        result.Rows.ShouldBeEmpty();
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/FragmentKeyTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/FragmentKeyTests.cs
@@ -1,0 +1,79 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates.TranslationAggregate;
+
+public sealed class FragmentKeyTests
+{
+    [Fact]
+    public void Create_WithValidValues_ShouldSucceed()
+    {
+        // Act
+        Result<FragmentKey> result = FragmentKey.Create(620756992, 1001);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.FileId.ShouldBe(620756992);
+        result.Value.GossipId.ShouldBe(1001);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_WithNonPositiveFileId_ShouldReturnInvalidFileId(int fileId)
+    {
+        // Act
+        Result<FragmentKey> result = FragmentKey.Create(fileId, 1001);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.TranslationEntity.FragmentKeyProperty.InvalidFileId);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Create_WithNegativeGossipId_ShouldReturnInvalidGossipId(long gossipId)
+    {
+        // Act
+        Result<FragmentKey> result = FragmentKey.Create(620756992, gossipId);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.TranslationEntity.FragmentKeyProperty.InvalidGossipId);
+    }
+
+    [Fact]
+    public void Create_WithZeroGossipId_ShouldSucceed()
+    {
+        // Act — the patcher applies no lower bound; a zero id must not fail the import.
+        Result<FragmentKey> result = FragmentKey.Create(620756992, 0);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_WithSameValues_ShouldBeEqual()
+    {
+        // Arrange
+        FragmentKey first = FragmentKey.Create(620756992, 1001).Value;
+        FragmentKey second = FragmentKey.Create(620756992, 1001).Value;
+
+        // Assert
+        first.ShouldBe(second);
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_WithDifferentValues_ShouldNotBeEqual()
+    {
+        // Arrange
+        FragmentKey first = FragmentKey.Create(620756992, 1001).Value;
+        FragmentKey second = FragmentKey.Create(620756992, 1002).Value;
+
+        // Assert
+        first.ShouldNotBe(second);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationDiffServiceTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationDiffServiceTests.cs
@@ -1,0 +1,212 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Services;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates.TranslationAggregate;
+
+public sealed class TranslationDiffServiceTests
+{
+    private static readonly DateTimeOffset StoredAt = new(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset ImportAt = new(2026, 6, 13, 12, 0, 0, TimeSpan.Zero);
+    private static readonly GameVersionId IntroducedVersion = GameVersionId.Create();
+    private static readonly GameVersionId TargetVersion = GameVersionId.Create();
+
+    private static Translation Existing(int fileId, long gossipId, string text, string? argsOrder = null)
+        => Translation.CreateUntranslated(
+            FragmentKey.Create(fileId, gossipId).Value,
+            TranslationSource.Create(text, argsOrder, argsOrder).Value,
+            IntroducedVersion,
+            StoredAt).Value;
+
+    private static IncomingTranslation Incoming(int fileId, long gossipId, string text, string? argsOrder = null)
+        => new(
+            FragmentKey.Create(fileId, gossipId).Value,
+            TranslationSource.Create(text, argsOrder, argsOrder).Value);
+
+    [Fact]
+    public void ComputePlan_OnEmptyStore_ShouldAddEveryRow()
+    {
+        // Arrange
+        IncomingTranslation[] incoming = [Incoming(1, 1, "A"), Incoming(1, 2, "B")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan([], incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.Added.Count.ShouldBe(2);
+        plan.SourceChanges.ShouldBeEmpty();
+        plan.Removed.ShouldBeEmpty();
+        plan.UnchangedCount.ShouldBe(0);
+        plan.RemovedFraction.ShouldBe(0d);
+        plan.Added.ShouldAllBe(translation => translation.IntroducedInVersion == TargetVersion);
+    }
+
+    [Fact]
+    public void ComputePlan_WithNewKey_ShouldAdd()
+    {
+        // Arrange
+        Translation[] existing = [Existing(1, 1, "A")];
+        IncomingTranslation[] incoming = [Incoming(1, 1, "A"), Incoming(1, 2, "B")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.Added.Count.ShouldBe(1);
+        plan.Added[0].FragmentKey.GossipId.ShouldBe(2);
+        plan.UnchangedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ComputePlan_WithIdenticalSource_ShouldBeUnchanged()
+    {
+        // Arrange
+        Translation[] existing = [Existing(1, 1, "A")];
+        IncomingTranslation[] incoming = [Incoming(1, 1, "A")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.UnchangedCount.ShouldBe(1);
+        plan.Added.ShouldBeEmpty();
+        plan.SourceChanges.ShouldBeEmpty();
+        plan.Removed.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ComputePlan_WithChangedSourceAndNoPolish_ShouldChangeSourceWithoutInvalidating()
+    {
+        // Arrange
+        Translation[] existing = [Existing(1, 1, "Old")];
+        IncomingTranslation[] incoming = [Incoming(1, 1, "New")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.SourceChanges.Count.ShouldBe(1);
+        plan.SourceChanges[0].NewSource.Text.ShouldBe("New");
+        plan.InvalidatedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ComputePlan_WithChangedSourceAndPolish_ShouldChangeAndInvalidate()
+    {
+        // Arrange
+        Translation withPolish = Existing(1, 1, "Old");
+        withPolish.ProvideTranslation("Polski", StoredAt);
+        IncomingTranslation[] incoming = [Incoming(1, 1, "New")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan([withPolish], incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.SourceChanges.Count.ShouldBe(1);
+        plan.InvalidatedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ComputePlan_WithChangedArgsOnly_ShouldBeSourceChange()
+    {
+        // Arrange — identical text, different argument structure is still a source change.
+        Translation[] existing = [Existing(1, 1, "Text", argsOrder: "1-2")];
+        IncomingTranslation[] incoming = [Incoming(1, 1, "Text", argsOrder: "2-1")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.SourceChanges.Count.ShouldBe(1);
+        plan.UnchangedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ComputePlan_WithExistingAbsentFromUpload_ShouldRemove()
+    {
+        // Arrange
+        Translation[] existing = [Existing(1, 1, "A"), Existing(1, 2, "B")];
+        IncomingTranslation[] incoming = [Incoming(1, 1, "A")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.Removed.Count.ShouldBe(1);
+        plan.Removed[0].FragmentKey.GossipId.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ComputePlan_WithAlreadyRemovedAbsentFromUpload_ShouldNotRemoveAgain()
+    {
+        // Arrange
+        Translation alreadyRemoved = Existing(1, 2, "B");
+        alreadyRemoved.MarkRemoved(IntroducedVersion, StoredAt);
+        Translation[] existing = [Existing(1, 1, "A"), alreadyRemoved];
+        IncomingTranslation[] incoming = [Incoming(1, 1, "A")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.Removed.ShouldBeEmpty();
+        plan.ComparableExistingCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ComputePlan_WhenRemovedKeyReappearsWithIdenticalSource_ShouldRestore()
+    {
+        // Arrange
+        Translation removed = Existing(1, 1, "A");
+        removed.MarkRemoved(IntroducedVersion, StoredAt);
+        IncomingTranslation[] incoming = [Incoming(1, 1, "A")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan([removed], incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.Restored.Count.ShouldBe(1);
+        plan.SourceChanges.ShouldBeEmpty();
+        plan.UnchangedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ComputePlan_WhenRemovedKeyReappearsWithChangedSource_ShouldBeSourceChange()
+    {
+        // Arrange
+        Translation removed = Existing(1, 1, "Old");
+        removed.MarkRemoved(IntroducedVersion, StoredAt);
+        IncomingTranslation[] incoming = [Incoming(1, 1, "New")];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan([removed], incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.SourceChanges.Count.ShouldBe(1);
+        plan.Restored.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ComputePlan_RemovedFraction_ShouldBeComputedFromActiveRows()
+    {
+        // Arrange — five active rows, the upload keeps four and drops one.
+        Translation[] existing =
+        [
+            Existing(1, 1, "A"), Existing(1, 2, "B"), Existing(1, 3, "C"), Existing(1, 4, "D"), Existing(1, 5, "E")
+        ];
+        IncomingTranslation[] incoming =
+        [
+            Incoming(1, 1, "A"), Incoming(1, 2, "B"), Incoming(1, 3, "C"), Incoming(1, 4, "D")
+        ];
+
+        // Act
+        TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
+
+        // Assert
+        plan.Removed.Count.ShouldBe(1);
+        plan.ComparableExistingCount.ShouldBe(5);
+        plan.RemovedFraction.ShouldBe(0.2d);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationSourceTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationSourceTests.cs
@@ -1,0 +1,83 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates.TranslationAggregate;
+
+public sealed class TranslationSourceTests
+{
+    [Fact]
+    public void Create_WithTextAndArgs_ShouldSucceed()
+    {
+        // Act
+        Result<TranslationSource> result = TranslationSource.Create("Welcome to <--DO_NOT_TOUCH!--> Middle-earth", "1", "1");
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Text.ShouldBe("Welcome to <--DO_NOT_TOUCH!--> Middle-earth");
+        result.Value.ArgsOrder.ShouldBe("1");
+        result.Value.ArgsId.ShouldBe("1");
+    }
+
+    [Fact]
+    public void Create_WithNullText_ShouldReturnTextRequired()
+    {
+        // Act
+        Result<TranslationSource> result = TranslationSource.Create(null!, null, null);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.TranslationEntity.SourceProperty.TextRequired);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("NULL")]
+    [InlineData("null")]
+    public void Create_WithAbsentArgs_ShouldNormalizeToNull(string? argsValue)
+    {
+        // Act
+        Result<TranslationSource> result = TranslationSource.Create("Some text", argsValue, argsValue);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ArgsOrder.ShouldBeNull();
+        result.Value.ArgsId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Equals_WithSameTextAndArgs_ShouldBeEqual()
+    {
+        // Arrange
+        TranslationSource first = TranslationSource.Create("Text", "1-2", "1-2").Value;
+        TranslationSource second = TranslationSource.Create("Text", "1-2", "1-2").Value;
+
+        // Assert
+        first.ShouldBe(second);
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_WithSameTextButDifferentArgs_ShouldNotBeEqual()
+    {
+        // Arrange — args are part of the source: a placeholder-structure change is a source change.
+        TranslationSource first = TranslationSource.Create("Text", "1-2", "1-2").Value;
+        TranslationSource second = TranslationSource.Create("Text", "2-1", "1-2").Value;
+
+        // Assert
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void Equals_WithNullArgsBothSides_ShouldBeEqual()
+    {
+        // Arrange
+        TranslationSource first = TranslationSource.Create("Text", null, null).Value;
+        TranslationSource second = TranslationSource.Create("Text", "NULL", "NULL").Value;
+
+        // Assert — NULL and absent collapse to the same value.
+        first.ShouldBe(second);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
@@ -1,0 +1,136 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates.TranslationAggregate;
+
+public sealed class TranslationTests
+{
+    private static readonly DateTimeOffset Created = new(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Changed = new(2026, 6, 13, 12, 0, 0, TimeSpan.Zero);
+    private static readonly GameVersionId IntroducedVersion = GameVersionId.Create();
+    private static readonly GameVersionId ChangeVersion = GameVersionId.Create();
+
+    private static FragmentKey Key() => FragmentKey.Create(620756992, 1001).Value;
+    private static TranslationSource Source(string text) => TranslationSource.Create(text, null, null).Value;
+
+    private static Translation CreateUntranslated()
+        => Translation.CreateUntranslated(Key(), Source("Old English"), IntroducedVersion, Created).Value;
+
+    [Fact]
+    public void CreateUntranslated_WithValidInputs_ShouldStartUntranslated()
+    {
+        // Act
+        Result<Translation> result = Translation.CreateUntranslated(Key(), Source("Hello"), IntroducedVersion, Created);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        Translation translation = result.Value;
+        translation.Status.ShouldBe(TranslationStatus.Untranslated);
+        translation.TranslatedText.ShouldBeNull();
+        translation.IntroducedInVersion.ShouldBe(IntroducedVersion);
+        translation.IsRemoved.ShouldBeFalse();
+        translation.CreatedAt.ShouldBe(Created);
+        translation.UpdatedAt.ShouldBe(Created);
+    }
+
+    [Fact]
+    public void ApplySourceChange_WhenUntranslated_ShouldUpdateSourceWithoutInvalidating()
+    {
+        // Arrange
+        Translation translation = CreateUntranslated();
+
+        // Act
+        translation.ApplySourceChange(Source("New English"), ChangeVersion, Changed);
+
+        // Assert
+        translation.Source.Text.ShouldBe("New English");
+        translation.Status.ShouldBe(TranslationStatus.Untranslated);
+        translation.PreviousSourceText.ShouldBeNull();
+        translation.LastSourceChangeInVersion.ShouldBe(ChangeVersion);
+        translation.UpdatedAt.ShouldBe(Changed);
+    }
+
+    [Fact]
+    public void ApplySourceChange_WhenPolishExists_ShouldInvalidateAndKeepPreviousSource()
+    {
+        // Arrange
+        Translation translation = CreateUntranslated();
+        translation.ProvideTranslation("Stary polski", Created);
+
+        // Act
+        translation.ApplySourceChange(Source("New English"), ChangeVersion, Changed);
+
+        // Assert
+        translation.Status.ShouldBe(TranslationStatus.NeedsReview);
+        translation.PreviousSourceText.ShouldBe("Old English");
+        translation.Source.Text.ShouldBe("New English");
+        translation.TranslatedText.ShouldBe("Stary polski");
+        translation.LastSourceChangeInVersion.ShouldBe(ChangeVersion);
+    }
+
+    [Fact]
+    public void MarkRemoved_ShouldSoftMarkWithVersion()
+    {
+        // Arrange
+        Translation translation = CreateUntranslated();
+
+        // Act
+        translation.MarkRemoved(ChangeVersion, Changed);
+
+        // Assert
+        translation.IsRemoved.ShouldBeTrue();
+        translation.RemovedInVersion.ShouldBe(ChangeVersion);
+        translation.UpdatedAt.ShouldBe(Changed);
+    }
+
+    [Fact]
+    public void Restore_ShouldClearRemovalAndKeepStatus()
+    {
+        // Arrange
+        Translation translation = CreateUntranslated();
+        translation.ProvideTranslation("Polski", Created);
+        translation.MarkRemoved(ChangeVersion, Changed);
+
+        // Act
+        translation.Restore(Changed);
+
+        // Assert
+        translation.IsRemoved.ShouldBeFalse();
+        translation.RemovedInVersion.ShouldBeNull();
+        translation.Status.ShouldBe(TranslationStatus.Draft);
+        translation.TranslatedText.ShouldBe("Polski");
+    }
+
+    [Fact]
+    public void ApplySourceChange_WhenRemoved_ShouldClearRemoval()
+    {
+        // Arrange — a re-added pair whose source differs lands here (spec 0001).
+        Translation translation = CreateUntranslated();
+        translation.MarkRemoved(ChangeVersion, Changed);
+
+        // Act
+        translation.ApplySourceChange(Source("Reworded"), ChangeVersion, Changed);
+
+        // Assert
+        translation.IsRemoved.ShouldBeFalse();
+        translation.Source.Text.ShouldBe("Reworded");
+    }
+
+    [Fact]
+    public void ProvideTranslation_ShouldAttachDraft()
+    {
+        // Arrange
+        Translation translation = CreateUntranslated();
+
+        // Act
+        translation.ProvideTranslation("Witaj", Changed);
+
+        // Assert
+        translation.Status.ShouldBe(TranslationStatus.Draft);
+        translation.TranslatedText.ShouldBe("Witaj");
+        translation.UpdatedAt.ShouldBe(Changed);
+    }
+}


### PR DESCRIPTION
Closes #97

First core-loop slice (spec 0001): the keystone **Translation** aggregate plus a version-bound import that parses an uploaded `exported.txt`, diffs it against the stored source state by `(FileId, GossipId)`, and applies the five outcomes (added / source-changed→invalidate / removed / re-added / unchanged) in a single transaction.

## Highlights
- `POST /api/v1/game-versions/{id}/import` (multipart, **admin-only**), single `SaveChanges` = all-or-nothing; `IsProcessed` flips only on commit; idempotent re-upload.
- TMS-side `||` parser (both-ends anchoring) with **dual truncation guards**: reject on any parse error; reject removed-fraction > 20% without an explicit override.
- Day-1 CQRS read/write split (Translation read model + EF config), de-mediatorized slice, FluentValidation on the command.

## Review pass (code-review + security-review)
- **Security: clean** — admin policy intact, no SQLi/path-traversal/injection surface, no data exposure.
- **Code review** drove a follow-up commit:
  - **Parser drift guard** (the previously-unmet acceptance criterion): a parity test asserts the patcher's and the TMS' parsers agree field-for-field on the same contract lines.
  - **Strict UTF-8 decoding** so a wrong-charset/corrupt upload is rejected, not silently mis-decoded past the truncation guard.
  - Empty/comments-only upload rejected; atomicity now proven by integration tests (`IsProcessed` set only on commit, cleared on a rejected import; unchanged rows keep their timestamp).
  - Declined the optimistic-concurrency token as YAGNI (import is admin-only and serial), documented inline.

## Tests
Build: 0 warnings. Green: 58 domain unit + 28 API unit (incl. 7-case cross-parser parity) + 17 integration (real PostgreSQL). Frozen patcher suite (223) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)