### PR TITLE
M2-11: Slice — upsert translation (PUT /api/v1/translations)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,8 +221,10 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
   aggregate ships with its read model + EF configuration in the same change.
 - **Patcher is frozen** (see Architecture) — never refactor it to serve the TMS.
 - **TMS ships with auth from day 1.** Endpoints are authorized by default (public ones are
-  explicit); the first migration already carries user attribution (`SubmittedById`,
-  `ApprovedById`). No auth-less interim state to retrofit later.
+  explicit) and edited rows carry user attribution: `Translation.SubmittedById` is stamped on
+  upsert (added in M2-11; persisted via the `IdentityId` converter in `TranslationSystem.Persistence`),
+  and `ApprovedById` lands with the approve slice (#101 / M2-12). No auth-less interim state to
+  retrofit later.
 - **Validation:** FluentValidation **for commands only** — the command handler injects
   `IValidator<TCommand>` and maps failures to `Result` (never throws). Queries validate inline
   in their handler. Every validator must be registered in DI.

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -51,6 +51,10 @@ internal static class ApiDependencyInjection
             // so ASP.NET Core's default writer handles plain JSON / RFC 7807 Accept values first.
             services.AddHateoasInfrastructure();
 
+            // Cross-cutting clock shared by every command handler that stamps timestamps
+            // (import diff, translation upsert, …) — registered once at the API root, not per feature.
+            services.AddSingleton(TimeProvider.System);
+
             services.AddImportFeature();
             services.AddTranslationsFeature();
             services.AddTranslationFilesFeature();
@@ -60,7 +64,6 @@ internal static class ApiDependencyInjection
 
         private void AddImportFeature()
         {
-            services.AddSingleton(TimeProvider.System);
             services.AddSingleton<ITranslationExportParser, TranslationExportParser>();
             services.AddOptions<ImportSettings>().BindConfiguration(ImportSettings.ConfigurationSection);
 
@@ -76,6 +79,11 @@ internal static class ApiDependencyInjection
             services.AddScoped<
                 IQueryHandler<GetTranslation.Query, Result<TranslationDetailResponse>>,
                 GetTranslation.Handler>();
+
+            services.AddScoped<IValidator<UpsertTranslation.Command>, UpsertTranslation.Validator>();
+            services.AddScoped<
+                ICommandHandler<UpsertTranslation.Command, Result<TranslationDetailResponse>>,
+                UpsertTranslation.Handler>();
         }
 
         private void AddTranslationFilesFeature()

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslation.cs
@@ -47,6 +47,7 @@ internal sealed class GetTranslation : IEndpoint
                     translation.ArgsId,
                     translation.TranslatedText,
                     translation.PreviousSourceText,
+                    translation.SubmittedById,
                     translation.Status,
                     translation.CreatedAt,
                     translation.UpdatedAt))

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/UpsertTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/UpsertTranslation.cs
@@ -1,0 +1,173 @@
+using FluentValidation;
+using FluentValidation.Results;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
+
+/// <summary>
+/// Creates or updates the Polish content of an existing translation row (spec 0001, #100): the row
+/// is born from import (English source only), this slice attaches the translator's Polish. Any prior
+/// status moves to <see cref="TranslationStatus.Draft"/> and the submitting translator is stamped
+/// from the authenticated identity. Editing an <see cref="TranslationStatus.Approved"/> row pulls it
+/// out of the distributed set, so the pre-built artifact is regenerated after the change commits;
+/// re-translating a <see cref="TranslationStatus.NeedsReview"/> row keeps its
+/// <c>PreviousSourceText</c> until approve. Placeholders are stored verbatim — the
+/// count-mismatch warning UX is M3.
+/// </summary>
+internal sealed class UpsertTranslation : IEndpoint
+{
+    internal sealed record Command(int FileId, long GossipId, string TranslatedText)
+        : ICommand<Result<TranslationDetailResponse>>;
+
+    internal sealed class Validator : AbstractValidator<Command>
+    {
+        public Validator()
+        {
+            RuleFor(command => command.FileId)
+                .GreaterThan(0);
+
+            RuleFor(command => command.GossipId)
+                .GreaterThanOrEqualTo(0);
+
+            RuleFor(command => command.TranslatedText)
+                .NotEmpty();
+        }
+    }
+
+    internal sealed class Handler : ICommandHandler<Command, Result<TranslationDetailResponse>>
+    {
+        private readonly IValidator<Command> _validator;
+        private readonly ITranslationRepository _translationRepository;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly ICurrentUserAccessor _currentUserAccessor;
+        private readonly TimeProvider _timeProvider;
+        private readonly ITranslationArtifactBuilder _artifactBuilder;
+
+        public Handler(
+            IValidator<Command> validator,
+            ITranslationRepository translationRepository,
+            IUnitOfWork unitOfWork,
+            ICurrentUserAccessor currentUserAccessor,
+            TimeProvider timeProvider,
+            ITranslationArtifactBuilder artifactBuilder)
+        {
+            _validator = validator;
+            _translationRepository = translationRepository;
+            _unitOfWork = unitOfWork;
+            _currentUserAccessor = currentUserAccessor;
+            _timeProvider = timeProvider;
+            _artifactBuilder = artifactBuilder;
+        }
+
+        public async ValueTask<Result<TranslationDetailResponse>> Handle(Command command, CancellationToken cancellationToken)
+        {
+            ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                string message = string.Join("; ", validationResult.Errors.Select(failure => failure.ErrorMessage));
+                return Result.Failure<TranslationDetailResponse>(new Error("Translations.Validation", message, TypeOfError.Validation));
+            }
+
+            ValueMaybe<IdentityId> currentUser = _currentUserAccessor.MaybeIdentityId;
+            if (currentUser.HasNoValue)
+            {
+                return Result.Failure<TranslationDetailResponse>(new Error(
+                    "Translations.Unauthenticated",
+                    "The current user identity is required to submit a translation.",
+                    TypeOfError.Forbidden));
+            }
+
+            Result<FragmentKey> keyResult = FragmentKey.Create(command.FileId, command.GossipId);
+            if (keyResult.IsFailure)
+            {
+                return Result.Failure<TranslationDetailResponse>(keyResult.Error);
+            }
+
+            Maybe<Translation> translationMaybe = await _translationRepository.GetByFragmentKeyAsync(keyResult.Value, cancellationToken);
+            if (translationMaybe.HasNoValue)
+            {
+                return Result.Failure<TranslationDetailResponse>(DomainErrors.TranslationEntity.NotFound(command.FileId, command.GossipId));
+            }
+
+            Translation translation = translationMaybe.Value;
+
+            // A soft-removed row was cut from the game and the distributed file — it is excluded from
+            // translation work (spec 0001), so it cannot receive new Polish.
+            if (translation.IsRemoved)
+            {
+                return Result.Failure<TranslationDetailResponse>(DomainErrors.TranslationEntity.CannotEditRemoved);
+            }
+
+            // Editing an Approved row drops it from the distributed set (Status -> Draft), so the
+            // artifact must be rebuilt; an edit to any other status does not change that set.
+            bool wasApproved = translation.Status is TranslationStatus.Approved;
+
+            translation.ProvideTranslation(command.TranslatedText, currentUser.Value, _timeProvider.GetUtcNow());
+
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            if (wasApproved)
+            {
+                await _artifactBuilder.RebuildAsync(SupportedLanguages.Polish, cancellationToken);
+            }
+
+            return Result.Success(ToDetailResponse(translation));
+        }
+
+        private static TranslationDetailResponse ToDetailResponse(Translation translation)
+            => new(
+                translation.Id,
+                translation.FragmentKey.FileId,
+                translation.FragmentKey.GossipId,
+                translation.Source.Text,
+                translation.Source.ArgsOrder,
+                translation.Source.ArgsId,
+                translation.TranslatedText,
+                translation.PreviousSourceText,
+                translation.SubmittedById?.Value,
+                translation.Status,
+                translation.CreatedAt,
+                translation.UpdatedAt);
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapPut("/api/v1/translations", async (
+                UpsertTranslationRequest request,
+                ICommandHandler<Command, Result<TranslationDetailResponse>> handler,
+                CancellationToken cancellationToken) =>
+            {
+                Command command = new(request.FileId, request.GossipId, request.TranslatedText);
+
+                Result<TranslationDetailResponse> result = await handler.Handle(command, cancellationToken);
+
+                return result.IsSuccess
+                    ? Results.Ok(result.Value)
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(UpsertTranslation))
+            .WithTags("Translations")
+            .RequireAuthorization(AuthorizationPolicies.RequireTranslatorRole)
+            .Produces<TranslationDetailResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/TranslationDetailResponse.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/TranslationDetailResponse.cs
@@ -6,7 +6,8 @@ namespace LotroKoniecDev.TranslationSystem.Contracts.Translations;
 /// <summary>
 /// A single translation in full: the English source plus its argument columns (for placeholder
 /// validation), the current Polish, the superseded English kept for side-by-side review when a
-/// game update invalidated the row, and the workflow status. Backs the side-by-side editor.
+/// game update invalidated the row, the workflow status and the id of the translator who last
+/// submitted Polish (<c>null</c> while still untranslated). Backs the side-by-side editor.
 /// </summary>
 public sealed record TranslationDetailResponse(
     TranslationId Id,
@@ -17,6 +18,7 @@ public sealed record TranslationDetailResponse(
     string? ArgsId,
     string? TranslatedText,
     string? PreviousSourceText,
+    Guid? SubmittedById,
     TranslationStatus Status,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/UpsertTranslationRequest.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/UpsertTranslationRequest.cs
@@ -1,0 +1,11 @@
+namespace LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+/// <summary>
+/// Creates or updates the Polish content of one translation row, identified by its stable fragment
+/// key <c>(FileId, GossipId)</c> (spec 0001). The submitting translator is taken from the
+/// authenticated identity, never the request body.
+/// </summary>
+public sealed record UpsertTranslationRequest(
+    int FileId,
+    long GossipId,
+    string TranslatedText);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
@@ -1,6 +1,7 @@
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
 using LotroKoniecDev.SharedKernel.Guards;
 using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
@@ -20,6 +21,7 @@ public sealed class Translation : AggregateRoot<TranslationId>
     public TranslationSource Source { get; private set; }
     public string? TranslatedText { get; private set; }
     public string? PreviousSourceText { get; private set; }
+    public IdentityId? SubmittedById { get; private set; }
     public TranslationStatus Status { get; private set; }
     public GameVersionId IntroducedInVersion { get; private set; }
     public GameVersionId? LastSourceChangeInVersion { get; private set; }
@@ -97,14 +99,20 @@ public sealed class Translation : AggregateRoot<TranslationId>
     }
 
     /// <summary>
-    /// Attaches the Polish draft for this row (the upsert/seed helper; #100 enriches it with
-    /// placeholder validation). Untranslated/NeedsReview move to <see cref="TranslationStatus.Draft"/>.
+    /// Attaches (or replaces) the Polish draft for this row and stamps the submitting translator
+    /// (spec 0001, #100). Any prior status — Untranslated, Draft, Approved or NeedsReview — moves to
+    /// <see cref="TranslationStatus.Draft"/>: editing an Approved row deliberately pulls it out of the
+    /// distributed set until it is re-approved. <see cref="PreviousSourceText"/> is left untouched, so
+    /// re-translating an invalidated row keeps the superseded English for side-by-side context until
+    /// approve clears it. The text is stored verbatim, preserving its <c>&lt;--DO_NOT_TOUCH!--&gt;</c>
+    /// placeholders; the placeholder-count-mismatch warning UX lives in M3.
     /// </summary>
-    public void ProvideTranslation(string translatedText, DateTimeOffset now)
+    public void ProvideTranslation(string translatedText, IdentityId submittedBy, DateTimeOffset now)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(translatedText);
 
         TranslatedText = translatedText;
+        SubmittedById = submittedBy;
         Status = TranslationStatus.Draft;
         UpdatedAt = now;
     }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Repositories/ITranslationRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Repositories/ITranslationRepository.cs
@@ -1,5 +1,7 @@
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 
 namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
@@ -13,6 +15,12 @@ public interface ITranslationRepository : IRepository<Translation, TranslationId
     /// proven ~780k-row envelope; revisit only if a real perf need appears.
     /// </summary>
     Task<IReadOnlyList<Translation>> GetAllAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Loads the single tracked translation for a fragment identity, or <see cref="Maybe{T}.None"/>
+    /// when the pair is unknown. Backs the editor upsert path, which mutates the returned aggregate.
+    /// </summary>
+    Task<Maybe<Translation>> GetByFragmentKeyAsync(FragmentKey fragmentKey, CancellationToken cancellationToken);
 
     void InsertRange(IEnumerable<Translation> translations);
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/TranslationAggregateDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/TranslationAggregateDomainErrors.cs
@@ -11,6 +11,16 @@ public static partial class DomainErrors
         public static Error NotFound(TranslationId id)
             => HasNotBeenFound(nameof(TranslationEntity), id.Value);
 
+        public static Error NotFound(int fileId, long gossipId)
+            => new($"{nameof(TranslationEntity)}.NotFound",
+                $"The translation for fragment ({fileId}, {gossipId}) has not been found.",
+                TypeOfError.NotFound);
+
+        public static Error CannotEditRemoved
+            => InvalidOperation(nameof(TranslationEntity),
+                "A soft-removed translation cannot be edited.",
+                "CannotEditRemoved");
+
         public static Error CannotApproveWithoutTranslation
             => InvalidOperation(nameof(TranslationEntity),
                 "A translation cannot be approved without Polish content.",

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdsConverters.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdsConverters.cs
@@ -1,3 +1,4 @@
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationArtifactAggregate;
@@ -29,6 +30,12 @@ public static class StronglyTypedIdsConverters
             .Properties<TranslationArtifactId>()
             .HaveConversion<TranslationArtifactIdConverter>();
 
+        // IdentityId is the AuthSystem user id (cross-context reference) stamped on edited rows as
+        // SubmittedById; it lives in the SharedKernel, not the TMS Primitives, but persists the same way.
+        configurationBuilder
+            .Properties<IdentityId>()
+            .HaveConversion<IdentityIdConverter>();
+
         return configurationBuilder;
     }
 
@@ -47,4 +54,8 @@ public static class StronglyTypedIdsConverters
     private sealed class TranslationArtifactIdConverter() : ValueConverter<TranslationArtifactId, Guid>(
         id => id.Value,
         value => new TranslationArtifactId(value));
+
+    private sealed class IdentityIdConverter() : ValueConverter<IdentityId, Guid>(
+        id => id.Value,
+        value => new IdentityId(value));
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
@@ -1,5 +1,7 @@
+using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using Microsoft.EntityFrameworkCore;
@@ -18,6 +20,18 @@ internal sealed class TranslationRepository : GenericRepository<Translation, Tra
             .ToListAsync(cancellationToken);
 
         return translations;
+    }
+
+    public async Task<Maybe<Translation>> GetByFragmentKeyAsync(FragmentKey fragmentKey, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(fragmentKey);
+
+        Translation? translation = await DbContext.Set<Translation>()
+            .FirstOrDefaultAsync(
+                row => row.FragmentKey.FileId == fragmentKey.FileId && row.FragmentKey.GossipId == fragmentKey.GossipId,
+                cancellationToken);
+
+        return Maybe<Translation>.From(translation);
     }
 
     public void InsertRange(IEnumerable<Translation> translations)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613231019_AddTranslationSubmittedById.Designer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613231019_AddTranslationSubmittedById.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationWriteDbContext))]
-    partial class ApplicationWriteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613231019_AddTranslationSubmittedById")]
+    partial class AddTranslationSubmittedById
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613231019_AddTranslationSubmittedById.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260613231019_AddTranslationSubmittedById.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTranslationSubmittedById : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "SubmittedById",
+                schema: "translation",
+                table: "Translations",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SubmittedById",
+                schema: "translation",
+                table: "Translations");
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Aggregates/TranslationAggregate/TranslationReadModel.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/Aggregates/TranslationAggregate/TranslationReadModel.cs
@@ -14,6 +14,7 @@ public sealed record TranslationReadModel(
     string? ArgsId,
     string? TranslatedText,
     string? PreviousSourceText,
+    Guid? SubmittedById,
     TranslationStatus Status,
     GameVersionId IntroducedInVersion,
     GameVersionId? LastSourceChangeInVersion,

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 using LotroKoniecDev.TranslationSystem.Contracts.Import;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
@@ -240,7 +241,7 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
         Translation translation = await dbContext.Translations
             .SingleAsync(row => row.FragmentKey.FileId == FileId && row.FragmentKey.GossipId == gossipId);
-        translation.ProvideTranslation(polish, DateTimeOffset.UtcNow);
+        translation.ProvideTranslation(polish, IdentityId.Create(), DateTimeOffset.UtcNow);
         await dbContext.SaveChangesAsync();
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
@@ -20,6 +21,7 @@ public sealed class GetTranslationFileTests : IAsyncLifetime
     private const int FileId = 620756992;
     private const string Route = "/api/v1/translation-files/pl";
     private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly IdentityId Submitter = IdentityId.Create();
 
     private readonly TranslationSystemApiFactory _factory;
     private GameVersionId _versionId;
@@ -224,18 +226,18 @@ public sealed class GetTranslationFileTests : IAsyncLifetime
         switch (status)
         {
             case SeedStatus.Draft:
-                row.ProvideTranslation(polish, Now);
+                row.ProvideTranslation(polish, Submitter, Now);
                 break;
             case SeedStatus.NeedsReview:
-                row.ProvideTranslation(polish, Now);
+                row.ProvideTranslation(polish, Submitter, Now);
                 row.ApplySourceChange(TranslationSource.Create("English reworded", null, null).Value, _versionId, Now);
                 break;
             case SeedStatus.Approved:
-                row.ProvideTranslation(polish, Now);
+                row.ProvideTranslation(polish, Submitter, Now);
                 row.Approve(Now);
                 break;
             case SeedStatus.ApprovedThenRemoved:
-                row.ProvideTranslation(polish, Now);
+                row.ProvideTranslation(polish, Submitter, Now);
                 row.Approve(Now);
                 row.MarkRemoved(_versionId, Now);
                 break;
@@ -251,7 +253,7 @@ public sealed class GetTranslationFileTests : IAsyncLifetime
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
         Translation row = await dbContext.Translations
             .SingleAsync(translation => translation.FragmentKey.FileId == FileId && translation.FragmentKey.GossipId == gossipId);
-        row.ProvideTranslation(polish, Now);
+        row.ProvideTranslation(polish, Submitter, Now);
         row.Approve(Now);
         await dbContext.SaveChangesAsync();
     }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationTests.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
@@ -145,7 +146,7 @@ public sealed class GetTranslationTests : IAsyncLifetime
             TranslationSource.Create("Original source", "1-2", "3-4").Value,
             _versionId,
             Now).Value;
-        row.ProvideTranslation("Polski tekst", Now);
+        row.ProvideTranslation("Polski tekst", IdentityId.Create(), Now);
         row.ApplySourceChange(TranslationSource.Create("Reworded source", "1-2", "3-4").Value, _versionId, Now);
         dbContext.Translations.Add(row);
         await dbContext.SaveChangesAsync();

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 using LotroKoniecDev.TranslationSystem.Contracts.Common;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
@@ -228,10 +229,10 @@ public sealed class ListTranslationsTests : IAsyncLifetime
         switch (status)
         {
             case TranslationStatus.Draft:
-                row.ProvideTranslation("Polski tekst", Now);
+                row.ProvideTranslation("Polski tekst", IdentityId.Create(), Now);
                 break;
             case TranslationStatus.NeedsReview:
-                row.ProvideTranslation("Polski tekst", Now);
+                row.ProvideTranslation("Polski tekst", IdentityId.Create(), Now);
                 row.ApplySourceChange(TranslationSource.Create($"{source} (reworded)", null, null).Value, _versionId, Now);
                 break;
         }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/UpsertTranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/UpsertTranslationTests.cs
@@ -1,0 +1,208 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
+
+[Collection("TranslationApi")]
+public sealed class UpsertTranslationTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+    private const string Route = "/api/v1/translations";
+    private const string FileRoute = "/api/v1/translation-files/pl";
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly IdentityId Seeder = IdentityId.Create();
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+
+    public UpsertTranslationTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+        _versionId = gameVersion.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Upsert_OnUntranslatedRow_ShouldReturn200DraftAndStampSubmitter()
+    {
+        // Arrange
+        await SeedAsync(gossipId: 1, source: "Welcome to Middle-earth!", SeedStatus.Untranslated);
+        Guid submitter = Guid.NewGuid();
+        using HttpClient client = TranslatorClient(submitter);
+
+        // Act
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            Route, new UpsertTranslationRequest(FileId, 1, "Witaj w Srodziemiu!"));
+        TranslationDetailResponse? body = await response.Content.ReadFromJsonAsync<TranslationDetailResponse>(JsonOptions);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        body.ShouldNotBeNull();
+        body.Status.ShouldBe(TranslationStatus.Draft);
+        body.TranslatedText.ShouldBe("Witaj w Srodziemiu!");
+        body.SubmittedById.ShouldBe(submitter);
+    }
+
+    [Fact]
+    public async Task Upsert_OnApprovedRow_ShouldMoveToDraftAndRegenerateArtifact()
+    {
+        // Arrange — two approved rows in the distributed file; editing row 1 must pull it out (spec 0001 Q1).
+        await SeedAsync(gossipId: 1, source: "One", SeedStatus.Approved, polish: "Alfa");
+        await SeedAsync(gossipId: 2, source: "Two", SeedStatus.Approved, polish: "Beta");
+        await RebuildArtifactAsync();
+        EntityTagHeaderValue firstEtag = (await _factory.CreateClient().GetAsync(FileRoute)).Headers.ETag!;
+        using HttpClient client = TranslatorClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            Route, new UpsertTranslationRequest(FileId, 1, "Alfa nowa"));
+        TranslationDetailResponse? body = await response.Content.ReadFromJsonAsync<TranslationDetailResponse>(JsonOptions);
+
+        HttpResponseMessage download = await _factory.CreateClient().GetAsync(FileRoute);
+        string file = await download.Content.ReadAsStringAsync();
+
+        // Assert — the edited row is now a draft and gone from the freshly rebuilt file; row 2 stays.
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        body!.Status.ShouldBe(TranslationStatus.Draft);
+        download.Headers.ETag.ShouldNotBe(firstEtag);
+        file.ShouldNotContain($"{FileId}||1||");
+        file.ShouldContain($"{FileId}||2||Beta||NULL||NULL||1");
+    }
+
+    [Fact]
+    public async Task Upsert_ForUnknownFragment_ShouldReturn404()
+    {
+        // Arrange — rows are born from import; there is no row for this pair.
+        using HttpClient client = TranslatorClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            Route, new UpsertTranslationRequest(FileId, 999, "Polski"));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Upsert_OnRemovedRow_ShouldReturn422()
+    {
+        // Arrange — a soft-removed row is excluded from translation work.
+        await SeedAsync(gossipId: 3, source: "Three", SeedStatus.ApprovedThenRemoved, polish: "Gamma");
+        using HttpClient client = TranslatorClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            Route, new UpsertTranslationRequest(FileId, 3, "Gamma nowa"));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Upsert_WithEmptyText_ShouldReturn400()
+    {
+        // Arrange
+        await SeedAsync(gossipId: 1, source: "One", SeedStatus.Untranslated);
+        using HttpClient client = TranslatorClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            Route, new UpsertTranslationRequest(FileId, 1, "   "));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Upsert_WithoutToken_ShouldReturn401()
+    {
+        // Arrange
+        await SeedAsync(gossipId: 1, source: "One", SeedStatus.Untranslated);
+
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().PutAsJsonAsync(
+            Route, new UpsertTranslationRequest(FileId, 1, "Polski"));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private enum SeedStatus
+    {
+        Untranslated,
+        Approved,
+        ApprovedThenRemoved,
+    }
+
+    private async Task SeedAsync(int gossipId, string source, SeedStatus status, string? polish = null)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create(source, null, null).Value,
+            _versionId,
+            Now).Value;
+
+        switch (status)
+        {
+            case SeedStatus.Approved:
+                row.ProvideTranslation(polish!, Seeder, Now);
+                row.Approve(Now);
+                break;
+            case SeedStatus.ApprovedThenRemoved:
+                row.ProvideTranslation(polish!, Seeder, Now);
+                row.Approve(Now);
+                row.MarkRemoved(_versionId, Now);
+                break;
+        }
+
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task RebuildArtifactAsync()
+    {
+        ITranslationArtifactBuilder builder = _factory.Services.GetRequiredService<ITranslationArtifactBuilder>();
+        await builder.RebuildAsync("pl", CancellationToken.None);
+    }
+
+    private HttpClient TranslatorClient(Guid subject)
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator, AuthConstants.Scopes.Api, subject));
+        return client;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
@@ -65,8 +65,9 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
 
     public static string CreateAccessToken(
         string role = AuthConstants.Roles.Translator,
-        string scope = AuthConstants.Scopes.Api)
-        => CreateToken(TestSigningKey, DateTime.UtcNow.AddMinutes(30), role, scope);
+        string scope = AuthConstants.Scopes.Api,
+        Guid? subject = null)
+        => CreateToken(TestSigningKey, DateTime.UtcNow.AddMinutes(30), role, scope, subject);
 
     public static string CreateExpiredAccessToken()
         => CreateToken(TestSigningKey, DateTime.UtcNow.AddMinutes(-20));
@@ -80,7 +81,8 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
         SymmetricSecurityKey signingKey,
         DateTime expires,
         string role = AuthConstants.Roles.Translator,
-        string scope = AuthConstants.Scopes.Api)
+        string scope = AuthConstants.Scopes.Api,
+        Guid? subject = null)
     {
         JsonWebTokenHandler handler = new();
 
@@ -94,7 +96,7 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
             SigningCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256),
             Claims = new Dictionary<string, object>
             {
-                ["sub"] = Guid.NewGuid().ToString(),
+                ["sub"] = (subject ?? Guid.NewGuid()).ToString(),
                 ["name"] = "integration-test-user",
                 ["email"] = "translator@lotro.koniec.dev",
                 ["role"] = role,

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/UpsertTranslationHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/UpsertTranslationHandlerTests.cs
@@ -1,0 +1,200 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.API.Features.Translations;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Translations;
+
+public sealed class UpsertTranslationHandlerTests
+{
+    private const int FileId = 620756992;
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly GameVersionId VersionId = GameVersionId.Create();
+    private static readonly IdentityId CurrentUser = IdentityId.Create();
+
+    // ITranslationRepository / IUnitOfWork are genuine public boundaries (stubbed); the current-user
+    // accessor and the artifact builder are internal interfaces NSubstitute can't proxy, so each gets
+    // a focused hand-written double.
+    private readonly ITranslationRepository _translationRepository = Substitute.For<ITranslationRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+    private readonly RecordingArtifactBuilder _artifactBuilder = new();
+
+    private UpsertTranslation.Handler CreateHandler(ValueMaybe<IdentityId>? currentUser = null)
+        => new(
+            new UpsertTranslation.Validator(),
+            _translationRepository,
+            _unitOfWork,
+            new StubCurrentUserAccessor(currentUser ?? ValueMaybe<IdentityId>.From(CurrentUser)),
+            TimeProvider.System,
+            _artifactBuilder);
+
+    private static UpsertTranslation.Command Command(int gossipId, string text)
+        => new(FileId, gossipId, text);
+
+    private static Translation Untranslated(int gossipId = 1, string source = "English")
+        => Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create(source, null, null).Value,
+            VersionId,
+            Now).Value;
+
+    private void GivenStoredRow(Translation translation)
+        => _translationRepository.GetByFragmentKeyAsync(Arg.Any<FragmentKey>(), Arg.Any<CancellationToken>())
+            .Returns(Maybe<Translation>.From(translation));
+
+    [Fact]
+    public async Task Handle_WhenTranslatedTextEmpty_ShouldReturnValidationError()
+    {
+        // Act
+        Result<TranslationDetailResponse> result = await CreateHandler().Handle(Command(1, "   "), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translations.Validation");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoCurrentUser_ShouldReturnForbidden()
+    {
+        // Arrange — defensive guard: the endpoint requires auth, but a token without a parseable
+        // subject must never be attributed to an empty submitter.
+        UpsertTranslation.Handler handler = CreateHandler(ValueMaybe<IdentityId>.None());
+
+        // Act
+        Result<TranslationDetailResponse> result = await handler.Handle(Command(1, "Polski"), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translations.Unauthenticated");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenRowUnknown_ShouldReturnNotFound()
+    {
+        // Arrange
+        _translationRepository.GetByFragmentKeyAsync(Arg.Any<FragmentKey>(), Arg.Any<CancellationToken>())
+            .Returns(Maybe<Translation>.None);
+
+        // Act
+        Result<TranslationDetailResponse> result = await CreateHandler().Handle(Command(404, "Polski"), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("TranslationEntity.NotFound");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenRowRemoved_ShouldReturnConflictAndNotPersist()
+    {
+        // Arrange — a soft-removed row is excluded from translation work (spec 0001).
+        Translation removed = Untranslated();
+        removed.ProvideTranslation("Polski", CurrentUser, Now);
+        removed.MarkRemoved(VersionId, Now);
+        GivenStoredRow(removed);
+
+        // Act
+        Result<TranslationDetailResponse> result = await CreateHandler().Handle(Command(1, "Nowy polski"), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("TranslationEntity.CannotEditRemoved");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_OnUntranslatedRow_ShouldSetDraftStampSubmitterAndNotRebuild()
+    {
+        // Arrange
+        Translation row = Untranslated();
+        GivenStoredRow(row);
+
+        // Act
+        Result<TranslationDetailResponse> result = await CreateHandler().Handle(Command(1, "Witaj"), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Status.ShouldBe(TranslationStatus.Draft);
+        result.Value.TranslatedText.ShouldBe("Witaj");
+        result.Value.SubmittedById.ShouldBe(CurrentUser.Value);
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+        // Editing a non-Approved row does not change the distributed set, so no artifact rebuild.
+        _artifactBuilder.RebuildCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Handle_OnApprovedRow_ShouldMoveToDraftAndRebuildArtifact()
+    {
+        // Arrange — an Approved row is in the distributed file; editing pulls it out (spec 0001 Q1).
+        Translation approved = Untranslated();
+        approved.ProvideTranslation("Stary polski", CurrentUser, Now);
+        approved.Approve(Now);
+        GivenStoredRow(approved);
+
+        // Act
+        Result<TranslationDetailResponse> result = await CreateHandler().Handle(Command(1, "Nowy polski"), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Status.ShouldBe(TranslationStatus.Draft);
+        _artifactBuilder.RebuildCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Handle_OnNeedsReviewRow_ShouldMoveToDraftAndKeepPreviousSource()
+    {
+        // Arrange — an invalidated row keeps its superseded English until approve (the re-translation path).
+        Translation needsReview = Untranslated(source: "Old English");
+        needsReview.ProvideTranslation("Stary polski", CurrentUser, Now);
+        needsReview.ApplySourceChange(TranslationSource.Create("New English", null, null).Value, VersionId, Now);
+        GivenStoredRow(needsReview);
+
+        // Act
+        Result<TranslationDetailResponse> result = await CreateHandler().Handle(Command(1, "Nowy polski"), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Status.ShouldBe(TranslationStatus.Draft);
+        result.Value.PreviousSourceText.ShouldBe("Old English");
+        result.Value.TranslatedText.ShouldBe("Nowy polski");
+        _artifactBuilder.RebuildCount.ShouldBe(0);
+    }
+
+    private sealed class RecordingArtifactBuilder : ITranslationArtifactBuilder
+    {
+        public int RebuildCount { get; private set; }
+
+        public Task RebuildAsync(string language, CancellationToken cancellationToken)
+        {
+            RebuildCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubCurrentUserAccessor : ICurrentUserAccessor
+    {
+        public StubCurrentUserAccessor(ValueMaybe<IdentityId> identityId)
+        {
+            MaybeIdentityId = identityId;
+        }
+
+        public ValueMaybe<IdentityId> MaybeIdentityId { get; }
+        public string? Email => null;
+        public string? Username => null;
+        public IEnumerable<string> Roles => [];
+        public bool IsAuthenticated => MaybeIdentityId.HasValue;
+        public bool IsInRole(string role) => false;
+        public bool HasOnlyRegularUserPrivileges() => true;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationDiffServiceTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationDiffServiceTests.cs
@@ -1,3 +1,4 @@
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Services;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
@@ -97,7 +98,7 @@ public sealed class TranslationDiffServiceTests
     {
         // Arrange
         Translation withPolish = Existing(1, 1, "Old");
-        withPolish.ProvideTranslation("Polski", StoredAt);
+        withPolish.ProvideTranslation("Polski", IdentityId.Create(), StoredAt);
         IncomingTranslation[] incoming = [Incoming(1, 1, "New")];
 
         // Act

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
@@ -1,4 +1,5 @@
 using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
@@ -12,6 +13,7 @@ public sealed class TranslationTests
     private static readonly DateTimeOffset Changed = new(2026, 6, 13, 12, 0, 0, TimeSpan.Zero);
     private static readonly GameVersionId IntroducedVersion = GameVersionId.Create();
     private static readonly GameVersionId ChangeVersion = GameVersionId.Create();
+    private static readonly IdentityId Submitter = IdentityId.Create();
 
     private static FragmentKey Key() => FragmentKey.Create(620756992, 1001).Value;
     private static TranslationSource Source(string text) => TranslationSource.Create(text, null, null).Value;
@@ -58,7 +60,7 @@ public sealed class TranslationTests
     {
         // Arrange
         Translation translation = CreateUntranslated();
-        translation.ProvideTranslation("Stary polski", Created);
+        translation.ProvideTranslation("Stary polski", Submitter, Created);
 
         // Act
         translation.ApplySourceChange(Source("New English"), ChangeVersion, Changed);
@@ -91,7 +93,7 @@ public sealed class TranslationTests
     {
         // Arrange
         Translation translation = CreateUntranslated();
-        translation.ProvideTranslation("Polski", Created);
+        translation.ProvideTranslation("Polski", Submitter, Created);
         translation.MarkRemoved(ChangeVersion, Changed);
 
         // Act
@@ -126,12 +128,34 @@ public sealed class TranslationTests
         Translation translation = CreateUntranslated();
 
         // Act
-        translation.ProvideTranslation("Witaj", Changed);
+        translation.ProvideTranslation("Witaj", Submitter, Changed);
 
         // Assert
         translation.Status.ShouldBe(TranslationStatus.Draft);
         translation.TranslatedText.ShouldBe("Witaj");
+        translation.SubmittedById.ShouldBe(Submitter);
         translation.UpdatedAt.ShouldBe(Changed);
+    }
+
+    [Fact]
+    public void ProvideTranslation_OnNeedsReviewRow_ShouldReturnToDraftAndKeepPreviousSource()
+    {
+        // Arrange — an invalidated row (a game update reworded its source): re-translating it is the
+        // #100 re-translation path. The superseded English must stay until approve clears it.
+        Translation translation = CreateUntranslated();
+        translation.ProvideTranslation("Stary polski", Submitter, Created);
+        translation.ApplySourceChange(Source("New English"), ChangeVersion, Changed);
+        translation.Status.ShouldBe(TranslationStatus.NeedsReview);
+        IdentityId reviewer = IdentityId.Create();
+
+        // Act
+        translation.ProvideTranslation("Nowy polski", reviewer, Changed);
+
+        // Assert
+        translation.Status.ShouldBe(TranslationStatus.Draft);
+        translation.TranslatedText.ShouldBe("Nowy polski");
+        translation.PreviousSourceText.ShouldBe("Old English");
+        translation.SubmittedById.ShouldBe(reviewer);
     }
 
     [Fact]
@@ -139,7 +163,7 @@ public sealed class TranslationTests
     {
         // Arrange
         Translation translation = CreateUntranslated();
-        translation.ProvideTranslation("Witaj", Created);
+        translation.ProvideTranslation("Witaj", Submitter, Created);
 
         // Act
         Result result = translation.Approve(Changed);
@@ -155,7 +179,7 @@ public sealed class TranslationTests
     {
         // Arrange — an invalidated row keeps its Polish; approving re-publishes it (spec 0001).
         Translation translation = CreateUntranslated();
-        translation.ProvideTranslation("Stary polski", Created);
+        translation.ProvideTranslation("Stary polski", Submitter, Created);
         translation.ApplySourceChange(Source("New English"), ChangeVersion, Changed);
         translation.Status.ShouldBe(TranslationStatus.NeedsReview);
 
@@ -187,7 +211,7 @@ public sealed class TranslationTests
     {
         // Arrange
         Translation translation = CreateUntranslated();
-        translation.ProvideTranslation("Polski", Created);
+        translation.ProvideTranslation("Polski", Submitter, Created);
         translation.MarkRemoved(ChangeVersion, Changed);
 
         // Act


### PR DESCRIPTION
Closes #100

## Summary
`PUT /api/v1/translations` — attaches/updates the Polish content of an existing translation row (the row is born from import with English source only).

- Any prior status → `Draft`; submitting translator stamped from the **authenticated identity** (`ICurrentUserAccessor`, never the request body).
- Re-translating a `NeedsReview` row keeps `PreviousSourceText` until approve.
- Editing an `Approved` row drops it from the distributed set → regenerates the pre-built artifact.
- Guards: unknown pair → 404, soft-removed row → 422, empty text → 400, missing identity → 403.
- Adds the nullable `SubmittedById` (`IdentityId` VO) column + EF converter + migration `AddTranslationSubmittedById`; corrected the stale CLAUDE.md bullet that claimed the first migration already carried it (`ApprovedById` lands with #101).

## Acceptance criteria — all met
- [x] Create + update paths; UNIQUE(FileId, GossipId) enforced
- [x] `NeedsReview` → Draft on upsert; `PreviousSourceText` preserved
- [x] Editing an Approved row regenerates the artifact
- [x] `SubmittedById` stamped from auth
- [x] Validation failures → `Result.Failure` (never throws)
- [x] Handler unit + endpoint integration tests

## Tests
Build: 0 warnings. 63 domain-unit + 55 API-unit + 45 integration (real PostgreSQL) — all green. `code-reviewer`: APPROVE (one nit actioned: declared 403 in OpenAPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)