### PR TITLE
M2-14: Docker compose stack — postgres + migrator + auth-api + tms-api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Copy to .env (git-ignored) and override as needed:  cp .env.example .env
+# The stack boots with these defaults out of the box (`docker compose up`),
+# so a .env is only needed when you want to change something.
+
+# --- Postgres ---
+POSTGRES_PASSWORD=postgres
+
+# --- Auth admin (seeded into the auth DB on first boot) ---
+# Leave blank to skip admin seeding. Set all three to seed a usable login.
+AUTH_ADMIN_USERNAME=
+AUTH_ADMIN_EMAIL=
+AUTH_ADMIN_PASSWORD=
+
+# --- Production-only OpenIddict keys (NOT needed for local dev) ---
+# In Development the auth-api generates EPHEMERAL signing/encryption keys, so this
+# dev stack boots without them. A production deployment runs auth-api under
+# ASPNETCORE_ENVIRONMENT=Production and injects these via its own orchestrator
+# (this dev compose pins auth-api to Development and does not wire them):
+#   OpenIddict__EncryptionKey__Key            base64 of a >=32-byte key
+#   OpenIddict__SigningKey__RsaPrivateKeyXml  base64 of RSA.ToXmlString(true), >=2048-bit
+#   OpenIddict__ApiClientSecret               >=32 characters

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,9 +158,20 @@ dotnet ef migrations add <Name> \
   --startup-project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
   --context ApplicationWriteDbContext \
   -- --connection "Host=localhost;Database=lotro_translation;Username=postgres;Password=postgres"
+
+# TMS — Docker compose stack (postgres + migrator + auth-api + tms-api + aspire-dashboard + mailpit)
+docker compose up -d                                   # boots the whole M2 backend (HTTP-only, dev defaults; no .env needed)
+docker compose build [<service>]                       # rebuild the API/migrator images after code changes
+docker compose logs -f migrator                        # watch the one-shot schema migration (TMS + Auth contexts)
+docker compose down                                    # stop; add -v to also drop the postgres volume (fresh DB)
+# Endpoints: tms-api :5002 · auth-api :5003 · aspire :18888 · mailpit :8025   (e.g. curl http://localhost:5002/health)
+# scripts/up.sh | up.ps1 = the same `up` with a one-time .env bootstrap from .env.example.
 ```
 
-TMS compose commands land with M2-14 — **add them to this section the moment they exist.**
+The compose stack runs the backend on **HTTP** for local dev; HTTPS + dev-cert mounting arrives with the
+M3 Frontend (OIDC RP). Dev uses **ephemeral** OpenIddict keys; production-like runs supply real keys via
+env (see `.env.example`). The migrator is a one-shot container (TMS migrates through its Persistence
+project, Auth through its API — only those carry EF Core Design); both APIs wait for it to complete.
 Exit codes (CLI): `0` success, `1` invalid arguments (incl. `ErrorType.Validation`), `2` file not
 found, `3` operation failed, `4` cancelled.
 

--- a/Dockerfile.migrator
+++ b/Dockerfile.migrator
@@ -1,0 +1,41 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+WORKDIR /app
+
+RUN dotnet tool install --global dotnet-ef
+ENV PATH="$PATH:/root/.dotnet/tools"
+
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
+COPY [".editorconfig", "."]
+
+ARG CACHEBUST=0
+COPY ["src/TranslationSystem/", "src/TranslationSystem/"]
+COPY ["src/AuthSystem/", "src/AuthSystem/"]
+COPY ["src/SharedKernel/", "src/SharedKernel/"]
+COPY ["src/Utilities/", "src/Utilities/"]
+
+# TMS migrations resolve through the Persistence project (it carries EF Core Design +
+# the design-time factory); Auth resolves through its API project (Auth Persistence
+# intentionally has no Design package). Build exactly those two startup projects.
+RUN dotnet restore src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/LotroKoniecDev.TranslationSystem.Persistence.csproj && \
+    dotnet restore src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj
+
+RUN dotnet build src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/LotroKoniecDev.TranslationSystem.Persistence.csproj --no-restore && \
+    dotnet build src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj --no-restore
+
+CMD echo "== MIGRATOR START ==" && \
+    dotnet ef database update \
+      --no-build \
+      --project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
+      --startup-project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
+      --context ApplicationWriteDbContext \
+      -- --connection "${ConnectionStrings__TranslationDatabase}" && \
+    echo "== TRANSLATION MIGRATOR DONE ==" && \
+    dotnet ef database update \
+      --no-build \
+      --project src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence \
+      --startup-project src/AuthSystem/LotroKoniecDev.AuthSystem.API \
+      --context AuthDbContext \
+      -- --connection "${ConnectionStrings__AuthDatabase}" && \
+    echo "== AUTH MIGRATOR DONE =="

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+WORKDIR /app
+
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
+COPY [".editorconfig", "."]
+
+COPY ["src/", "src/"]
+COPY ["tests/", "tests/"]
+
+RUN dotnet restore tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj && \
+    dotnet restore tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj && \
+    dotnet restore tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj
+
+RUN dotnet build tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj -c Release --no-restore && \
+    dotnet build tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj -c Release --no-restore && \
+    dotnet build tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj -c Release --no-restore
+
+CMD echo "== UNIT TESTS (TRANSLATION DOMAIN) START ==" && \
+    dotnet test tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj -c Release --no-build --logger "console;verbosity=minimal" && \
+    echo "== UNIT TESTS PASSED ==" && \
+    echo "== INTEGRATION TESTS (TRANSLATION) START ==" && \
+    dotnet test tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj -c Release --no-build --logger "console;verbosity=minimal" && \
+    echo "== INTEGRATION TESTS (TRANSLATION) PASSED ==" && \
+    echo "== INTEGRATION TESTS (AUTH) START ==" && \
+    dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj -c Release --no-build --logger "console;verbosity=minimal" && \
+    echo "== INTEGRATION TESTS (AUTH) PASSED ==" && \
+    echo "== ALL TESTS PASSED =="

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,98 @@
+name: lotrokoniecdev
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: lotro_translation
+    ports:
+      - "5432:5432"
+    volumes:
+      - lotrokoniecdev-postgres-data:/var/lib/postgresql/data
+      - ./scripts/init-postgres.sh:/docker-entrypoint-initdb.d/10-init-databases.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d lotro_translation"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
+  aspire-dashboard:
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:latest
+    environment:
+      DASHBOARD__UNSECURED_ALLOW_ANONYMOUS: "true"
+    ports:
+      - "18888:18888"
+      - "4317:18889"
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+
+  migrator:
+    build:
+      context: .
+      dockerfile: Dockerfile.migrator
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__TranslationDatabase: "Host=postgres;Port=5432;Database=lotro_translation;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}"
+      ConnectionStrings__AuthDatabase: "Host=postgres;Port=5432;Database=lotro_auth;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  auth-api:
+    build:
+      context: .
+      dockerfile: src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
+    ports:
+      - "5003:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: "http://+:8080"
+      ConnectionStrings__AuthDatabase: "Host=postgres;Port=5432;Database=lotro_auth;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}"
+      # Browser-facing issuer stamped into every token's 'iss'; tms-api validates against this exact value.
+      OpenIddict__Issuer: "https://localhost:5003"
+      AdminUser__Username: ${AUTH_ADMIN_USERNAME:-}
+      AdminUser__Email: ${AUTH_ADMIN_EMAIL:-}
+      AdminUser__Password: ${AUTH_ADMIN_PASSWORD:-}
+      Email__Host: mailpit
+      Email__Port: "1025"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://aspire-dashboard:18889"
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+    depends_on:
+      migrator:
+        condition: service_completed_successfully
+      mailpit:
+        condition: service_started
+
+  tms-api:
+    build:
+      context: .
+      dockerfile: src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
+    ports:
+      - "5002:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: "http://+:8080"
+      ConnectionStrings__TranslationDatabase: "Host=postgres;Port=5432;Database=lotro_translation;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}"
+      # Issuer must match the token 'iss' (auth-api's OpenIddict:Issuer — the browser-facing https URL);
+      # Authority is the in-network address tms-api uses to fetch OIDC metadata + JWKS.
+      Auth__Issuer: "https://localhost:5003"
+      Auth__Authority: "http://auth-api:8080"
+      Auth__Audience: lotrokoniecdev-api
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://aspire-dashboard:18889"
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+    depends_on:
+      migrator:
+        condition: service_completed_successfully
+      auth-api:
+        condition: service_healthy
+
+volumes:
+  lotrokoniecdev-postgres-data:

--- a/scripts/init-postgres.sh
+++ b/scripts/init-postgres.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Postgres docker-entrypoint-initdb.d script.
+# The official postgres image creates POSTGRES_DB (lotro_translation) on first boot;
+# this script adds the second database that AuthSystem needs.
+# Runs only when the data volume is empty (first container boot).
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE DATABASE "lotro_auth";
+EOSQL

--- a/scripts/up.ps1
+++ b/scripts/up.ps1
@@ -1,0 +1,17 @@
+# "docker compose up" with a one-time .env bootstrap.
+# The stack also boots fine without a .env (compose has sane defaults); this is
+# purely a convenience so you can edit secrets in one place. Extra args pass through.
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$envFile = Join-Path $repoRoot ".env"
+
+if (-not (Test-Path $envFile))
+{
+    Copy-Item (Join-Path $repoRoot ".env.example") $envFile
+    Write-Host ".env created from .env.example. Edit secrets if needed."
+}
+
+Set-Location $repoRoot
+docker compose up @args

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# "docker compose up" with a one-time .env bootstrap.
+# The stack also boots fine without a .env (compose has sane defaults); this is
+# purely a convenience so you can edit secrets in one place. Extra args pass through.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+    cp "$REPO_ROOT/.env.example" "$ENV_FILE"
+    echo ".env created from .env.example. Edit secrets if needed."
+fi
+
+cd "$REPO_ROOT"
+exec docker compose up "$@"

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
@@ -1,0 +1,47 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+COPY ["Directory.Build.props", "./"]
+COPY ["Directory.Packages.props", "./"]
+COPY [".editorconfig", "./"]
+COPY ["src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj", "src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/"]
+COPY ["src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/LotroKoniecDev.TranslationSystem.Contracts.csproj", "src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/"]
+COPY ["src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/LotroKoniecDev.TranslationSystem.Persistence.csproj", "src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/"]
+COPY ["src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/LotroKoniecDev.TranslationSystem.Domain.csproj", "src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/"]
+COPY ["src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/LotroKoniecDev.TranslationSystem.Primitives.csproj", "src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/"]
+COPY ["src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/LotroKoniecDev.TranslationSystem.ReadModels.csproj", "src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels/"]
+COPY ["src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework/LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework.csproj", "src/TranslationSystem/LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework/"]
+COPY ["src/SharedKernel/LotroKoniecDev.SharedKernel/LotroKoniecDev.SharedKernel.csproj", "src/SharedKernel/LotroKoniecDev.SharedKernel/"]
+COPY ["src/Utilities/LotroKoniecDev.Hateoas/LotroKoniecDev.Hateoas.csproj", "src/Utilities/LotroKoniecDev.Hateoas/"]
+COPY ["src/Utilities/LotroKoniecDev.Hateoas.Abstractions/LotroKoniecDev.Hateoas.Abstractions.csproj", "src/Utilities/LotroKoniecDev.Hateoas.Abstractions/"]
+COPY ["src/Utilities/LotroKoniecDev.Logging/LotroKoniecDev.Logging.csproj", "src/Utilities/LotroKoniecDev.Logging/"]
+COPY ["src/Utilities/LotroKoniecDev.Options/LotroKoniecDev.Options.csproj", "src/Utilities/LotroKoniecDev.Options/"]
+
+RUN dotnet restore "src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj"
+ARG CACHEBUST=0
+COPY . .
+WORKDIR "/src/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API"
+RUN dotnet build "./LotroKoniecDev.TranslationSystem.API.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./LotroKoniecDev.TranslationSystem.API.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+
+USER app
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8080/health/live || exit 1
+
+ENTRYPOINT ["dotnet", "LotroKoniecDev.TranslationSystem.API.dll"]


### PR DESCRIPTION
Closes #103

Brings up the full M2 backend locally — postgres + one-shot migrator + auth-api + tms-api (+ aspire-dashboard + mailpit), mirroring the KittySaver compose/Dockerfiles and right-sized to HTTP-only for dev (HTTPS + dev-cert mounting lands with the M3 frontend OIDC RP).

## Review fixes folded in (code-reviewer pass)
- **Issuer mismatch (critical):** tms-api `Auth__Issuer` was `http://localhost:5003` while auth-api stamps tokens with `https://localhost:5003` → every authenticated request would 401 on issuer validation. Corrected to `https://localhost:5003` (matches the token `iss`); `Auth__Authority=http://auth-api:8080` stays for in-network OIDC metadata/JWKS retrieval.
- **Explicit issuer contract:** added `OpenIddict__Issuer=https://localhost:5003` on auth-api so the inter-service issuer contract is visible in one file alongside tms-api's `Auth__Issuer`.
- **Startup ordering:** tms-api now `depends_on` auth-api `service_healthy` (auth-api has a `/health/live` HEALTHCHECK), removing a JWKS startup race.
- **`.env.example`:** tightened the production-key comment — this dev compose pins auth-api to `Development` and does not wire prod keys; a production deployment injects them via its own orchestrator.
- **Rejected** the reviewer's `OpenIddict__InternalIssuer` suggestion: `EffectiveInternalIssuer` is consumed only by the `RegisterUser→CreatePerson` saga client, which we deliberately did **not** lift (CLAUDE.md). Adding it would wire dead config.

## Verified live (`docker compose up`)
- migrator exits 0 — TMS + Auth schemas applied (idempotent)
- tms-api `/health` → **200**
- discovery (fetched via the internal authority `http://auth-api:8080`) advertises issuer `https://localhost:5003/` while serving JWKS at `http://auth-api:8080/.well-known/jwks` — **reachable from the tms-api container** (HTTP 200, keys present)
- protected route → **401**; anonymous translation-file route → **404** (not 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
