### PR TITLE
M2-13: Slice — translation-file distribution (pre-built artifact + ETag)

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -16,6 +16,7 @@ using LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
 using LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
 using LotroKoniecDev.TranslationSystem.API.Extensions;
 using LotroKoniecDev.TranslationSystem.API.Features.Import;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 using LotroKoniecDev.TranslationSystem.API.Features.Translations;
 using LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
@@ -52,6 +53,7 @@ internal static class ApiDependencyInjection
 
             services.AddImportFeature();
             services.AddTranslationsFeature();
+            services.AddTranslationFilesFeature();
 
             return services;
         }
@@ -74,6 +76,17 @@ internal static class ApiDependencyInjection
             services.AddScoped<
                 IQueryHandler<GetTranslation.Query, Result<TranslationDetailResponse>>,
                 GetTranslation.Handler>();
+        }
+
+        private void AddTranslationFilesFeature()
+        {
+            // Serializer + builder are stateless except the builder's single-flight gate, so both
+            // are singletons; the builder resolves scoped EF services through a fresh scope.
+            services.AddSingleton<ITranslationFileSerializer, TranslationFileSerializer>();
+            services.AddSingleton<ITranslationArtifactBuilder, TranslationArtifactBuilder>();
+            services.AddScoped<
+                IQueryHandler<GetTranslationFile.Query, Result<GetTranslationFile.TranslationFileResult>>,
+                GetTranslationFile.Handler>();
         }
 
         public IServiceCollection AddJwtBearerAuthentication(IWebHostEnvironment environment)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Common/SupportedLanguages.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Common/SupportedLanguages.cs
@@ -1,0 +1,10 @@
+namespace LotroKoniecDev.TranslationSystem.API.Common;
+
+/// <summary>
+/// The languages the catalog supports. Polish-only today; the single source of truth shared by the
+/// editor queries, the import rebuild trigger and the distribution endpoint so they can't drift.
+/// </summary>
+internal static class SupportedLanguages
+{
+    public const string Polish = "pl";
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
@@ -7,6 +7,7 @@ using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.API.Auth;
 using LotroKoniecDev.TranslationSystem.API.Common;
 using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
 using LotroKoniecDev.TranslationSystem.Contracts.Import;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
@@ -55,6 +56,7 @@ internal sealed class ImportExportedTexts : IEndpoint
         private readonly IUnitOfWork _unitOfWork;
         private readonly TimeProvider _timeProvider;
         private readonly ImportSettings _settings;
+        private readonly ITranslationArtifactBuilder _artifactBuilder;
 
         public Handler(
             IValidator<Command> validator,
@@ -63,7 +65,8 @@ internal sealed class ImportExportedTexts : IEndpoint
             ITranslationRepository translationRepository,
             IUnitOfWork unitOfWork,
             TimeProvider timeProvider,
-            IOptions<ImportSettings> settings)
+            IOptions<ImportSettings> settings,
+            ITranslationArtifactBuilder artifactBuilder)
         {
             _validator = validator;
             _parser = parser;
@@ -72,6 +75,7 @@ internal sealed class ImportExportedTexts : IEndpoint
             _unitOfWork = unitOfWork;
             _timeProvider = timeProvider;
             _settings = settings.Value;
+            _artifactBuilder = artifactBuilder;
         }
 
         public async ValueTask<Result<ImportSummary>> Handle(Command command, CancellationToken cancellationToken)
@@ -156,6 +160,11 @@ internal sealed class ImportExportedTexts : IEndpoint
             }
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            // Version processing changes the distributed set (removed rows drop out, re-added rows
+            // return), so regenerate the pre-built translation file after the import commits
+            // (spec 0001: regenerate on write — the download endpoint never builds per-request).
+            await _artifactBuilder.RebuildAsync(SupportedLanguages.Polish, cancellationToken);
 
             return Result.Success(BuildSummary(plan));
         }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/GetTranslationFile.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/GetTranslationFile.cs
@@ -1,0 +1,100 @@
+using System.Text;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Net.Http.Headers;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+
+/// <summary>
+/// Serves the pre-built translation file for a language (spec 0001): streams the stored artifact
+/// with its content hash as the <c>ETag</c> and honors <c>If-None-Match</c> with a 304. Anonymous
+/// (the CLI/player downloads it). Never builds per-request — the artifact is regenerated on write
+/// by <see cref="ITranslationArtifactBuilder"/>.
+/// </summary>
+internal sealed class GetTranslationFile : IEndpoint
+{
+    private const string SupportedLanguage = SupportedLanguages.Polish;
+
+    internal sealed record Query(string Lang) : IQuery<Result<TranslationFileResult>>;
+
+    internal sealed record TranslationFileResult(string Content, string ETag);
+
+    internal sealed class Handler : IQueryHandler<Query, Result<TranslationFileResult>>
+    {
+        private readonly IApplicationReadDbContext _readDbContext;
+
+        public Handler(IApplicationReadDbContext readDbContext)
+        {
+            _readDbContext = readDbContext;
+        }
+
+        public async ValueTask<Result<TranslationFileResult>> Handle(Query query, CancellationToken cancellationToken)
+        {
+            if (!string.Equals(query.Lang, SupportedLanguage, StringComparison.OrdinalIgnoreCase))
+            {
+                return Result.Failure<TranslationFileResult>(new Error(
+                    "TranslationFiles.UnsupportedLanguage",
+                    $"Language '{query.Lang}' is not supported; only '{SupportedLanguage}' exists today.",
+                    TypeOfError.Validation));
+            }
+
+            TranslationFileResult? result = await _readDbContext.TranslationArtifacts
+                .Where(artifact => artifact.Language == SupportedLanguage)
+                .Select(artifact => new TranslationFileResult(artifact.Content, artifact.ContentHash))
+                .FirstOrDefaultAsync(cancellationToken);
+
+            return result is null
+                ? Result.Failure<TranslationFileResult>(new Error(
+                    "TranslationFiles.NotFound",
+                    $"No translation file has been built for '{SupportedLanguage}' yet.",
+                    TypeOfError.NotFound))
+                : Result.Success(result);
+        }
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapGet("/api/v1/translation-files/{lang}", async (
+                string lang,
+                IQueryHandler<Query, Result<TranslationFileResult>> handler,
+                HttpContext httpContext,
+                CancellationToken cancellationToken) =>
+            {
+                Result<TranslationFileResult> result = await handler.Handle(new Query(lang), cancellationToken);
+
+                if (result.IsFailure)
+                {
+                    return Results.Problem(result.Error.ToProblemDetails());
+                }
+
+                EntityTagHeaderValue entityTag = new($"\"{result.Value.ETag}\"");
+
+                // Revalidation model: clients keep the cached file and re-check via If-None-Match.
+                // Setting Cache-Control explicitly stops GlobalNoCacheMiddleware from stamping no-store.
+                httpContext.Response.Headers.CacheControl = "private, no-cache";
+                httpContext.Response.GetTypedHeaders().ETag = entityTag;
+
+                // If-None-Match is a comma-separated list and may be "*" (RFC 9110 §13.1.2):
+                // 304 when any supplied validator matches the current strong tag.
+                bool notModified = httpContext.Request.GetTypedHeaders().IfNoneMatch
+                    .Any(candidate => candidate.Equals(EntityTagHeaderValue.Any)
+                                      || candidate.Compare(entityTag, useStrongComparison: true));
+
+                return notModified
+                    ? Results.StatusCode(StatusCodes.Status304NotModified)
+                    : Results.Text(result.Value.Content, "text/plain", Encoding.UTF8);
+            })
+            .WithName(nameof(GetTranslationFile))
+            .WithTags("TranslationFiles")
+            .AllowAnonymous()
+            .Produces<string>(StatusCodes.Status200OK, "text/plain")
+            .Produces(StatusCodes.Status304NotModified)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/ITranslationArtifactBuilder.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/ITranslationArtifactBuilder.cs
@@ -1,0 +1,11 @@
+namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+
+/// <summary>
+/// Regenerates the pre-built translation file for a language from the current Approved set. Called
+/// from writes (version processing now; approve/upsert later) so the distribution endpoint never
+/// builds per-request.
+/// </summary>
+internal interface ITranslationArtifactBuilder
+{
+    Task RebuildAsync(string language, CancellationToken cancellationToken);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/TranslationArtifactBuilder.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/TranslationArtifactBuilder.cs
@@ -1,0 +1,83 @@
+using System.Security.Cryptography;
+using System.Text;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+
+/// <summary>
+/// Regenerates the pre-built translation file on write (spec 0001: regenerate on version
+/// processing, approve, and upsert affecting an Approved row), so the distribution endpoint serves
+/// a stored artifact without ever building per-request. Single-flight: a process-wide gate
+/// serializes concurrent rebuilds, each producing a consistent snapshot of the Approved set.
+/// Registered as a singleton, so it resolves the scoped EF services through a fresh scope.
+/// </summary>
+internal sealed class TranslationArtifactBuilder : ITranslationArtifactBuilder
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public TranslationArtifactBuilder(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public async Task RebuildAsync(string language, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(language);
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
+            IApplicationReadDbContext readDbContext = scope.ServiceProvider.GetRequiredService<IApplicationReadDbContext>();
+            ITranslationArtifactRepository artifactRepository = scope.ServiceProvider.GetRequiredService<ITranslationArtifactRepository>();
+            IUnitOfWork unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            ITranslationFileSerializer serializer = scope.ServiceProvider.GetRequiredService<ITranslationFileSerializer>();
+            TimeProvider timeProvider = scope.ServiceProvider.GetRequiredService<TimeProvider>();
+
+            // The distributed file carries the Polish text and the source's argument columns; only
+            // Approved, non-removed rows are included (NeedsReview is the re-translation backlog).
+            // The RemovedInVersion guard is load-bearing, not redundant with the status: an Approved
+            // row can later be soft-removed by an import without losing its Approved status.
+            List<ArtifactRow> rows = await readDbContext.Translations
+                .Where(translation => translation.Status == TranslationStatus.Approved && translation.RemovedInVersion == null)
+                .OrderBy(translation => translation.FileId)
+                .ThenBy(translation => translation.GossipId)
+                .Select(translation => new ArtifactRow(
+                    translation.FileId,
+                    translation.GossipId,
+                    translation.TranslatedText!,
+                    translation.ArgsOrder,
+                    translation.ArgsId))
+                .ToListAsync(cancellationToken);
+
+            string content = serializer.Serialize(rows);
+            string contentHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
+            DateTimeOffset now = timeProvider.GetUtcNow();
+
+            Maybe<TranslationArtifact> existing = await artifactRepository.GetByLanguageAsync(language, cancellationToken);
+            if (existing.HasValue)
+            {
+                existing.Value.Replace(content, contentHash, now);
+            }
+            else
+            {
+                artifactRepository.Insert(TranslationArtifact.Create(language, content, contentHash, now));
+            }
+
+            await unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
@@ -25,7 +25,7 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
 internal sealed class ListTranslations : IEndpoint
 {
     /// <summary>The only language the catalog holds today; multi-language is post-MVP.</summary>
-    private const string SupportedLanguage = "pl";
+    private const string SupportedLanguage = SupportedLanguages.Polish;
 
     internal sealed record Query(string? Lang, string? Search, TranslationStatus? Status, int Page = 1, int PageSize = 50)
         : IQuery<Result<PaginationResponse<TranslationListItemResponse>>>

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/ITranslationFileSerializer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/ITranslationFileSerializer.cs
@@ -1,0 +1,16 @@
+namespace LotroKoniecDev.TranslationSystem.API.Parsing;
+
+/// <summary>
+/// One Approved row to serialize into the <c>||</c> translation file. There is no approved column —
+/// every distributed row is approved, so the serializer emits the constant <c>1</c>.
+/// </summary>
+internal sealed record ArtifactRow(int FileId, long GossipId, string Content, string? ArgsOrder, string? ArgsId);
+
+/// <summary>
+/// Serializes Approved rows into the LOTRO <c>||</c> contract the patcher's parser consumes. The
+/// caller supplies the rows already filtered and sorted; the serializer only formats.
+/// </summary>
+internal interface ITranslationFileSerializer
+{
+    string Serialize(IReadOnlyList<ArtifactRow> rows);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationFileSerializer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationFileSerializer.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using System.Text;
+
+namespace LotroKoniecDev.TranslationSystem.API.Parsing;
+
+/// <summary>
+/// Produces the LOTRO <c>||</c> translation file
+/// (<c>file_id||gossip_id||content||args_order||args_id||approved</c>). Byte-compatible with the
+/// patcher's own writer: content is emitted verbatim (already <c>\r</c>/<c>\n</c>-escaped on import),
+/// absent args become <c>NULL</c>, the approved column is always <c>1</c>, and lines are CRLF-
+/// terminated for a deterministic content hash across platforms. A golden fixture + a cross-parser
+/// round-trip test guard the contract against drift from the patcher.
+/// </summary>
+internal sealed class TranslationFileSerializer : ITranslationFileSerializer
+{
+    private const string FieldSeparator = "||";
+    private const string LineTerminator = "\r\n";
+    private const string NullArgs = "NULL";
+
+    public string Serialize(IReadOnlyList<ArtifactRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        StringBuilder builder = new();
+
+        foreach (ArtifactRow row in rows)
+        {
+            builder
+                .Append(row.FileId.ToString(CultureInfo.InvariantCulture)).Append(FieldSeparator)
+                .Append(row.GossipId.ToString(CultureInfo.InvariantCulture)).Append(FieldSeparator)
+                .Append(row.Content).Append(FieldSeparator)
+                .Append(row.ArgsOrder ?? NullArgs).Append(FieldSeparator)
+                .Append(row.ArgsId ?? NullArgs).Append(FieldSeparator)
+                .Append('1').Append(LineTerminator);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
@@ -2,6 +2,7 @@ using LotroKoniecDev.SharedKernel.BuildingBlocks;
 using LotroKoniecDev.SharedKernel.Guards;
 using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
@@ -106,6 +107,30 @@ public sealed class Translation : AggregateRoot<TranslationId>
         TranslatedText = translatedText;
         Status = TranslationStatus.Draft;
         UpdatedAt = now;
+    }
+
+    /// <summary>
+    /// Approves the Polish draft for distribution (spec 0001). Minimal seed form (#102): requires
+    /// Polish content and a non-removed row, then flips the status to
+    /// <see cref="TranslationStatus.Approved"/>. #101 enriches it — clears
+    /// <see cref="PreviousSourceText"/>, stamps the approver and triggers artifact regeneration.
+    /// </summary>
+    public Result Approve(DateTimeOffset now)
+    {
+        if (string.IsNullOrWhiteSpace(TranslatedText))
+        {
+            return Result.Failure(DomainErrors.TranslationEntity.CannotApproveWithoutTranslation);
+        }
+
+        if (IsRemoved)
+        {
+            return Result.Failure(DomainErrors.TranslationEntity.CannotApproveRemoved);
+        }
+
+        Status = TranslationStatus.Approved;
+        UpdatedAt = now;
+
+        return Result.Success();
     }
 
     private Translation(

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationArtifactAggregate/Entities/TranslationArtifact.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationArtifactAggregate/Entities/TranslationArtifact.cs
@@ -1,0 +1,64 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Guards;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationArtifactAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Entities;
+
+/// <summary>
+/// The pre-built translation file for one language (spec 0001): the serialized <c>||</c> content
+/// plus its content hash (the HTTP <c>ETag</c>). Regenerated on every write that changes the
+/// distributed set and served by the distribution endpoint without a per-request rebuild — a
+/// derived artifact (one row per language), never a source of truth.
+/// </summary>
+public sealed class TranslationArtifact : AggregateRoot<TranslationArtifactId>
+{
+    public const int LanguageMaxLength = 8;
+    public const int ContentHashLength = 64;
+
+    public string Language { get; }
+    public string Content { get; private set; }
+    public string ContentHash { get; private set; }
+    public DateTimeOffset GeneratedAt { get; private set; }
+
+    public static TranslationArtifact Create(string language, string content, string contentHash, DateTimeOffset now)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(language);
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentHash);
+        Ensure.NotEmpty(now);
+
+        return new TranslationArtifact(TranslationArtifactId.Create(), language, content, contentHash, now);
+    }
+
+    /// <summary>Regenerate-on-write: replaces the serialized content and its hash in place.</summary>
+    public void Replace(string content, string contentHash, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentHash);
+        Ensure.NotEmpty(now);
+
+        Content = content;
+        ContentHash = contentHash;
+        GeneratedAt = now;
+    }
+
+    private TranslationArtifact(
+        TranslationArtifactId id,
+        string language,
+        string content,
+        string contentHash,
+        DateTimeOffset now) : base(id)
+    {
+        Language = language;
+        Content = content;
+        ContentHash = contentHash;
+        GeneratedAt = now;
+    }
+
+    private TranslationArtifact()
+    {
+        Language = null!;
+        Content = null!;
+        ContentHash = null!;
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationArtifactAggregate/Repositories/ITranslationArtifactRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationArtifactAggregate/Repositories/ITranslationArtifactRepository.cs
@@ -1,0 +1,12 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationArtifactAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Repositories;
+
+public interface ITranslationArtifactRepository : IRepository<TranslationArtifact, TranslationArtifactId>
+{
+    /// <summary>The artifact is upserted by its natural key — one row per language.</summary>
+    Task<Maybe<TranslationArtifact>> GetByLanguageAsync(string language, CancellationToken cancellationToken);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/TranslationAggregateDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/TranslationAggregateDomainErrors.cs
@@ -11,6 +11,16 @@ public static partial class DomainErrors
         public static Error NotFound(TranslationId id)
             => HasNotBeenFound(nameof(TranslationEntity), id.Value);
 
+        public static Error CannotApproveWithoutTranslation
+            => InvalidOperation(nameof(TranslationEntity),
+                "A translation cannot be approved without Polish content.",
+                "CannotApproveWithoutTranslation");
+
+        public static Error CannotApproveRemoved
+            => InvalidOperation(nameof(TranslationEntity),
+                "A soft-removed translation cannot be approved.",
+                "CannotApproveRemoved");
+
         public static class FragmentKeyProperty
         {
             public static Error InvalidFileId

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationArtifactConfiguration.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationArtifactConfiguration.cs
@@ -1,0 +1,26 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Configurations;
+
+internal sealed class TranslationArtifactConfiguration : IEntityTypeConfiguration<TranslationArtifact>
+{
+    public void Configure(EntityTypeBuilder<TranslationArtifact> builder)
+    {
+        builder.ToTable("TranslationArtifacts");
+
+        builder.Property(translationArtifact => translationArtifact.Id)
+            .ValueGeneratedNever();
+
+        // Get-only property — EF Core convention skips it without an explicit mapping.
+        builder.Property(translationArtifact => translationArtifact.Language)
+            .HasMaxLength(TranslationArtifact.LanguageMaxLength);
+
+        builder.HasIndex(translationArtifact => translationArtifact.Language)
+            .IsUnique();
+
+        builder.Property(translationArtifact => translationArtifact.ContentHash)
+            .HasMaxLength(TranslationArtifact.ContentHashLength);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdsConverters.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdsConverters.cs
@@ -1,5 +1,6 @@
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationArtifactAggregate;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
@@ -24,6 +25,10 @@ public static class StronglyTypedIdsConverters
             .Properties<TranslationId>()
             .HaveConversion<TranslationIdConverter>();
 
+        configurationBuilder
+            .Properties<TranslationArtifactId>()
+            .HaveConversion<TranslationArtifactIdConverter>();
+
         return configurationBuilder;
     }
 
@@ -38,4 +43,8 @@ public static class StronglyTypedIdsConverters
     private sealed class TranslationIdConverter() : ValueConverter<TranslationId, Guid>(
         id => id.Value,
         value => new TranslationId(value));
+
+    private sealed class TranslationArtifactIdConverter() : ValueConverter<TranslationArtifactId, Guid>(
+        id => id.Value,
+        value => new TranslationArtifactId(value));
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/ReadDbContexts/ApplicationReadDbContext.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/ReadDbContexts/ApplicationReadDbContext.cs
@@ -1,6 +1,7 @@
 using LotroKoniecDev.TranslationSystem.Persistence.Converters;
 using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationArtifactAggregate;
 using LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 
@@ -15,6 +16,8 @@ internal sealed class ApplicationReadDbContext : DbContext, IApplicationReadDbCo
     public DbSet<GameVersionReadModel> GameVersions => Set<GameVersionReadModel>();
 
     public DbSet<TranslationReadModel> Translations => Set<TranslationReadModel>();
+
+    public DbSet<TranslationArtifactReadModel> TranslationArtifacts => Set<TranslationArtifactReadModel>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/ReadDbContexts/IApplicationReadDbContext.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/ReadDbContexts/IApplicationReadDbContext.cs
@@ -1,5 +1,6 @@
 using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationArtifactAggregate;
 using Microsoft.EntityFrameworkCore;
 
 namespace LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
@@ -9,4 +10,6 @@ public interface IApplicationReadDbContext
     DbSet<GameVersionReadModel> GameVersions { get; }
 
     DbSet<TranslationReadModel> Translations { get; }
+
+    DbSet<TranslationArtifactReadModel> TranslationArtifacts { get; }
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/WriteDbContexts/ApplicationWriteDbContext.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/WriteDbContexts/ApplicationWriteDbContext.cs
@@ -2,6 +2,7 @@ using System.Data;
 using System.Reflection;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Persistence.Converters;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using Microsoft.EntityFrameworkCore;
@@ -18,6 +19,8 @@ internal sealed class ApplicationWriteDbContext : DbContext, IUnitOfWork
     public DbSet<GameVersion> GameVersions => Set<GameVersion>();
 
     public DbSet<Translation> Translations => Set<Translation>();
+
+    public DbSet<TranslationArtifact> TranslationArtifacts => Set<TranslationArtifact>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationArtifactRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationArtifactRepository.cs
@@ -1,0 +1,26 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationArtifactAggregate;
+using Microsoft.EntityFrameworkCore;
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.DomainRepositories;
+
+internal sealed class TranslationArtifactRepository
+    : GenericRepository<TranslationArtifact, TranslationArtifactId>, ITranslationArtifactRepository
+{
+    public TranslationArtifactRepository(ApplicationWriteDbContext db) : base(db)
+    {
+    }
+
+    public async Task<Maybe<TranslationArtifact>> GetByLanguageAsync(string language, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(language);
+
+        TranslationArtifact? artifact = await DbContext.TranslationArtifacts
+            .FirstOrDefaultAsync(translationArtifact => translationArtifact.Language == language, cancellationToken);
+
+        return Maybe<TranslationArtifact>.From(artifact);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613210641_AddTranslationArtifactAggregate.Designer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613210641_AddTranslationArtifactAggregate.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationWriteDbContext))]
-    partial class ApplicationWriteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613210641_AddTranslationArtifactAggregate")]
+    partial class AddTranslationArtifactAggregate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613210641_AddTranslationArtifactAggregate.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613210641_AddTranslationArtifactAggregate.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTranslationArtifactAggregate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TranslationArtifacts",
+                schema: "translation",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Language = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+                    Content = table.Column<string>(type: "text", nullable: false),
+                    ContentHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    GeneratedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TranslationArtifacts", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TranslationArtifacts_Language",
+                schema: "translation",
+                table: "TranslationArtifacts",
+                column: "Language",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TranslationArtifacts",
+                schema: "translation");
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/PersistenceDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/PersistenceDependencyInjection.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using LotroKoniecDev.Options;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationArtifactAggregate.Repositories;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
@@ -56,6 +57,7 @@ public static class PersistenceDependencyInjection
 
             services.AddScoped<IGameVersionRepository, GameVersionRepository>();
             services.AddScoped<ITranslationRepository, TranslationRepository>();
+            services.AddScoped<ITranslationArtifactRepository, TranslationArtifactRepository>();
 
             return services;
         }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationArtifactAggregate/TranslationArtifactId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationArtifactAggregate/TranslationArtifactId.cs
@@ -1,0 +1,15 @@
+using LotroKoniecDev.SharedKernel.Guards;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+
+namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationArtifactAggregate;
+
+[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]
+public partial struct TranslationArtifactId : IStronglyTypedId<TranslationArtifactId>
+{
+    public static TranslationArtifactId Create() => new(Guid.CreateVersion7());
+    public static TranslationArtifactId Create(Guid id)
+    {
+        Ensure.NotEmpty(id);
+        return new TranslationArtifactId(id);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework/Aggregates/TranslationArtifactAggregate/TranslationArtifactReadModelConfiguration.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework/Aggregates/TranslationArtifactAggregate/TranslationArtifactReadModelConfiguration.cs
@@ -1,0 +1,19 @@
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationArtifactAggregate;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework.Aggregates.TranslationArtifactAggregate;
+
+public sealed class TranslationArtifactReadModelConfiguration : IEntityTypeConfiguration<TranslationArtifactReadModel>
+{
+    public void Configure(EntityTypeBuilder<TranslationArtifactReadModel> builder)
+    {
+        builder.ToTable("TranslationArtifacts");
+
+        builder.Property(translationArtifactReadModel => translationArtifactReadModel.Id)
+            .ValueGeneratedNever();
+
+        // CreatedAt is computed from GeneratedAt on the read model — there is no such column.
+        builder.Ignore(translationArtifactReadModel => translationArtifactReadModel.CreatedAt);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Aggregates/TranslationArtifactAggregate/TranslationArtifactReadModel.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Aggregates/TranslationArtifactAggregate/TranslationArtifactReadModel.cs
@@ -1,0 +1,16 @@
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationArtifactAggregate;
+using LotroKoniecDev.TranslationSystem.ReadModels.Core.BuildingBlocks;
+
+namespace LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationArtifactAggregate;
+
+public sealed record TranslationArtifactReadModel(
+    TranslationArtifactId Id,
+    string Language,
+    string Content,
+    string ContentHash,
+    DateTimeOffset GeneratedAt) : IReadOnlyEntity<TranslationArtifactId>
+{
+    // The artifact row is created when first built, so generation time is its creation time —
+    // kept unmapped to avoid a duplicate column (mirrors GameVersionReadModel).
+    public DateTimeOffset CreatedAt => GeneratedAt;
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj
@@ -28,6 +28,10 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.API\LotroKoniecDev.TranslationSystem.API.csproj" />
+      <!-- Test-only: the distribution round-trip parses the downloaded file with the patcher's own
+           parser (the export half of the || contract drift guard). The patcher Application is
+           net10.0/AnyCPU, so this reference stays cross-platform; the contexts remain decoupled in production. -->
+      <ProjectReference Include="..\..\src\LotroKoniecDev.Application\LotroKoniecDev.Application.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
@@ -1,0 +1,279 @@
+using System.Net.Http.Headers;
+using System.Text;
+using LotroKoniecDev.Application.Parsers;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.TranslationFiles;
+
+[Collection("TranslationApi")]
+public sealed class GetTranslationFileTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+    private const string Route = "/api/v1/translation-files/pl";
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+
+    public GetTranslationFileTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+        _versionId = gameVersion.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Get_AfterRebuild_ShouldReturn200WithApprovedNonRemovedRowsOnly()
+    {
+        // Arrange — only the approved, non-removed row belongs in the distributed file.
+        await SeedAsync(gossipId: 1, polish: "Alfa", status: SeedStatus.Approved);
+        await SeedAsync(gossipId: 2, polish: "Beta", status: SeedStatus.Draft);
+        await SeedAsync(gossipId: 3, polish: "Gamma", status: SeedStatus.NeedsReview);
+        await SeedAsync(gossipId: 4, polish: "Delta", status: SeedStatus.ApprovedThenRemoved);
+        await RebuildAsync();
+
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync(Route);
+        string body = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+        body.ShouldContain($"{FileId}||1||Alfa||NULL||NULL||1");
+        body.ShouldNotContain($"{FileId}||2||");
+        body.ShouldNotContain($"{FileId}||3||");
+        body.ShouldNotContain($"{FileId}||4||");
+    }
+
+    [Fact]
+    public async Task Get_WithMatchingIfNoneMatch_ShouldReturn304()
+    {
+        // Arrange
+        await SeedAsync(gossipId: 1, polish: "Alfa", status: SeedStatus.Approved);
+        await RebuildAsync();
+        HttpResponseMessage first = await _factory.CreateClient().GetAsync(Route);
+        EntityTagHeaderValue etag = first.Headers.ETag!;
+
+        // Act — re-request with the ETag the client already holds.
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.IfNoneMatch.Add(etag);
+        HttpResponseMessage second = await client.GetAsync(Route);
+
+        // Assert
+        second.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        (await second.Content.ReadAsStringAsync()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Get_WithIfNoneMatchListContainingTheETag_ShouldReturn304()
+    {
+        // Arrange — If-None-Match is a list (RFC 9110); a stale tag alongside the current one still 304s.
+        await SeedAsync(gossipId: 1, polish: "Alfa", status: SeedStatus.Approved);
+        await RebuildAsync();
+        EntityTagHeaderValue etag = (await _factory.CreateClient().GetAsync(Route)).Headers.ETag!;
+
+        // Act
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.IfNoneMatch.Add(new EntityTagHeaderValue("\"stale-tag\""));
+        client.DefaultRequestHeaders.IfNoneMatch.Add(etag);
+        HttpResponseMessage response = await client.GetAsync(Route);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+    }
+
+    [Fact]
+    public async Task Get_WithoutToken_ShouldBeAnonymousAndReturn200()
+    {
+        // Arrange
+        await SeedAsync(gossipId: 1, polish: "Alfa", status: SeedStatus.Approved);
+        await RebuildAsync();
+
+        // Act — no Authorization header at all.
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync(Route);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Get_WithUnsupportedLanguage_ShouldReturn400()
+    {
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync("/api/v1/translation-files/de");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Get_WhenNoArtifactBuilt_ShouldReturn404()
+    {
+        // Act — nothing imported or built yet.
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync(Route);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_AfterApprovingAnotherRow_ShouldAppearInNextDownloadWithNewETag()
+    {
+        // Arrange — first artifact has only Alfa.
+        await SeedAsync(gossipId: 1, polish: "Alfa", status: SeedStatus.Approved);
+        await RebuildAsync();
+        HttpResponseMessage firstDownload = await _factory.CreateClient().GetAsync(Route);
+        EntityTagHeaderValue firstEtag = firstDownload.Headers.ETag!;
+
+        // Act — approve a second row (no game-version bump) and rebuild.
+        await SeedAsync(gossipId: 2, polish: "Beta", status: SeedStatus.Approved);
+        await RebuildAsync();
+        HttpResponseMessage secondDownload = await _factory.CreateClient().GetAsync(Route);
+        string body = await secondDownload.Content.ReadAsStringAsync();
+
+        // Assert
+        secondDownload.Headers.ETag.ShouldNotBe(firstEtag);
+        body.ShouldContain($"{FileId}||1||Alfa||NULL||NULL||1");
+        body.ShouldContain($"{FileId}||2||Beta||NULL||NULL||1");
+    }
+
+    [Fact]
+    public async Task RoundTrip_ImportApproveDownload_ShouldParseIdenticallyWithThePatcher()
+    {
+        // Arrange — import the English baseline (admin), then approve Polish for both rows.
+        using HttpClient admin = AdminClient();
+        await admin.PostAsync(
+            $"/api/v1/game-versions/{_versionId.Value}/import",
+            ExportContent(
+                $"{FileId}||1||English source one||1-2||3-4||1",
+                $"{FileId}||2||English with || inside||NULL||NULL||1"));
+        await ApprovePolishAsync(gossipId: 1, polish: "Polski jeden");
+        await ApprovePolishAsync(gossipId: 2, polish: "Polski || dwa");
+        await RebuildAsync();
+
+        // Act — download, write to a temp file, and parse it with the patcher's own parser.
+        string body = await (await _factory.CreateClient().GetAsync(Route)).Content.ReadAsStringAsync();
+        string tempFile = Path.Combine(Path.GetTempPath(), $"polish_{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(tempFile, body);
+
+        try
+        {
+            IReadOnlyList<LotroKoniecDev.Domain.Models.Translation> parsed =
+                new TranslationFileParser().ParseFile(tempFile).Value;
+
+            // Assert — both rows round-trip: args preserved, || anchoring preserved, all approved.
+            parsed.Count.ShouldBe(2);
+
+            LotroKoniecDev.Domain.Models.Translation one = parsed.Single(translation => translation.GossipId == 1);
+            one.Content.ShouldBe("Polski jeden");
+            one.ArgsOrder.ShouldBe([0, 1]);
+            one.ArgsId.ShouldBe([2, 3]);
+            one.IsApproved.ShouldBeTrue();
+
+            LotroKoniecDev.Domain.Models.Translation two = parsed.Single(translation => translation.GossipId == 2);
+            two.Content.ShouldBe("Polski || dwa");
+            two.ArgsOrder.ShouldBeNull();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private enum SeedStatus
+    {
+        Approved,
+        Draft,
+        NeedsReview,
+        ApprovedThenRemoved,
+    }
+
+    private async Task SeedAsync(int gossipId, string polish, SeedStatus status)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create("English", null, null).Value,
+            _versionId,
+            Now).Value;
+
+        switch (status)
+        {
+            case SeedStatus.Draft:
+                row.ProvideTranslation(polish, Now);
+                break;
+            case SeedStatus.NeedsReview:
+                row.ProvideTranslation(polish, Now);
+                row.ApplySourceChange(TranslationSource.Create("English reworded", null, null).Value, _versionId, Now);
+                break;
+            case SeedStatus.Approved:
+                row.ProvideTranslation(polish, Now);
+                row.Approve(Now);
+                break;
+            case SeedStatus.ApprovedThenRemoved:
+                row.ProvideTranslation(polish, Now);
+                row.Approve(Now);
+                row.MarkRemoved(_versionId, Now);
+                break;
+        }
+
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task ApprovePolishAsync(int gossipId, string polish)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation row = await dbContext.Translations
+            .SingleAsync(translation => translation.FragmentKey.FileId == FileId && translation.FragmentKey.GossipId == gossipId);
+        row.ProvideTranslation(polish, Now);
+        row.Approve(Now);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task RebuildAsync()
+    {
+        ITranslationArtifactBuilder builder = _factory.Services.GetRequiredService<ITranslationArtifactBuilder>();
+        await builder.RebuildAsync("pl", CancellationToken.None);
+    }
+
+    private HttpClient AdminClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Admin));
+        return client;
+    }
+
+    private static MultipartFormDataContent ExportContent(params string[] lines)
+    {
+        ByteArrayContent fileContent = new(Encoding.UTF8.GetBytes(string.Join('\n', lines)));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        return new MultipartFormDataContent { { fileContent, "file", "exported.txt" } };
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.API.Features.Import;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
 using LotroKoniecDev.TranslationSystem.Contracts.Import;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
@@ -40,7 +41,16 @@ public sealed class ImportExportedTextsHandlerTests
             _translationRepository,
             _unitOfWork,
             TimeProvider.System,
-            Microsoft.Extensions.Options.Options.Create(new ImportSettings { MaxRemovedFractionWithoutOverride = maxRemovedFraction }));
+            Microsoft.Extensions.Options.Options.Create(new ImportSettings { MaxRemovedFractionWithoutOverride = maxRemovedFraction }),
+            new NoOpArtifactBuilder());
+
+    // The artifact builder is an internal interface (NSubstitute/Castle can't proxy it without a
+    // DynamicProxyGenAssembly2 hook); a hand-written no-op keeps the import handler tests focused
+    // on the diff, not on artifact regeneration (covered by the distribution integration tests).
+    private sealed class NoOpArtifactBuilder : ITranslationArtifactBuilder
+    {
+        public Task RebuildAsync(string language, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
 
     private static ImportExportedTexts.Command Command(GameVersionId versionId, string export, bool allowMassRemoval = false)
         => new(versionId, new MemoryStream(Encoding.UTF8.GetBytes(export)), allowMassRemoval);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/TranslationFiles/GetTranslationFileHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/TranslationFiles/GetTranslationFileHandlerTests.cs
@@ -1,0 +1,24 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.TranslationFiles;
+
+public sealed class GetTranslationFileHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenLanguageUnsupported_ShouldReturnValidationError()
+    {
+        // Arrange — an unsupported language is rejected before the read model is touched.
+        GetTranslationFile.Handler handler = new(Substitute.For<IApplicationReadDbContext>());
+
+        // Act
+        Result<GetTranslationFile.TranslationFileResult> result =
+            await handler.Handle(new GetTranslationFile.Query("de"), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("TranslationFiles.UnsupportedLanguage");
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileSerializerParityTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileSerializerParityTests.cs
@@ -1,0 +1,56 @@
+using LotroKoniecDev.Application.Parsers;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
+
+/// <summary>
+/// The export half of the inter-context drift guard (mirrors <c>ParserContractParityTests</c> on
+/// the import side): the TMS serializer's output must parse byte-identically through the patcher's
+/// own <see cref="TranslationFileParser"/>. Feeds serialized lines back into the patcher and asserts
+/// the contract fields round-trip.
+/// </summary>
+public sealed class TranslationFileSerializerParityTests
+{
+    [Fact]
+    public void SerializedRows_ShouldParseBackThroughThePatcherWithIdenticalFields()
+    {
+        // Arrange — includes a row whose content contains the || separator and args columns.
+        ArtifactRow[] rows =
+        [
+            new(620756992, 1001, "Witaj w Srodziemiu!", null, null),
+            new(620756992, 1004, "Multi||arg||content", "1-2", "1-2"),
+            new(620756992, 1005, "Trailing approved", null, null),
+        ];
+
+        // Act
+        string serialized = new TranslationFileSerializer().Serialize(rows);
+        string[] lines = serialized.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        TranslationFileParser patcher = new();
+
+        // Assert — every serialized line parses, and the contract fields match (no escapes here, so
+        // the patcher's unescape is a no-op and content compares directly).
+        lines.Length.ShouldBe(rows.Length);
+        for (int i = 0; i < rows.Length; i++)
+        {
+            LotroKoniecDev.Domain.Models.Translation parsed = patcher.ParseLine(lines[i]).Value;
+            parsed.FileId.ShouldBe(rows[i].FileId);
+            ((long)parsed.GossipId).ShouldBe(rows[i].GossipId);
+            parsed.Content.ShouldBe(rows[i].Content);
+            parsed.IsApproved.ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public void SerializedRow_WithEscapedNewline_ShouldBeUnescapedByThePatcher()
+    {
+        // Arrange — content is stored escaped; the patcher unescapes on its way into the DAT.
+        string serialized = new TranslationFileSerializer().Serialize([new ArtifactRow(1, 2, @"Line1\nLine2", null, null)]);
+
+        // Act
+        LotroKoniecDev.Domain.Models.Translation parsed =
+            new TranslationFileParser().ParseLine(serialized.TrimEnd('\r', '\n')).Value;
+
+        // Assert
+        parsed.Content.ShouldBe("Line1\nLine2");
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileSerializerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileSerializerTests.cs
@@ -1,0 +1,42 @@
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
+
+public sealed class TranslationFileSerializerTests
+{
+    private static string Serialize(params ArtifactRow[] rows) => new TranslationFileSerializer().Serialize(rows);
+
+    [Fact]
+    public void Serialize_WithNullArgs_ShouldEmitNullColumns()
+        => Serialize(new ArtifactRow(620756992, 1001, "Witaj", null, null))
+            .ShouldBe("620756992||1001||Witaj||NULL||NULL||1\r\n");
+
+    [Fact]
+    public void Serialize_WithArgs_ShouldEmitThemVerbatim()
+        => Serialize(new ArtifactRow(620756992, 1002, "Tekst", "1-2", "3-4"))
+            .ShouldBe("620756992||1002||Tekst||1-2||3-4||1\r\n");
+
+    [Fact]
+    public void Serialize_ShouldAlwaysEmitApprovedOne()
+        => Serialize(new ArtifactRow(1, 2, "x", null, null))
+            .ShouldBe("1||2||x||NULL||NULL||1\r\n");
+
+    [Fact]
+    public void Serialize_WithEscapedNewlines_ShouldKeepThemVerbatim()
+        => Serialize(new ArtifactRow(1, 2, @"Line1\nLine2", null, null))
+            .ShouldBe(@"1||2||Line1\nLine2||NULL||NULL||1" + "\r\n");
+
+    [Fact]
+    public void Serialize_WithSeparatorInContent_ShouldEmitItVerbatim()
+        => Serialize(new ArtifactRow(1, 2, "Multi||arg||content", null, null))
+            .ShouldBe("1||2||Multi||arg||content||NULL||NULL||1\r\n");
+
+    [Fact]
+    public void Serialize_MultipleRows_ShouldUseCrLfPerLine()
+        => Serialize(new ArtifactRow(1, 1, "a", null, null), new ArtifactRow(1, 2, "b", null, null))
+            .ShouldBe("1||1||a||NULL||NULL||1\r\n1||2||b||NULL||NULL||1\r\n");
+
+    [Fact]
+    public void Serialize_WithNoRows_ShouldReturnEmptyString()
+        => Serialize().ShouldBe(string.Empty);
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
@@ -133,4 +133,68 @@ public sealed class TranslationTests
         translation.TranslatedText.ShouldBe("Witaj");
         translation.UpdatedAt.ShouldBe(Changed);
     }
+
+    [Fact]
+    public void Approve_WhenDraft_ShouldSetApproved()
+    {
+        // Arrange
+        Translation translation = CreateUntranslated();
+        translation.ProvideTranslation("Witaj", Created);
+
+        // Act
+        Result result = translation.Approve(Changed);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        translation.Status.ShouldBe(TranslationStatus.Approved);
+        translation.UpdatedAt.ShouldBe(Changed);
+    }
+
+    [Fact]
+    public void Approve_WhenNeedsReview_ShouldSetApproved()
+    {
+        // Arrange — an invalidated row keeps its Polish; approving re-publishes it (spec 0001).
+        Translation translation = CreateUntranslated();
+        translation.ProvideTranslation("Stary polski", Created);
+        translation.ApplySourceChange(Source("New English"), ChangeVersion, Changed);
+        translation.Status.ShouldBe(TranslationStatus.NeedsReview);
+
+        // Act
+        Result result = translation.Approve(Changed);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        translation.Status.ShouldBe(TranslationStatus.Approved);
+    }
+
+    [Fact]
+    public void Approve_WithoutTranslation_ShouldFail()
+    {
+        // Arrange
+        Translation translation = CreateUntranslated();
+
+        // Act
+        Result result = translation.Approve(Changed);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("TranslationEntity.CannotApproveWithoutTranslation");
+        translation.Status.ShouldBe(TranslationStatus.Untranslated);
+    }
+
+    [Fact]
+    public void Approve_WhenRemoved_ShouldFail()
+    {
+        // Arrange
+        Translation translation = CreateUntranslated();
+        translation.ProvideTranslation("Polski", Created);
+        translation.MarkRemoved(ChangeVersion, Changed);
+
+        // Act
+        Result result = translation.Approve(Changed);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("TranslationEntity.CannotApproveRemoved");
+    }
 }


### PR DESCRIPTION
Closes #102

Closes the TMS core loop (spec 0001): serves the current Polish translation file, **regenerated on write** so the download endpoint never builds per-request.

## What's in it
- **Domain:** minimal `Translation.Approve(now)` (guards Polish present + not removed; #101 enriches it — clear `PreviousSourceText`, stamp approver, trigger regen — mirrors the `ProvideTranslation` seed precedent).
- **`TranslationArtifact` aggregate** (one row/language: serialized content + SHA-256 hash) — id/entity/repo/read model + EF config + converter + migration (unique `Language` index).
- **TMS `||` serializer** — byte-compatible with the patcher's writer (CRLF, `NULL` args, content verbatim, approved=1).
- **`ITranslationArtifactBuilder`** — singleton, single-flight (`SemaphoreSlim`), own scope; rebuilds from **Approved + non-removed** rows (NeedsReview excluded), sorted `(FileId, GossipId)`. Wired into the import handler (regenerate on version processing); approve/upsert add their triggers in #101/#100.
- **`GET /api/v1/translation-files/{lang}`** — anonymous, streams the stored artifact with the content hash as a strong **ETag**, RFC-9110 `If-None-Match` (list + `*`) → **304**; explicit `Cache-Control` so the no-cache middleware leaves the validator intact. 404 if not built, 400 for unsupported language.

## Reviews
- **Security: clean** — anonymous endpoint serves public-by-design content; no path traversal / SQLi / injection / data exposure; deny-by-default intact on every other endpoint.
- **code-reviewer: APPROVE-WITH-NITS** — acted on the substantive nit (hardened `If-None-Match` to spec-compliant list/`*` matching via typed headers + a pinning test) and the cheap ones (shared `SupportedLanguages.Polish` const to remove drift, `Replace` guard, clarifying builder comment). Polish-text escaping is correctly #100's territory (deferred).

## Tests
Build 0 warnings. Green: 62 domain unit (incl. `Approve`) + 48 API unit (serializer + **cross-parser parity vs the patcher**) + 39 integration on real PostgreSQL — Approved-only filter, ETag/304 (incl. multi-value `If-None-Match`), anonymous, 400/404, newly-approved-appears-next-download, and the headline **round-trip** (import → approve → download → patcher `ParseFile` → identical, incl. args + `||`-in-content anchoring). Frozen patcher suite (223) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)