### PR TITLE
M3-02: Auth — OIDC login/session UX (reactive dead-session backstop, redirect-to-login, soft expiry notice)

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
@@ -1,10 +1,19 @@
 @inherits LayoutComponentBase
+@using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession
+@inject ISessionExpiryNotice SessionExpiryNotice
 
 <div class="app-shell">
     <NavMenu/>
 
     <div class="app-main">
         <main class="content">
+            @if (_showSessionExpiredNotice)
+            {
+                <div class="status-message status-warning" role="status">
+                    <p>Twoja sesja wygasła. Zaloguj się ponownie, aby kontynuować.</p>
+                </div>
+            }
+
             <ErrorBoundary>
                 <ChildContent>
                     @Body
@@ -22,3 +31,11 @@
         </footer>
     </div>
 </div>
+
+@code {
+    private bool _showSessionExpiredNotice;
+
+    // One-shot: consumed at render time (no JS, no interactivity). Clearing the marker here means the
+    // banner shows exactly once after a forced logout and is gone on the next navigation.
+    protected override void OnInitialized() => _showSessionExpiredNotice = SessionExpiryNotice.Consume();
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Routes.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Routes.razor
@@ -2,7 +2,14 @@
     <Found Context="routeData">
         <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)">
             <NotAuthorized>
-                <p role="alert">Nie masz uprawnień do wyświetlenia tej strony.</p>
+                @if (context.User.Identity?.IsAuthenticated is not true)
+                {
+                    <RedirectToLogin/>
+                }
+                else
+                {
+                    <p role="alert">Nie masz uprawnień do wyświetlenia tej strony.</p>
+                }
             </NotAuthorized>
         </AuthorizeRouteView>
         <FocusOnNavigate RouteData="routeData" Selector="h1"/>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Shared/RedirectToLogin.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Shared/RedirectToLogin.razor
@@ -1,0 +1,10 @@
+@inject NavigationManager Navigation
+
+@code {
+    protected override void OnInitialized()
+    {
+        string returnUrl = Navigation.ToBaseRelativePath(Navigation.Uri);
+        string loginUrl = $"/auth/login?returnUrl=/{Uri.EscapeDataString(returnUrl)}";
+        Navigation.NavigateTo(loginUrl, forceLoad: true);
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/_Imports.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/_Imports.razor
@@ -10,3 +10,4 @@
 @using LotroKoniecDev.Frontend
 @using LotroKoniecDev.Frontend.Components
 @using LotroKoniecDev.Frontend.Components.Layout
+@using LotroKoniecDev.Frontend.Components.Shared

--- a/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FluentValidation;
 using LotroKoniecDev.Frontend.Infrastructure.Auth;
+using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
 using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 
@@ -17,6 +18,7 @@ public static class DependencyInjection
             services.AddAntiforgery(options => options.Cookie.Path = "/");
 
             services.AddHttpClients();
+            services.AddDeadSessionRegistry();
             services.AddDiscoveryCache();
             services.AddFrontendAuthentication();
 

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/DeadSessionDependencyInjectionExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/DeadSessionDependencyInjectionExtensions.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
+
+internal static class DeadSessionDependencyInjectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddDeadSessionRegistry()
+        {
+            services.AddScoped<IDeadSessionRegistry, DeadSessionRegistry>();
+            services.AddScoped<ISessionExpiryNotice, SessionExpiryNotice>();
+            return services;
+        }
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/DeadSessionRegistry.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/DeadSessionRegistry.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
+
+internal sealed class DeadSessionRegistry : IDeadSessionRegistry
+{
+    internal const string CacheKeyPrefix = "dead-session:";
+
+    // Stored value is the marked subject itself: presence is the signal, and a non-empty string is a
+    // truthier marker than a bool (which the analyzer flags as a redundant literal when cached).
+    private const string AbsentMarker = "";
+
+    // Short TTL: the marker only has to survive the gap between the request that observed the dead
+    // token and the immediately-following request whose principal validation consumes it. A
+    // self-healing token (a key roll the FE refetches) must not stay flagged, so we keep it brief.
+    private static readonly HybridCacheEntryOptions MarkerEntryOptions = new()
+    {
+        Expiration = TimeSpan.FromMinutes(5),
+        LocalCacheExpiration = TimeSpan.FromMinutes(5)
+    };
+
+    // The consume path runs on every authenticated request (via OnValidatePrincipal) but a marker is
+    // rare. Disabling cache writes makes the read a pure probe: on a miss the factory's absent value
+    // is returned without persisting an entry, so we never pollute the cache with per-user negatives.
+    private static readonly HybridCacheEntryOptions ProbeEntryOptions = new()
+    {
+        Expiration = TimeSpan.FromMinutes(5),
+        LocalCacheExpiration = TimeSpan.FromMinutes(5),
+        Flags = HybridCacheEntryFlags.DisableLocalCacheWrite | HybridCacheEntryFlags.DisableDistributedCacheWrite
+    };
+
+    private static readonly string[] DeadSessionTag = ["dead-session"];
+
+    private readonly HybridCache _hybridCache;
+
+    public DeadSessionRegistry(HybridCache hybridCache)
+    {
+        _hybridCache = hybridCache;
+    }
+
+    public async ValueTask MarkDeadAsync(string subject, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            return;
+        }
+
+        await _hybridCache.SetAsync(
+            CacheKeyPrefix + subject,
+            subject,
+            MarkerEntryOptions,
+            DeadSessionTag,
+            cancellationToken);
+    }
+
+    public async ValueTask<bool> ConsumeAsync(string subject, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            return false;
+        }
+
+        string cacheKey = CacheKeyPrefix + subject;
+
+        string marker = await _hybridCache.GetOrCreateAsync(
+            cacheKey,
+            static _ => ValueTask.FromResult(AbsentMarker),
+            ProbeEntryOptions,
+            DeadSessionTag,
+            cancellationToken);
+
+        bool isDead = !string.IsNullOrEmpty(marker);
+        if (isDead)
+        {
+            await _hybridCache.RemoveAsync(cacheKey, cancellationToken);
+        }
+
+        return isDead;
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/IDeadSessionRegistry.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/IDeadSessionRegistry.cs
@@ -1,0 +1,21 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
+
+/// <summary>
+/// Durable, per-session "dead token" marker. The reactive 401 net (the TMS delegating handler) raises
+/// a marker keyed by the authenticated subject; the cookie <c>OnValidatePrincipal</c> hook reads it on
+/// the next request — where the response has not started streaming yet — and performs the clean
+/// <c>SignOutAsync</c>. This indirection is what lets a 401 observed mid-stream (SSR responses use
+/// <c>[StreamRendering]</c>, so the response headers may already be flushed) still end the session
+/// cleanly on the very next request.
+/// </summary>
+internal interface IDeadSessionRegistry
+{
+    /// <summary>Marks the subject's session dead so the next principal validation signs it out.</summary>
+    ValueTask MarkDeadAsync(string subject, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns <see langword="true"/> exactly once if the subject was marked dead, clearing the
+    /// marker in the same call so the sign-out is performed only once.
+    /// </summary>
+    ValueTask<bool> ConsumeAsync(string subject, CancellationToken cancellationToken = default);
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/ISessionExpiryNotice.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/ISessionExpiryNotice.cs
@@ -1,0 +1,19 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
+
+/// <summary>
+/// One-shot "your session expired" banner state. It is raised at the moment a dead session is
+/// signed out (where the response has not started, so a marker cookie can still be written) and is
+/// consumed exactly once on the next render — so the soft notice appears a single time after a
+/// forced logout and never after a deliberate <c>/auth/logout</c>.
+/// </summary>
+internal interface ISessionExpiryNotice
+{
+    /// <summary>Raises the one-shot notice by writing the short-lived marker cookie.</summary>
+    void Raise();
+
+    /// <summary>
+    /// Returns <see langword="true"/> once if the notice was raised, clearing the marker so the
+    /// banner is not shown again on the next navigation.
+    /// </summary>
+    bool Consume();
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/SessionExpiryNotice.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/SessionExpiryNotice.cs
@@ -1,0 +1,72 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
+
+internal sealed class SessionExpiryNotice : ISessionExpiryNotice
+{
+    internal const string CookieName = ".lotrokoniecdev.session-expired";
+    private const string CookieValue = "1";
+
+    // Deliberately tiny: the cookie only needs to survive the redirect that follows the forced
+    // sign-out until the next render reads it. If the consuming Delete cannot be written (the SSR
+    // response already started streaming), the short max-age guarantees the banner self-clears
+    // within seconds instead of lingering across navigation.
+    private static readonly TimeSpan CookieLifetime = TimeSpan.FromSeconds(30);
+
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public SessionExpiryNotice(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public void Raise()
+    {
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext is null || httpContext.Response.HasStarted)
+        {
+            return;
+        }
+
+        httpContext.Response.Cookies.Append(CookieName, CookieValue, BuildOptions());
+    }
+
+    public bool Consume()
+    {
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            return false;
+        }
+
+        if (!httpContext.Request.Cookies.TryGetValue(CookieName, out string? value)
+            || value != CookieValue)
+        {
+            return false;
+        }
+
+        if (!httpContext.Response.HasStarted)
+        {
+            httpContext.Response.Cookies.Delete(CookieName, BuildDeleteOptions());
+        }
+
+        return true;
+    }
+
+    // Path "/" mirrors the auth + antiforgery cookies so the post-redirect read on any path finds it.
+    // HttpOnly because no client JS reads it. Secure is intentionally left at its default so the marker
+    // round-trips over both http and https dev origins — it carries no sensitive value, only a one-shot
+    // "show the banner" flag.
+    private static CookieOptions BuildOptions() => new()
+    {
+        Path = "/",
+        HttpOnly = true,
+        SameSite = SameSiteMode.Lax,
+        MaxAge = CookieLifetime,
+        IsEssential = true
+    };
+
+    private static CookieOptions BuildDeleteOptions() => new()
+    {
+        Path = "/",
+        SameSite = SameSiteMode.Lax
+    };
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/CookieTokenRefresher.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/TokenRefresh/CookieTokenRefresher.cs
@@ -7,17 +7,18 @@ using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
 
 namespace LotroKoniecDev.Frontend.Infrastructure.Auth.TokenRefresh;
 
 /// <summary>
-/// Runs on every cookie validation (<c>OnValidatePrincipal</c>). It refreshes the access token shortly
-/// before expiry using the stored refresh token, and — when the token is still locally alive —
-/// proactively re-validates its signature against the cached OIDC JWKS so a key rotated upstream signs
-/// the user out cleanly instead of letting a doomed token reach the API. A failed refresh or a token
-/// that fails signature validation after a metadata refresh rejects the principal and signs out the
-/// cookie. The reactive dead-session backstop and the soft "session expired" notice are deferred to
-/// the M3-02 auth-session slice; this lifts the core refresh + key-rotation mechanism.
+/// Runs on every cookie validation (<c>OnValidatePrincipal</c>). It first consumes any reactive
+/// "dead session" marker raised by a prior 401 and signs the cookie out cleanly; otherwise it
+/// refreshes the access token shortly before expiry using the stored refresh token, and — when the
+/// token is still locally alive — proactively re-validates its signature against the cached OIDC JWKS
+/// so a key rotated upstream signs the user out cleanly instead of letting a doomed token reach the
+/// API. Any rejection raises a one-shot "session expired" notice (a deliberate <c>/auth/logout</c>
+/// does not pass through here, so it never raises the notice).
 /// </summary>
 internal sealed class CookieTokenRefresher
 {
@@ -25,6 +26,7 @@ internal sealed class CookieTokenRefresher
     private const string RefreshTokenName = "refresh_token";
     private const string IdTokenName = "id_token";
     private const string ExpiresAtName = "expires_at";
+    private const string SubjectClaimType = "sub";
 
     /// <summary>
     /// Refresh slightly before actual expiry so an in-flight backend call cannot land with a token that
@@ -34,21 +36,40 @@ internal sealed class CookieTokenRefresher
 
     private readonly ITokenEndpointClient _tokenEndpointClient;
     private readonly IOptionsMonitor<OpenIdConnectOptions> _openIdConnectOptionsMonitor;
+    private readonly IDeadSessionRegistry _deadSessionRegistry;
+    private readonly ISessionExpiryNotice _sessionExpiryNotice;
     private readonly ILogger<CookieTokenRefresher> _logger;
 
     public CookieTokenRefresher(
         ITokenEndpointClient tokenEndpointClient,
         IOptionsMonitor<OpenIdConnectOptions> openIdConnectOptionsMonitor,
+        IDeadSessionRegistry deadSessionRegistry,
+        ISessionExpiryNotice sessionExpiryNotice,
         ILogger<CookieTokenRefresher> logger)
     {
         _tokenEndpointClient = tokenEndpointClient;
         _openIdConnectOptionsMonitor = openIdConnectOptionsMonitor;
+        _deadSessionRegistry = deadSessionRegistry;
+        _sessionExpiryNotice = sessionExpiryNotice;
         _logger = logger;
     }
 
     public async Task ValidateAsync(CookieValidatePrincipalContext context)
     {
         CancellationToken cancellationToken = context.HttpContext.RequestAborted;
+
+        // Reactive backstop: a 401 observed by the TMS delegating handler on a prior request marked
+        // this subject's session dead. The response there may already have been streaming, so the clean
+        // sign-out is deferred to here, where the response has not started. This runs first so a
+        // known-dead session never reaches the API again.
+        string? subject = GetSubject(context);
+        if (subject is not null
+            && await _deadSessionRegistry.ConsumeAsync(subject, cancellationToken))
+        {
+            LogReactiveDeadSession(_logger, null);
+            await RejectAsync(context);
+            return;
+        }
 
         RefreshOutcome refreshOutcome = await TryRefreshIfNearExpiryAsync(context, cancellationToken);
         if (refreshOutcome is RefreshOutcome.Stop)
@@ -220,8 +241,18 @@ internal sealed class CookieTokenRefresher
         return result.IsValid;
     }
 
-    private static async Task RejectAsync(CookieValidatePrincipalContext context)
+    private static string? GetSubject(CookieValidatePrincipalContext context)
     {
+        string? subject = context.Principal?.FindFirst(SubjectClaimType)?.Value;
+        return string.IsNullOrWhiteSpace(subject) ? null : subject;
+    }
+
+    private async Task RejectAsync(CookieValidatePrincipalContext context)
+    {
+        // Raise the one-shot soft notice BEFORE sign-out so it is written while the response has not
+        // started. A deliberate /auth/logout signs out directly (not through this rejection path), so
+        // it never raises the notice — exactly the "not shown to users who logged out" rule.
+        _sessionExpiryNotice.Raise();
         context.RejectPrincipal();
         await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
     }
@@ -268,4 +299,10 @@ internal sealed class CookieTokenRefresher
             LogLevel.Information,
             new EventId(3, nameof(LogProactiveInvalidToken)),
             "Access token failed local JWKS signature validation after a metadata refresh; principal rejected.");
+
+    private static readonly Action<ILogger, Exception?> LogReactiveDeadSession =
+        LoggerMessage.Define(
+            LogLevel.Information,
+            new EventId(4, nameof(LogReactiveDeadSession)),
+            "Session was marked dead by a prior 401; principal rejected.");
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/TranslationContentNegotiationAndAuthDelegatingHandler.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/TranslationSystemHttpClients/TranslationContentNegotiationAndAuthDelegatingHandler.cs
@@ -1,4 +1,6 @@
+using System.Net;
 using System.Net.Http.Headers;
+using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
 using LotroKoniecDev.Hateoas.Abstractions;
 using Microsoft.AspNetCore.Authentication;
 
@@ -7,13 +9,16 @@ namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHt
 /// <summary>
 /// Negotiates the TMS API's opt-in HATEOAS representation (sends
 /// <see cref="MediaTypes.HateoasJson"/> in <c>Accept</c>) and forwards the signed-in translator's
-/// bearer access token. The token only flows once the OIDC session exists (M3-02); anonymous
-/// requests (e.g. the public <c>GET /health</c> probe) pass through unauthenticated.
+/// bearer access token. The token only flows once the OIDC session exists; anonymous requests (e.g.
+/// the public <c>GET /health</c> probe) pass through unauthenticated. A <c>401</c> on an
+/// authenticated call marks the session dead so the next <c>OnValidatePrincipal</c> signs it out
+/// cleanly (the reactive backstop to the proactive JWKS check).
 /// </summary>
 internal sealed class TranslationContentNegotiationAndAuthDelegatingHandler : DelegatingHandler
 {
     private const string BearerScheme = "Bearer";
     private const string AccessTokenName = "access_token";
+    private const string SubjectClaimType = "sub";
 
     private static readonly MediaTypeWithQualityHeaderValue HateoasJsonMediaType = new(MediaTypes.HateoasJson);
 
@@ -42,6 +47,31 @@ internal sealed class TranslationContentNegotiationAndAuthDelegatingHandler : De
             request.Headers.Authorization = new AuthenticationHeaderValue(BearerScheme, accessToken);
         }
 
-        return await base.SendAsync(request, cancellationToken);
+        HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+
+        // Reactive backstop: the bearer token authenticated locally but was rejected upstream
+        // (typically the stale-JWKS window). Mark the session dead so the next OnValidatePrincipal
+        // signs it out cleanly — we cannot SignOutAsync here because the SSR response may already be
+        // streaming. The proactive JWKS check is the primary path; this only catches the gap before the
+        // FE refetches the rotated keys.
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            await MarkSessionDeadAsync(httpContext, cancellationToken);
+        }
+
+        return response;
+    }
+
+    private static async Task MarkSessionDeadAsync(HttpContext httpContext, CancellationToken cancellationToken)
+    {
+        string? subject = httpContext.User.FindFirst(SubjectClaimType)?.Value;
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            return;
+        }
+
+        IDeadSessionRegistry registry = httpContext.RequestServices
+            .GetRequiredService<IDeadSessionRegistry>();
+        await registry.MarkDeadAsync(subject, cancellationToken);
     }
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -323,6 +323,15 @@ code {
     background: rgba(217, 83, 79, 0.08);
 }
 
+.status-message.status-warning {
+    border-color: rgba(217, 164, 65, 0.4);
+    background: rgba(217, 164, 65, 0.08);
+}
+
+.status-message p {
+    margin: 0;
+}
+
 /* Responsive — stack the sidebar on top on small screens */
 @media (max-width: 760px) {
     .app-shell {

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/DeadSession/DeadSessionRegistryTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/DeadSession/DeadSessionRegistryTests.cs
@@ -1,0 +1,78 @@
+using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Auth.DeadSession;
+
+public sealed class DeadSessionRegistryTests
+{
+    private const string Subject = "11111111-1111-1111-1111-111111111111";
+
+    [Fact]
+    public async Task ConsumeAsync_WhenNeverMarked_ReturnsFalse()
+    {
+        DeadSessionRegistry registry = CreateRegistry();
+
+        bool isDead = await registry.ConsumeAsync(Subject);
+
+        isDead.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_AfterMarkDead_ReturnsTrue()
+    {
+        DeadSessionRegistry registry = CreateRegistry();
+
+        await registry.MarkDeadAsync(Subject);
+        bool isDead = await registry.ConsumeAsync(Subject);
+
+        isDead.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_IsOneShot_SecondCallReturnsFalse()
+    {
+        DeadSessionRegistry registry = CreateRegistry();
+
+        await registry.MarkDeadAsync(Subject);
+        bool first = await registry.ConsumeAsync(Subject);
+        bool second = await registry.ConsumeAsync(Subject);
+
+        first.ShouldBeTrue();
+        second.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_ForADifferentSubject_ReturnsFalse()
+    {
+        DeadSessionRegistry registry = CreateRegistry();
+
+        await registry.MarkDeadAsync(Subject);
+        bool isDead = await registry.ConsumeAsync("22222222-2222-2222-2222-222222222222");
+
+        isDead.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task MarkDeadAsync_WithBlankSubject_IsNoOp(string blankSubject)
+    {
+        DeadSessionRegistry registry = CreateRegistry();
+
+        await registry.MarkDeadAsync(blankSubject);
+
+        // Nothing was stored, so a subsequent consume for the same blank key finds no marker.
+        bool isDead = await registry.ConsumeAsync(blankSubject);
+        isDead.ShouldBeFalse();
+    }
+
+    private static DeadSessionRegistry CreateRegistry()
+    {
+        ServiceCollection services = new();
+        services.AddHybridCache();
+        ServiceProvider provider = services.BuildServiceProvider();
+        HybridCache hybridCache = provider.GetRequiredService<HybridCache>();
+        return new DeadSessionRegistry(hybridCache);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/DeadSession/SessionExpiryNoticeTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/DeadSession/SessionExpiryNoticeTests.cs
@@ -1,0 +1,99 @@
+using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Auth.DeadSession;
+
+public sealed class SessionExpiryNoticeTests
+{
+    [Fact]
+    public void Raise_WhenResponseNotStarted_WritesTheMarkerCookie()
+    {
+        DefaultHttpContext httpContext = new();
+        SessionExpiryNotice notice = CreateNotice(httpContext);
+
+        notice.Raise();
+
+        httpContext.Response.Headers.SetCookie
+            .ToString()
+            .ShouldContain(SessionExpiryNotice.CookieName);
+    }
+
+    [Fact]
+    public void Consume_WhenMarkerCookiePresent_ReturnsTrue()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.Headers.Cookie = $"{SessionExpiryNotice.CookieName}=1";
+        SessionExpiryNotice notice = CreateNotice(httpContext);
+
+        bool raised = notice.Consume();
+
+        raised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Consume_WhenMarkerCookieAbsent_ReturnsFalse()
+    {
+        DefaultHttpContext httpContext = new();
+        SessionExpiryNotice notice = CreateNotice(httpContext);
+
+        bool raised = notice.Consume();
+
+        raised.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Consume_WhenMarkerCookieHasUnexpectedValue_ReturnsFalse()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.Headers.Cookie = $"{SessionExpiryNotice.CookieName}=tampered";
+        SessionExpiryNotice notice = CreateNotice(httpContext);
+
+        bool raised = notice.Consume();
+
+        raised.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Consume_WhenMarkerPresent_EmitsCookieDeletionSoTheNoticeIsOneShot()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.Headers.Cookie = $"{SessionExpiryNotice.CookieName}=1";
+        SessionExpiryNotice notice = CreateNotice(httpContext);
+
+        notice.Consume();
+
+        // Deletion (not a re-append) is expressed as a Set-Cookie for the same name carrying the Unix
+        // epoch expiry — asserting on that distinguishes a genuine delete from any other Set-Cookie.
+        string setCookie = httpContext.Response.Headers.SetCookie.ToString();
+        setCookie.ShouldContain(SessionExpiryNotice.CookieName);
+        setCookie.ShouldContain("expires=Thu, 01 Jan 1970", Case.Insensitive);
+    }
+
+    [Fact]
+    public void Raise_WhenHttpContextIsNull_DoesNotThrow()
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+        SessionExpiryNotice notice = new(accessor);
+
+        Should.NotThrow(() => notice.Raise());
+    }
+
+    [Fact]
+    public void Consume_WhenHttpContextIsNull_ReturnsFalse()
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+        SessionExpiryNotice notice = new(accessor);
+
+        notice.Consume().ShouldBeFalse();
+    }
+
+    private static SessionExpiryNotice CreateNotice(HttpContext httpContext)
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+        return new SessionExpiryNotice(accessor);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/TokenRefresh/CookieTokenRefresherTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/TokenRefresh/CookieTokenRefresherTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
 using LotroKoniecDev.Frontend.Infrastructure.Auth.TokenRefresh;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -159,6 +160,80 @@ public sealed class CookieTokenRefresherTests : IDisposable
             Arg.Any<AuthenticationProperties>());
     }
 
+    [Fact]
+    public async Task ValidateAsync_WhenSessionMarkedDead_RejectsPrincipalAndSignsOut()
+    {
+        // A prior 401 marked this subject dead. The reactive backstop must reject before any refresh or
+        // proactive probe runs — even though the token is alive and signed by a trusted key.
+        RsaSecurityKey signingKey = CreateRsaKey();
+        string accessToken = MintAccessToken(signingKey, tokenIssuer: DiscoveryIssuer);
+
+        IDeadSessionRegistry deadSessionRegistry = Substitute.For<IDeadSessionRegistry>();
+        deadSessionRegistry
+            .ConsumeAsync(Subject, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        CookieTokenRefresher refresher = CreateRefresher(
+            trustedKeys: [signingKey],
+            discoveryIssuer: DiscoveryIssuer,
+            deadSessionRegistry: deadSessionRegistry);
+        CookieValidatePrincipalContext context = CreateContext(
+            accessToken, authenticationService, expiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        await refresher.ValidateAsync(context);
+
+        context.Principal.ShouldBeNull();
+        await authenticationService.Received(1).SignOutAsync(
+            Arg.Any<HttpContext>(),
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            Arg.Any<AuthenticationProperties>());
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenSessionAliveAndTrusted_DoesNotRaiseExpiryNotice()
+    {
+        RsaSecurityKey signingKey = CreateRsaKey();
+        string accessToken = MintAccessToken(signingKey, tokenIssuer: DiscoveryIssuer);
+
+        ISessionExpiryNotice sessionExpiryNotice = Substitute.For<ISessionExpiryNotice>();
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        CookieTokenRefresher refresher = CreateRefresher(
+            trustedKeys: [signingKey],
+            discoveryIssuer: DiscoveryIssuer,
+            sessionExpiryNotice: sessionExpiryNotice);
+        CookieValidatePrincipalContext context = CreateContext(
+            accessToken, authenticationService, expiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        await refresher.ValidateAsync(context);
+
+        sessionExpiryNotice.DidNotReceive().Raise();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenPrincipalRejected_RaisesOneShotExpiryNotice()
+    {
+        // A rotated key forces a rejection; the soft "session expired" notice must be raised so the next
+        // render can surface the banner.
+        RsaSecurityKey actualSigningKey = CreateRsaKey();
+        RsaSecurityKey trustedKey = CreateRsaKey();
+        string accessToken = MintAccessToken(actualSigningKey, tokenIssuer: DiscoveryIssuer);
+
+        ISessionExpiryNotice sessionExpiryNotice = Substitute.For<ISessionExpiryNotice>();
+        IAuthenticationService authenticationService = Substitute.For<IAuthenticationService>();
+        CookieTokenRefresher refresher = CreateRefresher(
+            trustedKeys: [trustedKey],
+            discoveryIssuer: DiscoveryIssuer,
+            sessionExpiryNotice: sessionExpiryNotice);
+        CookieValidatePrincipalContext context = CreateContext(
+            accessToken, authenticationService, expiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        await refresher.ValidateAsync(context);
+
+        context.Principal.ShouldBeNull();
+        sessionExpiryNotice.Received(1).Raise();
+    }
+
     public void Dispose()
     {
         foreach (RSA rsa in _rsaInstances)
@@ -170,7 +245,9 @@ public sealed class CookieTokenRefresherTests : IDisposable
     private CookieTokenRefresher CreateRefresher(
         IReadOnlyCollection<SecurityKey> trustedKeys,
         string? discoveryIssuer,
-        TokenResponse? refreshResult = null)
+        TokenResponse? refreshResult = null,
+        IDeadSessionRegistry? deadSessionRegistry = null,
+        ISessionExpiryNotice? sessionExpiryNotice = null)
     {
         ITokenEndpointClient tokenEndpointClient = Substitute.For<ITokenEndpointClient>();
         if (refreshResult is not null)
@@ -203,6 +280,8 @@ public sealed class CookieTokenRefresherTests : IDisposable
         return new CookieTokenRefresher(
             tokenEndpointClient,
             optionsMonitor,
+            deadSessionRegistry ?? Substitute.For<IDeadSessionRegistry>(),
+            sessionExpiryNotice ?? Substitute.For<ISessionExpiryNotice>(),
             NullLogger<CookieTokenRefresher>.Instance);
     }
 

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/TranslationContentNegotiationAndAuthDelegatingHandlerTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/TranslationContentNegotiationAndAuthDelegatingHandlerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Security.Claims;
+using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
 using LotroKoniecDev.Hateoas.Abstractions;
 using Microsoft.AspNetCore.Authentication;
@@ -65,14 +66,62 @@ public sealed class TranslationContentNegotiationAndAuthDelegatingHandlerTests
         inner.LastRequest!.Headers.Authorization.ShouldBeNull();
     }
 
-    private static (HttpMessageInvoker, StubHttpMessageHandler) CreateInvoker(IHttpContextAccessor accessor)
+    [Fact]
+    public async Task SendAsync_WhenAuthenticatedCallReturns401_MarksSessionDead()
     {
-        StubHttpMessageHandler inner = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        IDeadSessionRegistry deadSessionRegistry = Substitute.For<IDeadSessionRegistry>();
+        IHttpContextAccessor accessor = AuthenticatedContext(
+            accessToken: "the-access-token", deadSessionRegistry: deadSessionRegistry);
+        (HttpMessageInvoker invoker, _) = CreateInvoker(
+            accessor, StubHttpMessageHandler.RespondWith(HttpStatusCode.Unauthorized, "{}"));
+
+        using HttpRequestMessage request = new(HttpMethod.Get, "https://localhost:5004/translations");
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        await deadSessionRegistry.Received(1).MarkDeadAsync("user-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenAuthenticatedCallSucceeds_DoesNotMarkSessionDead()
+    {
+        IDeadSessionRegistry deadSessionRegistry = Substitute.For<IDeadSessionRegistry>();
+        IHttpContextAccessor accessor = AuthenticatedContext(
+            accessToken: "the-access-token", deadSessionRegistry: deadSessionRegistry);
+        (HttpMessageInvoker invoker, _) = CreateInvoker(accessor);
+
+        using HttpRequestMessage request = new(HttpMethod.Get, "https://localhost:5004/translations");
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        await deadSessionRegistry.DidNotReceive()
+            .MarkDeadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenAnonymousCallReturns401_DoesNotMarkSessionDead()
+    {
+        // An anonymous request returns before the 401 backstop (the handler short-circuits at the
+        // IsAuthenticated guard), so the registry is never resolved and no subject is ever marked.
+        IHttpContextAccessor accessor = AnonymousContext();
+        (HttpMessageInvoker invoker, _) = CreateInvoker(
+            accessor, StubHttpMessageHandler.RespondWith(HttpStatusCode.Unauthorized, "{}"));
+
+        using HttpRequestMessage request = new(HttpMethod.Get, "https://localhost:5004/translations");
+        HttpResponseMessage response = await invoker.SendAsync(request, CancellationToken.None);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        response.Dispose();
+    }
+
+    private static (HttpMessageInvoker, StubHttpMessageHandler) CreateInvoker(
+        IHttpContextAccessor accessor,
+        StubHttpMessageHandler? inner = null)
+    {
+        StubHttpMessageHandler stub = inner ?? StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
         TranslationContentNegotiationAndAuthDelegatingHandler handler = new(accessor)
         {
-            InnerHandler = inner
+            InnerHandler = stub
         };
-        return (new HttpMessageInvoker(handler), inner);
+        return (new HttpMessageInvoker(handler), stub);
     }
 
     private static IHttpContextAccessor AnonymousContext()
@@ -86,7 +135,9 @@ public sealed class TranslationContentNegotiationAndAuthDelegatingHandlerTests
         return accessor;
     }
 
-    private static IHttpContextAccessor AuthenticatedContext(string? accessToken)
+    private static IHttpContextAccessor AuthenticatedContext(
+        string? accessToken,
+        IDeadSessionRegistry? deadSessionRegistry = null)
     {
         ClaimsPrincipal principal = new(new ClaimsIdentity(
             [new Claim("sub", "user-1")],
@@ -110,6 +161,7 @@ public sealed class TranslationContentNegotiationAndAuthDelegatingHandlerTests
 
         ServiceCollection services = new();
         services.AddSingleton(authenticationService);
+        services.AddSingleton(deadSessionRegistry ?? Substitute.For<IDeadSessionRegistry>());
 
         DefaultHttpContext httpContext = new()
         {


### PR DESCRIPTION
Closes #62