### PR TITLE
M3-04: Side-by-side editor + placeholder validation + approve (Blazor SSR)

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
@@ -16,9 +16,6 @@
         <NavLink class="nav-link" href="/translations">
             <span class="nav-text">Tłumaczenia</span>
         </NavLink>
-        <NavLink class="nav-link" href="/editor">
-            <span class="nav-text">Edytor</span>
-        </NavLink>
         <NavLink class="nav-link" href="/import-export">
             <span class="nav-text">Import / Eksport</span>
         </NavLink>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
@@ -1,0 +1,294 @@
+@page "/editor/{Id:guid}"
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Mvc
+@using LotroKoniecDev.Frontend.Components.Pages.Translations
+@using LotroKoniecDev.Frontend.Infrastructure.HttpClients
+@using LotroKoniecDev.TranslationSystem.Contracts.Translations
+@using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate
+@using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums
+@inject TranslationEditorLoader Loader
+
+<PageTitle>Edytor tłumaczenia — LotroKoniecDev</PageTitle>
+
+<section class="page-head">
+    <h1>Edytor tłumaczenia</h1>
+    <p class="lede">
+        Po lewej tekst angielski (do odczytu), po prawej Twoje tłumaczenie. Zachowaj znaczniki
+        <code class="ph-token">@PlaceholderAnalyzer.Placeholder</code> w niezmienionej postaci.
+    </p>
+    <a class="btn btn-ghost btn-sm" href="/translations">← Wróć do listy</a>
+</section>
+
+@if (_detail is null)
+{
+    @if (_saveProblem is not null && _draftText is not null)
+    {
+        @* Recovery path: the row could not be reloaded AND the save failed in the same request.
+           Surface the error and keep the translator's typed text in a resubmittable form so it is
+           never silently lost (the hidden key fields survived the post). *@
+        <section class="panel">
+            <p class="status-line status-down" role="alert">
+                <span class="dot"></span>@(_saveProblem.Title ?? "Nie udało się zapisać tłumaczenia.")
+            </p>
+        </section>
+        <section class="panel editor-pane">
+            <h2 class="editor-pane-title">Tłumaczenie polskie</h2>
+            <form method="post" @formname="save-translation" @onsubmit="SaveAsync">
+                <AntiforgeryToken/>
+                <input type="hidden" name="FileIdField" value="@FileIdField"/>
+                <input type="hidden" name="GossipIdField" value="@GossipIdField"/>
+                <label class="visually-hidden" for="translated-recovery">Tłumaczenie polskie</label>
+                <textarea id="translated-recovery" name="DraftField" class="editor-textarea mono" rows="8"
+                          placeholder="Wpisz tłumaczenie…">@_draftText</textarea>
+                <div class="editor-actions">
+                    <button type="submit" class="btn btn-primary">Zapisz ponownie</button>
+                </div>
+            </form>
+        </section>
+    }
+    else if (_loadProblem is not null)
+    {
+        <section class="panel">
+            <p class="status-line status-down" role="alert">
+                <span class="dot"></span>@(_loadProblem.Title ?? "Nie udało się wczytać tłumaczenia.")
+            </p>
+        </section>
+    }
+    else
+    {
+        <section class="results-meta">
+            <div class="loading-indicator">
+                <span class="li-spin"></span> Wczytywanie tłumaczenia…
+            </div>
+        </section>
+    }
+}
+else
+{
+    TranslationDetailResponse detail = _detail;
+    PlaceholderComparison comparison = PlaceholderAnalyzer.Compare(detail.SourceText, _draftText ?? detail.TranslatedText);
+
+    <section class="results-meta">
+        <span class="count">FileId <strong class="mono">@detail.FileId</strong></span>
+        <span class="count">GossipId <strong class="mono">@detail.GossipId</strong></span>
+        <span class="badge @TranslationStatusDisplay.BadgeClass(detail.Status)">
+            <span class="dot"></span>@TranslationStatusDisplay.Label(detail.Status)
+        </span>
+    </section>
+
+    @if (_saveProblem is not null)
+    {
+        <section class="panel">
+            <p class="status-line status-down" role="alert">
+                <span class="dot"></span>@(_saveProblem.Title ?? "Nie udało się zapisać tłumaczenia.")
+            </p>
+        </section>
+    }
+    else if (_saved)
+    {
+        <section class="panel">
+            <p class="status-line status-ok" role="status">
+                <span class="dot"></span>Tłumaczenie zapisano.
+            </p>
+        </section>
+    }
+
+    @if (_approveProblem is not null)
+    {
+        <section class="panel">
+            <p class="status-line status-down" role="alert">
+                <span class="dot"></span>@(_approveProblem.Title ?? "Nie udało się zatwierdzić tłumaczenia.")
+            </p>
+        </section>
+    }
+    else if (_approved)
+    {
+        <section class="panel">
+            <p class="status-line status-ok" role="status">
+                <span class="dot"></span>Tłumaczenie zatwierdzono i dołączono do dystrybucji.
+            </p>
+        </section>
+    }
+
+    @if (!comparison.IsMatch)
+    {
+        <section class="panel">
+            <p class="status-line status-warning" role="alert">
+                <span class="dot"></span>
+                Liczba znaczników się nie zgadza: w tekście angielskim @comparison.SourceCount,
+                w tłumaczeniu @comparison.TranslatedCount. Zachowaj każdy znacznik
+                <code class="ph-token">@PlaceholderAnalyzer.Placeholder</code>.
+            </p>
+        </section>
+    }
+
+    <div class="editor-grid">
+        <section class="panel editor-pane">
+            <h2 class="editor-pane-title">Tekst angielski</h2>
+            <div class="editor-source">@RenderHighlighted(detail.SourceText)</div>
+
+            @if (!string.IsNullOrEmpty(detail.PreviousSourceText))
+            {
+                <div class="editor-superseded">
+                    <h3 class="editor-pane-subtitle">Poprzednia wersja angielska (do porównania)</h3>
+                    <div class="editor-source is-superseded">@RenderHighlighted(detail.PreviousSourceText)</div>
+                </div>
+            }
+        </section>
+
+        <section class="panel editor-pane">
+            <h2 class="editor-pane-title">Tłumaczenie polskie</h2>
+            <form method="post" @formname="save-translation" @onsubmit="SaveAsync">
+                <AntiforgeryToken/>
+                <input type="hidden" name="FileIdField" value="@detail.FileId"/>
+                <input type="hidden" name="GossipIdField" value="@detail.GossipId"/>
+                <label class="visually-hidden" for="translated">Tłumaczenie polskie</label>
+                <textarea id="translated" name="DraftField" class="editor-textarea mono" rows="8"
+                          placeholder="Wpisz tłumaczenie…">@(_draftText ?? detail.TranslatedText)</textarea>
+                <div class="editor-actions">
+                    <button type="submit" class="btn btn-primary">Zapisz</button>
+                </div>
+            </form>
+
+            @if (CanApprove)
+            {
+                <form method="post" @formname="approve-translation" @onsubmit="ApproveAsync" class="editor-approve">
+                    <AntiforgeryToken/>
+                    <button type="submit" class="btn btn-ghost"
+                            disabled="@(detail.Status is TranslationStatus.Approved || string.IsNullOrWhiteSpace(detail.TranslatedText))">
+                        Zatwierdź
+                    </button>
+                    @if (string.IsNullOrWhiteSpace(detail.TranslatedText))
+                    {
+                        <span class="text-dim">Nie można zatwierdzić pustego tłumaczenia.</span>
+                    }
+                </form>
+            }
+        </section>
+    </div>
+}
+
+@code
+{
+    [Parameter]
+    public Guid Id { get; set; }
+
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
+
+    [SupplyParameterFromForm(FormName = "save-translation")]
+    private string? DraftField { get; set; }
+
+    [SupplyParameterFromForm(FormName = "save-translation")]
+    private int FileIdField { get; set; }
+
+    [SupplyParameterFromForm(FormName = "save-translation")]
+    private long GossipIdField { get; set; }
+
+    private TranslationDetailResponse? _detail;
+    private ProblemDetails? _loadProblem;
+    private ProblemDetails? _saveProblem;
+    private ProblemDetails? _approveProblem;
+    private string? _draftText;
+    private bool _saved;
+    private bool _approved;
+    private bool _canApprove;
+
+    private bool CanApprove => _canApprove;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _canApprove = await IsAdminAsync();
+
+        ApiResult<TranslationDetailResponse> result = await Loader.LoadAsync(new TranslationId(Id), CancellationToken.None);
+        if (result.IsSuccess)
+        {
+            _detail = result.Value;
+            _loadProblem = null;
+        }
+        else
+        {
+            _detail = null;
+            _loadProblem = result.ProblemDetails;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        _saved = false;
+        _saveProblem = null;
+        _draftText = DraftField ?? string.Empty;
+
+        UpsertTranslationRequest request = new(FileIdField, GossipIdField, _draftText);
+        ApiResult<TranslationDetailResponse> result = await Loader.SaveAsync(request, CancellationToken.None);
+
+        if (result.IsSuccess)
+        {
+            _detail = result.Value;
+            _draftText = null;
+            _saved = true;
+        }
+        else
+        {
+            _saveProblem = result.ProblemDetails;
+        }
+    }
+
+    private async Task ApproveAsync()
+    {
+        _approved = false;
+        _approveProblem = null;
+
+        if (!await IsAdminAsync())
+        {
+            return;
+        }
+
+        ApiResult result = await Loader.ApproveAsync(new TranslationId(Id), CancellationToken.None);
+        if (result.IsSuccess)
+        {
+            _approved = true;
+
+            ApiResult<TranslationDetailResponse> reload = await Loader.LoadAsync(new TranslationId(Id), CancellationToken.None);
+            if (reload.IsSuccess)
+            {
+                _detail = reload.Value;
+            }
+        }
+        else
+        {
+            _approveProblem = result.ProblemDetails;
+        }
+    }
+
+    private async Task<bool> IsAdminAsync()
+    {
+        if (AuthenticationStateTask is null)
+        {
+            return false;
+        }
+
+        AuthenticationState authenticationState = await AuthenticationStateTask;
+        return authenticationState.User.IsInRole(EditorRoles.Approver);
+    }
+
+    private static RenderFragment RenderHighlighted(string text) => builder =>
+    {
+        int sequence = 0;
+        foreach (PlaceholderSegment segment in PlaceholderAnalyzer.Segment(text))
+        {
+            if (segment.IsPlaceholder)
+            {
+                builder.OpenElement(sequence++, "span");
+                builder.AddAttribute(sequence++, "class", "ph-token");
+                builder.AddContent(sequence++, segment.Text);
+                builder.CloseElement();
+            }
+            else
+            {
+                builder.AddContent(sequence++, segment.Text);
+            }
+        }
+    };
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/EditorRoles.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/EditorRoles.cs
@@ -1,0 +1,15 @@
+namespace LotroKoniecDev.Frontend.Components.Pages.Editor;
+
+/// <summary>
+/// The role names the editor gates on, mirrored from the TMS API authorization policies
+/// (<c>AuthConstants.Roles</c>): approving a translation requires the same role the API's
+/// <c>RequireAdminRole</c> policy enforces on <c>POST /api/v1/translations/{id}/approve</c>. Held as a
+/// Frontend-local constant — like <c>TranslationListQuery.Language</c> — so the UI gate is
+/// self-describing and the Frontend does not depend on another bounded context's kernel for a single
+/// claim value. The API remains the real gate; this only decides whether to render the control.
+/// </summary>
+internal static class EditorRoles
+{
+    /// <summary>The reviewer role that may approve translations (the API's <c>Admin</c> role).</summary>
+    public const string Approver = "Admin";
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/PlaceholderAnalyzer.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/PlaceholderAnalyzer.cs
@@ -1,0 +1,103 @@
+namespace LotroKoniecDev.Frontend.Components.Pages.Editor;
+
+/// <summary>
+/// Pure analysis of the <c>&lt;--DO_NOT_TOUCH!--&gt;</c> argument placeholder for the side-by-side
+/// editor: it counts the token in a piece of text and splits the text into literal / placeholder runs
+/// so the page can highlight the markers without an interactive layer. The token is the inter-context
+/// file contract (a piece separator); the Frontend owns its own copy as a constant rather than
+/// referencing the frozen patcher, exactly as each bounded context owns its own parser. Kept isolated
+/// so the count / comparison / segmentation rules are unit-testable without rendering the component
+/// (the Frontend has no bUnit).
+/// </summary>
+internal static class PlaceholderAnalyzer
+{
+    /// <summary>The argument placeholder marker; translators must keep it verbatim (file-format contract).</summary>
+    internal const string Placeholder = "<--DO_NOT_TOUCH!-->";
+
+    /// <summary>
+    /// Counts how many <see cref="Placeholder"/> markers occur in <paramref name="text"/>. A
+    /// <c>null</c> or empty text has none.
+    /// </summary>
+    public static int Count(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return 0;
+        }
+
+        int count = 0;
+        int index = text.IndexOf(Placeholder, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            count++;
+            index = text.IndexOf(Placeholder, index + Placeholder.Length, StringComparison.Ordinal);
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Compares the placeholder count of the English source against the Polish translation. The result
+    /// reports whether the counts match and carries both counts so the page can render an exact warning
+    /// (the warning is advisory — the API stores the Polish verbatim either way, spec 0001 / #100).
+    /// Untranslated Polish (no text yet) is never flagged: there is nothing to warn about until the
+    /// translator types.
+    /// </summary>
+    public static PlaceholderComparison Compare(string sourceText, string? translatedText)
+    {
+        int sourceCount = Count(sourceText);
+
+        if (string.IsNullOrEmpty(translatedText))
+        {
+            return new PlaceholderComparison(sourceCount, 0, IsMatch: true);
+        }
+
+        int translatedCount = Count(translatedText);
+        return new PlaceholderComparison(sourceCount, translatedCount, sourceCount == translatedCount);
+    }
+
+    /// <summary>
+    /// Splits <paramref name="text"/> into ordered runs, each flagged as the placeholder marker or
+    /// literal text, so the page can wrap only the markers in a highlight span. Adjacent literals are
+    /// never produced; an empty text yields no segments.
+    /// </summary>
+    public static IReadOnlyList<PlaceholderSegment> Segment(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return [];
+        }
+
+        List<PlaceholderSegment> segments = [];
+        int cursor = 0;
+
+        int index = text.IndexOf(Placeholder, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            if (index > cursor)
+            {
+                segments.Add(new PlaceholderSegment(text[cursor..index], IsPlaceholder: false));
+            }
+
+            segments.Add(new PlaceholderSegment(Placeholder, IsPlaceholder: true));
+            cursor = index + Placeholder.Length;
+            index = text.IndexOf(Placeholder, cursor, StringComparison.Ordinal);
+        }
+
+        if (cursor < text.Length)
+        {
+            segments.Add(new PlaceholderSegment(text[cursor..], IsPlaceholder: false));
+        }
+
+        return segments;
+    }
+}
+
+/// <summary>
+/// The outcome of comparing English vs Polish placeholder counts: the two counts and whether they
+/// match. <see cref="IsMatch"/> is <c>true</c> for still-untranslated Polish (nothing to warn about).
+/// </summary>
+internal sealed record PlaceholderComparison(int SourceCount, int TranslatedCount, bool IsMatch);
+
+/// <summary>One ordered run of text from <see cref="PlaceholderAnalyzer.Segment"/>: a literal or a marker.</summary>
+internal sealed record PlaceholderSegment(string Text, bool IsPlaceholder);

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/TranslationEditorLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/TranslationEditorLoader.cs
@@ -1,0 +1,66 @@
+using System.Globalization;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+
+namespace LotroKoniecDev.Frontend.Components.Pages.Editor;
+
+/// <summary>
+/// Drives the side-by-side editor's three TMS calls through the typed client: load one translation
+/// (<c>GET /api/v1/translations/{id}</c>), save the Polish (<c>PUT /api/v1/translations</c>, #100) and
+/// approve it (<c>POST /api/v1/translations/{id}/approve</c>, #101). Kept as a thin injectable seam so
+/// the editor's load / save / approve behavior is unit-testable end-to-end over a stubbed HTTP handler
+/// (the Frontend has no bUnit for component-level rendering tests).
+/// </summary>
+internal sealed class TranslationEditorLoader
+{
+    private const string TranslationsApiPath = "/api/v1/translations";
+
+    private readonly ITranslationSystemClient _client;
+
+    public TranslationEditorLoader(ITranslationSystemClient client)
+    {
+        _client = client;
+    }
+
+    public Task<ApiResult<TranslationDetailResponse>> LoadAsync(
+        TranslationId id,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.GetApiResultAsync<TranslationDetailResponse>(
+            DetailUri(id),
+            cancellationToken);
+    }
+
+    public Task<ApiResult<TranslationDetailResponse>> SaveAsync(
+        UpsertTranslationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return _client.PutApiResultAsync<TranslationDetailResponse>(
+            TranslationsApiPath,
+            request,
+            cancellationToken);
+    }
+
+    public Task<ApiResult> ApproveAsync(
+        TranslationId id,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.PostApiResultAsync(
+            ApproveUri(id),
+            EmptyApprovePayload,
+            cancellationToken);
+    }
+
+    /// <summary>The approve endpoint takes no body; an empty object keeps the typed POST helper happy.</summary>
+    private static readonly object EmptyApprovePayload = new();
+
+    private static string DetailUri(TranslationId id) =>
+        string.Create(CultureInfo.InvariantCulture, $"{TranslationsApiPath}/{id.Value}");
+
+    private static string ApproveUri(TranslationId id) =>
+        string.Create(CultureInfo.InvariantCulture, $"{TranslationsApiPath}/{id.Value}/approve");
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using FluentValidation;
+using LotroKoniecDev.Frontend.Components.Pages.Editor;
 using LotroKoniecDev.Frontend.Components.Pages.Translations;
 using LotroKoniecDev.Frontend.Infrastructure.Auth;
 using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
@@ -24,6 +25,7 @@ public static class DependencyInjection
             services.AddFrontendAuthentication();
 
             services.AddScoped<TranslationListLoader>();
+            services.AddScoped<TranslationEditorLoader>();
 
             return services;
         }

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -261,6 +261,10 @@ code {
     background: var(--danger);
 }
 
+.status-warning .dot {
+    background: var(--warn);
+}
+
 /* Status / error pages */
 .status-stage {
     display: grid;
@@ -600,8 +604,100 @@ code {
     border: 0;
 }
 
+/* Side-by-side editor */
+.editor-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    align-items: start;
+}
+
+.editor-pane {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.editor-pane-title {
+    margin: 0;
+    font-size: 15px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.editor-pane-subtitle {
+    margin: 0;
+    font-size: 13px;
+    color: var(--text-dim);
+}
+
+.editor-source {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.6;
+}
+
+.editor-source.is-superseded {
+    opacity: 0.75;
+}
+
+.editor-superseded {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.editor-textarea {
+    width: 100%;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    padding: 14px;
+    line-height: 1.6;
+    resize: vertical;
+}
+
+.editor-textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.editor-actions {
+    margin-top: 12px;
+    display: flex;
+    gap: 10px;
+}
+
+.editor-approve {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.ph-token {
+    background: rgba(200, 164, 92, 0.18);
+    color: var(--accent-strong);
+    border-radius: 4px;
+    padding: 0 4px;
+    font-family: var(--font-mono);
+    font-size: 0.92em;
+}
+
 /* Responsive — stack the sidebar on top on small screens */
 @media (max-width: 760px) {
+    .editor-grid {
+        grid-template-columns: 1fr;
+    }
+
     .app-shell {
         flex-direction: column;
     }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorRolesTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorRolesTests.cs
@@ -1,0 +1,16 @@
+using LotroKoniecDev.Frontend.Components.Pages.Editor;
+using LotroKoniecDev.SharedKernel.Authorization;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Editor;
+
+public sealed class EditorRolesTests
+{
+    [Fact]
+    public void Approver_MirrorsTheApiAdminRole()
+    {
+        // The editor only renders the approve control for this role; the API's RequireAdminRole policy
+        // is the real gate. If the API role name ever changes, this guard fails before the UI silently
+        // drifts (showing or hiding the button for the wrong users).
+        EditorRoles.Approver.ShouldBe(AuthConstants.Roles.Admin);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/PlaceholderAnalyzerTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/PlaceholderAnalyzerTests.cs
@@ -1,0 +1,160 @@
+using LotroKoniecDev.Frontend.Components.Pages.Editor;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Editor;
+
+public sealed class PlaceholderAnalyzerTests
+{
+    private const string Token = "<--DO_NOT_TOUCH!-->";
+
+    [Theory]
+    [InlineData(null, 0)]
+    [InlineData("", 0)]
+    [InlineData("No placeholders here", 0)]
+    [InlineData("One " + Token + " marker", 1)]
+    [InlineData("Two " + Token + " and " + Token + " markers", 2)]
+    [InlineData(Token + Token + Token, 3)]
+    [InlineData(Token, 1)]
+    public void Count_ReturnsTheNumberOfMarkers(string? text, int expected)
+    {
+        PlaceholderAnalyzer.Count(text).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Count_DoesNotMatchAcrossOverlappingPartialTokens()
+    {
+        // A truncated marker must not be double-counted; only the full token is a placeholder.
+        PlaceholderAnalyzer.Count("<--DO_NOT_TOUCH!--").ShouldBe(0);
+    }
+
+    [Fact]
+    public void Compare_WhenCountsAreEqual_ReportsAMatch()
+    {
+        PlaceholderComparison comparison = PlaceholderAnalyzer.Compare(
+            $"Hello {Token} world",
+            $"Witaj {Token} świecie");
+
+        comparison.IsMatch.ShouldBeTrue();
+        comparison.SourceCount.ShouldBe(1);
+        comparison.TranslatedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Compare_WhenTranslationDropsAMarker_ReportsAMismatchWithBothCounts()
+    {
+        PlaceholderComparison comparison = PlaceholderAnalyzer.Compare(
+            $"You have {Token} of {Token} items",
+            $"Masz {Token} przedmiotów");
+
+        comparison.IsMatch.ShouldBeFalse();
+        comparison.SourceCount.ShouldBe(2);
+        comparison.TranslatedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Compare_WhenTranslationAddsAMarker_ReportsAMismatch()
+    {
+        PlaceholderComparison comparison = PlaceholderAnalyzer.Compare(
+            "No markers in source",
+            $"Dodatkowy {Token} znacznik");
+
+        comparison.IsMatch.ShouldBeFalse();
+        comparison.SourceCount.ShouldBe(0);
+        comparison.TranslatedCount.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Compare_WhenTranslationIsStillEmpty_NeverWarnsEvenIfSourceHasMarkers(string? translatedText)
+    {
+        // An untranslated row must not show a mismatch warning — there is nothing to compare yet.
+        PlaceholderComparison comparison = PlaceholderAnalyzer.Compare(
+            $"Source with {Token} marker",
+            translatedText);
+
+        comparison.IsMatch.ShouldBeTrue();
+        comparison.SourceCount.ShouldBe(1);
+        comparison.TranslatedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Compare_WhenSourceHasNoMarkersAndTranslationIsTyped_ReportsAMatch()
+    {
+        PlaceholderComparison comparison = PlaceholderAnalyzer.Compare(
+            "Plain English",
+            "Zwykły polski");
+
+        comparison.IsMatch.ShouldBeTrue();
+        comparison.SourceCount.ShouldBe(0);
+        comparison.TranslatedCount.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Segment_WithNoText_YieldsNoSegments(string? text)
+    {
+        PlaceholderAnalyzer.Segment(text).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Segment_WithNoMarkers_YieldsASingleLiteralSegment()
+    {
+        IReadOnlyList<PlaceholderSegment> segments = PlaceholderAnalyzer.Segment("Just literal text");
+
+        PlaceholderSegment only = segments.ShouldHaveSingleItem();
+        only.IsPlaceholder.ShouldBeFalse();
+        only.Text.ShouldBe("Just literal text");
+    }
+
+    [Fact]
+    public void Segment_WithAMarkerInTheMiddle_SplitsLiteralMarkerLiteralInOrder()
+    {
+        IReadOnlyList<PlaceholderSegment> segments = PlaceholderAnalyzer.Segment($"before {Token} after");
+
+        segments.Count.ShouldBe(3);
+        segments[0].ShouldBe(new PlaceholderSegment("before ", false));
+        segments[1].ShouldBe(new PlaceholderSegment(Token, true));
+        segments[2].ShouldBe(new PlaceholderSegment(" after", false));
+    }
+
+    [Fact]
+    public void Segment_WithLeadingAndTrailingMarkers_DoesNotEmitEmptyLiterals()
+    {
+        IReadOnlyList<PlaceholderSegment> segments = PlaceholderAnalyzer.Segment($"{Token}middle{Token}");
+
+        segments.Count.ShouldBe(3);
+        segments[0].ShouldBe(new PlaceholderSegment(Token, true));
+        segments[1].ShouldBe(new PlaceholderSegment("middle", false));
+        segments[2].ShouldBe(new PlaceholderSegment(Token, true));
+    }
+
+    [Fact]
+    public void Segment_WithAdjacentMarkers_EmitsBackToBackPlaceholdersWithNoLiteralBetween()
+    {
+        IReadOnlyList<PlaceholderSegment> segments = PlaceholderAnalyzer.Segment($"{Token}{Token}");
+
+        segments.Count.ShouldBe(2);
+        segments.ShouldAllBe(segment => segment.IsPlaceholder);
+    }
+
+    [Fact]
+    public void Segment_PreservesNewlinesInsideLiteralRuns()
+    {
+        IReadOnlyList<PlaceholderSegment> segments = PlaceholderAnalyzer.Segment($"line1\r\nline2 {Token}");
+
+        segments[0].Text.ShouldBe("line1\r\nline2 ");
+        segments[1].IsPlaceholder.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Segment_RoundTripsToTheOriginalTextWhenConcatenated()
+    {
+        const string original = $"A {Token} B {Token}{Token} C";
+
+        string reconstructed = string.Concat(
+            PlaceholderAnalyzer.Segment(original).Select(segment => segment.Text));
+
+        reconstructed.ShouldBe(original);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/TranslationEditorLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/TranslationEditorLoaderTests.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.Frontend.Components.Pages.Editor;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Editor;
+
+public sealed class TranslationEditorLoaderTests
+{
+    private const string BaseUrl = "https://localhost:5004/";
+    private static readonly Guid TranslationGuid = Guid.Parse("0192a000-0000-7000-8000-000000000042");
+
+    // Mirrors the JSON options the Frontend's HTTP seam uses (HttpClientApiExtensions) so the stub
+    // body deserializes through the exact same contract the loader relies on.
+    private static readonly JsonSerializerOptions ApiJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    [Fact]
+    public async Task LoadAsync_WhenApiReturnsTheRow_DeserializesEveryFieldTheEditorRenders()
+    {
+        TranslationDetailResponse detail = DetailFixture();
+        TranslationEditorLoader loader = CreateLoader(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(detail, ApiJsonOptions),
+            out _);
+
+        ApiResult<TranslationDetailResponse> result =
+            await loader.LoadAsync(TranslationId.Create(TranslationGuid));
+
+        result.IsSuccess.ShouldBeTrue();
+        TranslationDetailResponse loaded = result.Value;
+        loaded.Id.Value.ShouldBe(TranslationGuid);
+        loaded.FileId.ShouldBe(620756992);
+        loaded.GossipId.ShouldBe(1002);
+        loaded.SourceText.ShouldBe("You have <--DO_NOT_TOUCH!--> gold");
+        loaded.TranslatedText.ShouldBe("Masz <--DO_NOT_TOUCH!--> złota");
+        loaded.PreviousSourceText.ShouldBe("You had <--DO_NOT_TOUCH!--> gold");
+        loaded.Status.ShouldBe(TranslationStatus.NeedsReview);
+        loaded.Submitter!.DisplayName.ShouldBe("Frodo");
+    }
+
+    [Fact]
+    public async Task LoadAsync_RequestsTheGetOneEndpointForTheGivenId()
+    {
+        TranslationEditorLoader loader = CreateLoader(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(DetailFixture(), ApiJsonOptions),
+            out StubHttpMessageHandler handler);
+
+        await loader.LoadAsync(TranslationId.Create(TranslationGuid));
+
+        handler.LastRequest.ShouldNotBeNull();
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
+        handler.LastRequest.RequestUri!.ToString()
+            .ShouldBe($"{BaseUrl}api/v1/translations/{TranslationGuid}");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenRowIsMissing_ReturnsFailureWithProblemDetails()
+    {
+        TranslationEditorLoader loader = CreateLoader(
+            HttpStatusCode.NotFound,
+            """{ "title": "Nie znaleziono tłumaczenia", "status": 404 }""",
+            out _);
+
+        ApiResult<TranslationDetailResponse> result =
+            await loader.LoadAsync(TranslationId.Create(TranslationGuid));
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(404);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PutsTheRequestBodyToTheCollectionEndpoint()
+    {
+        TranslationEditorLoader loader = CreateLoader(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(DetailFixture(), ApiJsonOptions),
+            out StubHttpMessageHandler handler);
+        UpsertTranslationRequest request = new(620756992, 1002, "Masz <--DO_NOT_TOUCH!--> złota");
+
+        await loader.SaveAsync(request);
+
+        handler.LastRequest.ShouldNotBeNull();
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Put);
+        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/translations");
+        handler.LastRequestBody.ShouldNotBeNull();
+        // Deserialize the sent JSON rather than substring-match it: System.Text.Json escapes '<', '>'
+        // and non-ASCII, so the placeholder/diacritics only survive a round-trip, not a raw contains.
+        UpsertTranslationRequest sent =
+            JsonSerializer.Deserialize<UpsertTranslationRequest>(handler.LastRequestBody!, ApiJsonOptions)!;
+        sent.FileId.ShouldBe(620756992);
+        sent.GossipId.ShouldBe(1002);
+        sent.TranslatedText.ShouldBe("Masz <--DO_NOT_TOUCH!--> złota");
+    }
+
+    [Fact]
+    public async Task SaveAsync_OnSuccess_DeserializesTheUpdatedRow()
+    {
+        TranslationEditorLoader loader = CreateLoader(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(DetailFixture(), ApiJsonOptions),
+            out _);
+
+        ApiResult<TranslationDetailResponse> result =
+            await loader.SaveAsync(new UpsertTranslationRequest(620756992, 1002, "x"));
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Id.Value.ShouldBe(TranslationGuid);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenApiRejects_ReturnsFailureWithProblemDetails()
+    {
+        TranslationEditorLoader loader = CreateLoader(
+            HttpStatusCode.UnprocessableEntity,
+            """{ "title": "Tłumaczenie nie może być puste", "status": 422 }""",
+            out _);
+
+        ApiResult<TranslationDetailResponse> result =
+            await loader.SaveAsync(new UpsertTranslationRequest(620756992, 1002, ""));
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(422);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_PostsToTheApproveEndpointForTheGivenId()
+    {
+        TranslationEditorLoader loader = CreateLoader(HttpStatusCode.NoContent, string.Empty, out StubHttpMessageHandler handler);
+
+        ApiResult result = await loader.ApproveAsync(TranslationId.Create(TranslationGuid));
+
+        result.IsSuccess.ShouldBeTrue();
+        handler.LastRequest.ShouldNotBeNull();
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.ToString()
+            .ShouldBe($"{BaseUrl}api/v1/translations/{TranslationGuid}/approve");
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenForbidden_ReturnsFailureWithProblemDetails()
+    {
+        TranslationEditorLoader loader = CreateLoader(
+            HttpStatusCode.Forbidden,
+            """{ "title": "Brak uprawnień", "status": 403 }""",
+            out _);
+
+        ApiResult result = await loader.ApproveAsync(TranslationId.Create(TranslationGuid));
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(403);
+    }
+
+    private static TranslationDetailResponse DetailFixture() =>
+        new(
+            TranslationId.Create(TranslationGuid),
+            FileId: 620756992,
+            GossipId: 1002,
+            SourceText: "You have <--DO_NOT_TOUCH!--> gold",
+            ArgsOrder: "1",
+            ArgsId: "1",
+            TranslatedText: "Masz <--DO_NOT_TOUCH!--> złota",
+            PreviousSourceText: "You had <--DO_NOT_TOUCH!--> gold",
+            Submitter: new TranslatorSummaryResponse(TranslatorId.Create(), "Frodo"),
+            Approver: null,
+            Status: TranslationStatus.NeedsReview,
+            CreatedAt: DateTimeOffset.UtcNow,
+            UpdatedAt: DateTimeOffset.UtcNow);
+
+    private static TranslationEditorLoader CreateLoader(
+        HttpStatusCode statusCode,
+        string jsonBody,
+        out StubHttpMessageHandler handler)
+    {
+        handler = StubHttpMessageHandler.RespondWith(statusCode, jsonBody);
+        return new TranslationEditorLoader(CreateClient(handler));
+    }
+
+    private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)
+    {
+        HttpClient httpClient = new(handler)
+        {
+            BaseAddress = new Uri(BaseUrl)
+        };
+        return new TranslationSystemClient(httpClient);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/StubHttpMessageHandler.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/StubHttpMessageHandler.cs
@@ -18,6 +18,13 @@ internal sealed class StubHttpMessageHandler : HttpMessageHandler
 
     public HttpRequestMessage? LastRequest { get; private set; }
 
+    /// <summary>
+    /// The body of the last request, captured at send time. Read here because the typed client disposes
+    /// the request (and its content) right after sending, so <see cref="LastRequest"/>.Content can no
+    /// longer be read once <c>SendAsync</c> returns.
+    /// </summary>
+    public string? LastRequestBody { get; private set; }
+
     public static StubHttpMessageHandler RespondWith(HttpStatusCode statusCode, string jsonBody)
     {
         return new StubHttpMessageHandler(_ => new HttpResponseMessage(statusCode)
@@ -31,11 +38,14 @@ internal sealed class StubHttpMessageHandler : HttpMessageHandler
         return new StubHttpMessageHandler(_ => throw exception);
     }
 
-    protected override Task<HttpResponseMessage> SendAsync(
+    protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
         LastRequest = request;
-        return Task.FromResult(_responder(request));
+        LastRequestBody = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken);
+        return _responder(request);
     }
 }


### PR DESCRIPTION
Closes #35

## Summary
Adds the side-by-side translation editor (Blazor SSR) at `/editor/{id:guid}` — the core translator workflow page (M3-04).

- **Left pane:** read-only English source, plus the superseded English (`PreviousSourceText`) when a game update invalidated the row. **Right pane:** editable Polish in a `method="post"` form.
- **Save** → `PUT /api/v1/translations` (#100). **Approve** → `POST /api/v1/translations/{id}/approve` (#101), rendered only for the `Admin` role and re-checked server-side before the call; the API's `RequireAdminRole` is the real gate.
- **Placeholders** (`<--DO_NOT_TOUCH!-->`) highlighted in both panes; an **advisory, non-blocking** warning fires when the PL marker count diverges from EN (the API stores Polish verbatim either way — spec 0001 / #100).
- Pure static SSR: plain forms + `<AntiforgeryToken/>`, no interactive render mode. Logic extracted into a pure `PlaceholderAnalyzer` + a thin `TranslationEditorLoader` seam over the typed client (mirrors the M3-03 list page), unit-tested over a stubbed HTTP handler. Dead `/editor` nav link removed.

## Acceptance criteria
- [x] Side-by-side view; edit + save via API
- [x] Placeholders highlighted; count mismatch → warning
- [x] Approve from the editor (role-gated)

## Verification
- `dotnet build LotroKoniecDev.slnx` — green, **zero warnings** (TreatWarningsAsErrors).
- 125 Frontend unit tests pass (placeholder analyzer boundary matrix, loader load/save/approve over stubbed HTTP, role-constant drift guard).
- code-reviewer agent: **APPROVE**. `/security-review`: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)