### PR TITLE
M2-20: CLI — auto-download translation file before launch (freeze exception)

### DIFF
--- a/src/LotroKoniecDev.Application/Abstractions/ITranslationFileCache.cs
+++ b/src/LotroKoniecDev.Application/Abstractions/ITranslationFileCache.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.Application.Abstractions;
+
+/// <summary>
+/// Persists the downloaded translation file and the ETag last seen from the server, so the launch
+/// sync can issue a conditional request and reuse the latest download.
+/// </summary>
+public interface ITranslationFileCache
+{
+    /// <summary>The ETag stored alongside the cached translation file, or <c>null</c> when none is cached.</summary>
+    string? ReadETag(string translationFilePath);
+
+    /// <summary>Writes the downloaded translation file and its ETag.</summary>
+    Result Save(string translationFilePath, string content, string eTag);
+}

--- a/src/LotroKoniecDev.Application/Abstractions/ITranslationFileDownloader.cs
+++ b/src/LotroKoniecDev.Application/Abstractions/ITranslationFileDownloader.cs
@@ -1,0 +1,21 @@
+namespace LotroKoniecDev.Application.Abstractions;
+
+/// <summary>
+/// Fetches the current Polish translation file from the TMS distribution endpoint, honouring a cached
+/// ETag so an unchanged file is reported as not-modified instead of being re-downloaded.
+/// </summary>
+public interface ITranslationFileDownloader
+{
+    Task<Result<TranslationFileFetchResult>> FetchAsync(string baseUrl, string? currentETag, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The outcome of a conditional translation-file fetch: either the server confirmed the cached copy is
+/// still current (<see cref="IsModified"/> is <c>false</c>), or it returned a newer file with its ETag.
+/// </summary>
+public sealed record TranslationFileFetchResult(bool IsModified, string? Content, string? ETag)
+{
+    public static TranslationFileFetchResult NotModified() => new(false, null, null);
+
+    public static TranslationFileFetchResult Modified(string content, string eTag) => new(true, content, eTag);
+}

--- a/src/LotroKoniecDev.Application/Extensions/ApplicationDependencyInjection.cs
+++ b/src/LotroKoniecDev.Application/Extensions/ApplicationDependencyInjection.cs
@@ -5,6 +5,7 @@ using LotroKoniecDev.Application.Features.Exporting;
 using LotroKoniecDev.Application.Features.GameLaunching;
 using LotroKoniecDev.Application.Features.Patching;
 using LotroKoniecDev.Application.Features.PreflightChecking;
+using LotroKoniecDev.Application.Features.TranslationFileSyncing;
 using LotroKoniecDev.Application.Features.UpdateChecking;
 using LotroKoniecDev.Application.Parsers;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,9 +26,11 @@ public static class ApplicationDependencyInjection
         services.AddScoped<IQueryHandler<PreflightCheckQuery, Result<PreflightReportResponse>>, PreflightCheckQueryHandler>();
         services.AddScoped<ICommandHandler<ApplyPatchCommand, Result<PatchSummaryResponse>>, ApplyPatchCommandHandler>();
         services.AddScoped<ICommandHandler<GameLaunchingCommand, Result<GameLaunchingResponse>>, GameLaunchingCommandHandler>();
+        services.AddScoped<ICommandHandler<SyncTranslationFileCommand, Result<TranslationFileSyncResponse>>, SyncTranslationFileCommandHandler>();
 
         services.AddSingleton<IValidator<ApplyPatchCommand>, ApplyPatchCommandValidator>();
         services.AddSingleton<IValidator<GameLaunchingCommand>, GameLaunchingCommandValidator>();
+        services.AddSingleton<IValidator<SyncTranslationFileCommand>, SyncTranslationFileCommandValidator>();
 
         services.AddSingleton<ITranslationParser, TranslationFileParser>();
         services.AddSingleton<IGameUpdateChecker, GameUpdateChecker>();

--- a/src/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommand.cs
+++ b/src/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommand.cs
@@ -1,0 +1,11 @@
+using LotroKoniecDev.Application.Abstractions.Messaging;
+
+namespace LotroKoniecDev.Application.Features.TranslationFileSyncing;
+
+/// <summary>
+/// Syncs the local translation file with the TMS distribution endpoint before a launch (spec 0001 Q5):
+/// conditional download keyed by the cached ETag, written to <see cref="TranslationFilePath"/>.
+/// </summary>
+public sealed record SyncTranslationFileCommand(
+    string TmsBaseUrl,
+    string TranslationFilePath) : ICommand<Result<TranslationFileSyncResponse>>;

--- a/src/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommandHandler.cs
+++ b/src/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommandHandler.cs
@@ -1,0 +1,67 @@
+using FluentValidation;
+using FluentValidation.Results;
+using LotroKoniecDev.Application.Abstractions;
+using LotroKoniecDev.Application.Abstractions.Messaging;
+using LotroKoniecDev.Application.Extensions;
+using LotroKoniecDev.Domain.Core.Errors;
+
+namespace LotroKoniecDev.Application.Features.TranslationFileSyncing;
+
+internal sealed class SyncTranslationFileCommandHandler
+    : ICommandHandler<SyncTranslationFileCommand, Result<TranslationFileSyncResponse>>
+{
+    private readonly ITranslationFileDownloader _downloader;
+    private readonly ITranslationFileCache _cache;
+    private readonly IValidator<SyncTranslationFileCommand> _validator;
+
+    public SyncTranslationFileCommandHandler(
+        ITranslationFileDownloader downloader,
+        ITranslationFileCache cache,
+        IValidator<SyncTranslationFileCommand> validator)
+    {
+        _downloader = downloader;
+        _cache = cache;
+        _validator = validator;
+    }
+
+    public async ValueTask<Result<TranslationFileSyncResponse>> Handle(
+        SyncTranslationFileCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        ValidationResult validationResult = _validator.Validate(command);
+        if (!validationResult.IsValid)
+        {
+            return Result.Failure<TranslationFileSyncResponse>(
+                validationResult.ToValidationError(nameof(SyncTranslationFileCommand)));
+        }
+
+        string? currentETag = _cache.ReadETag(command.TranslationFilePath);
+
+        Result<TranslationFileFetchResult> fetchResult =
+            await _downloader.FetchAsync(command.TmsBaseUrl, currentETag, cancellationToken);
+
+        if (fetchResult.IsFailure)
+        {
+            // The launch must never block on the network (spec 0001 Q5): a failed fetch falls back to
+            // the local translation file. Whether one actually exists is the launch path's concern
+            // (it reports a missing file), not the sync's — so the network stays strictly best-effort.
+            return Result.Success(new TranslationFileSyncResponse(
+                TranslationFileSyncOutcome.OfflineUsedCache, fetchResult.Error.Message));
+        }
+
+        TranslationFileFetchResult fetch = fetchResult.Value;
+        if (!fetch.IsModified)
+        {
+            return Result.Success(new TranslationFileSyncResponse(TranslationFileSyncOutcome.UpToDate, null));
+        }
+
+        Result save = _cache.Save(command.TranslationFilePath, fetch.Content!, fetch.ETag!);
+        if (save.IsFailure)
+        {
+            return Result.Failure<TranslationFileSyncResponse>(save.Error);
+        }
+
+        return Result.Success(new TranslationFileSyncResponse(TranslationFileSyncOutcome.Updated, null));
+    }
+}

--- a/src/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommandValidator.cs
+++ b/src/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommandValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace LotroKoniecDev.Application.Features.TranslationFileSyncing;
+
+public sealed class SyncTranslationFileCommandValidator : AbstractValidator<SyncTranslationFileCommand>
+{
+    public SyncTranslationFileCommandValidator()
+    {
+        RuleFor(command => command.TmsBaseUrl)
+            .NotEmpty()
+            .Must(BeAnAbsoluteHttpUrl)
+            .WithMessage("The TMS base URL must be a valid absolute http(s) URL.");
+
+        RuleFor(command => command.TranslationFilePath)
+            .NotEmpty();
+    }
+
+    private static bool BeAnAbsoluteHttpUrl(string value)
+        => Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+           && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+}

--- a/src/LotroKoniecDev.Application/Features/TranslationFileSyncing/TranslationFileSyncResponse.cs
+++ b/src/LotroKoniecDev.Application/Features/TranslationFileSyncing/TranslationFileSyncResponse.cs
@@ -1,0 +1,27 @@
+namespace LotroKoniecDev.Application.Features.TranslationFileSyncing;
+
+/// <summary>What the launch sync did with the local translation file.</summary>
+public enum TranslationFileSyncOutcome
+{
+    /// <summary>A newer file was downloaded and written to disk.</summary>
+    Updated,
+
+    /// <summary>The server confirmed the cached file is current (HTTP 304) — nothing downloaded.</summary>
+    UpToDate,
+
+    /// <summary>The server was unreachable; the launch continues with the local translation file so it is never blocked on the network.</summary>
+    OfflineUsedCache
+}
+
+/// <summary>The result of a translation-file sync, with a human-readable summary for the CLI report.</summary>
+public sealed record TranslationFileSyncResponse(TranslationFileSyncOutcome Outcome, string? Detail)
+{
+    public override string ToString() => Outcome switch
+    {
+        TranslationFileSyncOutcome.Updated => "Downloaded the latest translation file from the server.",
+        TranslationFileSyncOutcome.UpToDate => "Translation file is already up to date.",
+        TranslationFileSyncOutcome.OfflineUsedCache =>
+            $"Could not reach the translation server; continuing with the local translation file. {Detail}".TrimEnd(),
+        _ => Outcome.ToString()
+    };
+}

--- a/src/LotroKoniecDev.Cli/Commands/GlobalSettings.cs
+++ b/src/LotroKoniecDev.Cli/Commands/GlobalSettings.cs
@@ -6,6 +6,14 @@ namespace LotroKoniecDev.Cli.Commands;
 internal class GlobalSettings : CommandSettings
 {
     public const string TranslationsDir = "translations";
+
+    /// <summary>
+    /// TMS distribution base URL the launch sync downloads the translation file from. Empty until the
+    /// TMS is deployed — while blank the launch skips the sync and uses the local translation file. Set
+    /// here (or override per-run with <c>--tms-url</c>) once the server has a stable address.
+    /// </summary>
+    public const string DefaultTmsBaseUrl = "";
+
     public static string DataDir => Path.GetFullPath("data");
     public static string VersionFilePath => Path.Combine(DataDir, "last_known_game_version.txt");
     

--- a/src/LotroKoniecDev.Cli/Commands/LaunchCommand.cs
+++ b/src/LotroKoniecDev.Cli/Commands/LaunchCommand.cs
@@ -5,6 +5,7 @@ using LotroKoniecDev.Application.Abstractions.Messaging;
 using LotroKoniecDev.Application.Features.GameLaunching;
 using LotroKoniecDev.Application.Features.Patching;
 using LotroKoniecDev.Application.Features.PreflightChecking;
+using LotroKoniecDev.Application.Features.TranslationFileSyncing;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Domain.Models;
 using Spectre.Console.Cli;
@@ -14,17 +15,20 @@ namespace LotroKoniecDev.Cli.Commands;
 internal sealed class LaunchCommand : AsyncCommand<LaunchCommand.Settings>
 {
     private readonly ICommandHandler<GameLaunchingCommand, Result<GameLaunchingResponse>> _gameLaunchingHandler;
+    private readonly ICommandHandler<SyncTranslationFileCommand, Result<TranslationFileSyncResponse>> _translationFileSyncHandler;
     private readonly IFileProvider _fileProvider;
     private readonly IOperationStatusReporter _reporter;
     private readonly IDatPathResolver _datPathResolver;
 
     public LaunchCommand(
         ICommandHandler<GameLaunchingCommand, Result<GameLaunchingResponse>> gameLaunchingHandler,
+        ICommandHandler<SyncTranslationFileCommand, Result<TranslationFileSyncResponse>> translationFileSyncHandler,
         IFileProvider fileProvider,
         IOperationStatusReporter reporter,
         IDatPathResolver datPathResolver)
     {
         _gameLaunchingHandler = gameLaunchingHandler;
+        _translationFileSyncHandler = translationFileSyncHandler;
         _fileProvider = fileProvider;
         _reporter = reporter;
         _datPathResolver = datPathResolver;
@@ -39,11 +43,32 @@ internal sealed class LaunchCommand : AsyncCommand<LaunchCommand.Settings>
         [CommandOption("-d|--dat-file-path")]
         [Description("Optional path to the DAT file")]
         public string? DatFilePath { get; init; }
+
+        [CommandOption("--tms-url")]
+        [Description("TMS API base URL for translation auto-download (overrides the configured default)")]
+        public string TmsBaseUrl { get; init; } = DefaultTmsBaseUrl;
+
+        [CommandOption("--skip-sync")]
+        [Description("Skip auto-downloading the translation file from the TMS (offline use)")]
+        [DefaultValue(false)]
+        public bool SkipSync { get; init; }
     }
     
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings,
         CancellationToken cancellationToken)
     {
+        // Auto-download the current translation file before launch (spec 0001 Q5, freeze exception):
+        // skipped when disabled or no TMS URL is configured. Never blocks launch on the network — an
+        // offline server with a cached file proceeds; only "offline + nothing cached" aborts here.
+        if (!settings.SkipSync && !string.IsNullOrWhiteSpace(settings.TmsBaseUrl))
+        {
+            int? syncFailureExitCode = await SyncTranslationFileAsync(settings, cancellationToken);
+            if (syncFailureExitCode is not null)
+            {
+                return syncFailureExitCode.Value;
+            }
+        }
+
         (string TranslationsPath, string DatFilePath)? actualResolvedPaths = ResolveCommandPaths(settings);
         if (actualResolvedPaths is null)
         {
@@ -74,6 +99,22 @@ internal sealed class LaunchCommand : AsyncCommand<LaunchCommand.Settings>
         }
     }
     
+    private async Task<int?> SyncTranslationFileAsync(Settings settings, CancellationToken cancellationToken)
+    {
+        string translationsPath = ResolveTranslationsPath(settings.TranslationName);
+        SyncTranslationFileCommand command = new(settings.TmsBaseUrl, translationsPath);
+
+        Result<TranslationFileSyncResponse> result = await _translationFileSyncHandler.Handle(command, cancellationToken);
+        if (result.IsFailure)
+        {
+            _reporter.Report(result.Error.ToString());
+            return ErrorMapper.MapErrorToExitCode(result.Error);
+        }
+
+        _reporter.Report(result.Value.ToString());
+        return null;
+    }
+
     private (string TranslationsPath, string DatFilePath)? ResolveCommandPaths(Settings settings)
     {
         string actualTranslationsPath = ResolveTranslationsPath(settings.TranslationName);

--- a/src/LotroKoniecDev.Domain/Core/Errors/TranslationFileSyncDomainErrors.cs
+++ b/src/LotroKoniecDev.Domain/Core/Errors/TranslationFileSyncDomainErrors.cs
@@ -1,0 +1,15 @@
+using LotroKoniecDev.Domain.Core.BuildingBlocks;
+
+namespace LotroKoniecDev.Domain.Core.Errors;
+
+public static partial class DomainErrors
+{
+    public static class TranslationFileSync
+    {
+        public static Error NetworkError(string message) =>
+            IoError("TranslationFileSync", "NetworkError", message);
+
+        public static Error CacheWriteError(string path, string message) =>
+            IoError("TranslationFileSync", "CacheWriteError", $"'{path}': {message}");
+    }
+}

--- a/src/LotroKoniecDev.Infrastructure/InfrastructureDependencyInjection.cs
+++ b/src/LotroKoniecDev.Infrastructure/InfrastructureDependencyInjection.cs
@@ -35,6 +35,8 @@ public static class InfrastructureDependencyInjection
             return client;
         });
         services.AddSingleton<IForumPageFetcher, ForumPageFetcher>();
+        services.AddSingleton<ITranslationFileDownloader, TranslationFileDownloader>();
+        services.AddSingleton<ITranslationFileCache, TranslationFileCache>();
         services.AddSingleton<IGameVersionFileStore, GameVersionFileStore>();
         services.AddSingleton<IFileHasher, FileHasher>();
 

--- a/src/LotroKoniecDev.Infrastructure/Network/TranslationFileDownloader.cs
+++ b/src/LotroKoniecDev.Infrastructure/Network/TranslationFileDownloader.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using LotroKoniecDev.Application.Abstractions;
+using LotroKoniecDev.Domain.Core.Errors;
+using LotroKoniecDev.Domain.Core.Monads;
+
+namespace LotroKoniecDev.Infrastructure.Network;
+
+/// <summary>
+/// Downloads the Polish translation file from the TMS distribution endpoint over HTTP with a
+/// conditional <c>If-None-Match</c> request, so an unchanged file returns 304 rather than its bytes.
+/// </summary>
+public sealed class TranslationFileDownloader : ITranslationFileDownloader
+{
+    private const string TranslationFileRoute = "api/v1/translation-files/pl";
+
+    private readonly HttpClient _httpClient;
+
+    public TranslationFileDownloader(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    public async Task<Result<TranslationFileFetchResult>> FetchAsync(
+        string baseUrl, string? currentETag, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Uri requestUri = new($"{baseUrl.TrimEnd('/')}/{TranslationFileRoute}", UriKind.Absolute);
+            using HttpRequestMessage request = new(HttpMethod.Get, requestUri);
+            if (!string.IsNullOrEmpty(currentETag))
+            {
+                // The stored value is the server's quoted ETag; send it verbatim.
+                request.Headers.TryAddWithoutValidation("If-None-Match", currentETag);
+            }
+
+            using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+
+            if (response.StatusCode == HttpStatusCode.NotModified)
+            {
+                return Result.Success(TranslationFileFetchResult.NotModified());
+            }
+
+            response.EnsureSuccessStatusCode();
+
+            string content = await response.Content.ReadAsStringAsync(cancellationToken);
+            string eTag = response.Headers.ETag?.ToString() ?? string.Empty;
+            return Result.Success(TranslationFileFetchResult.Modified(content, eTag));
+        }
+        catch (HttpRequestException ex)
+        {
+            return Result.Failure<TranslationFileFetchResult>(DomainErrors.TranslationFileSync.NetworkError(ex.Message));
+        }
+        catch (TaskCanceledException)
+        {
+            return Result.Failure<TranslationFileFetchResult>(DomainErrors.TranslationFileSync.NetworkError("The request timed out."));
+        }
+    }
+}

--- a/src/LotroKoniecDev.Infrastructure/Storage/TranslationFileCache.cs
+++ b/src/LotroKoniecDev.Infrastructure/Storage/TranslationFileCache.cs
@@ -1,0 +1,53 @@
+using LotroKoniecDev.Application.Abstractions;
+using LotroKoniecDev.Domain.Core.Errors;
+using LotroKoniecDev.Domain.Core.Monads;
+
+namespace LotroKoniecDev.Infrastructure.Storage;
+
+/// <summary>
+/// Stores the downloaded translation file and a sidecar <c>.etag</c> file next to it, so the launch
+/// sync can issue a conditional request and reuse the cached file when the server is unreachable.
+/// </summary>
+public sealed class TranslationFileCache : ITranslationFileCache
+{
+    public string? ReadETag(string translationFilePath)
+    {
+        string eTagPath = ETagPath(translationFilePath);
+        if (!File.Exists(eTagPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            return File.ReadAllText(eTagPath);
+        }
+        catch (IOException)
+        {
+            // A missing or unreadable sidecar just means "no cached ETag" — fetch the full file.
+            return null;
+        }
+    }
+
+    public Result Save(string translationFilePath, string content, string eTag)
+    {
+        try
+        {
+            string? directory = Path.GetDirectoryName(translationFilePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(translationFilePath, content);
+            File.WriteAllText(ETagPath(translationFilePath), eTag);
+            return Result.Success();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return Result.Failure(DomainErrors.TranslationFileSync.CacheWriteError(translationFilePath, ex.Message));
+        }
+    }
+
+    private static string ETagPath(string translationFilePath) => translationFilePath + ".etag";
+}

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Features/SyncTranslationFileCommandHandlerTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Features/SyncTranslationFileCommandHandlerTests.cs
@@ -1,0 +1,129 @@
+using LotroKoniecDev.Application.Abstractions;
+using LotroKoniecDev.Application.Features.TranslationFileSyncing;
+using LotroKoniecDev.Domain.Core.Errors;
+using LotroKoniecDev.Domain.Core.Monads;
+using LotroKoniecDev.Primitives.Enums;
+
+namespace LotroKoniecDev.Tests.Unit.Tests.Features;
+
+public sealed class SyncTranslationFileCommandHandlerTests
+{
+    private const string BaseUrl = "https://tms.example.com";
+    private const string FilePath = "translations/polish.txt";
+
+    private readonly ITranslationFileDownloader _downloader = Substitute.For<ITranslationFileDownloader>();
+    private readonly ITranslationFileCache _cache = Substitute.For<ITranslationFileCache>();
+    private readonly SyncTranslationFileCommandHandler _sut;
+
+    public SyncTranslationFileCommandHandlerTests()
+    {
+        _sut = new SyncTranslationFileCommandHandler(_downloader, _cache, new SyncTranslationFileCommandValidator());
+    }
+
+    private static SyncTranslationFileCommand Command() => new(BaseUrl, FilePath);
+
+    [Fact]
+    public async Task Handle_NullCommand_ShouldThrow()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => _sut.Handle(null!, CancellationToken.None).AsTask());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://tms.example.com")]
+    public async Task Handle_InvalidBaseUrl_ShouldReturnValidationErrorAndNotFetch(string baseUrl)
+    {
+        // Act
+        Result<TranslationFileSyncResponse> result =
+            await _sut.Handle(new SyncTranslationFileCommand(baseUrl, FilePath), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Type.ShouldBe(ErrorType.Validation);
+        await _downloader.DidNotReceive().FetchAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenServerReturnsNewFile_ShouldSaveItAndReportUpdated()
+    {
+        // Arrange
+        _downloader.FetchAsync(BaseUrl, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(TranslationFileFetchResult.Modified("polish content", "\"etag-1\"")));
+        _cache.Save(FilePath, "polish content", "\"etag-1\"").Returns(Result.Success());
+
+        // Act
+        Result<TranslationFileSyncResponse> result = await _sut.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Outcome.ShouldBe(TranslationFileSyncOutcome.Updated);
+    }
+
+    [Fact]
+    public async Task Handle_WhenServerReturnsNotModified_ShouldKeepCacheAndNotSave()
+    {
+        // Arrange
+        _downloader.FetchAsync(BaseUrl, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(TranslationFileFetchResult.NotModified()));
+
+        // Act
+        Result<TranslationFileSyncResponse> result = await _sut.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Outcome.ShouldBe(TranslationFileSyncOutcome.UpToDate);
+        _cache.DidNotReceive().Save(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenServerUnreachable_ShouldNotBlockLaunchAndContinueWithLocalFile()
+    {
+        // Arrange — the launch must never be blocked on the network (spec 0001 Q5). Whether a local
+        // translation file exists is the launch path's concern, so the sync only ever warns here.
+        _downloader.FetchAsync(BaseUrl, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<TranslationFileFetchResult>(DomainErrors.TranslationFileSync.NetworkError("offline")));
+
+        // Act
+        Result<TranslationFileSyncResponse> result = await _sut.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Outcome.ShouldBe(TranslationFileSyncOutcome.OfflineUsedCache);
+        _cache.DidNotReceive().Save(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenSaveFails_ShouldReturnFailure()
+    {
+        // Arrange
+        _downloader.FetchAsync(BaseUrl, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(TranslationFileFetchResult.Modified("content", "\"etag\"")));
+        _cache.Save(FilePath, "content", "\"etag\"")
+            .Returns(Result.Failure(DomainErrors.TranslationFileSync.CacheWriteError(FilePath, "disk full")));
+
+        // Act
+        Result<TranslationFileSyncResponse> result = await _sut.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("TranslationFileSync.CacheWriteError");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSendTheCachedETagOnTheConditionalRequest()
+    {
+        // Arrange
+        _cache.ReadETag(FilePath).Returns("\"cached-etag\"");
+        _downloader.FetchAsync(BaseUrl, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(TranslationFileFetchResult.NotModified()));
+
+        // Act
+        Result<TranslationFileSyncResponse> result = await _sut.Handle(Command(), CancellationToken.None);
+
+        // Assert — the conditional request carries the cached ETag, enabling the 304 path.
+        result.IsSuccess.ShouldBeTrue();
+        await _downloader.Received(1).FetchAsync(BaseUrl, "\"cached-etag\"", Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Closes #108

## Summary
The M2 capstone: the CLI `launch` command now auto-fetches the current Polish translation file from the TMS distribution endpoint, caches it (ETag), and feeds the proven hash → patch → launch flow (spec 0001 Q5, ADR-0002 §2). The **sole sanctioned exception to the patcher freeze** — one additive slice + launch-flow wiring; the launch handler and `SimplifiedGameLaunchingStrategy` are untouched and every pre-existing test stays green.

- New `Features/TranslationFileSyncing/` slice (command + slim handler + validator + response), de-mediatorized per the patcher recipe. Decision matrix: **200** → save file + ETag; **304** → keep cached; **offline/unreachable** → warn and continue with the local file. **The launch never blocks on the network** — a missing file is the existing launch path's concern (exit 2), not the sync's.
- New ports: `ITranslationFileDownloader` (HTTP conditional `If-None-Match`, impl mirrors `ForumPageFetcher`, reuses the shared `HttpClient`) + `ITranslationFileCache` (file + `.etag` sidecar).
- New additive `DomainErrors.TranslationFileSync` partial (no existing file touched).
- `LaunchCommand` runs the sync before the existing path/hash flow when `--tms-url` is configured and `--skip-sync` is unset; a blank URL (pre-deployment default) or `--skip-sync` skips it → identical behaviour to before. `patch <name>` untouched.

## Acceptance criteria — all met
- [x] 304 → no download; launch proceeds with the cached file
- [x] 200 → new file + ETag saved; hash flow patches; launch
- [x] API unreachable → warning + launch proceeds with the local file (never blocks)
- [x] Sync skippable via `--skip-sync` / blank `--tms-url`
- [x] All pre-existing patcher tests green, assertions untouched
- [x] Unit tests for the decision matrix (200/304/offline/save-failure/invalid-url/null + cached-ETag round-trip)

## Reviews & tests
Build 0 warnings. **232 patcher unit tests green** (E2E launch stays Windows-only, auto-skips here). `code-reviewer`: **APPROVE** (a first-pass blocker — "offline + no cache blocked launch", violating the spec's "never block on the network" — was fixed by making the network strictly best-effort; freeze confirmed intact). `/security-review`: **PASS, no findings** (ETag→`If-None-Match` header-injection candidate empirically confirmed non-exploitable; no path-traversal/SSRF/cert-bypass/RCE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)