### PR TITLE
M2-21: Normalize LotroNotationVersion — 48 / 48.0 / 48.0.0 are one version (#132)

### DIFF
--- a/docs/adr/0003-lotronotationversion-canonical-form.md
+++ b/docs/adr/0003-lotronotationversion-canonical-form.md
@@ -1,0 +1,114 @@
+# ADR-0003: Canonical form for `LotroNotationVersion` — collapse trailing-zero segments
+
+**Status:** Accepted
+**Date:** 2026-06-14
+**Decision-makers:** Solo maintainer
+**Related:** `TranslationSystem.Domain` GameVersion aggregate, ticket #132 (M2-21), spec 0001
+(game-update lifecycle), ADR-0002 (TMS pivot), `docs/knowledge-base/lotro-update-history.md`
+(forum version regex)
+
+## Context
+
+`LotroNotationVersion` is the canonical content-version identifier the whole update lifecycle keys
+off (spec 0001): duplicate-registration guard (`VersionAlreadyRegistered`), forum-watcher
+idempotency, and supersede/process/invalidation all assume **one canonical identity per game
+version**. The VO shipped (M2-04) with a latent bug, flagged by an in-code `//todo`:
+
+- It stored the **raw trimmed string** and validated only non-empty + `VersionMaxLength` (12).
+- `Create("banana")` succeeded — despite the XML doc claiming "dotted notation", anything ≤ 12
+  chars was accepted.
+- Equality was raw-string (`GetAtomicValues()` yields the raw `Value`), so `48`, `48.0`, `48.0.0`
+  were **three distinct versions**, and dedup — `GameVersionRepository.ExistsByVersionAsync`
+  (ordinal compare) plus the EF unique index, both on the same raw column — let equivalents coexist
+  as separate rows. This silently defeats every identity-keyed guard above.
+
+Pre-release, **zero users** → changing the stored representation is free (no data migration, no
+back-compat). Ticket #132 raised four open questions to settle before coding. They are **not
+contested business decisions** — three are directly answerable from the empirically-settled
+knowledge base / existing spec, and the fourth (the canonical form itself) is a low-stakes internal
+engineering choice. This ADR records the resolution.
+
+### Empirical grounding (the format is observed, not chosen)
+
+The **only** producer of these strings is the lotro.com release-notes title, parsed by the regex
+the patcher's `UpdateChecking` feature uses and the TMS forum watcher duplicates
+(`docs/knowledge-base/lotro-update-history.md`,
+`src/LotroKoniecDev.Application/Features/UpdateChecking/GameUpdateChecker.cs`):
+
+```
+Update\s+(\d+(?:\.\d+)*)\s+Release\s+Notes
+```
+
+The captured version is therefore **always** one or more dot-separated runs of ASCII digits —
+`digits(.digits)*`. Observed in the wild: `48.0`, `47.1.1`, `47.2` (2-3 segments). No prerelease
+tags, no build metadata, no letters. The grammar is the documented source format, not a design
+decision.
+
+## Decision
+
+### 1. Format grammar — `digits(.digits)*`, validated on `Create`
+
+`LotroNotationVersion.Create` parses the (trimmed) input as **one or more non-empty
+dot-separated segments, each a run of ASCII digits**, and rejects anything else with a new
+`VersionProperty.InvalidFormat` domain error (`TypeOfError.Validation`). Rejected: `banana`,
+`48.x`, `48..0` (empty segment), `.48` / `48.` (leading/trailing dot), `""`, whitespace-only.
+A segment may carry leading zeros in the input (`047`); they are stripped on normalization (see §2).
+This mirrors the regex above exactly — we enforce the format we already know the source emits.
+
+### 2. Canonical form — collapse insignificant trailing-zero segments
+
+The stored `Value` is the **canonical** form: parse to integer segments, drop trailing zero
+segments, and re-join with `.` — keeping at least the leading (major) segment.
+
+| Input | Canonical `Value` |
+|---|---|
+| `48`, `48.0`, `48.0.0` | `48` |
+| `47.1`, `47.1.0`, `47.1.0.0` | `47.1` |
+| `47.1.1` | `47.1.1` |
+| `0`, `0.0` | `0` |
+| `47.0.1` | `47.0.1` (interior zero is significant) |
+| `047` | `47` (leading zeros stripped per-segment) |
+
+Equality then **falls out of the canonical `Value`** with no `GetAtomicValues()` change: equal
+canonical strings ⇒ equal VOs, equal hash codes. Both dedup paths (`ExistsByVersionAsync` ordinal
+compare + the EF unique index on the same column) now correctly collapse `48` / `48.0` / `48.0.0`
+to a single `GameVersion` row.
+
+**Why collapse, not pad to a fixed segment count.** Padding (`48` → `48.0.0`) requires *inventing*
+a fixed width, but observed notation already varies between 2 and 3 segments, and nothing
+guarantees a future `48.0.0.1` won't appear — so any fixed width is a guess about LOTRO's
+versioning we have no authority to make (it would *invent* a business constraint). Collapsing
+assumes nothing about segment count, is lossless for identity (trailing zeros carry no information),
+and keeps `Value` the shortest faithful representation of what the forum published. Interior zeros
+(`47.0.1`) are preserved — only **trailing** zeros are insignificant.
+
+### 3. Equivalence rule — trailing-zero segments are always insignificant
+
+Yes, `47.1 == 47.1.0 == 47.1.0.0`. This is §2 applied generally and matches universal
+dotted-numeric/semver intuition. No maximum **segment count** is imposed beyond the existing
+`VersionMaxLength = 12` character cap (which already bounds practical depth); the format check
+rejects garbage, the length check rejects the absurd.
+
+### 4. Ordering — out of scope, no `IComparable`
+
+`LotroNotationVersion` does **not** become `IComparable`. Supersede/processing order is `DetectedAt`
+(spec 0001 — the forum is chronological), not version order. This ticket is scoped to
+identity/equality only; version ordering would be a separate decision if ever needed.
+
+## Consequences
+
+- **Positive.** `48` / `48.0` / `48.0.0` are now one version end-to-end; the
+  `VersionAlreadyRegistered` guard, forum-watcher idempotency, and spec-0001 supersede/invalidation
+  all key off a single canonical identity. Garbage input is rejected at the domain boundary with a
+  `Validation` error (maps to HTTP 400) instead of silently persisting. No `GetAtomicValues()` /
+  EF-mapping / repository changes required — the canonical `Value` does the work.
+- **Neutral.** `Value` is now a derived (canonical) string, not the verbatim forum input. The forum
+  string and the canonical string are identical for the common already-minimal case (`47.1.1`); the
+  only divergence is dropped trailing zeros, which carry no identity. Spec 0001 line 105 ("stored as
+  the raw forum string") is superseded by this ADR for the trailing-zero case — noted there is
+  unnecessary; the spec's intent (a stable per-version identity) is what this strengthens.
+- **Trade-off / YAGNI.** No `IComparable`, no semver library, no configurable max-segment knob — the
+  format is fixed and tiny, parsing is a `Split` + per-segment digit check. Added only what #132
+  requires.
+- **Data.** Pre-release, zero users, no rows to migrate; the unique index already exists on the
+  canonical column, so no schema change.

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/ValueObjects/LotroNotationVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/ValueObjects/LotroNotationVersion.cs
@@ -5,13 +5,27 @@ using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
 namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
 
 /// <summary>
-/// The LOTRO game version in dotted notation as published in the official forum release notes
-/// (e.g. <c>48.0</c>, <c>47.1.1</c>) — the reliable content-version identifier.
+/// The LOTRO game version in dotted-numeric notation as published in the official forum release
+/// notes (e.g. <c>48.0</c>, <c>47.1.1</c>) — the reliable content-version identifier.
 /// </summary>
-//todo: we should normalize 48 - 48.0 - 48.0.0 as the same value.
+/// <remarks>
+/// <para>
+/// Input must match the forum grammar <c>digits(.digits)*</c> (one or more non-empty
+/// dot-separated runs of ASCII digits); anything else is rejected with
+/// <see cref="DomainErrors.GameVersionEntity.VersionProperty.InvalidFormat"/>.
+/// </para>
+/// <para>
+/// The stored <see cref="Value"/> is the <em>canonical</em> form: insignificant trailing-zero
+/// segments are collapsed, so <c>48</c>, <c>48.0</c> and <c>48.0.0</c> are one and the same
+/// version (equal <see cref="Value"/>, equal VOs). Interior zeros (<c>47.0.1</c>) are significant
+/// and preserved. See ADR-0003.
+/// </para>
+/// </remarks>
 public sealed class LotroNotationVersion : ValueObject
 {
     public const int VersionMaxLength = 12;
+
+    private const char SegmentSeparator = '.';
 
     public string Value { get; }
 
@@ -23,12 +37,21 @@ public sealed class LotroNotationVersion : ValueObject
         }
 
         value = value.Trim();
+
+        // Length is checked on the raw input deliberately: the forum producer emits short 2-3 segment
+        // versions, so a >12-char input is malformed regardless of how trailing zeros would collapse.
         if (value.Length > VersionMaxLength)
         {
             return Result.Failure<LotroNotationVersion>(DomainErrors.GameVersionEntity.VersionProperty.LongerThanAllowed);
         }
 
-        LotroNotationVersion instance = new(value);
+        Maybe<string> canonical = Canonicalize(value);
+        if (canonical.HasNoValue)
+        {
+            return Result.Failure<LotroNotationVersion>(DomainErrors.GameVersionEntity.VersionProperty.InvalidFormat);
+        }
+
+        LotroNotationVersion instance = new(canonical.Value);
 
         return Result.Success(instance);
     }
@@ -43,5 +66,64 @@ public sealed class LotroNotationVersion : ValueObject
     protected override IEnumerable<object> GetAtomicValues()
     {
         yield return Value;
+    }
+
+    /// <summary>
+    /// Parses dotted-numeric input and returns its canonical string (each segment's leading zeros
+    /// stripped, trailing all-zero segments dropped), or <see cref="Maybe{T}.None"/> when the input
+    /// is not <c>digits(.digits)*</c>. Operates purely on the string so arbitrarily large segments
+    /// never overflow a numeric type.
+    /// </summary>
+    private static Maybe<string> Canonicalize(string value)
+    {
+        string[] segments = value.Split(SegmentSeparator);
+
+        string[] normalizedSegments = new string[segments.Length];
+        for (int i = 0; i < segments.Length; i++)
+        {
+            if (!IsAsciiDigits(segments[i]))
+            {
+                return Maybe<string>.None;
+            }
+
+            normalizedSegments[i] = StripLeadingZeros(segments[i]);
+        }
+
+        int lastSignificant = normalizedSegments.Length - 1;
+        while (lastSignificant > 0 && normalizedSegments[lastSignificant] == "0")
+        {
+            lastSignificant--;
+        }
+
+        return string.Join(SegmentSeparator, normalizedSegments.Take(lastSignificant + 1));
+    }
+
+    /// <summary>
+    /// Strips leading zeros from an all-digit segment, leaving a single <c>0</c> for an all-zero
+    /// segment (e.g. <c>047</c> → <c>47</c>, <c>000</c> → <c>0</c>).
+    /// </summary>
+    private static string StripLeadingZeros(string segment)
+    {
+        string trimmed = segment.TrimStart('0');
+
+        return trimmed.Length is 0 ? "0" : trimmed;
+    }
+
+    private static bool IsAsciiDigits(string segment)
+    {
+        if (segment.Length is 0)
+        {
+            return false;
+        }
+
+        foreach (char character in segment)
+        {
+            if (!char.IsAsciiDigit(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/BaseDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/BaseDomainErrors.cs
@@ -35,4 +35,9 @@ public static partial class DomainErrors
 
     private static Error InvalidOperation(string entity, string message, string code)
         => new($"{entity}.{code}", message, TypeOfError.DataConflict);
+
+    private static Error InvalidDottedNumericFormat(string entity, string property)
+        => new($"{entity}.{property}.InvalidFormat",
+            $"The {property.ToLowerInvariant()} must be dotted-numeric notation (e.g. '48.0', '47.1.1').",
+            TypeOfError.Validation);
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
@@ -34,6 +34,9 @@ public static partial class DomainErrors
 
             public static Error LongerThanAllowed
                 => TooManyCharacters(nameof(GameVersionEntity), nameof(GameVersion.LotroNotationVersion), LotroNotationVersion.VersionMaxLength);
+
+            public static Error InvalidFormat
+                => InvalidDottedNumericFormat(nameof(GameVersionEntity), nameof(GameVersion.LotroNotationVersion));
         }
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/ListGameVersionsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/ListGameVersionsTests.cs
@@ -50,14 +50,14 @@ public sealed class ListGameVersionsTests : IAsyncLifetime
         GameVersionResponse[]? body = await (await client.GetAsync(Route))
             .Content.ReadFromJsonAsync<GameVersionResponse[]>(JsonOptions);
 
-        // Assert — newest first; status round-trips.
+        // Assert — newest first; status round-trips; versions are stored canonical (trailing zeros dropped).
         body.ShouldNotBeNull();
         body.Length.ShouldBe(3);
-        body[0].Version.ShouldBe("48.0");
+        body[0].Version.ShouldBe("48");
         body[0].Status.ShouldBe(GameVersionStatus.Unprocessed);
         body[1].Version.ShouldBe("47.1");
         body[1].Status.ShouldBe(GameVersionStatus.Processed);
-        body[2].Version.ShouldBe("47.0");
+        body[2].Version.ShouldBe("47");
         body[2].Status.ShouldBe(GameVersionStatus.Superseded);
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/RegisterGameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/RegisterGameVersionTests.cs
@@ -37,7 +37,7 @@ public sealed class RegisterGameVersionTests : IAsyncLifetime
     [Fact]
     public async Task Register_WithNewVersion_ShouldReturn201UnprocessedAndAppearInList()
     {
-        // Arrange
+        // Arrange — input carries an insignificant trailing zero; it is stored canonical ("48").
         using HttpClient client = AdminClient();
 
         // Act
@@ -49,24 +49,42 @@ public sealed class RegisterGameVersionTests : IAsyncLifetime
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
         body.ShouldNotBeNull();
-        body.Version.ShouldBe("48.0");
+        body.Version.ShouldBe("48");
         body.Status.ShouldBe(GameVersionStatus.Unprocessed);
         list.ShouldNotBeNull();
-        list.ShouldContain(version => version.Version == "48.0");
+        list.ShouldContain(version => version.Version == "48");
     }
 
     [Fact]
-    public async Task Register_DuplicateVersion_ShouldReturn422()
+    public async Task Register_DuplicateAcrossEquivalentNotations_ShouldReturn422()
     {
-        // Arrange — registering the same version twice is a conflict (idempotent in effect).
+        // Arrange — "48" and "48.0.0" canonicalize to the same version, so the second is a conflict.
         using HttpClient client = AdminClient();
-        await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("48.0"));
+        await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("48"));
 
         // Act
-        HttpResponseMessage response = await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("48.0"));
+        HttpResponseMessage response = await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("48.0.0"));
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+
+        GameVersionResponse[]? list = await (await client.GetAsync(Route))
+            .Content.ReadFromJsonAsync<GameVersionResponse[]>(JsonOptions);
+        list.ShouldNotBeNull();
+        list.Count(version => version.Version == "48").ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Register_WithInvalidFormat_ShouldReturn400()
+    {
+        // Arrange
+        using HttpClient client = AdminClient();
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(Route, new RegisterGameVersionRequest("banana"));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/GameVersions/RegisterGameVersionHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/GameVersions/RegisterGameVersionHandlerTests.cs
@@ -69,12 +69,12 @@ public sealed class RegisterGameVersionHandlerTests
     {
         // Arrange — repository reports the version is new (default substitute returns false).
 
-        // Act
+        // Act — input is trimmed and normalized to canonical ("48.0" → "48").
         Result<GameVersionResponse> result = await CreateHandler().Handle(new RegisterGameVersion.Command(" 48.0 "), CancellationToken.None);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.Version.ShouldBe("48.0");
+        result.Value.Version.ShouldBe("48");
         result.Value.Status.ShouldBe(GameVersionStatus.Unprocessed);
         // Persistence is invisible in the returned response (built from the in-memory aggregate),
         // so SaveChanges is the persistence proof — matching the sibling command tests.

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/GameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/GameVersionTests.cs
@@ -17,14 +17,14 @@ public sealed class GameVersionTests
     public void Create_WithValidVersion_ShouldSucceedAsUnprocessed()
     {
         // Arrange
-        LotroNotationVersion version = LotroNotationVersion.Create("48.0").Value;
+        LotroNotationVersion version = LotroNotationVersion.Create("47.1.1").Value;
 
         // Act
         Result<GameVersion> result = GameVersion.Create(version, DetectedAt);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.LotroNotationVersion.Value.ShouldBe("48.0");
+        result.Value.LotroNotationVersion.Value.ShouldBe("47.1.1");
         result.Value.DetectedAt.ShouldBe(DetectedAt);
         result.Value.Status.ShouldBe(GameVersionStatus.Unprocessed);
         result.Value.Id.Value.ShouldNotBe(Guid.Empty);

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/LotroNotationVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/LotroNotationVersionTests.cs
@@ -1,3 +1,4 @@
+using LotroKoniecDev.SharedKernel.Enums;
 using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
@@ -7,14 +8,14 @@ namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates.Ga
 public sealed class LotroNotationVersionTests
 {
     [Fact]
-    public void Create_WithValidValue_ShouldSucceed()
+    public void Create_WithCanonicalValue_ShouldSucceedAndRoundTrip()
     {
         // Act
-        Result<LotroNotationVersion> result = LotroNotationVersion.Create("48.0");
+        Result<LotroNotationVersion> result = LotroNotationVersion.Create("47.1.1");
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.Value.ShouldBe("48.0");
+        result.Value.Value.ShouldBe("47.1.1");
     }
 
     [Fact]
@@ -26,6 +27,68 @@ public sealed class LotroNotationVersionTests
         // Assert
         result.IsSuccess.ShouldBeTrue();
         result.Value.Value.ShouldBe("47.1.1");
+    }
+
+    [Theory]
+    [InlineData("48", "48")]
+    [InlineData("48.0", "48")]
+    [InlineData("48.0.0", "48")]
+    [InlineData("47.1", "47.1")]
+    [InlineData("47.1.0", "47.1")]
+    [InlineData("47.1.0.0", "47.1")]
+    [InlineData("47.1.1", "47.1.1")]
+    [InlineData("47.0.1", "47.0.1")]
+    [InlineData("0", "0")]
+    [InlineData("0.0", "0")]
+    [InlineData("0.0.0", "0")]
+    [InlineData("0.0.0.0", "0")]
+    [InlineData("047", "47")]
+    [InlineData("48.01", "48.1")]
+    [InlineData("4.8.15.16", "4.8.15.16")]
+    public void Create_WithVariousNotations_ShouldNormalizeToCanonicalValue(string input, string expectedCanonical)
+    {
+        // Act
+        Result<LotroNotationVersion> result = LotroNotationVersion.Create(input);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Value.ShouldBe(expectedCanonical);
+    }
+
+    [Theory]
+    [InlineData("48", "48.0")]
+    [InlineData("48", "48.0.0")]
+    [InlineData("48.0", "48.0.0")]
+    [InlineData("47.1", "47.1.0")]
+    [InlineData("47.1", "47.1.0.0")]
+    public void Create_WithTrailingZeroEquivalents_ShouldProduceEqualValueObjects(string left, string right)
+    {
+        // Act
+        LotroNotationVersion first = LotroNotationVersion.Create(left).Value;
+        LotroNotationVersion second = LotroNotationVersion.Create(right).Value;
+
+        // Assert
+        (first == second).ShouldBeTrue();
+        first.Equals(second).ShouldBeTrue();
+        first.Value.ShouldBe(second.Value);
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+
+    [Theory]
+    [InlineData("48", "47")]
+    [InlineData("48.1", "48.2")]
+    [InlineData("47.0.1", "47.1")]
+    [InlineData("48.0.1", "48")]
+    public void Create_WithDifferentVersions_ShouldProduceUnequalValueObjects(string left, string right)
+    {
+        // Act
+        LotroNotationVersion first = LotroNotationVersion.Create(left).Value;
+        LotroNotationVersion second = LotroNotationVersion.Create(right).Value;
+
+        // Assert
+        (first == second).ShouldBeFalse();
+        first.Equals(second).ShouldBeFalse();
+        first.Value.ShouldNotBe(second.Value);
     }
 
     [Theory]
@@ -57,7 +120,7 @@ public sealed class LotroNotationVersionTests
     }
 
     [Fact]
-    public void Create_WithValueAtMaxLength_ShouldSucceed()
+    public void Create_WithSingleSegmentAtMaxLength_ShouldSucceed()
     {
         // Arrange
         string value = new('1', LotroNotationVersion.VersionMaxLength);
@@ -67,5 +130,30 @@ public sealed class LotroNotationVersionTests
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
+        result.Value.Value.ShouldBe(value);
+    }
+
+    [Theory]
+    [InlineData("banana")]
+    [InlineData("48.x")]
+    [InlineData("v48")]
+    [InlineData("48-0")]
+    [InlineData("48,0")]
+    [InlineData("48..0")]
+    [InlineData(".48")]
+    [InlineData("48.")]
+    [InlineData(".")]
+    [InlineData("48.0.")]
+    [InlineData("48 0")]
+    [InlineData("48.0 beta")]
+    public void Create_WithInvalidFormat_ShouldReturnInvalidFormatValidationError(string value)
+    {
+        // Act
+        Result<LotroNotationVersion> result = LotroNotationVersion.Create(value);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.VersionProperty.InvalidFormat);
+        result.Error.Type.ShouldBe(TypeOfError.Validation);
     }
 }


### PR DESCRIPTION
Closes #132

## What
Makes `LotroNotationVersion` (TMS Domain VO) treat `48` / `48.0` / `48.0.0` as **one** version. The VO now parses dotted-numeric notation, validates the format, and stores the **canonical** form (insignificant trailing-zero segments collapsed). Equality and both dedup paths — `GameVersionRepository.ExistsByVersionAsync` (ordinal compare) + the EF unique index — fall out of the canonical `Value` with no `GetAtomicValues` or EF-mapping change.

Resolves the latent correctness bug flagged by the in-code `//todo`: previously the raw trimmed string was stored, `Create("banana")` succeeded, and `48`/`48.0`/`48.0.0` were three distinct rows — silently defeating the `VersionAlreadyRegistered` guard and spec-0001 supersede/invalidation.

## Decisions (ADR-0003, Accepted)
The ticket's four open questions were **not contested business decisions** — three are answerable from the empirically-settled forum regex in the knowledge base, the fourth (canonical form) is a low-stakes engineering choice. Recorded in `docs/adr/0003-lotronotationversion-canonical-form.md`:
1. **Canonical form:** collapse trailing-zero segments (`48.0.0` → `48`), not pad — padding would invent a fixed segment count LOTRO doesn't guarantee.
2. **Equivalence:** trailing-zero segments always insignificant (`47.1 == 47.1.0`); interior zeros (`47.0.1`) significant; no max segment count beyond the existing 12-char cap.
3. **Grammar:** `digits(.digits)*` — exactly the forum regex `Update\s+(\d+(?:\.\d+)*)\s+Release\s+Notes` (the sole producer of these strings). Rejects `banana`, `48.x`, `48..0`, `.48`, `48.`, empty segments.
4. **Ordering:** out of scope — no `IComparable`; supersede order stays `DetectedAt` (spec 0001).

## Acceptance criteria
- ✅ `Create("48")`/`Create("48.0")`/`Create("48.0.0")` produce equal VOs (`==`, `Value`, `GetHashCode`).
- ✅ Register `48` then `48.0.0` ⇒ 422 `VersionAlreadyRegistered`, one row (integration test, real PostgreSQL).
- ✅ Invalid format ⇒ `Result.Failure` (`TypeOfError.Validation` → 400).
- ✅ Canonical form documented (ADR-0003); `//todo` removed; XML doc matches enforced behavior.
- ✅ `[Theory]`/`[InlineData]` equivalence + rejection matrices; full build green, zero warnings.

## Tests
Domain unit **100 passed** · API unit **74 passed** · API integration (real PostgreSQL) **65 passed**. Canonicalization is overflow-safe (pure string ops) and ASCII-digit-strict. code-reviewer verdict: **APPROVE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)