### PR TITLE
M2-10: Slice — get one translation

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -71,6 +71,9 @@ internal static class ApiDependencyInjection
             services.AddScoped<
                 IQueryHandler<ListTranslations.Query, Result<PaginationResponse<TranslationListItemResponse>>>,
                 ListTranslations.Handler>();
+            services.AddScoped<
+                IQueryHandler<GetTranslation.Query, Result<TranslationDetailResponse>>,
+                GetTranslation.Handler>();
         }
 
         public IServiceCollection AddJwtBearerAuthentication(IWebHostEnvironment environment)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslation.cs
@@ -1,0 +1,80 @@
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using Microsoft.EntityFrameworkCore;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
+
+/// <summary>
+/// Returns one translation in full by id (spec 0001), read from the POCO read model — never the
+/// write aggregate (CQRS, ADR-0002 amendment). An unknown (or all-zeros) id is a <c>NotFound</c>.
+/// </summary>
+internal sealed class GetTranslation : IEndpoint
+{
+    internal sealed record Query(TranslationId Id) : IQuery<Result<TranslationDetailResponse>>;
+
+    internal sealed class Handler : IQueryHandler<Query, Result<TranslationDetailResponse>>
+    {
+        private readonly IApplicationReadDbContext _readDbContext;
+
+        public Handler(IApplicationReadDbContext readDbContext)
+        {
+            _readDbContext = readDbContext;
+        }
+
+        public async ValueTask<Result<TranslationDetailResponse>> Handle(Query query, CancellationToken cancellationToken)
+        {
+            // An all-zeros id never identifies a row — short-circuit before touching the database.
+            if (query.Id == TranslationId.Empty)
+            {
+                return Result.Failure<TranslationDetailResponse>(DomainErrors.TranslationEntity.NotFound(query.Id));
+            }
+
+            TranslationDetailResponse? response = await _readDbContext.Translations
+                .Where(translation => translation.Id == query.Id)
+                .Select(translation => new TranslationDetailResponse(
+                    translation.Id,
+                    translation.FileId,
+                    translation.GossipId,
+                    translation.SourceText,
+                    translation.ArgsOrder,
+                    translation.ArgsId,
+                    translation.TranslatedText,
+                    translation.PreviousSourceText,
+                    translation.Status,
+                    translation.CreatedAt,
+                    translation.UpdatedAt))
+                .FirstOrDefaultAsync(cancellationToken);
+
+            return response is null
+                ? Result.Failure<TranslationDetailResponse>(DomainErrors.TranslationEntity.NotFound(query.Id))
+                : Result.Success(response);
+        }
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapGet("/api/v1/translations/{id:guid}", async (
+                Guid id,
+                IQueryHandler<Query, Result<TranslationDetailResponse>> handler,
+                CancellationToken cancellationToken) =>
+            {
+                Result<TranslationDetailResponse> result = await handler.Handle(new Query(new TranslationId(id)), cancellationToken);
+
+                return result.IsSuccess
+                    ? Results.Ok(result.Value)
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(GetTranslation))
+            .WithTags("Translations")
+            .RequireAuthorization(AuthorizationPolicies.RequireTranslatorRole)
+            .Produces<TranslationDetailResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/TranslationDetailResponse.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/TranslationDetailResponse.cs
@@ -1,0 +1,22 @@
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+/// <summary>
+/// A single translation in full: the English source plus its argument columns (for placeholder
+/// validation), the current Polish, the superseded English kept for side-by-side review when a
+/// game update invalidated the row, and the workflow status. Backs the side-by-side editor.
+/// </summary>
+public sealed record TranslationDetailResponse(
+    TranslationId Id,
+    int FileId,
+    long GossipId,
+    string SourceText,
+    string? ArgsOrder,
+    string? ArgsId,
+    string? TranslatedText,
+    string? PreviousSourceText,
+    TranslationStatus Status,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationTests.cs
@@ -1,0 +1,154 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
+
+[Collection("TranslationApi")]
+public sealed class GetTranslationTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+
+    public GetTranslationTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\" CASCADE;");
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+        _versionId = gameVersion.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Get_WithExistingId_ShouldReturn200AndPayload()
+    {
+        // Arrange
+        TranslationId id = await SeedAsync(gossipId: 1001, source: "Witaj w Srodziemiu!");
+
+        // Act
+        HttpResponseMessage response = await TranslatorClient().GetAsync($"/api/v1/translations/{id.Value}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        TranslationDetailResponse? body = await response.Content.ReadFromJsonAsync<TranslationDetailResponse>(JsonOptions);
+        body.ShouldNotBeNull();
+        body.Id.ShouldBe(id);
+        body.FileId.ShouldBe(FileId);
+        body.GossipId.ShouldBe(1001);
+        body.SourceText.ShouldBe("Witaj w Srodziemiu!");
+        body.Status.ShouldBe(TranslationStatus.Untranslated);
+    }
+
+    [Fact]
+    public async Task Get_WithInvalidatedRow_ShouldExposePreviousSourceArgsAndTranslation()
+    {
+        // Arrange — a row that carried Polish, then a game update reworded its source: NeedsReview,
+        // with the args columns and the superseded English preserved for side-by-side review. These
+        // are the detail endpoint's reason to exist beyond the list item; distinct args values also
+        // pin the projection's column order (a swapped ArgsOrder/ArgsId would fail here).
+        TranslationId id = await SeedInvalidatedAsync();
+
+        // Act
+        HttpResponseMessage response = await TranslatorClient().GetAsync($"/api/v1/translations/{id.Value}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        TranslationDetailResponse? body = await response.Content.ReadFromJsonAsync<TranslationDetailResponse>(JsonOptions);
+        body.ShouldNotBeNull();
+        body.Status.ShouldBe(TranslationStatus.NeedsReview);
+        body.SourceText.ShouldBe("Reworded source");
+        body.PreviousSourceText.ShouldBe("Original source");
+        body.TranslatedText.ShouldBe("Polski tekst");
+        body.ArgsOrder.ShouldBe("1-2");
+        body.ArgsId.ShouldBe("3-4");
+    }
+
+    [Fact]
+    public async Task Get_WithUnknownId_ShouldReturn404()
+    {
+        // Act
+        HttpResponseMessage response = await TranslatorClient().GetAsync($"/api/v1/translations/{Guid.NewGuid()}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_WithoutToken_ShouldReturn401()
+    {
+        // Arrange
+        TranslationId id = await SeedAsync(gossipId: 1001, source: "Witaj");
+
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync($"/api/v1/translations/{id.Value}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private HttpClient TranslatorClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+        return client;
+    }
+
+    private async Task<TranslationId> SeedAsync(int gossipId, string source)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create(source, null, null).Value,
+            _versionId,
+            Now).Value;
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+        return row.Id;
+    }
+
+    private async Task<TranslationId> SeedInvalidatedAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, 2002).Value,
+            TranslationSource.Create("Original source", "1-2", "3-4").Value,
+            _versionId,
+            Now).Value;
+        row.ProvideTranslation("Polski tekst", Now);
+        row.ApplySourceChange(TranslationSource.Create("Reworded source", "1-2", "3-4").Value, _versionId, Now);
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+        return row.Id;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/GetTranslationHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/GetTranslationHandlerTests.cs
@@ -1,0 +1,26 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Features.Translations;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Translations;
+
+public sealed class GetTranslationHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenIdIsEmpty_ShouldReturnNotFound()
+    {
+        // Arrange — an all-zeros id is short-circuited before the read model is queried.
+        GetTranslation.Handler handler = new(Substitute.For<IApplicationReadDbContext>());
+
+        // Act
+        Result<TranslationDetailResponse> result =
+            await handler.Handle(new GetTranslation.Query(TranslationId.Empty), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("TranslationEntity.NotFound");
+    }
+}


### PR DESCRIPTION
Closes #99

Get-one query slice (spec 0001): `GET /api/v1/translations/{id}` (translator+), reading the POCO read model by id (CQRS — never the write aggregate), de-mediatorized, closed handler in DI.

- Returns the full `TranslationDetailResponse` — source, **args columns** (placeholder validation), current Polish, superseded **`PreviousSourceText`** (side-by-side review), status, timestamps.
- Unknown id → `NotFound` (404 via `Result`). An all-zeros id is short-circuited to NotFound before any query: the endpoint builds `new TranslationId(id)` (public ctor, no throw) and the handler guards `TranslationId.Empty` — so a pathological id is a clean 404, not a 400-via-thrown-exception (resolves the M2-08 exception-as-control-flow note) and gives the handler a pure unit-testable branch.

## Review
code-reviewer: **APPROVE-WITH-NITS** — projection translates, empty-id design sound, auth/CQRS correct. Acted on the one substantive nit (Medium): added an integration test asserting the detail-specific projections (`PreviousSourceText`, `ArgsOrder`/`ArgsId` with distinct values to pin column order, `TranslatedText`) via an invalidated `NeedsReview` row.

## Tests
Build 0 warnings. Green: API unit (empty-id NotFound, no read-model query) + 4 integration on real PostgreSQL (200 + payload, invalidated-row detail projections, 404 unknown, 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)