### PR TITLE
M2-09: Slice — list translations (search/filter/paginate)

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -16,9 +16,12 @@ using LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
 using LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
 using LotroKoniecDev.TranslationSystem.API.Extensions;
 using LotroKoniecDev.TranslationSystem.API.Features.Import;
+using LotroKoniecDev.TranslationSystem.API.Features.Translations;
 using LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
 using LotroKoniecDev.TranslationSystem.Contracts.Import;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 
 namespace LotroKoniecDev.TranslationSystem.API;
 
@@ -48,6 +51,7 @@ internal static class ApiDependencyInjection
             services.AddHateoasInfrastructure();
 
             services.AddImportFeature();
+            services.AddTranslationsFeature();
 
             return services;
         }
@@ -60,6 +64,13 @@ internal static class ApiDependencyInjection
 
             services.AddScoped<IValidator<ImportExportedTexts.Command>, ImportExportedTexts.Validator>();
             services.AddScoped<ICommandHandler<ImportExportedTexts.Command, Result<ImportSummary>>, ImportExportedTexts.Handler>();
+        }
+
+        private void AddTranslationsFeature()
+        {
+            services.AddScoped<
+                IQueryHandler<ListTranslations.Query, Result<PaginationResponse<TranslationListItemResponse>>>,
+                ListTranslations.Handler>();
         }
 
         public IServiceCollection AddJwtBearerAuthentication(IWebHostEnvironment environment)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
@@ -1,0 +1,128 @@
+using System.Globalization;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
+
+/// <summary>
+/// Lists translations for the editor (spec 0001): paginated, optionally text-searched and
+/// status-filtered, sorted deterministically by <c>(FileId, GossipId)</c>. Soft-removed rows are
+/// excluded; <c>status=NeedsReview</c> is the "needs re-translation" view (rows a game update
+/// invalidated). Reads the POCO read model — never the write aggregate (CQRS, ADR-0002 amendment).
+/// </summary>
+internal sealed class ListTranslations : IEndpoint
+{
+    /// <summary>The only language the catalog holds today; multi-language is post-MVP.</summary>
+    private const string SupportedLanguage = "pl";
+
+    internal sealed record Query(string? Lang, string? Search, TranslationStatus? Status, int Page = 1, int PageSize = 50)
+        : IQuery<Result<PaginationResponse<TranslationListItemResponse>>>
+    {
+        public int Page { get; } = Math.Max(Page, 1);
+        public int PageSize { get; } = Math.Clamp(PageSize, 1, 100);
+    }
+
+    internal sealed class Handler : IQueryHandler<Query, Result<PaginationResponse<TranslationListItemResponse>>>
+    {
+        private readonly IApplicationReadDbContext _readDbContext;
+
+        public Handler(IApplicationReadDbContext readDbContext)
+        {
+            _readDbContext = readDbContext;
+        }
+
+        public async ValueTask<Result<PaginationResponse<TranslationListItemResponse>>> Handle(
+            Query query,
+            CancellationToken cancellationToken)
+        {
+            // Queries validate inline (house rule — FluentValidation is for commands only).
+            if (!string.IsNullOrWhiteSpace(query.Lang)
+                && !string.Equals(query.Lang, SupportedLanguage, StringComparison.OrdinalIgnoreCase))
+            {
+                return Result.Failure<PaginationResponse<TranslationListItemResponse>>(new Error(
+                    "Translations.UnsupportedLanguage",
+                    $"Language '{query.Lang}' is not supported; only '{SupportedLanguage}' exists today.",
+                    TypeOfError.Validation));
+            }
+
+            IQueryable<TranslationReadModel> filtered = _readDbContext.Translations
+                .Where(translation => translation.RemovedInVersion == null);
+
+            if (query.Status is { } status)
+            {
+                filtered = filtered.Where(translation => translation.Status == status);
+            }
+
+            if (!string.IsNullOrWhiteSpace(query.Search))
+            {
+                string term = query.Search.Trim().ToLower(CultureInfo.InvariantCulture);
+                filtered = filtered.Where(translation =>
+                    translation.SourceText.ToLower().Contains(term)
+                    || translation.TranslatedText != null && translation.TranslatedText.ToLower().Contains(term));
+            }
+
+            int totalCount = await filtered.CountAsync(cancellationToken);
+
+            List<TranslationListItemResponse> items = await filtered
+                .OrderBy(translation => translation.FileId)
+                .ThenBy(translation => translation.GossipId)
+                .Skip((query.Page - 1) * query.PageSize)
+                .Take(query.PageSize)
+                .Select(translation => new TranslationListItemResponse(
+                    translation.Id,
+                    translation.FileId,
+                    translation.GossipId,
+                    translation.SourceText,
+                    translation.TranslatedText,
+                    translation.Status,
+                    translation.UpdatedAt))
+                .ToListAsync(cancellationToken);
+
+            return Result.Success(new PaginationResponse<TranslationListItemResponse>
+            {
+                Items = items,
+                Page = query.Page,
+                PageSize = query.PageSize,
+                TotalCount = totalCount
+            });
+        }
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapGet("/api/v1/translations", async (
+                IQueryHandler<Query, Result<PaginationResponse<TranslationListItemResponse>>> handler,
+                CancellationToken cancellationToken,
+                [FromQuery] string? lang = null,
+                [FromQuery] string? search = null,
+                [FromQuery] TranslationStatus? status = null,
+                [FromQuery] int page = 1,
+                [FromQuery] int pageSize = 50) =>
+            {
+                Query query = new(lang, search, status, page, pageSize);
+
+                Result<PaginationResponse<TranslationListItemResponse>> result = await handler.Handle(query, cancellationToken);
+
+                return result.IsSuccess
+                    ? Results.Ok(result.Value)
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(ListTranslations))
+            .WithTags("Translations")
+            .RequireAuthorization(AuthorizationPolicies.RequireTranslatorRole)
+            .Produces<PaginationResponse<TranslationListItemResponse>>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
 using LotroKoniecDev.SharedKernel.Enums;
 using LotroKoniecDev.SharedKernel.Messaging;
@@ -17,10 +16,11 @@ using Microsoft.EntityFrameworkCore;
 namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
 
 /// <summary>
-/// Lists translations for the editor (spec 0001): paginated, optionally text-searched and
-/// status-filtered, sorted deterministically by <c>(FileId, GossipId)</c>. Soft-removed rows are
-/// excluded; <c>status=NeedsReview</c> is the "needs re-translation" view (rows a game update
-/// invalidated). Reads the POCO read model — never the write aggregate (CQRS, ADR-0002 amendment).
+/// Lists translations for the editor (spec 0001): paginated, optionally text-searched (English
+/// source or Polish translation) and status-filtered, sorted deterministically by
+/// <c>(FileId, GossipId)</c>. Soft-removed rows are excluded; <c>status=NeedsReview</c> is the
+/// "needs re-translation" view (rows a game update invalidated). Reads the POCO read model — never
+/// the write aggregate (CQRS, ADR-0002 amendment).
 /// </summary>
 internal sealed class ListTranslations : IEndpoint
 {
@@ -67,10 +67,13 @@ internal sealed class ListTranslations : IEndpoint
 
             if (!string.IsNullOrWhiteSpace(query.Search))
             {
-                string term = query.Search.Trim().ToLower(CultureInfo.InvariantCulture);
+                // ILIKE is case-insensitive; escape LIKE metacharacters so a literal % or _ in the
+                // term (LOTRO source carries both) matches literally instead of as a wildcard.
+                string pattern = $"%{EscapeLike(query.Search.Trim())}%";
                 filtered = filtered.Where(translation =>
-                    translation.SourceText.ToLower().Contains(term)
-                    || translation.TranslatedText != null && translation.TranslatedText.ToLower().Contains(term));
+                    EF.Functions.ILike(translation.SourceText, pattern, LikeEscapeCharacter)
+                    || translation.TranslatedText != null
+                       && EF.Functions.ILike(translation.TranslatedText, pattern, LikeEscapeCharacter));
             }
 
             int totalCount = await filtered.CountAsync(cancellationToken);
@@ -98,6 +101,15 @@ internal sealed class ListTranslations : IEndpoint
                 TotalCount = totalCount
             });
         }
+
+        private const string LikeEscapeCharacter = "\\";
+
+        /// <summary>Escapes the LIKE/ILIKE metacharacters so the search term matches literally.</summary>
+        private static string EscapeLike(string term)
+            => term
+                .Replace("\\", "\\\\")
+                .Replace("%", "\\%")
+                .Replace("_", "\\_");
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/TranslationListItemResponse.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/TranslationListItemResponse.cs
@@ -1,0 +1,18 @@
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+/// <summary>
+/// One row of the paginated translation list: the English source, the current Polish (if any) and
+/// the workflow status, keyed by the <c>(FileId, GossipId)</c> fragment. Full per-row context
+/// (args, superseded source) belongs to the get-one detail endpoint.
+/// </summary>
+public sealed record TranslationListItemResponse(
+    TranslationId Id,
+    int FileId,
+    long GossipId,
+    string SourceText,
+    string? TranslatedText,
+    TranslationStatus Status,
+    DateTimeOffset UpdatedAt);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
+
+[Collection("TranslationApi")]
+public sealed class ListTranslationsTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+
+    public ListTranslationsTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\" CASCADE;");
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+        _versionId = gameVersion.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task List_ShouldReturnRowsSortedByFileIdThenGossipId()
+    {
+        // Arrange — seeded out of order, across two file ids.
+        await SeedAsync(Row(1, "B", fileId: 200), Row(2, "A", fileId: 100), Row(1, "C", fileId: 100));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> page = await ListAsync("?page=1&pageSize=10");
+
+        // Assert
+        page.TotalCount.ShouldBe(3);
+        page.Items.Select(item => (item.FileId, item.GossipId))
+            .ShouldBe([(100, 1L), (100, 2L), (200, 1L)]);
+    }
+
+    [Fact]
+    public async Task List_ShouldPaginate()
+    {
+        // Arrange — five rows, two per page.
+        await SeedAsync(Row(1, "a"), Row(2, "b"), Row(3, "c"), Row(4, "d"), Row(5, "e"));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> firstPage = await ListAsync("?page=1&pageSize=2");
+        PaginationResponse<TranslationListItemResponse> lastPage = await ListAsync("?page=3&pageSize=2");
+
+        // Assert
+        firstPage.TotalCount.ShouldBe(5);
+        firstPage.Items.Count.ShouldBe(2);
+        firstPage.HasNextPage.ShouldBeTrue();
+        firstPage.HasPreviousPage.ShouldBeFalse();
+
+        lastPage.Items.Count.ShouldBe(1);
+        lastPage.Items.Single().GossipId.ShouldBe(5);
+        lastPage.HasNextPage.ShouldBeFalse();
+        lastPage.HasPreviousPage.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task List_WithSearch_ShouldMatchContentCaseInsensitively()
+    {
+        // Arrange
+        await SeedAsync(Row(1, "Frodo Baggins"), Row(2, "Samwise Gamgee"));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> page = await ListAsync("?search=FRODO");
+
+        // Assert
+        page.Items.Single().GossipId.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task List_WithStatusNeedsReview_ShouldReturnOnlyInvalidatedRows()
+    {
+        // Arrange — one of each status; NeedsReview is the "needs re-translation" view.
+        await SeedAsync(
+            Row(1, "untranslated"),
+            Row(2, "drafted", TranslationStatus.Draft),
+            Row(3, "invalidated", TranslationStatus.NeedsReview));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> page = await ListAsync("?status=NeedsReview");
+
+        // Assert
+        TranslationListItemResponse item = page.Items.ShouldHaveSingleItem();
+        item.GossipId.ShouldBe(3);
+        item.Status.ShouldBe(TranslationStatus.NeedsReview);
+    }
+
+    [Fact]
+    public async Task List_ShouldHideSoftRemovedRowsByDefault()
+    {
+        // Arrange
+        await SeedAsync(Row(1, "kept"), Row(2, "removed", removed: true));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> page = await ListAsync("?page=1&pageSize=10");
+
+        // Assert
+        page.TotalCount.ShouldBe(1);
+        page.Items.Single().GossipId.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task List_WithUnsupportedLanguage_ShouldReturn400()
+    {
+        // Act
+        HttpResponseMessage response = await TranslatorClient().GetAsync("/api/v1/translations?lang=de");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task List_WithoutToken_ShouldReturn401()
+    {
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync("/api/v1/translations");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<PaginationResponse<TranslationListItemResponse>> ListAsync(string queryString)
+    {
+        HttpResponseMessage response = await TranslatorClient().GetAsync($"/api/v1/translations{queryString}");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        return (await response.Content.ReadFromJsonAsync<PaginationResponse<TranslationListItemResponse>>(JsonOptions))!;
+    }
+
+    private HttpClient TranslatorClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+        return client;
+    }
+
+    private async Task SeedAsync(params Translation[] rows)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        dbContext.Translations.AddRange(rows);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private Translation Row(
+        int gossipId,
+        string source,
+        TranslationStatus status = TranslationStatus.Untranslated,
+        bool removed = false,
+        int fileId = FileId)
+    {
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(fileId, gossipId).Value,
+            TranslationSource.Create(source, null, null).Value,
+            _versionId,
+            Now).Value;
+
+        switch (status)
+        {
+            case TranslationStatus.Draft:
+                row.ProvideTranslation("Polski tekst", Now);
+                break;
+            case TranslationStatus.NeedsReview:
+                row.ProvideTranslation("Polski tekst", Now);
+                row.ApplySourceChange(TranslationSource.Create($"{source} (reworded)", null, null).Value, _versionId, Now);
+                break;
+        }
+
+        if (removed)
+        {
+            row.MarkRemoved(_versionId, Now);
+        }
+
+        return row;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
@@ -1,6 +1,4 @@
-using System.Net;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.Authorization;
@@ -87,6 +85,20 @@ public sealed class ListTranslationsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task List_WithPageBeyondRange_ShouldReturnEmptyWithAccurateTotal()
+    {
+        // Arrange
+        await SeedAsync(Row(1, "a"), Row(2, "b"), Row(3, "c"));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> page = await ListAsync("?page=99&pageSize=2");
+
+        // Assert
+        page.Items.ShouldBeEmpty();
+        page.TotalCount.ShouldBe(3);
+    }
+
+    [Fact]
     public async Task List_WithSearch_ShouldMatchContentCaseInsensitively()
     {
         // Arrange
@@ -94,6 +106,32 @@ public sealed class ListTranslationsTests : IAsyncLifetime
 
         // Act
         PaginationResponse<TranslationListItemResponse> page = await ListAsync("?search=FRODO");
+
+        // Assert
+        page.Items.Single().GossipId.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task List_WithSearch_ShouldAlsoMatchTheTranslatedText()
+    {
+        // Arrange — only the drafted row carries Polish ("Polski tekst").
+        await SeedAsync(Row(1, "Aragorn"), Row(2, "Boromir", TranslationStatus.Draft));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> page = await ListAsync("?search=tekst");
+
+        // Assert
+        page.Items.Single().GossipId.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task List_WithLikeMetacharacterInSearch_ShouldMatchItLiterally()
+    {
+        // Arrange — '%' must be a literal, not a LIKE wildcard, or "100%" would also match "1000".
+        await SeedAsync(Row(1, "Reward 100% bonus"), Row(2, "Reward 1000 bonus"));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> page = await ListAsync("?search=100%25");
 
         // Assert
         page.Items.Single().GossipId.ShouldBe(1);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/ListTranslationsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/ListTranslationsHandlerTests.cs
@@ -1,0 +1,47 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Features.Translations;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Translations;
+
+public sealed class ListTranslationsHandlerTests
+{
+    // The read DbContext is the only boundary; on the branches tested here it is never queried,
+    // so a bare substitute suffices. Filter/search/sort behavior is data-dependent and lives in
+    // the integration suite (real PostgreSQL).
+    private readonly IApplicationReadDbContext _readDbContext = Substitute.For<IApplicationReadDbContext>();
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(-5, 1)]
+    [InlineData(1, 1)]
+    [InlineData(7, 7)]
+    public void Query_Page_IsClampedToAtLeastOne(int input, int expected)
+        => new ListTranslations.Query(null, null, null, Page: input).Page.ShouldBe(expected);
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(-1, 1)]
+    [InlineData(101, 100)]
+    [InlineData(50, 50)]
+    public void Query_PageSize_IsClampedBetweenOneAndHundred(int input, int expected)
+        => new ListTranslations.Query(null, null, null, PageSize: input).PageSize.ShouldBe(expected);
+
+    [Fact]
+    public async Task Handle_WhenLanguageUnsupported_ShouldReturnValidationError()
+    {
+        // Arrange
+        ListTranslations.Handler handler = new(_readDbContext);
+
+        // Act
+        Result<PaginationResponse<TranslationListItemResponse>> result =
+            await handler.Handle(new ListTranslations.Query("de", null, null), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translations.UnsupportedLanguage");
+    }
+}


### PR DESCRIPTION
Closes #98

First TMS **query** slice (spec 0001) — establishes the read-side pattern: an `IQueryHandler` reading the POCO `TranslationReadModel` via `IApplicationReadDbContext` (CQRS — never the write aggregate), de-mediatorized, closed handler interface registered in DI.

## Endpoint
`GET /api/v1/translations?lang=&search=&status=&page=&pageSize=` — `RequireTranslatorRole`.
- Pagination (page/pageSize clamped 1 / 1–100 in the `Query` record).
- Case-insensitive `ILIKE` search over **SourceText + TranslatedText**, with LIKE-metacharacter escaping (a literal `%`/`_` matches literally — LOTRO source carries both).
- Optional status filter incl. `status=NeedsReview` (the "needs re-translation" view a game update produces).
- Soft-removed rows hidden; deterministic `(FileId, GossipId)` sort (backed by the unique composite index).
- `lang` validated inline (Polish-only today; queries validate in the handler, not FluentValidation).
- Reuses the lifted `PaginationResponse<T>` contract; new `TranslationListItemResponse` DTO.

## Review
code-reviewer: **APPROVE-WITH-NITS** (architecture/style fully compliant). Addressed in a follow-up commit: switched search to `ILIKE` + wildcard escaping (the one substantive finding), pinned literal-`%`, the TranslatedText branch, and beyond-range pagination with tests.

## Tests
Build 0 warnings. Green: 37 API unit (clamping + unsupported-language) + 24 integration on real PostgreSQL (10 for this slice: sort, pagination, beyond-range, search incl. literal-`%` + TranslatedText branch, `status=NeedsReview`, removed-hidden, 400 bad lang, 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)