### PR TITLE
chore: refine Translation aggregate domain model

### DIFF
--- a/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
+++ b/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
@@ -159,6 +159,12 @@ For every row of the uploaded export, compared against the stored source state b
   slice #101 gains this rule). The stale Polish is **kept** as the draft starting point, and the
   superseded English is stored in a single `PreviousSourceText` column so the translator sees
   old-vs-new source side by side — one column, not a history table (#50 stays post-MVP).
+- **Multi-update-before-review:** when a row is reworded by several patches before anyone reviews
+  it, `PreviousSourceText` is **frozen at the first invalidation** — the English the still-current
+  Polish was written against — not overwritten by each intermediate source the translator never
+  saw. It refreshes only when the row is re-drafted (upsert against the new English), so it always
+  tracks the baseline the current Polish actually corresponds to. Per-patch history stays #50,
+  post-MVP.
 - Worst case is by design: every patch may invalidate some translations; that is the system
   working, not failing.
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
@@ -106,7 +106,7 @@ internal sealed class ImportExportedTexts : IEndpoint
                 return Result.Failure<ImportSummary>(ImportErrors.EmptyUpload());
             }
 
-            Result<IReadOnlyList<IncomingTranslation>> incomingResult = MapToIncoming(parsed.Rows);
+            Result<IReadOnlyList<IncomingSourceRow>> incomingResult = MapToIncoming(parsed.Rows);
             if (incomingResult.IsFailure)
             {
                 return Result.Failure<ImportSummary>(incomingResult.Error);
@@ -169,9 +169,9 @@ internal sealed class ImportExportedTexts : IEndpoint
             return Result.Success(BuildSummary(plan));
         }
 
-        private static Result<IReadOnlyList<IncomingTranslation>> MapToIncoming(IReadOnlyList<ParsedExportRow> rows)
+        private static Result<IReadOnlyList<IncomingSourceRow>> MapToIncoming(IReadOnlyList<ParsedExportRow> rows)
         {
-            List<IncomingTranslation> incoming = new(rows.Count);
+            List<IncomingSourceRow> incoming = new(rows.Count);
             HashSet<FragmentKey> seen = [];
 
             foreach (ParsedExportRow row in rows)
@@ -179,27 +179,27 @@ internal sealed class ImportExportedTexts : IEndpoint
                 Result<FragmentKey> keyResult = FragmentKey.Create(row.FileId, row.GossipId);
                 if (keyResult.IsFailure)
                 {
-                    return Result.Failure<IReadOnlyList<IncomingTranslation>>(
+                    return Result.Failure<IReadOnlyList<IncomingSourceRow>>(
                         ImportErrors.InvalidRow(row.FileId, row.GossipId, keyResult.Error.Message));
                 }
 
                 Result<TranslationSource> sourceResult = TranslationSource.Create(row.Content, row.ArgsOrder, row.ArgsId);
                 if (sourceResult.IsFailure)
                 {
-                    return Result.Failure<IReadOnlyList<IncomingTranslation>>(
+                    return Result.Failure<IReadOnlyList<IncomingSourceRow>>(
                         ImportErrors.InvalidRow(row.FileId, row.GossipId, sourceResult.Error.Message));
                 }
 
                 if (!seen.Add(keyResult.Value))
                 {
-                    return Result.Failure<IReadOnlyList<IncomingTranslation>>(
+                    return Result.Failure<IReadOnlyList<IncomingSourceRow>>(
                         ImportErrors.DuplicateFragmentKey(row.FileId, row.GossipId));
                 }
 
-                incoming.Add(new IncomingTranslation(keyResult.Value, sourceResult.Value));
+                incoming.Add(new IncomingSourceRow(keyResult.Value, sourceResult.Value));
             }
 
-            return Result.Success<IReadOnlyList<IncomingTranslation>>(incoming);
+            return Result.Success<IReadOnlyList<IncomingSourceRow>>(incoming);
         }
 
         private static ImportSummary BuildSummary(TranslationDiffPlan plan)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
@@ -54,17 +54,24 @@ public sealed class Translation : AggregateRoot<TranslationId>
 
     /// <summary>
     /// Source-changed (spec 0001): overwrite the stored English; if Polish work exists it is
-    /// invalidated (parked as <see cref="TranslationStatus.NeedsReview"/>, the superseded English
-    /// kept in <see cref="PreviousSourceText"/> for side-by-side context); stamps
-    /// <see cref="LastSourceChangeInVersion"/>. Also clears any soft-removal — a re-added pair
-    /// whose source differs lands here.
+    /// invalidated (parked as <see cref="TranslationStatus.NeedsReview"/>, the English the current
+    /// Polish was written against kept in <see cref="PreviousSourceText"/> for side-by-side context);
+    /// stamps <see cref="LastSourceChangeInVersion"/>. Also clears any soft-removal — a re-added pair
+    /// whose source differs lands here. Further source changes while still
+    /// <see cref="TranslationStatus.NeedsReview"/> overwrite the source but leave
+    /// <see cref="PreviousSourceText"/> frozen, so a row reworded across several updates before review
+    /// still shows the translator the English their Polish actually corresponds to; it refreshes only
+    /// once the row is re-drafted (<see cref="ProvideTranslation"/>).
     /// </summary>
     public void ApplySourceChange(TranslationSource newSource, GameVersionId changedInVersion, DateTimeOffset now)
     {
         ArgumentNullException.ThrowIfNull(newSource);
         Ensure.NotEmpty(changedInVersion);
 
-        if (Status is TranslationStatus.Draft or TranslationStatus.Approved or TranslationStatus.NeedsReview)
+        // Capture the superseded English only when leaving a state where the Polish was valid
+        // (Draft/Approved). Re-entering from NeedsReview would clobber the baseline the current Polish
+        // was written against with an intermediate source the translator never saw.
+        if (Status is TranslationStatus.Draft or TranslationStatus.Approved)
         {
             PreviousSourceText = Source.Text;
             Status = TranslationStatus.NeedsReview;

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/IncomingSourceRow.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/IncomingSourceRow.cs
@@ -7,4 +7,4 @@ namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregat
 /// English source. The API parser produces the raw rows; the import handler validates them into
 /// these value-object pairs before handing them to <see cref="TranslationDiffService"/>.
 /// </summary>
-public sealed record IncomingTranslation(FragmentKey Key, TranslationSource Source);
+public sealed record IncomingSourceRow(FragmentKey Key, TranslationSource Source);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffPlan.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffPlan.cs
@@ -19,10 +19,14 @@ public sealed class TranslationDiffPlan
     public IReadOnlyList<Translation> Restored { get; }
     public int UnchangedCount { get; }
 
-    /// <summary>Source-changed rows that carried Polish work and were therefore invalidated.</summary>
+    /// <summary>
+    /// Source-changed rows that carried Polish work and were therefore invalidated.
+    /// </summary>
     public int InvalidatedCount { get; }
 
-    /// <summary>Active (non-removed) stored rows — the denominator of the removed-fraction guard.</summary>
+    /// <summary>
+    /// Active (non-removed) stored rows — the denominator of the removed-fraction guard.
+    /// </summary>
     public int ComparableExistingCount { get; }
 
     public TranslationDiffPlan(

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffService.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffService.cs
@@ -15,7 +15,7 @@ public static class TranslationDiffService
 {
     public static TranslationDiffPlan ComputePlan(
         IReadOnlyCollection<Translation> existing,
-        IReadOnlyCollection<IncomingTranslation> incoming,
+        IReadOnlyCollection<IncomingSourceRow> incoming,
         GameVersionId targetVersion,
         DateTimeOffset now)
     {
@@ -31,7 +31,7 @@ public static class TranslationDiffService
         int unchangedCount = 0;
         int invalidatedCount = 0;
 
-        foreach (IncomingTranslation row in incoming)
+        foreach (IncomingSourceRow row in incoming)
         {
             if (!existingByKey.TryGetValue(row.Key, out Translation? current))
             {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/ValueObjects/TranslationSource.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/ValueObjects/TranslationSource.cs
@@ -1,6 +1,5 @@
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
 using LotroKoniecDev.SharedKernel.Monads;
-using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
 
 namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 
@@ -19,10 +18,10 @@ public sealed class TranslationSource : ValueObject
 
     public static Result<TranslationSource> Create(string text, string? argsOrder, string? argsId)
     {
-        if (text is null)
-        {
-            return Result.Failure<TranslationSource>(DomainErrors.TranslationEntity.SourceProperty.TextRequired);
-        }
+        // Source text is exported verbatim from the DAT — empty fragments are legal game content and
+        // must round-trip. A null here is never produced by the parser, so it is a programmer error,
+        // not a per-row validation failure.
+        ArgumentNullException.ThrowIfNull(text);
 
         TranslationSource instance = new(text, NormalizeArgs(argsOrder), NormalizeArgs(argsId));
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationArtifactAggregate/Entities/TranslationArtifact.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationArtifactAggregate/Entities/TranslationArtifact.cs
@@ -30,7 +30,9 @@ public sealed class TranslationArtifact : AggregateRoot<TranslationArtifactId>
         return new TranslationArtifact(TranslationArtifactId.Create(), language, content, contentHash, now);
     }
 
-    /// <summary>Regenerate-on-write: replaces the serialized content and its hash in place.</summary>
+    /// <summary>
+    /// Regenerate-on-write: replaces the serialized content and its hash in place.
+    /// </summary>
     public void Replace(string content, string contentHash, DateTimeOffset now)
     {
         ArgumentNullException.ThrowIfNull(content);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/TranslationAggregateDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/TranslationAggregateDomainErrors.cs
@@ -43,11 +43,5 @@ public static partial class DomainErrors
                     "The gossip id must not be negative.",
                     TypeOfError.Validation);
         }
-
-        public static class SourceProperty
-        {
-            public static Error TextRequired
-                => Required(nameof(TranslationEntity), "SourceText");
-        }
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationDiffServiceTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationDiffServiceTests.cs
@@ -21,7 +21,7 @@ public sealed class TranslationDiffServiceTests
             IntroducedVersion,
             StoredAt).Value;
 
-    private static IncomingTranslation Incoming(int fileId, long gossipId, string text, string? argsOrder = null)
+    private static IncomingSourceRow Incoming(int fileId, long gossipId, string text, string? argsOrder = null)
         => new(
             FragmentKey.Create(fileId, gossipId).Value,
             TranslationSource.Create(text, argsOrder, argsOrder).Value);
@@ -30,7 +30,7 @@ public sealed class TranslationDiffServiceTests
     public void ComputePlan_OnEmptyStore_ShouldAddEveryRow()
     {
         // Arrange
-        IncomingTranslation[] incoming = [Incoming(1, 1, "A"), Incoming(1, 2, "B")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "A"), Incoming(1, 2, "B")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan([], incoming, TargetVersion, ImportAt);
@@ -49,7 +49,7 @@ public sealed class TranslationDiffServiceTests
     {
         // Arrange
         Translation[] existing = [Existing(1, 1, "A")];
-        IncomingTranslation[] incoming = [Incoming(1, 1, "A"), Incoming(1, 2, "B")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "A"), Incoming(1, 2, "B")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
@@ -65,7 +65,7 @@ public sealed class TranslationDiffServiceTests
     {
         // Arrange
         Translation[] existing = [Existing(1, 1, "A")];
-        IncomingTranslation[] incoming = [Incoming(1, 1, "A")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "A")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
@@ -82,7 +82,7 @@ public sealed class TranslationDiffServiceTests
     {
         // Arrange
         Translation[] existing = [Existing(1, 1, "Old")];
-        IncomingTranslation[] incoming = [Incoming(1, 1, "New")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "New")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
@@ -99,7 +99,7 @@ public sealed class TranslationDiffServiceTests
         // Arrange
         Translation withPolish = Existing(1, 1, "Old");
         withPolish.ProvideTranslation("Polski", IdentityId.Create(), StoredAt);
-        IncomingTranslation[] incoming = [Incoming(1, 1, "New")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "New")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan([withPolish], incoming, TargetVersion, ImportAt);
@@ -114,7 +114,7 @@ public sealed class TranslationDiffServiceTests
     {
         // Arrange — identical text, different argument structure is still a source change.
         Translation[] existing = [Existing(1, 1, "Text", argsOrder: "1-2")];
-        IncomingTranslation[] incoming = [Incoming(1, 1, "Text", argsOrder: "2-1")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "Text", argsOrder: "2-1")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
@@ -129,7 +129,7 @@ public sealed class TranslationDiffServiceTests
     {
         // Arrange
         Translation[] existing = [Existing(1, 1, "A"), Existing(1, 2, "B")];
-        IncomingTranslation[] incoming = [Incoming(1, 1, "A")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "A")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
@@ -146,7 +146,7 @@ public sealed class TranslationDiffServiceTests
         Translation alreadyRemoved = Existing(1, 2, "B");
         alreadyRemoved.MarkRemoved(IntroducedVersion, StoredAt);
         Translation[] existing = [Existing(1, 1, "A"), alreadyRemoved];
-        IncomingTranslation[] incoming = [Incoming(1, 1, "A")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "A")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan(existing, incoming, TargetVersion, ImportAt);
@@ -162,7 +162,7 @@ public sealed class TranslationDiffServiceTests
         // Arrange
         Translation removed = Existing(1, 1, "A");
         removed.MarkRemoved(IntroducedVersion, StoredAt);
-        IncomingTranslation[] incoming = [Incoming(1, 1, "A")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "A")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan([removed], incoming, TargetVersion, ImportAt);
@@ -179,7 +179,7 @@ public sealed class TranslationDiffServiceTests
         // Arrange
         Translation removed = Existing(1, 1, "Old");
         removed.MarkRemoved(IntroducedVersion, StoredAt);
-        IncomingTranslation[] incoming = [Incoming(1, 1, "New")];
+        IncomingSourceRow[] incoming = [Incoming(1, 1, "New")];
 
         // Act
         TranslationDiffPlan plan = TranslationDiffService.ComputePlan([removed], incoming, TargetVersion, ImportAt);
@@ -197,7 +197,7 @@ public sealed class TranslationDiffServiceTests
         [
             Existing(1, 1, "A"), Existing(1, 2, "B"), Existing(1, 3, "C"), Existing(1, 4, "D"), Existing(1, 5, "E")
         ];
-        IncomingTranslation[] incoming =
+        IncomingSourceRow[] incoming =
         [
             Incoming(1, 1, "A"), Incoming(1, 2, "B"), Incoming(1, 3, "C"), Incoming(1, 4, "D")
         ];

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationSourceTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationSourceTests.cs
@@ -1,6 +1,5 @@
 using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
-using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
 
 namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates.TranslationAggregate;
 
@@ -17,17 +16,6 @@ public sealed class TranslationSourceTests
         result.Value.Text.ShouldBe("Welcome to <--DO_NOT_TOUCH!--> Middle-earth");
         result.Value.ArgsOrder.ShouldBe("1");
         result.Value.ArgsId.ShouldBe("1");
-    }
-
-    [Fact]
-    public void Create_WithNullText_ShouldReturnTextRequired()
-    {
-        // Act
-        Result<TranslationSource> result = TranslationSource.Create(null!, null, null);
-
-        // Assert
-        result.IsFailure.ShouldBeTrue();
-        result.Error.ShouldBe(DomainErrors.TranslationEntity.SourceProperty.TextRequired);
     }
 
     [Theory]

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
@@ -75,6 +75,47 @@ public sealed class TranslationTests
     }
 
     [Fact]
+    public void ApplySourceChange_OnAlreadyNeedsReviewRow_ShouldKeepFirstSupersededSource()
+    {
+        // Arrange — a row reworded by several updates before anyone reviews it (spec 0001): the
+        // superseded English must stay pinned to what the still-current Polish was written against,
+        // not drift to an intermediate source the translator never translated.
+        Translation translation = CreateUntranslated();
+        translation.ProvideTranslation("Stary polski", Submitter, Created);
+        translation.ApplySourceChange(Source("Reworded once"), ChangeVersion, Changed);
+
+        // Act
+        translation.ApplySourceChange(Source("Reworded twice"), ChangeVersion, Changed);
+
+        // Assert
+        translation.Status.ShouldBe(TranslationStatus.NeedsReview);
+        translation.PreviousSourceText.ShouldBe("Old English");
+        translation.Source.Text.ShouldBe("Reworded twice");
+        translation.TranslatedText.ShouldBe("Stary polski");
+    }
+
+    [Fact]
+    public void ApplySourceChange_AfterReDraftingInvalidatedRow_ShouldRefreshPreviousSource()
+    {
+        // Arrange — translator re-translates an invalidated row against its new English, then a later
+        // update rewords it again: the superseded English must now track the re-drafted baseline, not
+        // the original (spec 0001).
+        Translation translation = CreateUntranslated();
+        translation.ProvideTranslation("Stary polski", Submitter, Created);
+        translation.ApplySourceChange(Source("Reworded once"), ChangeVersion, Changed);
+        translation.ProvideTranslation("Nowy polski", Submitter, Changed);
+
+        // Act
+        translation.ApplySourceChange(Source("Reworded twice"), ChangeVersion, Changed);
+
+        // Assert
+        translation.Status.ShouldBe(TranslationStatus.NeedsReview);
+        translation.PreviousSourceText.ShouldBe("Reworded once");
+        translation.Source.Text.ShouldBe("Reworded twice");
+        translation.TranslatedText.ShouldBe("Nowy polski");
+    }
+
+    [Fact]
     public void MarkRemoved_ShouldSoftMarkWithVersion()
     {
         // Arrange


### PR DESCRIPTION
- Rename IncomingTranslation to IncomingSourceRow for clarity
- Adjust TranslationDiffPlan and TranslationDiffService signatures
- Simplify TranslationSource value object
- Update Translation entity and TranslationArtifact
- Remove unused domain errors
- Update spec and tests to match

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
