### PR TITLE
M2-16: Gitleaks pre-commit + CI + .gitignore hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,11 @@
-# Copy to .env (git-ignored) and override as needed:  cp .env.example .env
-# The stack boots with these defaults out of the box (`docker compose up`),
-# so a .env is only needed when you want to change something.
+# Template for the git-ignored .env. scripts/up.sh copies this file to .env on first run
+# (or do it manually: cp .env.example .env). The compose stack has no secret defaults, so a
+# .env IS required — a bare `docker compose up` without one will fail to start Postgres.
 
 # --- Postgres ---
-POSTGRES_PASSWORD=postgres
+# Local dev password for the bundled Postgres (any non-empty value). Placeholder — pick your
+# own; it never leaves your machine (.env is git-ignored).
+POSTGRES_PASSWORD=changeme
 
 # --- Auth admin (seeded into the auth DB on first boot) ---
 # Leave blank to skip admin seeding. Set all three to seed a usable login.

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,34 @@
+name: gitleaks
+
+# Secret-scanning safety net — complements the local pre-commit hook (.pre-commit-config.yaml)
+# and the GitGuardian app. Scans every PR and every push to main; a committed secret fails here.
+# gitleaks-action is free for personal/public repos (GITLEAKS_LICENSE is only needed for GitHub
+# Organizations), so no license secret is required for koniecdev/LotroKoniecDev.
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          # Full history so the scan covers every commit in the push / PR range.
+          fetch-depth: 0
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,13 @@
 ##
 ## Get latest from `dotnet new gitignore`
 
-# dotenv files
+# dotenv files & secrets (M2-16) — only .env.example (placeholders) is tracked
 .env
+*.env
+.env.*
+!.env.example
+appsettings.*.local.json
+**/secrets.json
 
 # User-specific files
 *.rsuser

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,27 @@
+# gitleaks configuration — extends the default ruleset with repo-specific allowlisting only.
+# Local usage:  gitleaks git --staged   (what the pre-commit hook runs)
+#               gitleaks dir             (scan the whole working tree)
+title = "LotroKoniecDev"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentionally committed dev defaults and placeholders — no real credentials"
+paths = [
+    # The committed dotenv template holds placeholder values only; real secrets live in the
+    # git-ignored .env (bootstrapped by scripts/up.sh) or in dotnet user-secrets / env.
+    '''\.env\.example$''',
+]
+regexes = [
+    # Synthetic OpenIddict keys in the AuthSystem integration fixtures (env "Testing"). gitleaks
+    # flags both the base64 literal and its decoded form, so exempt both VALUES rather than the
+    # whole file — this keeps the high-confidence fingerprint rules (AWS / GitHub / Stripe / …)
+    # armed on the fixtures, so a real key fat-fingered there is still caught.
+    '''RGV2RW5jcnlwdGlvbktleTMyQnl0ZXNMb25nMTIzNDU=''',
+    '''RGV2U2lnbmluZ0tleTMyQnl0ZXNMb25nRW5vdWdoMTI=''',
+    '''Dev(Encryption|Signing)Key32Bytes[A-Za-z0-9]+''',
+    # Pre-emptive: the dev OpenIddict client secret in appsettings.Development.json. Not flagged by
+    # the current default ruleset, but exempted explicitly so a stricter gitleaks build can't trip CI.
+    '''dev-api-secret-min-32-characters-long''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# Local secret-scanning gate. One-time setup per clone:
+#   pip install pre-commit   (or: brew install pre-commit)
+#   pre-commit install
+# Thereafter `git commit` runs gitleaks on staged changes and blocks any leaked secret.
+# Keep `rev` in sync with the gitleaks version pinned in .github/workflows/gitleaks.yml.
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,15 +157,15 @@ dotnet ef migrations add <Name> \
   --project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
   --startup-project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
   --context ApplicationWriteDbContext \
-  -- --connection "Host=localhost;Database=lotro_translation;Username=postgres;Password=postgres"
+  -- --connection "Host=localhost;Database=lotro_translation;Username=postgres;Password=changeme"
 
 # TMS — Docker compose stack (postgres + migrator + auth-api + tms-api + aspire-dashboard + mailpit)
-docker compose up -d                                   # boots the whole M2 backend (HTTP-only, dev defaults; no .env needed)
+docker compose up -d                                   # boots the M2 backend (HTTP-only); requires a .env — scripts/up.sh creates one
 docker compose build [<service>]                       # rebuild the API/migrator images after code changes
 docker compose logs -f migrator                        # watch the one-shot schema migration (TMS + Auth contexts)
 docker compose down                                    # stop; add -v to also drop the postgres volume (fresh DB)
 # Endpoints: tms-api :5002 · auth-api :5003 · aspire :18888 · mailpit :8025   (e.g. curl http://localhost:5002/health)
-# scripts/up.sh | up.ps1 = the same `up` with a one-time .env bootstrap from .env.example.
+# scripts/up.sh | up.ps1 = recommended boot — bootstraps .env from .env.example (compose has no secret defaults), then up.
 ```
 
 The compose stack runs the backend on **HTTP** for local dev; HTTPS + dev-cert mounting arrives with the

--- a/README.md
+++ b/README.md
@@ -160,3 +160,27 @@ LotroKoniecDev/
 ## Przywracanie oryginalu
 
 Backup pliku DAT jest tworzony automatycznie z rozszerzeniem `.backup` obok oryginalu. Aby przywrocic oryginal, skopiuj backup z powrotem na `client_local_English.dat`.
+
+## Bezpieczenstwo i sekrety (backend / TMS)
+
+Repo bedzie publiczne — **realne sekrety nigdy nie trafiaja do historii gita**. Trzy warstwy ochrony:
+
+1. **pre-commit (gitleaks)** — blokuje commit z sekretem lokalnie. Setup raz na klon:
+   ```
+   pip install pre-commit      # lub: brew install pre-commit
+   pre-commit install
+   ```
+   Od teraz `git commit` skanuje staged changes (gitleaks). Konfiguracja: `.pre-commit-config.yaml` + `.gitleaks.toml`.
+2. **CI** (`.github/workflows/gitleaks.yml`) — skanuje kazdy PR i push do `main`; PR z sekretem nie przejdzie.
+3. **GitGuardian app** — serwerowy skan PR (warstwa dodatkowa).
+
+**Sekrety w dev:** uzywaj `dotnet user-secrets` (per-projekt) albo `.env` (git-ignored, bootstrapowany przez
+`scripts/up.sh` z `.env.example`). W `.gitignore` sa `*.env` / `.env.*` (poza `.env.example`),
+`appsettings.*.local.json` i `**/secrets.json`. `appsettings.Development.json` trzyma **wylacznie** wartosci dev,
+nigdy realne sekrety.
+
+Przyklad ustawienia sekretu w dev przez user-secrets:
+```
+dotnet user-secrets set "OpenIddict:ApiClientSecret" "<twoj-sekret>" \
+  --project src/AuthSystem/LotroKoniecDev.AuthSystem.API
+```

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
     image: postgres:17-alpine
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: lotro_translation
     ports:
       - "5432:5432"
@@ -39,8 +39,8 @@ services:
       dockerfile: Dockerfile.migrator
     environment:
       ASPNETCORE_ENVIRONMENT: Development
-      ConnectionStrings__TranslationDatabase: "Host=postgres;Port=5432;Database=lotro_translation;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}"
-      ConnectionStrings__AuthDatabase: "Host=postgres;Port=5432;Database=lotro_auth;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}"
+      ConnectionStrings__TranslationDatabase: "Host=postgres;Port=5432;Database=lotro_translation;Username=postgres;Password=${POSTGRES_PASSWORD}"
+      ConnectionStrings__AuthDatabase: "Host=postgres;Port=5432;Database=lotro_auth;Username=postgres;Password=${POSTGRES_PASSWORD}"
     depends_on:
       postgres:
         condition: service_healthy
@@ -55,7 +55,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: "http://+:8080"
-      ConnectionStrings__AuthDatabase: "Host=postgres;Port=5432;Database=lotro_auth;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}"
+      ConnectionStrings__AuthDatabase: "Host=postgres;Port=5432;Database=lotro_auth;Username=postgres;Password=${POSTGRES_PASSWORD}"
       # Browser-facing issuer stamped into every token's 'iss'; tms-api validates against this exact value.
       OpenIddict__Issuer: "https://localhost:5003"
       AdminUser__Username: ${AUTH_ADMIN_USERNAME:-}
@@ -80,7 +80,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: "http://+:8080"
-      ConnectionStrings__TranslationDatabase: "Host=postgres;Port=5432;Database=lotro_translation;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}"
+      ConnectionStrings__TranslationDatabase: "Host=postgres;Port=5432;Database=lotro_translation;Username=postgres;Password=${POSTGRES_PASSWORD}"
       # Issuer must match the token 'iss' (auth-api's OpenIddict:Issuer — the browser-facing https URL);
       # Authority is the in-network address tms-api uses to fetch OIDC metadata + JWKS.
       Auth__Issuer: "https://localhost:5003"

--- a/scripts/up.ps1
+++ b/scripts/up.ps1
@@ -1,6 +1,6 @@
 # "docker compose up" with a one-time .env bootstrap.
-# The stack also boots fine without a .env (compose has sane defaults); this is
-# purely a convenience so you can edit secrets in one place. Extra args pass through.
+# compose has no secret defaults, so a .env is required; this creates it from .env.example
+# on first run (edit secrets there afterwards). Extra args pass through.
 
 $ErrorActionPreference = "Stop"
 

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # "docker compose up" with a one-time .env bootstrap.
-# The stack also boots fine without a .env (compose has sane defaults); this is
-# purely a convenience so you can edit secrets in one place. Extra args pass through.
+# compose has no secret defaults, so a .env is required; this creates it from .env.example
+# on first run (edit secrets there afterwards). Extra args pass through.
 
 set -euo pipefail
 


### PR DESCRIPTION
Closes #86

Adds **prevention before push** for secrets (GitGuardian/GitHub scanning only catch after the fact) via three complementary layers, and folds in the agreed KittySaver-aligned Postgres password handling.

## Secret-scanning (3 layers)
- **pre-commit** (`.pre-commit-config.yaml`) — gitleaks hook pinned `v8.30.1`; `git commit` with a staged secret is blocked locally. One-time `pre-commit install` (documented in README).
- **CI** (`.github/workflows/gitleaks.yml`) — `gitleaks-action@v2` on every PR + push to main (free for personal/public repos). Mirrors the repo's workflow conventions (`checkout@v5`, `ubuntu-24.04`, `concurrency`); deliberately omits the `paths-ignore` the build workflows use — a scanner must see every file.
- **GitGuardian app** — existing server-side layer, unchanged.

## Hardening
- **`.gitleaks.toml`** — extends the default ruleset; allowlists only intentional dev/placeholder **values**: the `.env.example` template (path) + the synthetic OpenIddict keys in the AuthSystem integration fixtures (**value-targeted regexes, not a whole-file exemption** — so AWS/GitHub/Stripe fingerprint rules stay armed on those files).
- **`.gitignore`** — `*.env`, `.env.*` (keeping `!.env.example`), `appsettings.*.local.json`, `**/secrets.json`.
- **README** — secret-scanning + dev-secrets section (`pre-commit install`, `dotnet user-secrets`).

## Folded in — KittySaver password alignment (agreed)
Drop the zero-config `:-postgres` compose defaults → bare `${POSTGRES_PASSWORD}` (no literal secret in `compose.yaml` — removes the GitGuardian friction at the source). `.env.example` uses a `changeme` placeholder; `scripts/up.sh` + `up.ps1` bootstrap `.env` (a `.env` is now required — documented in CLAUDE.md, `.env.example`, both up scripts; the EF-migrations example matches).

## Review fixes folded in (code-reviewer pass)
- **Blocker:** `scripts/up.ps1` still advertised the removed zero-config behavior — now mirrors `up.sh`.
- **Security (major):** narrowed the fixture allowlist from a whole-file `paths` exemption to value-targeted `regexes`, keeping fingerprint rules armed on fixtures.

## Verified live (gitleaks 8.30.1)
- full history + staged diff → **0 leaks**
- value-targeted allowlist exempts the 4 synthetic fixture keys, yet a **real** secret planted in the same fixture is **still caught** (1 leak)
- a planted high-entropy secret is blocked by `gitleaks git --staged` → **exit 1**
- `docker compose config` valid with a `.env` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)
