### PR TITLE
M2-19: Slice — GameVersion endpoints (list + manual register fallback)

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -15,12 +15,14 @@ using LotroKoniecDev.TranslationSystem.API.Auth;
 using LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
 using LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
 using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
 using LotroKoniecDev.TranslationSystem.API.Features.Import;
 using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 using LotroKoniecDev.TranslationSystem.API.Features.Translations;
 using LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
 using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
 using LotroKoniecDev.TranslationSystem.Contracts.Import;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 
@@ -58,6 +60,7 @@ internal static class ApiDependencyInjection
             services.AddImportFeature();
             services.AddTranslationsFeature();
             services.AddTranslationFilesFeature();
+            services.AddGameVersionsFeature();
 
             return services;
         }
@@ -100,6 +103,18 @@ internal static class ApiDependencyInjection
             services.AddScoped<
                 IQueryHandler<GetTranslationFile.Query, Result<GetTranslationFile.TranslationFileResult>>,
                 GetTranslationFile.Handler>();
+        }
+
+        private void AddGameVersionsFeature()
+        {
+            services.AddScoped<
+                IQueryHandler<ListGameVersions.Query, Result<IReadOnlyList<GameVersionResponse>>>,
+                ListGameVersions.Handler>();
+
+            services.AddScoped<IValidator<RegisterGameVersion.Command>, RegisterGameVersion.Validator>();
+            services.AddScoped<
+                ICommandHandler<RegisterGameVersion.Command, Result<GameVersionResponse>>,
+                RegisterGameVersion.Handler>();
         }
 
         public IServiceCollection AddJwtBearerAuthentication(IWebHostEnvironment environment)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/ListGameVersions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/ListGameVersions.cs
@@ -1,0 +1,63 @@
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
+
+/// <summary>
+/// Lists every known game version newest-first (spec 0001): the admin watches which versions are
+/// pending (Unprocessed), already Processed, or Superseded. Reads the POCO read model — never the
+/// write aggregate (CQRS, ADR-0002 amendment). Few rows ever exist (one per game update), so this is
+/// an unpaged ordered list by design.
+/// </summary>
+internal sealed class ListGameVersions : IEndpoint
+{
+    internal sealed record Query : IQuery<Result<IReadOnlyList<GameVersionResponse>>>;
+
+    internal sealed class Handler : IQueryHandler<Query, Result<IReadOnlyList<GameVersionResponse>>>
+    {
+        private readonly IApplicationReadDbContext _readDbContext;
+
+        public Handler(IApplicationReadDbContext readDbContext)
+        {
+            _readDbContext = readDbContext;
+        }
+
+        public async ValueTask<Result<IReadOnlyList<GameVersionResponse>>> Handle(Query query, CancellationToken cancellationToken)
+        {
+            List<GameVersionResponse> items = await _readDbContext.GameVersions
+                .OrderByDescending(gameVersion => gameVersion.DetectedAt)
+                .Select(gameVersion => new GameVersionResponse(
+                    gameVersion.Id,
+                    gameVersion.LotroNotationVersion,
+                    gameVersion.DetectedAt,
+                    gameVersion.Status))
+                .ToListAsync(cancellationToken);
+
+            return Result.Success<IReadOnlyList<GameVersionResponse>>(items);
+        }
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapGet("/api/v1/game-versions", async (
+                IQueryHandler<Query, Result<IReadOnlyList<GameVersionResponse>>> handler,
+                CancellationToken cancellationToken) =>
+            {
+                Result<IReadOnlyList<GameVersionResponse>> result = await handler.Handle(new Query(), cancellationToken);
+
+                return result.IsSuccess
+                    ? Results.Ok(result.Value)
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(ListGameVersions))
+            .WithTags("GameVersions")
+            .RequireAuthorization(AuthorizationPolicies.RequireTranslatorRole)
+            .Produces<IReadOnlyList<GameVersionResponse>>(StatusCodes.Status200OK);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/RegisterGameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/RegisterGameVersion.cs
@@ -1,0 +1,120 @@
+using FluentValidation;
+using FluentValidation.Results;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
+
+/// <summary>
+/// Manually registers a game version (spec 0001): the degenerate fallback the admin uses when the
+/// forum scrape breaks. Creates an Unprocessed version; a duplicate version string is a conflict
+/// (the registration is idempotent in effect — the existing version stands).
+/// </summary>
+internal sealed class RegisterGameVersion : IEndpoint
+{
+    internal sealed record Command(string Version) : ICommand<Result<GameVersionResponse>>;
+
+    internal sealed class Validator : AbstractValidator<Command>
+    {
+        public Validator()
+        {
+            RuleFor(command => command.Version)
+                .NotEmpty()
+                .MaximumLength(LotroNotationVersion.VersionMaxLength);
+        }
+    }
+
+    internal sealed class Handler : ICommandHandler<Command, Result<GameVersionResponse>>
+    {
+        private readonly IValidator<Command> _validator;
+        private readonly IGameVersionRepository _gameVersionRepository;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly TimeProvider _timeProvider;
+
+        public Handler(
+            IValidator<Command> validator,
+            IGameVersionRepository gameVersionRepository,
+            IUnitOfWork unitOfWork,
+            TimeProvider timeProvider)
+        {
+            _validator = validator;
+            _gameVersionRepository = gameVersionRepository;
+            _unitOfWork = unitOfWork;
+            _timeProvider = timeProvider;
+        }
+
+        public async ValueTask<Result<GameVersionResponse>> Handle(Command command, CancellationToken cancellationToken)
+        {
+            ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                string message = string.Join("; ", validationResult.Errors.Select(failure => failure.ErrorMessage));
+                return Result.Failure<GameVersionResponse>(new Error("GameVersions.Validation", message, TypeOfError.Validation));
+            }
+
+            Result<LotroNotationVersion> versionResult = LotroNotationVersion.Create(command.Version);
+            if (versionResult.IsFailure)
+            {
+                return Result.Failure<GameVersionResponse>(versionResult.Error);
+            }
+
+            LotroNotationVersion version = versionResult.Value;
+
+            if (await _gameVersionRepository.ExistsByVersionAsync(version, cancellationToken))
+            {
+                return Result.Failure<GameVersionResponse>(DomainErrors.GameVersionEntity.VersionAlreadyRegistered(version.Value));
+            }
+
+            Result<GameVersion> gameVersionResult = GameVersion.Create(version, _timeProvider.GetUtcNow());
+            if (gameVersionResult.IsFailure)
+            {
+                return Result.Failure<GameVersionResponse>(gameVersionResult.Error);
+            }
+
+            GameVersion gameVersion = gameVersionResult.Value;
+            _gameVersionRepository.Insert(gameVersion);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success(new GameVersionResponse(
+                gameVersion.Id,
+                gameVersion.LotroNotationVersion.Value,
+                gameVersion.DetectedAt,
+                gameVersion.Status));
+        }
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapPost("/api/v1/game-versions", async (
+                RegisterGameVersionRequest request,
+                ICommandHandler<Command, Result<GameVersionResponse>> handler,
+                CancellationToken cancellationToken) =>
+            {
+                Command command = new(request.Version);
+
+                Result<GameVersionResponse> result = await handler.Handle(command, cancellationToken);
+
+                // No item endpoint yet (YAGNI); the created version is discoverable in the collection.
+                return result.IsSuccess
+                    ? Results.Created("/api/v1/game-versions", result.Value)
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(RegisterGameVersion))
+            .WithTags("GameVersions")
+            .RequireAuthorization(AuthorizationPolicies.RequireAdminRole)
+            .Produces<GameVersionResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/GameVersions/GameVersionResponse.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/GameVersions/GameVersionResponse.cs
@@ -1,0 +1,15 @@
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+
+/// <summary>
+/// One detected (or manually registered) LOTRO game version: the dotted version string, when it was
+/// detected and its lifecycle status (Unprocessed, Processed, or Superseded when a newer version was
+/// processed first). Backs the admin's update dashboard (spec 0001).
+/// </summary>
+public sealed record GameVersionResponse(
+    GameVersionId Id,
+    string Version,
+    DateTimeOffset DetectedAt,
+    GameVersionStatus Status);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/GameVersions/RegisterGameVersionRequest.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/GameVersions/RegisterGameVersionRequest.cs
@@ -1,0 +1,7 @@
+namespace LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+
+/// <summary>
+/// Manually registers a game version — the degenerate fallback for when the forum scrape breaks
+/// (spec 0001): the dotted LOTRO notation string, e.g. <c>48.0</c>.
+/// </summary>
+public sealed record RegisterGameVersionRequest(string Version);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/ListGameVersionsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/ListGameVersionsTests.cs
@@ -1,0 +1,117 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.GameVersions;
+
+[Collection("TranslationApi")]
+public sealed class ListGameVersionsTests : IAsyncLifetime
+{
+    private const string Route = "/api/v1/game-versions";
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+
+    public ListGameVersionsTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task List_ReturnsVersionsNewestFirstWithStatus()
+    {
+        // Arrange — three versions detected on different days, with mixed lifecycle statuses.
+        await SeedAsync("47.0", Now, GameVersionStatus.Superseded);
+        await SeedAsync("47.1", Now.AddDays(1), GameVersionStatus.Processed);
+        await SeedAsync("48.0", Now.AddDays(2), GameVersionStatus.Unprocessed);
+        using HttpClient client = TranslatorClient();
+
+        // Act
+        GameVersionResponse[]? body = await (await client.GetAsync(Route))
+            .Content.ReadFromJsonAsync<GameVersionResponse[]>(JsonOptions);
+
+        // Assert — newest first; status round-trips.
+        body.ShouldNotBeNull();
+        body.Length.ShouldBe(3);
+        body[0].Version.ShouldBe("48.0");
+        body[0].Status.ShouldBe(GameVersionStatus.Unprocessed);
+        body[1].Version.ShouldBe("47.1");
+        body[1].Status.ShouldBe(GameVersionStatus.Processed);
+        body[2].Version.ShouldBe("47.0");
+        body[2].Status.ShouldBe(GameVersionStatus.Superseded);
+    }
+
+    [Fact]
+    public async Task List_WhenEmpty_ReturnsEmptyArray()
+    {
+        // Arrange
+        using HttpClient client = TranslatorClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(Route);
+        GameVersionResponse[]? body = await response.Content.ReadFromJsonAsync<GameVersionResponse[]>(JsonOptions);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        body.ShouldNotBeNull();
+        body.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task List_WithoutToken_ShouldReturn401()
+    {
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync(Route);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task SeedAsync(string version, DateTimeOffset detectedAt, GameVersionStatus status)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, detectedAt).Value;
+        switch (status)
+        {
+            case GameVersionStatus.Processed:
+                gameVersion.MarkProcessed();
+                break;
+            case GameVersionStatus.Superseded:
+                gameVersion.MarkSuperseded();
+                break;
+        }
+
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private HttpClient TranslatorClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+        return client;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/RegisterGameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/RegisterGameVersionTests.cs
@@ -1,0 +1,123 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.GameVersions;
+
+[Collection("TranslationApi")]
+public sealed class RegisterGameVersionTests : IAsyncLifetime
+{
+    private const string Route = "/api/v1/game-versions";
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+
+    public RegisterGameVersionTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Register_WithNewVersion_ShouldReturn201UnprocessedAndAppearInList()
+    {
+        // Arrange
+        using HttpClient client = AdminClient();
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("48.0"));
+        GameVersionResponse? body = await response.Content.ReadFromJsonAsync<GameVersionResponse>(JsonOptions);
+        GameVersionResponse[]? list = await (await client.GetAsync(Route))
+            .Content.ReadFromJsonAsync<GameVersionResponse[]>(JsonOptions);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+        body.ShouldNotBeNull();
+        body.Version.ShouldBe("48.0");
+        body.Status.ShouldBe(GameVersionStatus.Unprocessed);
+        list.ShouldNotBeNull();
+        list.ShouldContain(version => version.Version == "48.0");
+    }
+
+    [Fact]
+    public async Task Register_DuplicateVersion_ShouldReturn422()
+    {
+        // Arrange — registering the same version twice is a conflict (idempotent in effect).
+        using HttpClient client = AdminClient();
+        await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("48.0"));
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("48.0"));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Register_WithEmptyVersion_ShouldReturn400()
+    {
+        // Arrange
+        using HttpClient client = AdminClient();
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("   "));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Register_AsTranslator_ShouldReturn403()
+    {
+        // Arrange — manual registration is an admin-only fallback.
+        using HttpClient client = TranslatorClient();
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("48.0"));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Register_WithoutToken_ShouldReturn401()
+    {
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().PostAsJsonAsync(Route, new RegisterGameVersionRequest("48.0"));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private HttpClient AdminClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Admin));
+        return client;
+    }
+
+    private HttpClient TranslatorClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+        return client;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/GameVersions/RegisterGameVersionHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/GameVersions/RegisterGameVersionHandlerTests.cs
@@ -1,0 +1,83 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.GameVersions;
+
+public sealed class RegisterGameVersionHandlerTests
+{
+    // ITranslationRepository-style genuine boundaries; both are public interfaces NSubstitute proxies.
+    private readonly IGameVersionRepository _gameVersionRepository = Substitute.For<IGameVersionRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private RegisterGameVersion.Handler CreateHandler()
+        => new(new RegisterGameVersion.Validator(), _gameVersionRepository, _unitOfWork, TimeProvider.System);
+
+    [Fact]
+    public async Task Handle_WhenVersionEmpty_ShouldReturnValidationError()
+    {
+        // Act
+        Result<GameVersionResponse> result = await CreateHandler().Handle(new RegisterGameVersion.Command("  "), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("GameVersions.Validation");
+        _gameVersionRepository.DidNotReceive().Insert(Arg.Any<GameVersion>());
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenVersionTooLong_ShouldReturnValidationError()
+    {
+        // Arrange — past the LotroNotationVersion max length.
+        string tooLong = new('9', LotroNotationVersion.VersionMaxLength + 1);
+
+        // Act
+        Result<GameVersionResponse> result = await CreateHandler().Handle(new RegisterGameVersion.Command(tooLong), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("GameVersions.Validation");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenVersionAlreadyRegistered_ShouldReturnConflictAndNotPersist()
+    {
+        // Arrange
+        _gameVersionRepository.ExistsByVersionAsync(Arg.Any<LotroNotationVersion>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        Result<GameVersionResponse> result = await CreateHandler().Handle(new RegisterGameVersion.Command("48.0"), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("GameVersionEntity.LotroNotationVersion.AlreadyTaken");
+        _gameVersionRepository.DidNotReceive().Insert(Arg.Any<GameVersion>());
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenNew_ShouldCreateUnprocessedAndPersist()
+    {
+        // Arrange — repository reports the version is new (default substitute returns false).
+
+        // Act
+        Result<GameVersionResponse> result = await CreateHandler().Handle(new RegisterGameVersion.Command(" 48.0 "), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Version.ShouldBe("48.0");
+        result.Value.Status.ShouldBe(GameVersionStatus.Unprocessed);
+        // Persistence is invisible in the returned response (built from the in-memory aggregate),
+        // so SaveChanges is the persistence proof — matching the sibling command tests.
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Closes #107

## Summary
Two slices over the already-built GameVersion aggregate so the admin can watch detected versions and register one manually if the forum scrape breaks (spec 0001).

- **`GET /api/v1/game-versions`** (`RequireTranslatorRole`): every version newest-first with `DetectedAt` + lifecycle `Status` (Unprocessed/Processed/Superseded), read from the POCO read model. Unpaged by design — one row per game update.
- **`POST /api/v1/game-versions`** (`RequireAdminRole`): manual register fallback. Validates the dotted notation (FluentValidation + the `LotroNotationVersion` VO), rejects a duplicate as a **422** conflict (`ExistsByVersionAsync`), creates `Unprocessed`, returns **201** with the created version.
- New Contracts (`GameVersionResponse`, `RegisterGameVersionRequest`); DI via `AddGameVersionsFeature`. No domain/persistence change — the aggregate, repo and read model already existed.

## Acceptance criteria — all met
- [x] List shows detection + processing state, newest first
- [x] Manual register creates an unprocessed version; duplicate → conflict via Result
- [x] Auth enforced (401 anonymous; translator → 403 on register)
- [x] Handler unit tests + endpoint integration tests (real PostgreSQL)

## Tests
Build: 0 warnings. 66 API-unit + 60 integration (real PostgreSQL) — all green. `code-reviewer`: **APPROVE** (one nit actioned: success-path persistence proven via `SaveChangesAsync.Received(1)` to match sibling command tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)