### PR TITLE
M3-01: Frontend project (Blazor SSR) + lifted OIDC RP infra + layout

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,9 @@
     <PackageVersion Include="StronglyTypedId" Version="0.2.1" />
     <!-- ASP.NET Core & API -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.13.14" />
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <!-- Authentication & Identity -->

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -37,6 +37,7 @@
     <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/LotroKoniecDev.TranslationSystem.Persistence.csproj" />
     <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/LotroKoniecDev.TranslationSystem.Contracts.csproj" />
     <Project Path="src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj" />
+    <Project Path="src/Frontend/LotroKoniecDev.Frontend/LotroKoniecDev.Frontend.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <File Path="tests/README.md" />
@@ -48,5 +49,6 @@
     <Project Path="tests/LotroKoniecDev.Tests.Infrastructure/LotroKoniecDev.Tests.Infrastructure.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj" />
+    <Project Path="tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj" />
   </Folder>
 </Solution>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/App.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/App.razor
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pl">
+
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <base href="/"/>
+    <link rel="preconnect" href="https://fonts.googleapis.com"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"/>
+    <link rel="stylesheet" href="@Assets["layout.css"]"/>
+    <ImportMap/>
+    <link rel="icon" href="data:,"/>
+    <HeadOutlet/>
+</head>
+
+<body>
+<Routes/>
+<script src="@Assets["_framework/blazor.web.js"]"></script>
+</body>
+
+</html>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
@@ -1,0 +1,24 @@
+@inherits LayoutComponentBase
+
+<div class="app-shell">
+    <NavMenu/>
+
+    <div class="app-main">
+        <main class="content">
+            <ErrorBoundary>
+                <ChildContent>
+                    @Body
+                </ChildContent>
+                <ErrorContent>
+                    <div class="status-message status-error" role="alert">
+                        <p>Wystąpił nieoczekiwany błąd. Odśwież stronę lub spróbuj ponownie później.</p>
+                    </div>
+                </ErrorContent>
+            </ErrorBoundary>
+        </main>
+
+        <footer class="app-footer">
+            <span>© @DateTime.UtcNow.Year LotroKoniecDev — polskie tłumaczenie LOTRO</span>
+        </footer>
+    </div>
+</div>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
@@ -1,0 +1,46 @@
+@using LotroKoniecDev.Frontend.Infrastructure.Auth
+
+<aside class="sidebar">
+    <div class="sidebar-brand">
+        <a class="brand" href="/">
+            <span class="brand-mark">LK</span>
+            <span class="brand-text">LotroKoniec<span class="brand-accent">Dev</span></span>
+        </a>
+        <p class="brand-sub">Tłumaczenie LOTRO</p>
+    </div>
+
+    <nav class="sidebar-nav" aria-label="Nawigacja główna">
+        <NavLink class="nav-link" href="/" Match="NavLinkMatch.All">
+            <span class="nav-text">Start</span>
+        </NavLink>
+        <NavLink class="nav-link" href="/translations">
+            <span class="nav-text">Tłumaczenia</span>
+        </NavLink>
+        <NavLink class="nav-link" href="/editor">
+            <span class="nav-text">Edytor</span>
+        </NavLink>
+        <NavLink class="nav-link" href="/import-export">
+            <span class="nav-text">Import / Eksport</span>
+        </NavLink>
+        <NavLink class="nav-link" href="/dashboard">
+            <span class="nav-text">Panel</span>
+        </NavLink>
+    </nav>
+
+    <div class="sidebar-auth">
+        <AuthorizeView>
+            <Authorized>
+                <span class="auth-user">@(context.User.Identity?.Name)</span>
+                <form method="post" action="@AuthenticationDependencyInjectionExtensions.LogoutPath">
+                    <AntiforgeryToken/>
+                    <button type="submit" class="btn btn-ghost btn-block">Wyloguj</button>
+                </form>
+            </Authorized>
+            <NotAuthorized>
+                <a class="btn btn-primary btn-block" href="@AuthenticationDependencyInjectionExtensions.LoginPath">
+                    Zaloguj
+                </a>
+            </NotAuthorized>
+        </AuthorizeView>
+    </div>
+</aside>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/AccessDenied.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/AccessDenied.razor
@@ -1,0 +1,17 @@
+@page "/auth/access-denied"
+@layout MainLayout
+@attribute [AllowAnonymous]
+@using Microsoft.AspNetCore.Authorization
+
+<PageTitle>Brak dostępu — LotroKoniecDev</PageTitle>
+
+<div class="status-stage">
+    <div class="status-card status-danger">
+        <div class="status-code">403</div>
+        <h1>Brak dostępu</h1>
+        <p class="status-desc">Nie masz uprawnień do wyświetlenia tej strony.</p>
+        <div class="status-actions">
+            <a href="/" class="btn btn-primary">Wróć na stronę główną</a>
+        </div>
+    </div>
+</div>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/BadRequest.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/BadRequest.razor
@@ -1,0 +1,17 @@
+@page "/bad-request"
+@layout MainLayout
+@attribute [AllowAnonymous]
+@using Microsoft.AspNetCore.Authorization
+
+<PageTitle>Nieprawidłowe żądanie — LotroKoniecDev</PageTitle>
+
+<div class="status-stage">
+    <div class="status-card status-warning">
+        <div class="status-code">400</div>
+        <h1>Nieprawidłowe żądanie</h1>
+        <p class="status-desc">Serwer nie mógł przetworzyć żądania. Sprawdź wprowadzone dane i spróbuj ponownie.</p>
+        <div class="status-actions">
+            <a href="/" class="btn btn-primary">Wróć na stronę główną</a>
+        </div>
+    </div>
+</div>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Error.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Error.razor
@@ -1,0 +1,34 @@
+@page "/Error"
+@layout MainLayout
+@attribute [AllowAnonymous]
+@using System.Diagnostics
+@using Microsoft.AspNetCore.Authorization
+
+<PageTitle>Błąd — LotroKoniecDev</PageTitle>
+
+<div class="status-stage">
+    <div class="status-card status-danger">
+        <div class="status-code">500</div>
+        <h1>Coś poszło nie tak</h1>
+        <p class="status-desc">Wystąpił nieoczekiwany błąd po stronie serwera. Spróbuj ponownie za chwilę.</p>
+        @if (!string.IsNullOrEmpty(RequestId))
+        {
+            <div class="status-detail">
+                <span class="det-k">Identyfikator żądania</span>
+                <code>@RequestId</code>
+            </div>
+        }
+        <div class="status-actions">
+            <a href="/" class="btn btn-primary">Wróć na stronę główną</a>
+        </div>
+    </div>
+</div>
+
+@code {
+    [CascadingParameter] private HttpContext? HttpContext { get; set; }
+
+    private string? RequestId { get; set; }
+
+    protected override void OnInitialized() =>
+        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home.razor
@@ -1,0 +1,50 @@
+@page "/"
+@attribute [AllowAnonymous]
+@attribute [StreamRendering]
+@using Microsoft.AspNetCore.Authorization
+@using LotroKoniecDev.Frontend.Infrastructure.HttpClients
+@using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients
+@inject ITranslationSystemClient TranslationSystemClient
+
+<PageTitle>LotroKoniecDev — Tłumaczenie LOTRO</PageTitle>
+
+<section class="hero">
+    <h1>System zarządzania tłumaczeniami</h1>
+    <p class="lede">
+        Panel tłumacza polskiej wersji The Lord of the Rings Online: import tekstów z gry,
+        edycja z obiegiem zatwierdzania i eksport pliku tłumaczenia do patchera.
+    </p>
+</section>
+
+<section class="panel">
+    <h2>Połączenie z API</h2>
+    @if (_healthResult is null)
+    {
+        <p class="status-line status-pending">
+            <span class="dot"></span> Sprawdzanie dostępności API…
+        </p>
+    }
+    else if (_healthResult.IsSuccess)
+    {
+        <p class="status-line status-ok">
+            <span class="dot"></span> API odpowiada — stan: <strong>@_healthResult.Value.Status</strong>
+        </p>
+    }
+    else
+    {
+        <p class="status-line status-down" role="alert">
+            <span class="dot"></span>
+            @(_healthResult.ProblemDetails?.Title ?? "API jest nieosiągalne")
+        </p>
+    }
+</section>
+
+@code
+{
+    private ApiResult<HealthStatusResponse>? _healthResult;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _healthResult = await TranslationSystemClient.GetHealthAsync();
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/NotFound.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/NotFound.razor
@@ -1,0 +1,17 @@
+@page "/not-found"
+@layout MainLayout
+@attribute [AllowAnonymous]
+@using Microsoft.AspNetCore.Authorization
+
+<PageTitle>Nie znaleziono — LotroKoniecDev</PageTitle>
+
+<div class="status-stage">
+    <div class="status-card">
+        <div class="status-code">404</div>
+        <h1>Strony nie znaleziono</h1>
+        <p class="status-desc">Strona, której szukasz, nie istnieje lub została przeniesiona.</p>
+        <div class="status-actions">
+            <a href="/" class="btn btn-primary">Wróć na stronę główną</a>
+        </div>
+    </div>
+</div>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Routes.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Routes.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+    <Found Context="routeData">
+        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)">
+            <NotAuthorized>
+                <p role="alert">Nie masz uprawnień do wyświetlenia tej strony.</p>
+            </NotAuthorized>
+        </AuthorizeRouteView>
+        <FocusOnNavigate RouteData="routeData" Selector="h1"/>
+    </Found>
+</Router>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/_Imports.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/_Imports.razor
@@ -1,0 +1,12 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using LotroKoniecDev.Frontend
+@using LotroKoniecDev.Frontend.Components
+@using LotroKoniecDev.Frontend.Components.Layout

--- a/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using FluentValidation;
+using LotroKoniecDev.Frontend.Infrastructure.Auth;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+
+namespace LotroKoniecDev.Frontend;
+
+public static class DependencyInjection
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddFrontend()
+        {
+            services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly(), includeInternalTypes: true);
+
+            services.AddAntiforgery(options => options.Cookie.Path = "/");
+
+            services.AddHttpClients();
+            services.AddDiscoveryCache();
+            services.AddFrontendAuthentication();
+
+            return services;
+        }
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthEndpointsExtensions.cs
@@ -1,0 +1,69 @@
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Options;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth;
+
+/// <summary>
+/// Maps the login (challenge) and logout (cookie sign-out + RP-initiated end-session) endpoints the
+/// OIDC RP wiring relies on. The navbar wires its login/logout controls to these in M3-02.
+/// </summary>
+internal static class AuthEndpointsExtensions
+{
+    private const string EndSessionPath = "connect/logout";
+    private const string IdTokenName = "id_token";
+
+    extension(IEndpointRouteBuilder endpoints)
+    {
+        public IEndpointRouteBuilder MapAuthEndpoints()
+        {
+            endpoints.MapGet(
+                AuthenticationDependencyInjectionExtensions.LoginPath,
+                (HttpContext context, string? returnUrl) =>
+                {
+                    string redirectUri = IsLocalUrl(returnUrl) ? returnUrl! : "/";
+                    return Results.Challenge(
+                        new AuthenticationProperties { RedirectUri = redirectUri },
+                        [OpenIdConnectDefaults.AuthenticationScheme]);
+                });
+
+            endpoints.MapPost(
+                AuthenticationDependencyInjectionExtensions.LogoutPath,
+                LogoutAsync);
+
+            return endpoints;
+        }
+    }
+
+    private static async Task<IResult> LogoutAsync(
+        HttpContext context,
+        IOptions<AuthSystemSettings> authSystemOptions)
+    {
+        string? idToken = await context.GetTokenAsync(IdTokenName);
+
+        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        string authority = authSystemOptions.Value.Authority.TrimEnd('/');
+        string postLogoutRedirect = $"{context.Request.Scheme}://{context.Request.Host}";
+
+        string endSessionUrl = $"{authority}/{EndSessionPath}" +
+                               $"?post_logout_redirect_uri={Uri.EscapeDataString(postLogoutRedirect)}";
+
+        if (!string.IsNullOrWhiteSpace(idToken))
+        {
+            endSessionUrl += $"&id_token_hint={Uri.EscapeDataString(idToken)}";
+        }
+
+        return Results.Redirect(endSessionUrl);
+    }
+
+    private static bool IsLocalUrl(string? url)
+    {
+        return !string.IsNullOrWhiteSpace(url)
+               && url.StartsWith('/')
+               && !url.StartsWith("//", StringComparison.Ordinal)
+               && !url.StartsWith("/\\", StringComparison.Ordinal);
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthenticationDependencyInjectionExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthenticationDependencyInjectionExtensions.cs
@@ -1,0 +1,155 @@
+using LotroKoniecDev.Frontend.Infrastructure.Auth.TokenRefresh;
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth;
+
+/// <summary>
+/// Wires the OpenID Connect relying-party: a cookie session as the default scheme, the OpenIddict
+/// AuthSystem as the challenge/sign-out scheme (authorization-code + PKCE), and
+/// <see cref="CookieTokenRefresher"/> on <c>OnValidatePrincipal</c>. The interactive login/logout UX,
+/// protected-vs-public page policy, and navbar user info land in the M3-02 auth-session slice; this
+/// lifts the RP infrastructure so that slice is pure activation.
+/// </summary>
+internal static class AuthenticationDependencyInjectionExtensions
+{
+    internal const string LoginPath = "/auth/login";
+    internal const string LogoutPath = "/auth/logout";
+    internal const string AccessDeniedPath = "/auth/access-denied";
+    private const string ErrorPath = "/Error";
+
+    private static readonly Action<ILogger, string?, Exception?> LogOidcRemoteFailure =
+        LoggerMessage.Define<string?>(
+            LogLevel.Warning,
+            new EventId(1, nameof(LogOidcRemoteFailure)),
+            "OIDC remote failure: {FailureMessage}");
+
+    private static readonly Action<ILogger, Exception?> LogOidcAccessDenied =
+        LoggerMessage.Define(
+            LogLevel.Information,
+            new EventId(2, nameof(LogOidcAccessDenied)),
+            "OIDC access denied by identity provider.");
+
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddFrontendAuthentication()
+        {
+            services.AddCascadingAuthenticationState();
+            services.AddAuthorization();
+
+            // Scoped, not singleton — ITokenEndpointClient wraps an HttpClient supplied by
+            // IHttpClientFactory. Capturing a transient typed client inside a singleton would defeat the
+            // factory's connection lifecycle and DNS-refresh story.
+            services.AddScoped<CookieTokenRefresher>();
+            services.AddHttpClient<ITokenEndpointClient, TokenEndpointClient>((sp, client) =>
+            {
+                AuthSystemSettings settings = sp
+                    .GetRequiredService<IOptions<AuthSystemSettings>>().Value;
+                client.BaseAddress = new Uri(settings.BaseUrl);
+            });
+
+            services.AddAuthentication(options =>
+                {
+                    options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                    options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+                    options.DefaultSignOutScheme = OpenIdConnectDefaults.AuthenticationScheme;
+                })
+                .AddCookie(options =>
+                {
+                    options.Cookie.Name = ".lotrokoniecdev.auth";
+                    options.Cookie.HttpOnly = true;
+                    options.Cookie.SameSite = SameSiteMode.Lax;
+                    options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+                    // Lock path so SignIn/SignOut cookies always match — without this, a future code path
+                    // that signs in under a non-root PathBase would produce a cookie that /auth/logout
+                    // (PathBase="") cannot delete.
+                    options.Cookie.Path = "/";
+                    options.ExpireTimeSpan = TimeSpan.FromHours(8);
+                    options.SlidingExpiration = true;
+                    options.LoginPath = LoginPath;
+                    options.LogoutPath = LogoutPath;
+                    options.AccessDeniedPath = AccessDeniedPath;
+                    options.Events.OnValidatePrincipal = ValidatePrincipalAsync;
+                })
+                .AddOpenIdConnect();
+
+            services.AddOptions<OpenIdConnectOptions>(OpenIdConnectDefaults.AuthenticationScheme)
+                .Configure<IOptions<AuthSystemSettings>>(ConfigureOpenIdConnect);
+
+            return services;
+        }
+    }
+
+    private static Task ValidatePrincipalAsync(CookieValidatePrincipalContext context)
+    {
+        CookieTokenRefresher refresher = context.HttpContext
+            .RequestServices.GetRequiredService<CookieTokenRefresher>();
+        return refresher.ValidateAsync(context);
+    }
+
+    private static void ConfigureOpenIdConnect(
+        OpenIdConnectOptions options,
+        IOptions<AuthSystemSettings> authSystemOptions)
+    {
+        AuthSystemSettings settings = authSystemOptions.Value;
+
+        options.Authority = settings.Authority;
+        options.ClientId = settings.ClientId;
+        options.RequireHttpsMetadata = !settings.Authority.StartsWith(
+            "http://", StringComparison.OrdinalIgnoreCase);
+
+        options.ResponseType = OpenIdConnectResponseType.Code;
+        options.UsePkce = true;
+        options.SaveTokens = true;
+        options.GetClaimsFromUserInfoEndpoint = true;
+        options.MapInboundClaims = false;
+
+        options.CallbackPath = settings.CallbackPath;
+        options.SignedOutCallbackPath = settings.SignedOutCallbackPath;
+        options.SignedOutRedirectUri = "/";
+
+        options.Scope.Clear();
+        foreach (string scope in settings.Scopes)
+        {
+            options.Scope.Add(scope);
+        }
+
+        options.TokenValidationParameters.NameClaimType = "name";
+        options.TokenValidationParameters.RoleClaimType = "role";
+
+        // Without these handlers, OIDC remote failures (AuthSystem down, correlation cookie lost, user
+        // denied consent) propagate as 500s and the user lands on the generic /Error page with no
+        // actionable context. Redirecting to dedicated pages keeps the trace ID flow intact
+        // (UseExceptionHandler/UseStatusCodePages re-execute with the rewritten path).
+        options.Events.OnRemoteFailure = OnRemoteFailureAsync;
+        options.Events.OnAccessDenied = OnAccessDeniedAsync;
+    }
+
+    private static Task OnRemoteFailureAsync(RemoteFailureContext context)
+    {
+        ILogger logger = context.HttpContext.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(AuthenticationDependencyInjectionExtensions).FullName!);
+        LogOidcRemoteFailure(logger, context.Failure?.Message, context.Failure);
+
+        context.Response.Redirect(ErrorPath);
+        context.HandleResponse();
+        return Task.CompletedTask;
+    }
+
+    private static Task OnAccessDeniedAsync(AccessDeniedContext context)
+    {
+        ILogger logger = context.HttpContext.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(AuthenticationDependencyInjectionExtensions).FullName!);
+        LogOidcAccessDenied(logger, null);
+
+        context.Response.Redirect(AccessDeniedPath);
+        context.HandleResponse();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DataProtectionDependencyInjectionExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DataProtectionDependencyInjectionExtensions.cs
@@ -1,0 +1,50 @@
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth;
+
+internal static class DataProtectionDependencyInjectionExtensions
+{
+    private const string ApplicationName = "LotroKoniecDev.Frontend";
+
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        /// Configures ASP.NET Core Data Protection: a stable application name in every environment (so a
+        /// key minted by one instance/path is readable by another), and filesystem key persistence only
+        /// when a keyring path is configured. In Development the path is left empty and the framework
+        /// default location is used (it already persists on the host). The keyring path is read straight
+        /// from configuration at registration time — Data Protection is set up before the DI container is
+        /// built, so there is no validated options instance to resolve yet, and binding
+        /// <see cref="IServiceProvider"/> here would trip ASP0000.
+        /// </summary>
+        public IServiceCollection AddFrontendDataProtection(IConfiguration configuration, IHostEnvironment environment)
+        {
+            DataProtectionSettings settings = configuration
+                .GetSection(DataProtectionSettings.ConfigurationSection)
+                .Get<DataProtectionSettings>() ?? new DataProtectionSettings();
+
+            // Loud over silent: an ephemeral keyring outside Development is never intended — it silently
+            // invalidates every auth cookie / antiforgery token / OIDC correlation cookie on each deploy
+            // and makes multi-replica impossible. Fail fast at startup rather than degrade in prod.
+            if (!environment.IsDevelopment() && string.IsNullOrWhiteSpace(settings.KeyRingPath))
+            {
+                throw new InvalidOperationException(
+                    $"{DataProtectionSettings.ConfigurationSection}:{nameof(DataProtectionSettings.KeyRingPath)} "
+                    + "must be set outside Development. Mount a shared volume and point the keyring at it; "
+                    + "otherwise every deploy/scale-out logs all users out.");
+            }
+
+            IDataProtectionBuilder builder = services
+                .AddDataProtection()
+                .SetApplicationName(ApplicationName);
+
+            if (!string.IsNullOrWhiteSpace(settings.KeyRingPath))
+            {
+                builder.PersistKeysToFileSystem(new DirectoryInfo(settings.KeyRingPath));
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/CookieTokenRefresher.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/CookieTokenRefresher.cs
@@ -1,0 +1,271 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth.TokenRefresh;
+
+/// <summary>
+/// Runs on every cookie validation (<c>OnValidatePrincipal</c>). It refreshes the access token shortly
+/// before expiry using the stored refresh token, and — when the token is still locally alive —
+/// proactively re-validates its signature against the cached OIDC JWKS so a key rotated upstream signs
+/// the user out cleanly instead of letting a doomed token reach the API. A failed refresh or a token
+/// that fails signature validation after a metadata refresh rejects the principal and signs out the
+/// cookie. The reactive dead-session backstop and the soft "session expired" notice are deferred to
+/// the M3-02 auth-session slice; this lifts the core refresh + key-rotation mechanism.
+/// </summary>
+internal sealed class CookieTokenRefresher
+{
+    private const string AccessTokenName = "access_token";
+    private const string RefreshTokenName = "refresh_token";
+    private const string IdTokenName = "id_token";
+    private const string ExpiresAtName = "expires_at";
+
+    /// <summary>
+    /// Refresh slightly before actual expiry so an in-flight backend call cannot land with a token that
+    /// is technically alive locally but already rejected upstream.
+    /// </summary>
+    private static readonly TimeSpan RefreshSkew = TimeSpan.FromSeconds(60);
+
+    private readonly ITokenEndpointClient _tokenEndpointClient;
+    private readonly IOptionsMonitor<OpenIdConnectOptions> _openIdConnectOptionsMonitor;
+    private readonly ILogger<CookieTokenRefresher> _logger;
+
+    public CookieTokenRefresher(
+        ITokenEndpointClient tokenEndpointClient,
+        IOptionsMonitor<OpenIdConnectOptions> openIdConnectOptionsMonitor,
+        ILogger<CookieTokenRefresher> logger)
+    {
+        _tokenEndpointClient = tokenEndpointClient;
+        _openIdConnectOptionsMonitor = openIdConnectOptionsMonitor;
+        _logger = logger;
+    }
+
+    public async Task ValidateAsync(CookieValidatePrincipalContext context)
+    {
+        CancellationToken cancellationToken = context.HttpContext.RequestAborted;
+
+        RefreshOutcome refreshOutcome = await TryRefreshIfNearExpiryAsync(context, cancellationToken);
+        if (refreshOutcome is RefreshOutcome.Stop)
+        {
+            return;
+        }
+
+        if (refreshOutcome is RefreshOutcome.Refreshed)
+        {
+            // A token we just refreshed was minted by the IdP over TLS on this very request, so its
+            // signing key cannot have rotated out from under it yet: the proactive JWKS probe below
+            // would have nothing to catch and could only misfire against momentarily-stale local JWKS.
+            return;
+        }
+
+        // Proactive local validation: even when the token is alive on the local clock, its signing key
+        // may have rotated upstream (the FE still trusts the previous JWKS). Validate the signature
+        // against the cached OIDC keys — no API round-trip. Lifetime/audience are intentionally NOT
+        // checked here: the skew window above owns expiry, and the FE is not the token's audience.
+        if (!await IsAccessTokenCryptographicallyValidAsync(context, cancellationToken))
+        {
+            LogProactiveInvalidToken(_logger, null);
+            await RejectAsync(context);
+        }
+    }
+
+    /// <returns>
+    /// <see cref="RefreshOutcome.Stop"/> when validation must stop (no expiry claim, or the principal
+    /// was already rejected); <see cref="RefreshOutcome.Refreshed"/> when a fresh token was just
+    /// obtained from the IdP, so the caller must skip the proactive signature probe; otherwise
+    /// <see cref="RefreshOutcome.Unchanged"/> when the still-alive token should be probed.
+    /// </returns>
+    private async Task<RefreshOutcome> TryRefreshIfNearExpiryAsync(
+        CookieValidatePrincipalContext context,
+        CancellationToken cancellationToken)
+    {
+        AuthenticationProperties properties = context.Properties;
+
+        string? expiresAtRaw = properties.GetTokenValue(ExpiresAtName);
+        if (string.IsNullOrEmpty(expiresAtRaw)
+            || !DateTimeOffset.TryParse(
+                expiresAtRaw,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out DateTimeOffset expiresAt))
+        {
+            return RefreshOutcome.Stop;
+        }
+
+        if (DateTimeOffset.UtcNow + RefreshSkew < expiresAt)
+        {
+            return RefreshOutcome.Unchanged;
+        }
+
+        string? refreshToken = properties.GetTokenValue(RefreshTokenName);
+        if (string.IsNullOrEmpty(refreshToken))
+        {
+            LogNoRefreshToken(_logger, null);
+            await RejectAsync(context);
+            return RefreshOutcome.Stop;
+        }
+
+        TokenResponse? tokenResponse = await _tokenEndpointClient.RefreshAsync(
+            refreshToken, cancellationToken);
+
+        if (tokenResponse?.AccessToken is null)
+        {
+            LogRefreshFailed(_logger, null);
+            await RejectAsync(context);
+            return RefreshOutcome.Stop;
+        }
+
+        properties.UpdateTokenValue(AccessTokenName, tokenResponse.AccessToken);
+
+        if (!string.IsNullOrEmpty(tokenResponse.RefreshToken))
+        {
+            properties.UpdateTokenValue(RefreshTokenName, tokenResponse.RefreshToken);
+        }
+
+        if (!string.IsNullOrEmpty(tokenResponse.IdToken))
+        {
+            properties.UpdateTokenValue(IdTokenName, tokenResponse.IdToken);
+        }
+
+        DateTimeOffset newExpiresAt = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn);
+        properties.UpdateTokenValue(
+            ExpiresAtName,
+            newExpiresAt.ToString("o", CultureInfo.InvariantCulture));
+
+        context.ShouldRenew = true;
+        return RefreshOutcome.Refreshed;
+    }
+
+    private async Task<bool> IsAccessTokenCryptographicallyValidAsync(
+        CookieValidatePrincipalContext context,
+        CancellationToken cancellationToken)
+    {
+        string? accessToken = context.Properties.GetTokenValue(AccessTokenName);
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            // No token to validate — leave the decision to the skew/refresh path, which already ran.
+            return true;
+        }
+
+        OpenIdConnectOptions oidcOptions = _openIdConnectOptionsMonitor.Get(
+            OpenIdConnectDefaults.AuthenticationScheme);
+        if (oidcOptions.ConfigurationManager is null)
+        {
+            // Without a configuration manager we cannot fetch JWKS; do not falsely log the user out.
+            return true;
+        }
+
+        OpenIdConnectConfiguration configuration = await oidcOptions.ConfigurationManager
+            .GetConfigurationAsync(cancellationToken);
+
+        if (await TryValidateAsync(
+                accessToken, configuration.SigningKeys, configuration.Issuer, cancellationToken))
+        {
+            return true;
+        }
+
+        // A benign key roll the FE has not refetched yet would fail the first pass. Force a metadata
+        // refresh and re-validate exactly once before concluding the token is truly dead.
+        oidcOptions.ConfigurationManager.RequestRefresh();
+        OpenIdConnectConfiguration refreshedConfiguration = await oidcOptions.ConfigurationManager
+            .GetConfigurationAsync(cancellationToken);
+
+        return await TryValidateAsync(
+            accessToken, refreshedConfiguration.SigningKeys, refreshedConfiguration.Issuer, cancellationToken);
+    }
+
+    [SuppressMessage(
+        "Security",
+        "CA5404:Do not disable token validation checks",
+        Justification =
+            "Intentional: this is a cryptographic-validity / key-rotation probe, not a full access-token "
+            + "validation. Audience is disabled because the FE is not the token's audience (the API is), "
+            + "and lifetime is disabled because the skew/refresh window above already owns expiry — "
+            + "re-checking it here would double-handle and could falsely reject.")]
+    private static async Task<bool> TryValidateAsync(
+        string accessToken,
+        IEnumerable<SecurityKey> signingKeys,
+        string? issuer,
+        CancellationToken cancellationToken)
+    {
+        // Issuer is anchored on the discovery document (ConfigurationManager), the same source the
+        // provider stamps into the token 'iss' — so they cannot drift the way a hand-configured Authority
+        // can (trailing slash, internal URL, empty-by-default in prod). If discovery has not yielded an
+        // issuer yet, skip rather than falsely log the user out.
+        if (string.IsNullOrWhiteSpace(issuer))
+        {
+            return true;
+        }
+
+        TokenValidationParameters validationParameters = new()
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys = signingKeys,
+            ValidateIssuer = true,
+            ValidIssuer = issuer,
+            ValidateAudience = false,
+            ValidateLifetime = false
+        };
+
+        TokenValidationResult result = await new JsonWebTokenHandler()
+            .ValidateTokenAsync(accessToken, validationParameters);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return result.IsValid;
+    }
+
+    private static async Task RejectAsync(CookieValidatePrincipalContext context)
+    {
+        context.RejectPrincipal();
+        await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+    }
+
+    /// <summary>
+    /// Result of the near-expiry refresh attempt, telling <see cref="ValidateAsync"/> whether the
+    /// proactive JWKS signature probe still has anything to validate.
+    /// </summary>
+    private enum RefreshOutcome
+    {
+        /// <summary>
+        /// Validation must stop: there was no usable <c>expires_at</c> claim, or the principal was
+        /// already rejected inside the refresh attempt.
+        /// </summary>
+        Stop,
+
+        /// <summary>
+        /// The token was left untouched and is still alive on the local clock — the one case worth
+        /// probing for an upstream key roll.
+        /// </summary>
+        Unchanged,
+
+        /// <summary>
+        /// A fresh token was just obtained from the IdP this request, so the proactive signature probe
+        /// is skipped.
+        /// </summary>
+        Refreshed
+    }
+
+    private static readonly Action<ILogger, Exception?> LogNoRefreshToken =
+        LoggerMessage.Define(
+            LogLevel.Information,
+            new EventId(1, nameof(LogNoRefreshToken)),
+            "Cookie has no refresh_token; principal rejected.");
+
+    private static readonly Action<ILogger, Exception?> LogRefreshFailed =
+        LoggerMessage.Define(
+            LogLevel.Information,
+            new EventId(2, nameof(LogRefreshFailed)),
+            "Refresh token grant returned no access_token; principal rejected.");
+
+    private static readonly Action<ILogger, Exception?> LogProactiveInvalidToken =
+        LoggerMessage.Define(
+            LogLevel.Information,
+            new EventId(3, nameof(LogProactiveInvalidToken)),
+            "Access token failed local JWKS signature validation after a metadata refresh; principal rejected.");
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/ITokenEndpointClient.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/ITokenEndpointClient.cs
@@ -1,0 +1,6 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth.TokenRefresh;
+
+internal interface ITokenEndpointClient
+{
+    Task<TokenResponse?> RefreshAsync(string refreshToken, CancellationToken cancellationToken = default);
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/TokenEndpointClient.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/TokenEndpointClient.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.Extensions.Options;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth.TokenRefresh;
+
+internal sealed class TokenEndpointClient : ITokenEndpointClient
+{
+    private const string GrantTypeParam = "grant_type";
+    private const string RefreshTokenGrantType = "refresh_token";
+    private const string RefreshTokenParam = "refresh_token";
+    private const string ClientIdParam = "client_id";
+    private static readonly Uri TokenRelativeUri = new("connect/token", UriKind.Relative);
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _httpClient;
+    private readonly IOptions<AuthSystemSettings> _authSystemOptions;
+    private readonly ILogger<TokenEndpointClient> _logger;
+
+    public TokenEndpointClient(
+        HttpClient httpClient,
+        IOptions<AuthSystemSettings> authSystemOptions,
+        ILogger<TokenEndpointClient> logger)
+    {
+        _httpClient = httpClient;
+        _authSystemOptions = authSystemOptions;
+        _logger = logger;
+    }
+
+    public async Task<TokenResponse?> RefreshAsync(
+        string refreshToken,
+        CancellationToken cancellationToken = default)
+    {
+        using FormUrlEncodedContent content = new(
+        [
+            new KeyValuePair<string, string>(GrantTypeParam, RefreshTokenGrantType),
+            new KeyValuePair<string, string>(RefreshTokenParam, refreshToken),
+            new KeyValuePair<string, string>(ClientIdParam, _authSystemOptions.Value.ClientId)
+        ]);
+
+        try
+        {
+            using HttpResponseMessage response = await _httpClient.PostAsync(
+                TokenRelativeUri, content, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                LogRefreshFailed(_logger, (int)response.StatusCode, null);
+                return null;
+            }
+
+            string body = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonSerializer.Deserialize<TokenResponse>(body, JsonOptions);
+        }
+        catch (HttpRequestException ex)
+        {
+            LogRefreshError(_logger, ex);
+            return null;
+        }
+        catch (TaskCanceledException ex)
+        {
+            LogRefreshError(_logger, ex);
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            LogRefreshError(_logger, ex);
+            return null;
+        }
+    }
+
+    private static readonly Action<ILogger, int, Exception?> LogRefreshFailed =
+        LoggerMessage.Define<int>(
+            LogLevel.Warning,
+            new EventId(1, nameof(LogRefreshFailed)),
+            "Refresh token grant failed with status {StatusCode}.");
+
+    private static readonly Action<ILogger, Exception> LogRefreshError =
+        LoggerMessage.Define(
+            LogLevel.Warning,
+            new EventId(2, nameof(LogRefreshError)),
+            "Refresh token grant threw an exception.");
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/TokenResponse.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/TokenResponse.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth.TokenRefresh;
+
+internal sealed class TokenResponse
+{
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; init; }
+
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; init; }
+
+    [JsonPropertyName("id_token")]
+    public string? IdToken { get; init; }
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; init; }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/DiscoveryCache.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/DiscoveryCache.cs
@@ -1,0 +1,114 @@
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Hybrid;
+using LotroKoniecDev.TranslationSystem.Contracts.Discovery;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Discovery;
+
+internal sealed class DiscoveryCache : IDiscoveryCache
+{
+    internal const string TranslationSystemDiscoveryCacheKeyPrefix = "discovery:translation-system:";
+
+    private const string AnonymousSuffix = "anon";
+    private const string UserSuffix = "user";
+
+    private static readonly HybridCacheEntryOptions OneDayEntryOptions = new()
+    {
+        Expiration = TimeSpan.FromDays(1),
+        LocalCacheExpiration = TimeSpan.FromDays(1)
+    };
+
+    private readonly HybridCache _hybridCache;
+    private readonly ITranslationSystemClient _translationSystemClient;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public DiscoveryCache(
+        HybridCache hybridCache,
+        ITranslationSystemClient translationSystemClient,
+        IHttpContextAccessor httpContextAccessor)
+    {
+        _hybridCache = hybridCache;
+        _translationSystemClient = translationSystemClient;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<ApiResult<DiscoveryResponse>> GetTranslationSystemDiscoveryAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // Keyed by auth state because the API tailors its HATEOAS link set per role. A shared key
+        // would let the first caller (anon or authed) freeze the wrong link set for everyone for a day.
+        string authSuffix = GetAuthSuffix();
+
+        try
+        {
+            DiscoveryResponse value = await GetOrCreateAsync(authSuffix, cancellationToken);
+            return ApiResult.Success(value);
+        }
+        catch (DiscoveryUnavailableException ex) when (ex.ProblemDetails is not null)
+        {
+            return ApiResult.Failure<DiscoveryResponse>(ex.ProblemDetails);
+        }
+    }
+
+    private async ValueTask<DiscoveryResponse> GetOrCreateAsync(
+        string authSuffix,
+        CancellationToken cancellationToken)
+    {
+        // Only successful, correctly-shaped payloads are cached. A ProblemDetails failure must never be
+        // persisted under the 1-day TTL (it would keep the app broken for 24h after a transient outage):
+        // the factory throws so HybridCache discards the entry and the next request retries the live
+        // endpoint.
+        return await _hybridCache.GetOrCreateAsync(
+            TranslationSystemDiscoveryCacheKeyPrefix + authSuffix,
+            _translationSystemClient,
+            static async (client, ct) =>
+            {
+                ApiResult<DiscoveryResponse> result = await client.GetDiscoveryAsync(ct);
+                if (result.IsFailure)
+                {
+                    throw new DiscoveryUnavailableException(result.ProblemDetails);
+                }
+
+                return result.Value;
+            },
+            options: OneDayEntryOptions,
+            cancellationToken: cancellationToken);
+    }
+
+    private string GetAuthSuffix()
+    {
+        HttpContext? context = _httpContextAccessor.HttpContext;
+        return context?.User.Identity?.IsAuthenticated is true
+            ? UserSuffix
+            : AnonymousSuffix;
+    }
+}
+
+/// <summary>
+/// Sentinel exception used to bubble an API failure out of the <c>HybridCache</c> factory without
+/// having it persisted as a cache entry. The public 3-constructor shape appeases CA1032.
+/// </summary>
+public sealed class DiscoveryUnavailableException : Exception
+{
+    public DiscoveryUnavailableException()
+    {
+    }
+
+    public DiscoveryUnavailableException(string message)
+        : base(message)
+    {
+    }
+
+    public DiscoveryUnavailableException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public DiscoveryUnavailableException(ProblemDetails? problemDetails)
+    {
+        ProblemDetails = problemDetails;
+    }
+
+    public ProblemDetails? ProblemDetails { get; }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/DiscoveryDependencyInjectionExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/DiscoveryDependencyInjectionExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Discovery;
+
+public static class DiscoveryDependencyInjectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddDiscoveryCache()
+        {
+            // L1-only HybridCache: no IDistributedCache is registered, so HybridCache falls back to its
+            // in-memory store. Discovery responses are tiny and tied to the local process; a distributed
+            // cache would add latency for no gain.
+            services.AddHybridCache(options =>
+            {
+                options.MaximumPayloadBytes = 1024 * 64;
+                options.MaximumKeyLength = 256;
+                options.DefaultEntryOptions = new HybridCacheEntryOptions
+                {
+                    Expiration = TimeSpan.FromDays(1),
+                    LocalCacheExpiration = TimeSpan.FromDays(1)
+                };
+            });
+
+            // Scoped because the typed HTTP client it depends on is scoped (per request). HybridCache
+            // itself is a singleton internally, so the TTL still spans requests.
+            services.AddScoped<IDiscoveryCache, DiscoveryCache>();
+
+            return services;
+        }
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/IDiscoveryCache.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/IDiscoveryCache.cs
@@ -1,0 +1,14 @@
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Discovery;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Discovery;
+
+internal interface IDiscoveryCache
+{
+    /// <summary>
+    /// Returns the TMS HATEOAS discovery root, cached per auth state for a day. Pages resolve their
+    /// API links from it instead of hardcoding routes.
+    /// </summary>
+    Task<ApiResult<DiscoveryResponse>> GetTranslationSystemDiscoveryAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/StatusCodePagesApplicationBuilderExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/StatusCodePagesApplicationBuilderExtensions.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Errors;
+
+/// <summary>
+/// Same contract as the built-in <c>UseStatusCodePagesWithReExecute(string, string?)</c> but lets the
+/// host pick a re-execute path per status code, so 401/403/404/5xx each land on a page that honestly
+/// represents what happened instead of pretending every 4xx/5xx is a 404.
+/// </summary>
+/// <remarks>
+/// Mirrors the runtime implementation: sets <see cref="IStatusCodeReExecuteFeature"/> so middleware can
+/// recognise the re-executed request, clears the routed endpoint so the rewritten path is matched
+/// again, and restores request state in <c>finally</c>.
+/// </remarks>
+public static class StatusCodePagesApplicationBuilderExtensions
+{
+    extension(IApplicationBuilder app)
+    {
+        public IApplicationBuilder UseStatusCodePagesByStatusCode(
+            Func<int, string> pathSelector,
+            bool createScopeForStatusCodePages = false)
+        {
+            ArgumentNullException.ThrowIfNull(pathSelector);
+
+            return app.UseStatusCodePages(async context =>
+            {
+                HttpContext httpContext = context.HttpContext;
+                int statusCode = httpContext.Response.StatusCode;
+
+                string newPath = pathSelector(statusCode);
+                if (string.IsNullOrWhiteSpace(newPath))
+                {
+                    return;
+                }
+
+                PathString originalPath = httpContext.Request.Path;
+                PathString originalPathBase = httpContext.Request.PathBase;
+                QueryString originalQueryString = httpContext.Request.QueryString;
+
+                httpContext.Features.Set<IStatusCodeReExecuteFeature>(new ReExecuteFeature
+                {
+                    OriginalPath = originalPath.Value ?? string.Empty,
+                    OriginalPathBase = originalPathBase.Value ?? string.Empty,
+                    OriginalQueryString = originalQueryString.HasValue ? originalQueryString.Value : null,
+                    OriginalStatusCode = statusCode
+                });
+
+                // EndpointRoutingMiddleware short-circuits when an endpoint is already set, so the
+                // rewritten path would otherwise hit the original (now-irrelevant) endpoint.
+                httpContext.SetEndpoint(endpoint: null);
+                httpContext.Features.Get<IRouteValuesFeature>()?.RouteValues?.Clear();
+
+                httpContext.Request.Path = new PathString(newPath);
+                httpContext.Request.QueryString = QueryString.Empty;
+
+                try
+                {
+                    if (createScopeForStatusCodePages)
+                    {
+                        IServiceScopeFactory scopeFactory = httpContext.RequestServices
+                            .GetRequiredService<IServiceScopeFactory>();
+                        using IServiceScope scope = scopeFactory.CreateScope();
+                        IServiceProvider previousServices = httpContext.RequestServices;
+                        httpContext.RequestServices = scope.ServiceProvider;
+                        try
+                        {
+                            await context.Next(httpContext);
+                        }
+                        finally
+                        {
+                            httpContext.RequestServices = previousServices;
+                        }
+                    }
+                    else
+                    {
+                        await context.Next(httpContext);
+                    }
+                }
+                finally
+                {
+                    httpContext.Request.QueryString = originalQueryString;
+                    httpContext.Request.Path = originalPath;
+                    httpContext.Features.Set<IStatusCodeReExecuteFeature?>(null);
+                }
+            });
+        }
+    }
+
+    private sealed class ReExecuteFeature : IStatusCodeReExecuteFeature
+    {
+        public string OriginalPath { get; set; } = string.Empty;
+        public string OriginalPathBase { get; set; } = string.Empty;
+        public string? OriginalQueryString { get; set; }
+        public int OriginalStatusCode { get; set; }
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/ApiResult.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/ApiResult.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+
+/// <summary>
+/// A small result monad for HTTP calls: on failure it carries the API's <see cref="ProblemDetails"/>
+/// (or a synthesized one for transport failures) so pages can render a Polish message instead of
+/// throwing. Mirrors the API-side <c>Result</c> discipline at the Frontend's HTTP seam.
+/// </summary>
+public class ApiResult
+{
+    protected ApiResult(bool isSuccess, ProblemDetails? problemDetails)
+    {
+        if (isSuccess && problemDetails is not null)
+        {
+            throw new InvalidOperationException();
+        }
+
+        IsSuccess = isSuccess;
+        ProblemDetails = problemDetails;
+    }
+
+    public bool IsSuccess { get; }
+
+    public bool IsFailure => !IsSuccess;
+
+    public ProblemDetails? ProblemDetails { get; }
+
+    public static ApiResult Success() => new(true, null);
+
+    public static ApiResult<TValue> Success<TValue>(TValue value) => new(value, true, null);
+
+    public static ApiResult Failure(ProblemDetails problemDetails) => new(false, problemDetails);
+
+    public static ApiResult<TValue> Failure<TValue>(ProblemDetails problemDetails) =>
+        new(default!, false, problemDetails);
+}
+
+public sealed class ApiResult<TValue> : ApiResult
+{
+    internal ApiResult(TValue value, bool isSuccess, ProblemDetails? problemDetails)
+        : base(isSuccess, problemDetails)
+    {
+        Value = value;
+    }
+
+    public static implicit operator ApiResult<TValue>(TValue value) => Success(value);
+
+    public TValue Value => IsSuccess
+        ? field
+        : throw new InvalidOperationException("The value of a failure result can not be accessed.");
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
@@ -1,0 +1,220 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Polly.CircuitBreaker;
+using Polly.Timeout;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+
+/// <summary>
+/// Turns raw <see cref="HttpClient"/> calls into <see cref="ApiResult"/>/<see cref="ApiResult{T}"/>:
+/// success deserializes the body, an error status deserializes the API's <c>ProblemDetails</c>, and a
+/// transport failure (no HTTP status — Polly timeout/circuit-open, socket error) is mapped to a Polish
+/// <c>ProblemDetails</c> so the SSR page renders a message instead of crashing. The Frontend is
+/// Polish-only, so these messages are inlined rather than localized.
+/// </summary>
+internal static class HttpClientApiExtensions
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    extension(HttpClient httpClient)
+    {
+        public async Task<ApiResult<T>> GetApiResultAsync<T>(
+            string uri,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(
+                HttpMethod.Get,
+                new Uri(uri, UriKind.RelativeOrAbsolute));
+            return await SendForApiResultAsync<T>(httpClient, request, cancellationToken);
+        }
+
+        public async Task<ApiResult> PostApiResultAsync(
+            string uri,
+            object body,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(HttpMethod.Post, new Uri(uri, UriKind.RelativeOrAbsolute));
+            request.Content = JsonContent.Create(body, body.GetType(), options: JsonOptions);
+            return await SendForApiResultAsync(httpClient, request, cancellationToken);
+        }
+
+        public async Task<ApiResult<T>> PostApiResultAsync<T>(
+            string uri,
+            object body,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(HttpMethod.Post, new Uri(uri, UriKind.RelativeOrAbsolute));
+            request.Content = JsonContent.Create(body, body.GetType(), options: JsonOptions);
+            return await SendForApiResultAsync<T>(httpClient, request, cancellationToken);
+        }
+
+        public async Task<ApiResult> PutApiResultAsync(
+            string uri,
+            object body,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(HttpMethod.Put, new Uri(uri, UriKind.RelativeOrAbsolute));
+            request.Content = JsonContent.Create(body, body.GetType(), options: JsonOptions);
+            return await SendForApiResultAsync(httpClient, request, cancellationToken);
+        }
+
+        public async Task<ApiResult<T>> PutApiResultAsync<T>(
+            string uri,
+            object body,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(HttpMethod.Put, new Uri(uri, UriKind.RelativeOrAbsolute));
+            request.Content = JsonContent.Create(body, body.GetType(), options: JsonOptions);
+            return await SendForApiResultAsync<T>(httpClient, request, cancellationToken);
+        }
+
+        public async Task<ApiResult> PutApiResultAsync(
+            string uri,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(HttpMethod.Put, new Uri(uri, UriKind.RelativeOrAbsolute));
+            return await SendForApiResultAsync(httpClient, request, cancellationToken);
+        }
+
+        public async Task<ApiResult> PatchApiResultAsync(
+            string uri,
+            object body,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(HttpMethod.Patch, new Uri(uri, UriKind.RelativeOrAbsolute));
+            request.Content = JsonContent.Create(body, body.GetType(), options: JsonOptions);
+            return await SendForApiResultAsync(httpClient, request, cancellationToken);
+        }
+
+        public async Task<ApiResult> DeleteApiResultAsync(
+            string uri,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(HttpMethod.Delete, new Uri(uri, UriKind.RelativeOrAbsolute));
+            return await SendForApiResultAsync(httpClient, request, cancellationToken);
+        }
+
+        public async Task<ApiResult> SendMultipartApiResultAsync(
+            HttpMethod method,
+            string uri,
+            MultipartFormDataContent content,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(method, new Uri(uri, UriKind.RelativeOrAbsolute))
+            {
+                Content = content
+            };
+            return await SendForApiResultAsync(httpClient, request, cancellationToken);
+        }
+
+        public async Task<ApiResult<T>> SendMultipartApiResultAsync<T>(
+            HttpMethod method,
+            string uri,
+            MultipartFormDataContent content,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(method, new Uri(uri, UriKind.RelativeOrAbsolute))
+            {
+                Content = content
+            };
+            return await SendForApiResultAsync<T>(httpClient, request, cancellationToken);
+        }
+    }
+
+    private static async Task<ApiResult<T>> SendForApiResultAsync<T>(
+        HttpClient httpClient,
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
+            string content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                // A success with no body (e.g. 204 No Content) has nothing to deserialize — surface the
+                // default value rather than throwing a JsonException on an empty string.
+                if (string.IsNullOrWhiteSpace(content))
+                {
+                    return ApiResult.Success<T>(default!);
+                }
+
+                T value = JsonSerializer.Deserialize<T>(content, JsonOptions)
+                          ?? throw new JsonException($"Failed to deserialize {typeof(T).Name}");
+                return ApiResult.Success(value);
+            }
+
+            ProblemDetails problem = JsonSerializer.Deserialize<ProblemDetails>(content, JsonOptions)
+                                     ?? throw new JsonException("Failed to deserialize ProblemDetails");
+            return ApiResult.Failure<T>(problem);
+        }
+        catch (Exception ex) when (IsTransportFailure(ex))
+        {
+            return ApiResult.Failure<T>(MapTransportFailureToProblemDetails(ex));
+        }
+    }
+
+    private static async Task<ApiResult> SendForApiResultAsync(
+        HttpClient httpClient,
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return ApiResult.Success();
+            }
+
+            string content = await response.Content.ReadAsStringAsync(cancellationToken);
+            ProblemDetails problem = JsonSerializer.Deserialize<ProblemDetails>(content, JsonOptions)
+                                     ?? throw new JsonException("Failed to deserialize ProblemDetails");
+            return ApiResult.Failure(problem);
+        }
+        catch (Exception ex) when (IsTransportFailure(ex))
+        {
+            return ApiResult.Failure(MapTransportFailureToProblemDetails(ex));
+        }
+    }
+
+    /// <summary>
+    /// The resilience pipeline (Polly) can throw before we ever see an HTTP status code.
+    /// These are translated into a <see cref="ProblemDetails"/> so callers stay on the
+    /// <c>ApiResult</c> path and can render a message instead of crashing the page.
+    /// </summary>
+    private static bool IsTransportFailure(Exception ex) =>
+        ex is HttpRequestException
+            or TaskCanceledException
+            or BrokenCircuitException
+            or TimeoutRejectedException;
+
+    private static ProblemDetails MapTransportFailureToProblemDetails(Exception ex) => ex switch
+    {
+        BrokenCircuitException => new ProblemDetails
+        {
+            Title = "Usługa chwilowo niedostępna",
+            Detail = "Połączenie z serwerem zostało tymczasowo wstrzymane. Spróbuj ponownie za chwilę.",
+            Status = StatusCodes.Status503ServiceUnavailable
+        },
+        TimeoutRejectedException or TaskCanceledException => new ProblemDetails
+        {
+            Title = "Przekroczono czas oczekiwania",
+            Detail = "Serwer nie odpowiedział w wyznaczonym czasie. Spróbuj ponownie.",
+            Status = StatusCodes.Status504GatewayTimeout
+        },
+        _ => new ProblemDetails
+        {
+            Title = "Błąd połączenia",
+            Detail = "Nie udało się połączyć z serwerem. Spróbuj ponownie za chwilę.",
+            Status = StatusCodes.Status503ServiceUnavailable
+        }
+    };
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientsDependencyInjectionExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientsDependencyInjectionExtensions.cs
@@ -1,0 +1,74 @@
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Options;
+using Polly;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+
+public static class HttpClientsDependencyInjectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddHttpClients()
+        {
+            services.AddTransient<TranslationContentNegotiationAndAuthDelegatingHandler>();
+
+            services.AddHttpClient<ITranslationSystemClient, TranslationSystemClient>((sp, client) =>
+                {
+                    TranslationSystemSettings settings = sp
+                        .GetRequiredService<IOptions<TranslationSystemSettings>>().Value;
+                    client.BaseAddress = new Uri(settings.BaseUrl);
+                })
+                .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+                {
+                    PooledConnectionLifetime = TimeSpan.FromMinutes(15)
+                })
+                .SetHandlerLifetime(Timeout.InfiniteTimeSpan)
+                .AddHttpMessageHandler<TranslationContentNegotiationAndAuthDelegatingHandler>()
+                .AddResilienceHandler("TranslationSystemResilience", ConfigureResiliencePipeline);
+
+            return services;
+        }
+    }
+
+    private static void ConfigureResiliencePipeline(ResiliencePipelineBuilder<HttpResponseMessage> pipeline)
+    {
+        pipeline.AddRetry(new HttpRetryStrategyOptions
+        {
+            MaxRetryAttempts = 2,
+            Delay = TimeSpan.FromMilliseconds(500),
+            BackoffType = DelayBackoffType.Exponential,
+            UseJitter = true,
+            ShouldHandle = args => ValueTask.FromResult(IsHandledTransientFailure(args.Outcome, args.Context))
+        });
+
+        pipeline.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
+        {
+            SamplingDuration = TimeSpan.FromSeconds(30),
+            FailureRatio = 0.5,
+            MinimumThroughput = 10,
+            BreakDuration = TimeSpan.FromSeconds(30),
+            ShouldHandle = args => ValueTask.FromResult(IsHandledTransientFailure(args.Outcome, args.Context))
+        });
+
+        pipeline.AddTimeout(TimeSpan.FromSeconds(10));
+    }
+
+    /// <summary>
+    /// Multipart uploads are excluded: their body stream is forward-only and cannot be replayed, so a
+    /// retry would re-send an exhausted stream, and a rejected oversized upload (413 surfacing as a
+    /// broken-pipe write error) is not transient. Replaying it only multiplies the load and stalls the
+    /// request through every attempt and timeout.
+    /// </summary>
+    private static bool IsHandledTransientFailure(Outcome<HttpResponseMessage> outcome, ResilienceContext context)
+    {
+        if (context.GetRequestMessage()?.Content is MultipartFormDataContent)
+        {
+            return false;
+        }
+
+        return outcome.Result?.StatusCode >= System.Net.HttpStatusCode.InternalServerError
+               || outcome.Exception is not null;
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/HealthStatusResponse.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/HealthStatusResponse.cs
@@ -1,0 +1,8 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+
+/// <summary>
+/// Minimal projection of the TMS API <c>GET /health</c> payload. The Frontend only needs the
+/// aggregate <see cref="Status"/> (e.g. <c>Healthy</c>) to confirm the API is reachable; the
+/// per-check breakdown the API also returns is intentionally not modelled here.
+/// </summary>
+internal sealed record HealthStatusResponse(string Status);

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/ITranslationSystemClient.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/ITranslationSystemClient.cs
@@ -1,0 +1,70 @@
+using LotroKoniecDev.TranslationSystem.Contracts.Discovery;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+
+/// <summary>
+/// Typed client over the TMS API (<c>TranslationSystem.API</c>). It owns the base address and the
+/// content-negotiation + bearer-token delegating handler; pages compose relative URIs (preferring
+/// HATEOAS links from <see cref="GetDiscoveryAsync"/>) and call through the verb helpers.
+/// </summary>
+internal interface ITranslationSystemClient
+{
+    /// <summary>
+    /// Calls the anonymous <c>GET /health</c> endpoint to confirm the API is reachable and healthy.
+    /// </summary>
+    Task<ApiResult<HealthStatusResponse>> GetHealthAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches the HATEOAS discovery root (<c>GET /</c>) — the entry point pages use to resolve links.
+    /// </summary>
+    Task<ApiResult<DiscoveryResponse>> GetDiscoveryAsync(CancellationToken cancellationToken = default);
+
+    Task<ApiResult<T>> GetApiResultAsync<T>(
+        string relativeUri,
+        CancellationToken cancellationToken = default);
+
+    Task<ApiResult> PostApiResultAsync(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default);
+
+    Task<ApiResult<T>> PostApiResultAsync<T>(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default);
+
+    Task<ApiResult> PutApiResultAsync(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default);
+
+    Task<ApiResult<T>> PutApiResultAsync<T>(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default);
+
+    Task<ApiResult> PutApiResultAsync(
+        string relativeUri,
+        CancellationToken cancellationToken = default);
+
+    Task<ApiResult> PatchApiResultAsync(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default);
+
+    Task<ApiResult> DeleteApiResultAsync(
+        string relativeUri,
+        CancellationToken cancellationToken = default);
+
+    Task<ApiResult> SendMultipartApiResultAsync(
+        HttpMethod method,
+        string relativeUri,
+        MultipartFormDataContent content,
+        CancellationToken cancellationToken = default);
+
+    Task<ApiResult<T>> SendMultipartApiResultAsync<T>(
+        HttpMethod method,
+        string relativeUri,
+        MultipartFormDataContent content,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/TranslationContentNegotiationAndAuthDelegatingHandler.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/TranslationContentNegotiationAndAuthDelegatingHandler.cs
@@ -1,0 +1,47 @@
+using System.Net.Http.Headers;
+using LotroKoniecDev.Hateoas.Abstractions;
+using Microsoft.AspNetCore.Authentication;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+
+/// <summary>
+/// Negotiates the TMS API's opt-in HATEOAS representation (sends
+/// <see cref="MediaTypes.HateoasJson"/> in <c>Accept</c>) and forwards the signed-in translator's
+/// bearer access token. The token only flows once the OIDC session exists (M3-02); anonymous
+/// requests (e.g. the public <c>GET /health</c> probe) pass through unauthenticated.
+/// </summary>
+internal sealed class TranslationContentNegotiationAndAuthDelegatingHandler : DelegatingHandler
+{
+    private const string BearerScheme = "Bearer";
+    private const string AccessTokenName = "access_token";
+
+    private static readonly MediaTypeWithQualityHeaderValue HateoasJsonMediaType = new(MediaTypes.HateoasJson);
+
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public TranslationContentNegotiationAndAuthDelegatingHandler(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        request.Headers.Accept.Add(HateoasJsonMediaType);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext?.User.Identity?.IsAuthenticated is not true)
+        {
+            return await base.SendAsync(request, cancellationToken);
+        }
+
+        string? accessToken = await httpContext.GetTokenAsync(AccessTokenName);
+        if (!string.IsNullOrWhiteSpace(accessToken))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue(BearerScheme, accessToken);
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/TranslationSystemClient.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/TranslationSystemClient.cs
@@ -1,0 +1,110 @@
+using LotroKoniecDev.TranslationSystem.Contracts.Discovery;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+
+internal sealed class TranslationSystemClient : ITranslationSystemClient
+{
+    private const string HealthRelativeUri = "health";
+    private const string DiscoveryRelativeUri = "";
+
+    private readonly HttpClient _httpClient;
+
+    public TranslationSystemClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public Task<ApiResult<HealthStatusResponse>> GetHealthAsync(CancellationToken cancellationToken = default)
+    {
+        return _httpClient.GetApiResultAsync<HealthStatusResponse>(HealthRelativeUri, cancellationToken);
+    }
+
+    public Task<ApiResult<DiscoveryResponse>> GetDiscoveryAsync(CancellationToken cancellationToken = default)
+    {
+        return _httpClient.GetApiResultAsync<DiscoveryResponse>(DiscoveryRelativeUri, cancellationToken);
+    }
+
+    public Task<ApiResult<T>> GetApiResultAsync<T>(string relativeUri, CancellationToken cancellationToken = default)
+    {
+        return _httpClient.GetApiResultAsync<T>(relativeUri, cancellationToken);
+    }
+
+    public Task<ApiResult> PostApiResultAsync(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return _httpClient.PostApiResultAsync(relativeUri, body, cancellationToken);
+    }
+
+    public Task<ApiResult<T>> PostApiResultAsync<T>(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return _httpClient.PostApiResultAsync<T>(relativeUri, body, cancellationToken);
+    }
+
+    public Task<ApiResult> PutApiResultAsync(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return _httpClient.PutApiResultAsync(relativeUri, body, cancellationToken);
+    }
+
+    public Task<ApiResult<T>> PutApiResultAsync<T>(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return _httpClient.PutApiResultAsync<T>(relativeUri, body, cancellationToken);
+    }
+
+    public Task<ApiResult> PutApiResultAsync(
+        string relativeUri,
+        CancellationToken cancellationToken = default)
+    {
+        return _httpClient.PutApiResultAsync(relativeUri, cancellationToken);
+    }
+
+    public Task<ApiResult> PatchApiResultAsync(
+        string relativeUri,
+        object body,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return _httpClient.PatchApiResultAsync(relativeUri, body, cancellationToken);
+    }
+
+    public Task<ApiResult> DeleteApiResultAsync(
+        string relativeUri,
+        CancellationToken cancellationToken = default)
+    {
+        return _httpClient.DeleteApiResultAsync(relativeUri, cancellationToken);
+    }
+
+    public Task<ApiResult> SendMultipartApiResultAsync(
+        HttpMethod method,
+        string relativeUri,
+        MultipartFormDataContent content,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        return _httpClient.SendMultipartApiResultAsync(method, relativeUri, content, cancellationToken);
+    }
+
+    public Task<ApiResult<T>> SendMultipartApiResultAsync<T>(
+        HttpMethod method,
+        string relativeUri,
+        MultipartFormDataContent content,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        return _httpClient.SendMultipartApiResultAsync<T>(method, relativeUri, content, cancellationToken);
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/LotroKoniecDev.Frontend.csproj
+++ b/src/Frontend/LotroKoniecDev.Frontend/LotroKoniecDev.Frontend.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="LotroKoniecDev.Frontend.Tests.Unit" />
+        <!-- Castle DynamicProxy (used by NSubstitute in the unit tests) proxies internal interfaces. -->
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentValidation" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+        <PackageReference Include="Serilog.AspNetCore" />
+        <PackageReference Include="Serilog.Enrichers.Environment" />
+        <PackageReference Include="Serilog.Enrichers.Thread" />
+        <PackageReference Include="Serilog.Sinks.Console" />
+        <PackageReference Include="Serilog.Sinks.File" />
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\TranslationSystem\LotroKoniecDev.TranslationSystem.Contracts\LotroKoniecDev.TranslationSystem.Contracts.csproj" />
+        <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Hateoas.Abstractions\LotroKoniecDev.Hateoas.Abstractions.csproj" />
+        <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Options\LotroKoniecDev.Options.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -1,0 +1,129 @@
+using System.Globalization;
+using LotroKoniecDev.Frontend;
+using LotroKoniecDev.Frontend.Components;
+using LotroKoniecDev.Frontend.Infrastructure.Auth;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
+using LotroKoniecDev.Frontend.Settings;
+using LotroKoniecDev.Options;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Serilog;
+using Serilog.Sinks.OpenTelemetry;
+
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
+    .CreateBootstrapLogger();
+
+try
+{
+    Log.Information("Starting Frontend");
+
+    WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+    builder.Services.AddSerilog((serviceProvider, loggerConfiguration) =>
+    {
+        loggerConfiguration
+            .ReadFrom.Configuration(builder.Configuration)
+            .ReadFrom.Services(serviceProvider);
+
+        string? otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+        if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+        {
+            loggerConfiguration.WriteTo.OpenTelemetry(opts =>
+            {
+                opts.Endpoint = otlpEndpoint;
+                opts.Protocol = string.Equals(
+                    builder.Configuration["OTEL_EXPORTER_OTLP_PROTOCOL"],
+                    "http/protobuf",
+                    StringComparison.OrdinalIgnoreCase)
+                    ? OtlpProtocol.HttpProtobuf
+                    : OtlpProtocol.Grpc;
+                opts.ResourceAttributes = new Dictionary<string, object>
+                {
+                    ["service.name"] = builder.Environment.ApplicationName
+                };
+            });
+        }
+    });
+
+    builder.Services.AddOpenTelemetry()
+        .ConfigureResource(resource => resource.AddService(builder.Environment.ApplicationName))
+        .WithTracing(tracing => tracing
+            .AddHttpClientInstrumentation()
+            .AddAspNetCoreInstrumentation())
+        .WithMetrics(metrics => metrics
+            .AddHttpClientInstrumentation()
+            .AddAspNetCoreInstrumentation()
+            .AddRuntimeInstrumentation())
+        .UseOtlpExporter();
+
+    builder.Services.AddRazorComponents();
+
+    builder.Services
+        .AddOptionsWithFluentValidation<TranslationSystemSettings>(TranslationSystemSettings.ConfigurationSection)
+        .AddOptionsWithFluentValidation<AuthSystemSettings>(AuthSystemSettings.ConfigurationSection)
+        .AddOptionsWithFluentValidation<DataProtectionSettings>(DataProtectionSettings.ConfigurationSection);
+
+    builder.Services.AddHttpContextAccessor();
+
+    // Configured before the host is built and read straight from configuration: the keyring must be
+    // persistent + the application name pinned so cookies/antiforgery/OIDC correlation survive restarts
+    // and are shared across replicas.
+    builder.Services.AddFrontendDataProtection(builder.Configuration, builder.Environment);
+
+    builder.Services.AddFrontend();
+
+    WebApplication app = builder.Build();
+
+    app.UseSerilogRequestLogging();
+
+    if (!app.Environment.IsDevelopment())
+    {
+        app.UseExceptionHandler("/Error", createScopeForErrors: true);
+        app.UseHsts();
+    }
+
+    app.UseStatusCodePagesByStatusCode(
+        statusCode => statusCode switch
+        {
+            StatusCodes.Status400BadRequest => "/bad-request",
+            StatusCodes.Status401Unauthorized or StatusCodes.Status403Forbidden => "/auth/access-denied",
+            StatusCodes.Status404NotFound => "/not-found",
+            _ => "/Error"
+        },
+        createScopeForStatusCodePages: true);
+
+    app.UseHttpsRedirection();
+
+    app.UseRouting();
+
+    app.UseAuthentication();
+    app.UseAuthorization();
+
+    app.UseAntiforgery();
+
+    app.MapStaticAssets();
+    app.MapAuthEndpoints();
+    app.MapRazorComponents<App>();
+
+    await app.RunAsync();
+}
+#pragma warning disable S2139
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Frontend terminated unexpectedly");
+    throw;
+}
+#pragma warning restore S2139
+finally
+{
+    await Log.CloseAndFlushAsync();
+}
+
+/// <summary>
+/// Exposed so the integration test host (<c>WebApplicationFactory</c>) can reference the Frontend's
+/// entry-point assembly.
+/// </summary>
+public partial class Program;

--- a/src/Frontend/LotroKoniecDev.Frontend/Properties/launchSettings.json
+++ b/src/Frontend/LotroKoniecDev.Frontend/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7017;http://localhost:5001",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5001",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"
+      }
+    }
+  }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Settings/AuthSystemSettings.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Settings/AuthSystemSettings.cs
@@ -1,0 +1,24 @@
+namespace LotroKoniecDev.Frontend.Settings;
+
+/// <summary>
+/// Binds the OpenID Connect relying-party configuration the Frontend uses to authenticate
+/// translators against the self-hosted AuthSystem (OpenIddict). <see cref="BaseUrl"/> is the
+/// token endpoint host used by <c>CookieTokenRefresher</c>; <see cref="Authority"/> is the OIDC
+/// metadata/discovery host stamped into tokens.
+/// </summary>
+internal sealed class AuthSystemSettings
+{
+    public const string ConfigurationSection = "AuthSystem";
+
+    public required string BaseUrl { get; init; }
+
+    public required string Authority { get; init; }
+
+    public required string ClientId { get; init; }
+
+    public required string CallbackPath { get; init; }
+
+    public required string SignedOutCallbackPath { get; init; }
+
+    public required IReadOnlyList<string> Scopes { get; init; }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Settings/AuthSystemSettingsValidator.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Settings/AuthSystemSettingsValidator.cs
@@ -1,0 +1,46 @@
+using FluentValidation;
+
+namespace LotroKoniecDev.Frontend.Settings;
+
+internal sealed class AuthSystemSettingsValidator : AbstractValidator<AuthSystemSettings>
+{
+    public AuthSystemSettingsValidator()
+    {
+        RuleFor(x => x.BaseUrl)
+            .NotEmpty()
+            .Must(BeAbsoluteHttpUrl)
+            .WithMessage($"{nameof(AuthSystemSettings.BaseUrl)} must be an absolute http(s) URL.");
+
+        RuleFor(x => x.Authority)
+            .NotEmpty()
+            .Must(BeAbsoluteHttpUrl)
+            .WithMessage($"{nameof(AuthSystemSettings.Authority)} must be an absolute http(s) URL.");
+
+        RuleFor(x => x.ClientId)
+            .NotEmpty();
+
+        RuleFor(x => x.CallbackPath)
+            .NotEmpty()
+            .Must(BeRootedPath)
+            .WithMessage($"{nameof(AuthSystemSettings.CallbackPath)} must be a rooted path (starting with '/').");
+
+        RuleFor(x => x.SignedOutCallbackPath)
+            .NotEmpty()
+            .Must(BeRootedPath)
+            .WithMessage($"{nameof(AuthSystemSettings.SignedOutCallbackPath)} must be a rooted path (starting with '/').");
+
+        RuleFor(x => x.Scopes)
+            .NotEmpty();
+    }
+
+    private static bool BeAbsoluteHttpUrl(string value)
+    {
+        return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+               && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+    }
+
+    private static bool BeRootedPath(string value)
+    {
+        return !string.IsNullOrWhiteSpace(value) && value.StartsWith('/');
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Settings/DataProtectionSettings.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Settings/DataProtectionSettings.cs
@@ -1,0 +1,16 @@
+namespace LotroKoniecDev.Frontend.Settings;
+
+/// <summary>
+/// Filesystem directory the Data Protection keyring is persisted to (mounted to a shared
+/// volume in container deployments). Empty is valid in Development: the framework default
+/// location at <c>~/.aspnet/DataProtection-Keys</c> already persists across host restarts, so
+/// dev must not hardcode a container path. A non-dev startup guard rejects an empty value (an
+/// ephemeral keyring in production mass-logs-out users on every deploy because every auth cookie
+/// / antiforgery token / OIDC correlation cookie becomes unreadable).
+/// </summary>
+internal sealed class DataProtectionSettings
+{
+    public const string ConfigurationSection = "DataProtection";
+
+    public string? KeyRingPath { get; init; }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Settings/DataProtectionSettingsValidator.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Settings/DataProtectionSettingsValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace LotroKoniecDev.Frontend.Settings;
+
+/// <summary>
+/// <see cref="DataProtectionSettings.KeyRingPath"/> is optional and has no binding-time constraint:
+/// null or empty both legitimately mean "use the framework default keyring location" (valid in
+/// Development). The only real rule — the path MUST be set outside Development — is a startup guard
+/// inside <c>AddFrontendDataProtection</c>, because Data Protection is configured before the DI
+/// container is built, so there is no validated options instance to resolve at that point. This
+/// validator therefore intentionally carries no rules.
+/// </summary>
+internal sealed class DataProtectionSettingsValidator : AbstractValidator<DataProtectionSettings>;

--- a/src/Frontend/LotroKoniecDev.Frontend/Settings/TranslationSystemSettings.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Settings/TranslationSystemSettings.cs
@@ -1,0 +1,11 @@
+namespace LotroKoniecDev.Frontend.Settings;
+
+/// <summary>
+/// Binds the base address of the TMS API (<c>TranslationSystem.API</c>) the Frontend calls over HTTP.
+/// </summary>
+internal sealed class TranslationSystemSettings
+{
+    public const string ConfigurationSection = "TranslationSystem";
+
+    public required string BaseUrl { get; init; }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Settings/TranslationSystemSettingsValidator.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Settings/TranslationSystemSettingsValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace LotroKoniecDev.Frontend.Settings;
+
+internal sealed class TranslationSystemSettingsValidator : AbstractValidator<TranslationSystemSettings>
+{
+    public TranslationSystemSettingsValidator()
+    {
+        RuleFor(x => x.BaseUrl)
+            .NotEmpty()
+            .Must(BeAbsoluteHttpUrl)
+            .WithMessage($"{nameof(TranslationSystemSettings.BaseUrl)} must be an absolute http(s) URL.");
+    }
+
+    private static bool BeAbsoluteHttpUrl(string value)
+    {
+        return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+               && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/appsettings.Development.json
+++ b/src/Frontend/LotroKoniecDev.Frontend/appsettings.Development.json
@@ -1,0 +1,54 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Information"
+      }
+    },
+    "WriteTo": [
+      { "Name": "Console" },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "./Logs/frontend-.log",
+          "rollingInterval": "Day",
+          "retainedFileCountLimit": 7,
+          "shared": true,
+          "flushToDiskInterval": "00:00:01",
+          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff} {Level:u3}] {SourceContext} {Message:lj} {Properties:j}{NewLine}{Exception}"
+        }
+      }
+    ]
+  },
+  "DataProtection": {
+    "KeyRingPath": ""
+  },
+  "TranslationSystem": {
+    "BaseUrl": "https://localhost:5004/"
+  },
+  "AuthSystem": {
+    "BaseUrl": "https://localhost:5003/",
+    "Authority": "https://localhost:5003",
+    "ClientId": "lotrokoniecdev-web",
+    "CallbackPath": "/callback",
+    "SignedOutCallbackPath": "/signout-callback-oidc",
+    "Scopes": [
+      "openid",
+      "email",
+      "profile",
+      "roles",
+      "api",
+      "offline_access"
+    ]
+  },
+  "DetailedErrors": true
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/appsettings.json
+++ b/src/Frontend/LotroKoniecDev.Frontend/appsettings.json
@@ -1,0 +1,45 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      { "Name": "Console" }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
+  },
+  "DataProtection": {
+    "KeyRingPath": ""
+  },
+  "TranslationSystem": {
+    "BaseUrl": ""
+  },
+  "AuthSystem": {
+    "BaseUrl": "",
+    "Authority": "",
+    "ClientId": "lotrokoniecdev-web",
+    "CallbackPath": "/callback",
+    "SignedOutCallbackPath": "/signout-callback-oidc",
+    "Scopes": [
+      "openid",
+      "email",
+      "profile",
+      "roles",
+      "api",
+      "offline_access"
+    ]
+  }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -1,0 +1,359 @@
+:root {
+    --bg: #0f1115;
+    --surface: #171a21;
+    --surface-2: #1e222b;
+    --border: #2a2f3a;
+    --text: #e6e8ec;
+    --text-dim: #9aa1ad;
+    --accent: #c8a45c;
+    --accent-strong: #e0bd72;
+    --ok: #4caf78;
+    --warn: #d9a441;
+    --danger: #d9534f;
+    --radius: 10px;
+    --sidebar-w: 248px;
+    --font-sans: "Manrope", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 15px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3 {
+    font-weight: 700;
+    line-height: 1.2;
+    margin: 0 0 0.5em;
+}
+
+a {
+    color: var(--accent-strong);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+}
+
+/* App shell — sidebar + content */
+.app-shell {
+    display: flex;
+    min-height: 100vh;
+}
+
+.app-main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.content {
+    flex: 1;
+    padding: 40px clamp(20px, 5vw, 56px);
+    max-width: 1100px;
+    width: 100%;
+}
+
+.app-footer {
+    padding: 18px clamp(20px, 5vw, 56px);
+    border-top: 1px solid var(--border);
+    color: var(--text-dim);
+    font-size: 13px;
+}
+
+/* Sidebar */
+.sidebar {
+    width: var(--sidebar-w);
+    flex-shrink: 0;
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    padding: 24px 18px;
+    gap: 24px;
+}
+
+.sidebar-brand .brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text);
+    font-weight: 800;
+    font-size: 18px;
+}
+
+.sidebar-brand .brand:hover {
+    text-decoration: none;
+}
+
+.brand-mark {
+    display: inline-grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
+    background: var(--accent);
+    color: #1a1300;
+    font-weight: 800;
+    letter-spacing: 0.5px;
+}
+
+.brand-accent {
+    color: var(--accent-strong);
+}
+
+.brand-sub {
+    margin: 8px 0 0 2px;
+    color: var(--text-dim);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+}
+
+.nav-link {
+    display: block;
+    padding: 10px 12px;
+    border-radius: 8px;
+    color: var(--text-dim);
+    font-weight: 600;
+    transition: background 0.12s, color 0.12s;
+}
+
+.nav-link:hover {
+    background: var(--surface-2);
+    color: var(--text);
+    text-decoration: none;
+}
+
+.nav-link.active {
+    background: var(--surface-2);
+    color: var(--accent-strong);
+    box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.sidebar-auth {
+    border-top: 1px solid var(--border);
+    padding-top: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.auth-user {
+    color: var(--text-dim);
+    font-size: 13px;
+    padding-left: 2px;
+}
+
+/* Buttons */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 9px 16px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: filter 0.12s, background 0.12s;
+}
+
+.btn:hover {
+    text-decoration: none;
+    filter: brightness(1.08);
+}
+
+.btn-block {
+    width: 100%;
+}
+
+.btn-primary {
+    background: var(--accent);
+    color: #1a1300;
+}
+
+.btn-ghost {
+    background: transparent;
+    border-color: var(--border);
+    color: var(--text);
+}
+
+/* Hero + panels */
+.hero {
+    margin-bottom: 36px;
+}
+
+.hero h1 {
+    font-size: clamp(26px, 4vw, 36px);
+}
+
+.lede {
+    color: var(--text-dim);
+    font-size: 17px;
+    max-width: 60ch;
+}
+
+.panel {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+}
+
+.panel h2 {
+    font-size: 18px;
+}
+
+/* Status lines (API connectivity) */
+.status-line {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0;
+    font-size: 15px;
+}
+
+.status-line .dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.status-pending .dot {
+    background: var(--text-dim);
+}
+
+.status-ok .dot {
+    background: var(--ok);
+}
+
+.status-down .dot {
+    background: var(--danger);
+}
+
+/* Status / error pages */
+.status-stage {
+    display: grid;
+    place-items: center;
+    min-height: 60vh;
+}
+
+.status-card {
+    text-align: center;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 48px 40px;
+    max-width: 480px;
+}
+
+.status-card.status-danger {
+    border-color: rgba(217, 83, 79, 0.4);
+}
+
+.status-card.status-warning {
+    border-color: rgba(217, 164, 65, 0.4);
+}
+
+.status-code {
+    font-family: var(--font-mono);
+    font-size: 44px;
+    font-weight: 700;
+    color: var(--accent-strong);
+}
+
+.status-desc {
+    color: var(--text-dim);
+}
+
+.status-detail {
+    margin: 18px 0;
+    font-size: 13px;
+    color: var(--text-dim);
+}
+
+.det-k {
+    display: block;
+    margin-bottom: 4px;
+}
+
+.status-actions {
+    margin-top: 24px;
+}
+
+/* Inline status message (error boundary) */
+.status-message {
+    padding: 16px 20px;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+}
+
+.status-message.status-error {
+    border-color: rgba(217, 83, 79, 0.4);
+    background: rgba(217, 83, 79, 0.08);
+}
+
+/* Responsive — stack the sidebar on top on small screens */
+@media (max-width: 760px) {
+    .app-shell {
+        flex-direction: column;
+    }
+
+    .sidebar {
+        width: 100%;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 12px;
+        padding: 14px 16px;
+    }
+
+    .sidebar-brand {
+        flex: 1;
+    }
+
+    .brand-sub {
+        display: none;
+    }
+
+    .sidebar-nav {
+        flex-direction: row;
+        flex-wrap: wrap;
+        flex: 1 0 100%;
+    }
+
+    .sidebar-auth {
+        border-top: none;
+        padding-top: 0;
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/TokenRefresh/CookieTokenRefresherTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/TokenRefresh/CookieTokenRefresherTests.cs
@@ -1,0 +1,278 @@
+using System.Globalization;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using LotroKoniecDev.Frontend.Infrastructure.Auth.TokenRefresh;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Auth.TokenRefresh;
+
+public sealed class CookieTokenRefresherTests : IDisposable
+{
+    private const string DiscoveryIssuer = "https://localhost:5003";
+    private const string Subject = "11111111-1111-1111-1111-111111111111";
+    private const string AccessTokenName = "access_token";
+    private const string RefreshTokenName = "refresh_token";
+    private const string ExpiresAtName = "expires_at";
+
+    private readonly List<RSA> _rsaInstances = [];
+
+    [Fact]
+    public async Task ValidateAsync_WithUnexpiredTokenSignedByRotatedKey_RejectsPrincipalAndSignsOut()
+    {
+        // The token is alive on the local clock but its signature does not verify against the only key
+        // the FE currently trusts — the upstream key has rotated.
+        RsaSecurityKey actualSigningKey = CreateRsaKey();
+        RsaSecurityKey trustedKey = CreateRsaKey();
+        string accessToken = MintAccessToken(actualSigningKey, tokenIssuer: DiscoveryIssuer);
+
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        CookieTokenRefresher refresher = CreateRefresher(trustedKeys: [trustedKey], discoveryIssuer: DiscoveryIssuer);
+        CookieValidatePrincipalContext context = CreateContext(
+            accessToken, authenticationService, expiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        await refresher.ValidateAsync(context);
+
+        context.Principal.ShouldBeNull();
+        await authenticationService.Received(1).SignOutAsync(
+            Arg.Any<HttpContext>(),
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            Arg.Any<AuthenticationProperties>());
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithUnexpiredTokenSignedByTrustedKey_KeepsPrincipal()
+    {
+        RsaSecurityKey signingKey = CreateRsaKey();
+        string accessToken = MintAccessToken(signingKey, tokenIssuer: DiscoveryIssuer);
+
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        CookieTokenRefresher refresher = CreateRefresher(trustedKeys: [signingKey], discoveryIssuer: DiscoveryIssuer);
+        CookieValidatePrincipalContext context = CreateContext(
+            accessToken, authenticationService, expiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        await refresher.ValidateAsync(context);
+
+        context.Principal.ShouldNotBeNull();
+        await authenticationService.DidNotReceive().SignOutAsync(
+            Arg.Any<HttpContext>(),
+            Arg.Any<string>(),
+            Arg.Any<AuthenticationProperties>());
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithTrustedKeyButTokenIssuerMismatch_RejectsPrincipal()
+    {
+        // The signature verifies against the trusted key, but the token 'iss' differs from the
+        // discovery issuer. Anchoring on configuration.Issuer means this must be rejected.
+        RsaSecurityKey signingKey = CreateRsaKey();
+        string accessToken = MintAccessToken(signingKey, tokenIssuer: "https://evil.example.com");
+
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        CookieTokenRefresher refresher = CreateRefresher(trustedKeys: [signingKey], discoveryIssuer: DiscoveryIssuer);
+        CookieValidatePrincipalContext context = CreateContext(
+            accessToken, authenticationService, expiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        await refresher.ValidateAsync(context);
+
+        context.Principal.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenDiscoveryIssuerIsEmpty_KeepsPrincipal()
+    {
+        // Discovery has not yielded an issuer yet. The empty-issuer guard must skip the proactive check
+        // rather than falsely log the user out — even with a key the FE doesn't trust.
+        RsaSecurityKey actualSigningKey = CreateRsaKey();
+        RsaSecurityKey trustedKey = CreateRsaKey();
+        string accessToken = MintAccessToken(actualSigningKey, tokenIssuer: DiscoveryIssuer);
+
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        CookieTokenRefresher refresher = CreateRefresher(trustedKeys: [trustedKey], discoveryIssuer: null);
+        CookieValidatePrincipalContext context = CreateContext(
+            accessToken, authenticationService, expiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        await refresher.ValidateAsync(context);
+
+        context.Principal.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenTokenRefreshedNearExpiry_SkipsProactiveProbeAndStoresFreshToken()
+    {
+        // A token inside the 60s pre-expiry skew is refreshed. The fresh token is signed by a key the FE
+        // does not (yet) trust — the momentarily-stale-JWKS window. Because the token was just minted
+        // upstream, the proactive probe must be skipped: the session survives and the token is stored.
+        RsaSecurityKey trustedKey = CreateRsaKey();
+        RsaSecurityKey freshUpstreamKey = CreateRsaKey();
+        string staleAccessToken = MintAccessToken(trustedKey, tokenIssuer: DiscoveryIssuer);
+        string refreshedAccessToken = MintAccessToken(freshUpstreamKey, tokenIssuer: DiscoveryIssuer);
+
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        CookieTokenRefresher refresher = CreateRefresher(
+            trustedKeys: [trustedKey],
+            discoveryIssuer: DiscoveryIssuer,
+            refreshResult: new TokenResponse { AccessToken = refreshedAccessToken, ExpiresIn = 3600 });
+        CookieValidatePrincipalContext context = CreateContext(
+            staleAccessToken,
+            authenticationService,
+            expiresAt: DateTimeOffset.UtcNow.AddSeconds(30),
+            refreshToken: "refresh-token");
+
+        await refresher.ValidateAsync(context);
+
+        context.Principal.ShouldNotBeNull();
+        context.ShouldRenew.ShouldBeTrue();
+        context.Properties.GetTokenValue(AccessTokenName).ShouldBe(refreshedAccessToken);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenNearExpiryWithoutRefreshToken_RejectsPrincipal()
+    {
+        RsaSecurityKey signingKey = CreateRsaKey();
+        string accessToken = MintAccessToken(signingKey, tokenIssuer: DiscoveryIssuer);
+
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        CookieTokenRefresher refresher = CreateRefresher(trustedKeys: [signingKey], discoveryIssuer: DiscoveryIssuer);
+        CookieValidatePrincipalContext context = CreateContext(
+            accessToken,
+            authenticationService,
+            expiresAt: DateTimeOffset.UtcNow.AddSeconds(30),
+            refreshToken: null);
+
+        await refresher.ValidateAsync(context);
+
+        context.Principal.ShouldBeNull();
+        await authenticationService.Received(1).SignOutAsync(
+            Arg.Any<HttpContext>(),
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            Arg.Any<AuthenticationProperties>());
+    }
+
+    public void Dispose()
+    {
+        foreach (RSA rsa in _rsaInstances)
+        {
+            rsa.Dispose();
+        }
+    }
+
+    private CookieTokenRefresher CreateRefresher(
+        IReadOnlyCollection<SecurityKey> trustedKeys,
+        string? discoveryIssuer,
+        TokenResponse? refreshResult = null)
+    {
+        ITokenEndpointClient tokenEndpointClient = Substitute.For<ITokenEndpointClient>();
+        if (refreshResult is not null)
+        {
+            tokenEndpointClient
+                .RefreshAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(refreshResult);
+        }
+
+        OpenIdConnectConfiguration configuration = new();
+        if (discoveryIssuer is not null)
+        {
+            configuration.Issuer = discoveryIssuer;
+        }
+
+        foreach (SecurityKey key in trustedKeys)
+        {
+            configuration.SigningKeys.Add(key);
+        }
+
+        OpenIdConnectOptions openIdConnectOptions = new()
+        {
+            ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(configuration)
+        };
+
+        IOptionsMonitor<OpenIdConnectOptions> optionsMonitor =
+            Substitute.For<IOptionsMonitor<OpenIdConnectOptions>>();
+        optionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme).Returns(openIdConnectOptions);
+
+        return new CookieTokenRefresher(
+            tokenEndpointClient,
+            optionsMonitor,
+            NullLogger<CookieTokenRefresher>.Instance);
+    }
+
+    private static CookieValidatePrincipalContext CreateContext(
+        string accessToken,
+        IAuthenticationService authenticationService,
+        DateTimeOffset expiresAt,
+        string? refreshToken = null)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton(authenticationService);
+
+        DefaultHttpContext httpContext = new()
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+
+        ClaimsPrincipal principal = new(new ClaimsIdentity(
+            [new Claim("sub", Subject)],
+            CookieAuthenticationDefaults.AuthenticationScheme));
+
+        List<AuthenticationToken> tokens =
+        [
+            new AuthenticationToken { Name = AccessTokenName, Value = accessToken },
+            new AuthenticationToken
+            {
+                Name = ExpiresAtName,
+                Value = expiresAt.ToString("o", CultureInfo.InvariantCulture)
+            }
+        ];
+
+        if (refreshToken is not null)
+        {
+            tokens.Add(new AuthenticationToken { Name = RefreshTokenName, Value = refreshToken });
+        }
+
+        AuthenticationProperties properties = new();
+        properties.StoreTokens(tokens);
+
+        AuthenticationTicket ticket = new(
+            principal, properties, CookieAuthenticationDefaults.AuthenticationScheme);
+
+        AuthenticationScheme scheme = new(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            displayName: null,
+            handlerType: typeof(CookieAuthenticationHandler));
+
+        return new CookieValidatePrincipalContext(
+            httpContext, scheme, new CookieAuthenticationOptions(), ticket);
+    }
+
+    private static string MintAccessToken(SecurityKey signingKey, string tokenIssuer)
+    {
+        SigningCredentials signingCredentials = new(signingKey, SecurityAlgorithms.RsaSha256);
+
+        SecurityTokenDescriptor descriptor = new()
+        {
+            Issuer = tokenIssuer,
+            Subject = new ClaimsIdentity([new Claim("sub", Subject)]),
+            Expires = DateTime.UtcNow.AddHours(1),
+            SigningCredentials = signingCredentials
+        };
+
+        return new JsonWebTokenHandler().CreateToken(descriptor);
+    }
+
+    private RsaSecurityKey CreateRsaKey()
+    {
+        RSA rsa = RSA.Create(2048);
+        _rsaInstances.Add(rsa);
+        return new RsaSecurityKey(rsa) { KeyId = Guid.NewGuid().ToString("N") };
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientApiExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientApiExtensionsTests.cs
@@ -1,0 +1,51 @@
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using Polly.CircuitBreaker;
+using Polly.Timeout;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+
+public sealed class HttpClientApiExtensionsTests
+{
+    [Fact]
+    public async Task GetApiResultAsync_WhenCircuitIsOpen_MapsToServiceUnavailableProblem()
+    {
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.Throw(new BrokenCircuitException()));
+
+        ApiResult<string> result = await httpClient.GetApiResultAsync<string>("health");
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+    }
+
+    [Fact]
+    public async Task GetApiResultAsync_WhenRequestTimesOut_MapsToGatewayTimeoutProblem()
+    {
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.Throw(new TimeoutRejectedException()));
+
+        ApiResult<string> result = await httpClient.GetApiResultAsync<string>("health");
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(504);
+    }
+
+    [Fact]
+    public async Task GetApiResultAsync_WhenTransportFails_MapsToServiceUnavailableProblem()
+    {
+        HttpClient httpClient = CreateClient(
+            StubHttpMessageHandler.Throw(new HttpRequestException("connection refused")));
+
+        ApiResult<string> result = await httpClient.GetApiResultAsync<string>("health");
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+        result.ProblemDetails.Title.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    private static HttpClient CreateClient(StubHttpMessageHandler handler)
+    {
+        return new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://localhost:5004/")
+        };
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/StubHttpMessageHandler.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/StubHttpMessageHandler.cs
@@ -1,0 +1,41 @@
+using System.Net;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+
+/// <summary>
+/// A controllable <see cref="HttpMessageHandler"/> for the HTTP seam: it records the last request it
+/// saw and returns a canned response (or throws a supplied transport exception), so the typed client
+/// and delegating handler can be tested without a live API.
+/// </summary>
+internal sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+    private StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        _responder = responder;
+    }
+
+    public HttpRequestMessage? LastRequest { get; private set; }
+
+    public static StubHttpMessageHandler RespondWith(HttpStatusCode statusCode, string jsonBody)
+    {
+        return new StubHttpMessageHandler(_ => new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(jsonBody, System.Text.Encoding.UTF8, "application/json")
+        });
+    }
+
+    public static StubHttpMessageHandler Throw(Exception exception)
+    {
+        return new StubHttpMessageHandler(_ => throw exception);
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        return Task.FromResult(_responder(request));
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/TranslationContentNegotiationAndAuthDelegatingHandlerTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/TranslationContentNegotiationAndAuthDelegatingHandlerTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Security.Claims;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Hateoas.Abstractions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+
+public sealed class TranslationContentNegotiationAndAuthDelegatingHandlerTests
+{
+    private const string AccessTokenName = "access_token";
+
+    [Fact]
+    public async Task SendAsync_AlwaysRequestsTheHateoasRepresentation()
+    {
+        IHttpContextAccessor accessor = AnonymousContext();
+        (HttpMessageInvoker invoker, StubHttpMessageHandler inner) = CreateInvoker(accessor);
+
+        using HttpRequestMessage request = new(HttpMethod.Get, "https://localhost:5004/translations");
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        inner.LastRequest.ShouldNotBeNull();
+        inner.LastRequest!.Headers.Accept
+            .ShouldContain(header => header.MediaType == MediaTypes.HateoasJson);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenUserIsAnonymous_DoesNotAttachAuthorizationHeader()
+    {
+        IHttpContextAccessor accessor = AnonymousContext();
+        (HttpMessageInvoker invoker, StubHttpMessageHandler inner) = CreateInvoker(accessor);
+
+        using HttpRequestMessage request = new(HttpMethod.Get, "https://localhost:5004/health");
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        inner.LastRequest!.Headers.Authorization.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenUserIsAuthenticated_AttachesBearerAccessToken()
+    {
+        IHttpContextAccessor accessor = AuthenticatedContext(accessToken: "the-access-token");
+        (HttpMessageInvoker invoker, StubHttpMessageHandler inner) = CreateInvoker(accessor);
+
+        using HttpRequestMessage request = new(HttpMethod.Get, "https://localhost:5004/translations");
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        inner.LastRequest!.Headers.Authorization.ShouldNotBeNull();
+        inner.LastRequest.Headers.Authorization!.Scheme.ShouldBe("Bearer");
+        inner.LastRequest.Headers.Authorization.Parameter.ShouldBe("the-access-token");
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenAuthenticatedButNoTokenStored_DoesNotAttachAuthorizationHeader()
+    {
+        IHttpContextAccessor accessor = AuthenticatedContext(accessToken: null);
+        (HttpMessageInvoker invoker, StubHttpMessageHandler inner) = CreateInvoker(accessor);
+
+        using HttpRequestMessage request = new(HttpMethod.Get, "https://localhost:5004/translations");
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        inner.LastRequest!.Headers.Authorization.ShouldBeNull();
+    }
+
+    private static (HttpMessageInvoker, StubHttpMessageHandler) CreateInvoker(IHttpContextAccessor accessor)
+    {
+        StubHttpMessageHandler inner = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        TranslationContentNegotiationAndAuthDelegatingHandler handler = new(accessor)
+        {
+            InnerHandler = inner
+        };
+        return (new HttpMessageInvoker(handler), inner);
+    }
+
+    private static IHttpContextAccessor AnonymousContext()
+    {
+        DefaultHttpContext httpContext = new()
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity())
+        };
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+        return accessor;
+    }
+
+    private static IHttpContextAccessor AuthenticatedContext(string? accessToken)
+    {
+        ClaimsPrincipal principal = new(new ClaimsIdentity(
+            [new Claim("sub", "user-1")],
+            authenticationType: "Cookies"));
+
+        // HttpContext.GetTokenAsync(name) is an extension that calls IAuthenticationService
+        // .AuthenticateAsync and reads the token out of the resulting ticket's properties — so the
+        // token is supplied via a successful AuthenticateResult, not a GetTokenAsync stub.
+        AuthenticationProperties properties = new();
+        if (accessToken is not null)
+        {
+            properties.StoreTokens([new AuthenticationToken { Name = AccessTokenName, Value = accessToken }]);
+        }
+
+        AuthenticationTicket ticket = new(principal, properties, authenticationScheme: "Cookies");
+
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        authenticationService
+            .AuthenticateAsync(Arg.Any<HttpContext>(), Arg.Any<string?>())
+            .Returns(AuthenticateResult.Success(ticket));
+
+        ServiceCollection services = new();
+        services.AddSingleton(authenticationService);
+
+        DefaultHttpContext httpContext = new()
+        {
+            RequestServices = services.BuildServiceProvider(),
+            User = principal
+        };
+
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+        return accessor;
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/TranslationSystemClientTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/TranslationSystemClientTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+
+public sealed class TranslationSystemClientTests
+{
+    private const string BaseUrl = "https://localhost:5004/";
+
+    [Fact]
+    public async Task GetHealthAsync_WhenApiReportsHealthy_ReturnsSuccessWithStatus()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            """{ "status": "Healthy", "totalDuration": "00:00:00.01", "checks": [] }""");
+        ITranslationSystemClient client = CreateClient(handler);
+
+        ApiResult<HealthStatusResponse> result = await client.GetHealthAsync();
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Status.ShouldBe("Healthy");
+    }
+
+    [Fact]
+    public async Task GetHealthAsync_RequestsTheHealthEndpointRelativeToTheBaseAddress()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            """{ "status": "Healthy" }""");
+        ITranslationSystemClient client = CreateClient(handler);
+
+        await client.GetHealthAsync();
+
+        handler.LastRequest.ShouldNotBeNull();
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
+        handler.LastRequest.RequestUri.ShouldBe(new Uri("https://localhost:5004/health"));
+    }
+
+    [Fact]
+    public async Task GetApiResultAsync_WhenSuccessHasEmptyBody_ReturnsSuccessWithDefaultValue()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.NoContent, string.Empty);
+        ITranslationSystemClient client = CreateClient(handler);
+
+        ApiResult<string> result = await client.GetApiResultAsync<string>("anything");
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetHealthAsync_WhenApiReturnsServiceUnavailable_ReturnsFailureWithProblemDetails()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.ServiceUnavailable,
+            """{ "title": "Unhealthy", "status": 503 }""");
+        ITranslationSystemClient client = CreateClient(handler);
+
+        ApiResult<HealthStatusResponse> result = await client.GetHealthAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails.ShouldNotBeNull();
+        result.ProblemDetails!.Status.ShouldBe(503);
+    }
+
+    private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)
+    {
+        HttpClient httpClient = new(handler)
+        {
+            BaseAddress = new Uri(BaseUrl)
+        };
+        return new TranslationSystemClient(httpClient);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+        <Using Include="Shouldly" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Frontend\LotroKoniecDev.Frontend\LotroKoniecDev.Frontend.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/AuthSystemSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/AuthSystemSettingsValidatorTests.cs
@@ -1,0 +1,70 @@
+using FluentValidation.Results;
+using LotroKoniecDev.Frontend.Settings;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Settings;
+
+public sealed class AuthSystemSettingsValidatorTests
+{
+    private readonly AuthSystemSettingsValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithCompleteValidSettings_Passes()
+    {
+        AuthSystemSettings settings = Settings();
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://localhost:5003")]
+    public void Validate_WithNonHttpAuthority_Fails(string authority)
+    {
+        AuthSystemSettings settings = Settings(authority: authority);
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSystemSettings.Authority));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("callback")]
+    public void Validate_WithNonRootedCallbackPath_Fails(string callbackPath)
+    {
+        AuthSystemSettings settings = Settings(callbackPath: callbackPath);
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSystemSettings.CallbackPath));
+    }
+
+    [Fact]
+    public void Validate_WithNoScopes_Fails()
+    {
+        AuthSystemSettings settings = Settings(scopes: []);
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSystemSettings.Scopes));
+    }
+
+    private static AuthSystemSettings Settings(
+        string authority = "https://localhost:5003",
+        string callbackPath = "/callback",
+        IReadOnlyList<string>? scopes = null) => new()
+    {
+        BaseUrl = "https://localhost:5003/",
+        Authority = authority,
+        ClientId = "lotrokoniecdev-web",
+        CallbackPath = callbackPath,
+        SignedOutCallbackPath = "/signout-callback-oidc",
+        Scopes = scopes ?? ["openid", "profile", "api"]
+    };
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/TranslationSystemSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/TranslationSystemSettingsValidatorTests.cs
@@ -1,0 +1,34 @@
+using FluentValidation.Results;
+using LotroKoniecDev.Frontend.Settings;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Settings;
+
+public sealed class TranslationSystemSettingsValidatorTests
+{
+    private readonly TranslationSystemSettingsValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithAbsoluteHttpsUrl_Passes()
+    {
+        TranslationSystemSettings settings = new() { BaseUrl = "https://localhost:5004/" };
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    [InlineData("/relative/path")]
+    [InlineData("ftp://localhost:5004")]
+    public void Validate_WithNonHttpBaseUrl_Fails(string baseUrl)
+    {
+        TranslationSystemSettings settings = new() { BaseUrl = baseUrl };
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(TranslationSystemSettings.BaseUrl));
+    }
+}


### PR DESCRIPTION
Closes #60

## What

Scaffolds the **LotroKoniecDev.Frontend** Blazor SSR project and lifts the OIDC relying-party infrastructure from TheKittySaver, right-sized for the TMS (Polish-only, internal translator tool).

### Lifted / built
- **Typed HttpClient** (`ITranslationSystemClient`) + `TranslationContentNegotiationAndAuthDelegatingHandler` (sends the HATEOAS `Accept` media type, attaches the bearer access token when the user is authenticated) + Polly resilience pipeline. `ApiResult` monad maps transport failures to Polish `ProblemDetails` so SSR pages render a message instead of throwing.
- **OIDC RP wiring** — cookie + OpenIddict schemes, authorization-code + PKCE, claim types, remote-failure handlers; `CookieTokenRefresher` (near-expiry refresh + proactive JWKS signature/issuer probe); login (challenge) / logout (RP-initiated end-session) endpoints; `DataProtection` keyring with a fail-fast startup guard outside Development; per-status-code error pages (400/403/404/500).
- **Lean `DiscoveryCache`** (HybridCache; the discovery requires auth so the KittySaver auth-poisoning/dead-session machinery has no present consumer — deferred to M3-02).
- **Layout** — sidebar + content shell, Polish nav (Start / Tłumaczenia / Edytor / Import-Eksport / Panel). The Home page probes the API `/health` through the typed client and renders connection status.

### References
Only `TranslationSystem.Contracts` + `Utilities/Hateoas.Abstractions` + `Utilities/Options`. No `TranslationSystem.Persistence`/`Domain`, no patcher `Infrastructure`.

### Deliberately dropped as YAGNI
Localization / culture routing, cookie consent, account export, `DeadSessionRegistry`, `SessionExpiryNotice` — TMS is Polish-only and internal. The interactive login/session (#62), translation pages (#34/#35/#105/#36), and the Frontend Dockerfile + compose + bUnit (#40) are separate tickets that build on this scaffold.

## Acceptance criteria
- [x] **Frontend starts; layout + nav visible** — verified at runtime (host boots, `GET /` → 200, sidebar nav + hero render, 404 page works).
- [x] **References only `TranslationSystem.Contracts` (+ lifted infra)** — csproj confirms; no Persistence/Domain/patcher refs.
- [x] **Typed HttpClient hits the API `/health`** — verified at runtime: log shows `GET https://localhost:5004/health` through the resilience + delegating-handler pipeline; failure handled as a value (no crash). Covered by unit tests.
- [x] **Zero warnings** — `dotnet build LotroKoniecDev.slnx` = 0 warnings (TreatWarningsAsErrors repo-wide).

## Tests
29 unit tests (xUnit + Shouldly + NSubstitute): typed client (`/health` happy path + request shape + empty-body + failure→ProblemDetails), transport-failure mapping (timeout/circuit-open/generic), delegating handler (bearer attach + HATEOAS Accept, anonymous, no-token), `CookieTokenRefresher` key-rotation matrix (rotated/trusted key, issuer mismatch, empty-discovery-issuer, near-expiry refresh skips probe, no-refresh-token→reject), and the settings validators.

## Reviews
- **code-reviewer: APPROVE.** Folded in its empty-body guard for `SendForApiResultAsync<T>` + the `TranslationSystemSettingsValidator` test.
- **/security-review: clean** — no high/medium findings (evaluated the JWKS-probe disabled-audience/lifetime checks, logout redirect host handling, `IsLocalUrl` guard, forwarded headers, XSS, CSRF, cookie flags, secrets, data protection).

## Notes for follow-up tickets
- Dev Frontend runs on `https://localhost:7017` to match the AuthSystem-seeded web-client redirect URIs (`/callback`, root post-logout). #62 activates the live login flow.
- A Frontend middleware-ordering / forwarded-headers decision (reverse proxy) is best made with an ADR when #40 adds the Dockerfile + compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)