### PR TITLE
M3-05: Mini-dashboard — progress counters (API stats slice + Blazor page)

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/Dashboard.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/Dashboard.razor
@@ -1,0 +1,78 @@
+@page "/dashboard"
+@attribute [Authorize]
+@attribute [StreamRendering]
+@using System.Globalization
+@using Microsoft.AspNetCore.Authorization
+@using LotroKoniecDev.Frontend.Infrastructure.HttpClients
+@using LotroKoniecDev.TranslationSystem.Contracts.Translations
+@inject DashboardStatsLoader Loader
+
+<PageTitle>Panel — LotroKoniecDev</PageTitle>
+
+<section class="page-head">
+    <h1>Panel</h1>
+    <p class="lede">Postęp tłumaczenia polskiej wersji LOTRO w skrócie.</p>
+</section>
+
+@if (_result is null)
+{
+    <section class="results-meta">
+        <div class="loading-indicator">
+            <span class="li-spin"></span> Wczytywanie statystyk…
+        </div>
+    </section>
+}
+else if (_result.IsFailure)
+{
+    <section class="panel">
+        <p class="status-line status-down" role="alert">
+            <span class="dot"></span>
+            @(_result.ProblemDetails?.Title ?? "Nie udało się wczytać statystyk.")
+        </p>
+    </section>
+}
+else
+{
+    DashboardView view = DashboardView.From(_result.Value);
+
+    <section class="stat-grid">
+        <article class="stat-card">
+            <span class="stat-label">Wszystkie</span>
+            <span class="stat-value mono">@view.Total</span>
+        </article>
+        <article class="stat-card">
+            <span class="stat-label">Przetłumaczone</span>
+            <span class="stat-value mono">@view.Translated</span>
+        </article>
+        <article class="stat-card">
+            <span class="stat-label">Zatwierdzone</span>
+            <span class="stat-value mono stat-value-ok">@view.Approved</span>
+        </article>
+        <article class="stat-card">
+            <span class="stat-label">Pozostałe</span>
+            <span class="stat-value mono">@view.Remaining</span>
+        </article>
+    </section>
+
+    <section class="panel">
+        <h2>Postęp zatwierdzania</h2>
+        <div class="progress" role="progressbar"
+             aria-valuenow="@view.ApprovedPercent" aria-valuemin="0" aria-valuemax="100"
+             aria-label="Zatwierdzone tłumaczenia">
+            <div class="progress-bar" style="width: @view.ApprovedPercent.ToString(CultureInfo.InvariantCulture)%;"></div>
+        </div>
+        <p class="progress-caption">
+            <strong>@view.ApprovedPercent%</strong> zatwierdzone (@view.Approved z @view.Total)
+        </p>
+    </section>
+}
+
+@code
+{
+    private ApiResult<TranslationStatsResponse>? _result;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _result = await Loader.LoadAsync(CancellationToken.None);
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/DashboardStatsLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/DashboardStatsLoader.cs
@@ -1,0 +1,27 @@
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+namespace LotroKoniecDev.Frontend.Components.Pages.Dashboard;
+
+/// <summary>
+/// Fetches the mini-dashboard's progress counters (M3-05) through the typed TMS client. Kept as a thin
+/// injectable seam so the page's data flow is unit-testable end-to-end over a stubbed HTTP handler (the
+/// Frontend has no bUnit for component-level rendering tests).
+/// </summary>
+internal sealed class DashboardStatsLoader
+{
+    private const string StatsRelativeUri = "/api/v1/translations/stats";
+
+    private readonly ITranslationSystemClient _client;
+
+    public DashboardStatsLoader(ITranslationSystemClient client)
+    {
+        _client = client;
+    }
+
+    public Task<ApiResult<TranslationStatsResponse>> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        return _client.GetApiResultAsync<TranslationStatsResponse>(StatsRelativeUri, cancellationToken);
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/DashboardView.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/DashboardView.cs
@@ -1,0 +1,54 @@
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+namespace LotroKoniecDev.Frontend.Components.Pages.Dashboard;
+
+/// <summary>
+/// The mini-dashboard's view state derived from the API counters (M3-05): the four counters as-is plus
+/// the approval-progress percentage the progress bar renders. Pure and isolated from the razor so the
+/// percent math — chiefly the zero-catalog guard and rounding — is unit-testable without rendering the
+/// component (the Frontend has no bUnit).
+/// </summary>
+internal sealed record DashboardView
+{
+    private DashboardView(int total, int translated, int approved, int remaining, int approvedPercent)
+    {
+        Total = total;
+        Translated = translated;
+        Approved = approved;
+        Remaining = remaining;
+        ApprovedPercent = approvedPercent;
+    }
+
+    public int Total { get; }
+
+    public int Translated { get; }
+
+    public int Approved { get; }
+
+    public int Remaining { get; }
+
+    /// <summary>Approved as a whole-number percentage of the active catalog; <c>0</c> when empty.</summary>
+    public int ApprovedPercent { get; }
+
+    public static DashboardView From(TranslationStatsResponse stats)
+    {
+        ArgumentNullException.ThrowIfNull(stats);
+
+        return new DashboardView(
+            stats.Total,
+            stats.Translated,
+            stats.Approved,
+            stats.Remaining,
+            Percent(stats.Approved, stats.Total));
+    }
+
+    private static int Percent(int part, int whole)
+    {
+        if (whole <= 0)
+        {
+            return 0;
+        }
+
+        return (int)Math.Round(part / (double)whole * 100, MidpointRounding.AwayFromZero);
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using FluentValidation;
+using LotroKoniecDev.Frontend.Components.Pages.Dashboard;
 using LotroKoniecDev.Frontend.Components.Pages.Editor;
 using LotroKoniecDev.Frontend.Components.Pages.Translations;
 using LotroKoniecDev.Frontend.Infrastructure.Auth;
@@ -26,6 +27,7 @@ public static class DependencyInjection
 
             services.AddScoped<TranslationListLoader>();
             services.AddScoped<TranslationEditorLoader>();
+            services.AddScoped<DashboardStatsLoader>();
 
             return services;
         }

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -434,6 +434,66 @@ code {
     }
 }
 
+/* Dashboard — stat cards + progress */
+.stat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 14px;
+    margin-bottom: 18px;
+}
+
+.stat-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 18px 20px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+
+.stat-label {
+    color: var(--text-dim);
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.stat-value {
+    font-size: 30px;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.stat-value-ok {
+    color: var(--ok);
+}
+
+.progress {
+    height: 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.progress-bar {
+    height: 100%;
+    background: var(--ok);
+    border-radius: inherit;
+    transition: width 0.3s ease;
+}
+
+.progress-caption {
+    margin: 10px 0 0;
+    color: var(--text-dim);
+    font-size: 14px;
+}
+
+.progress-caption strong {
+    color: var(--text);
+}
+
 /* Data table */
 .table-wrap {
     border: 1px solid var(--border);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -85,6 +85,9 @@ internal static class ApiDependencyInjection
             services.AddScoped<
                 IQueryHandler<GetTranslation.Query, Result<TranslationDetailResponse>>,
                 GetTranslation.Handler>();
+            services.AddScoped<
+                IQueryHandler<GetTranslationStats.Query, Result<TranslationStatsResponse>>,
+                GetTranslationStats.Handler>();
 
             services.AddScoped<IValidator<UpsertTranslation.Command>, UpsertTranslation.Validator>();
             services.AddScoped<

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslationStats.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslationStats.cs
@@ -1,0 +1,81 @@
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
+
+/// <summary>
+/// The mini-dashboard's progress counters (M3-05): total / translated / approved / remaining over the
+/// active (non-removed) catalog. Reads the POCO read model — never the write aggregate (CQRS, ADR-0002
+/// amendment) — with a single grouped count per <see cref="TranslationStatus"/>, then buckets in
+/// memory, so it stays one cheap round-trip regardless of catalog size. Counters only, by design
+/// (YAGNI — not analytics).
+/// </summary>
+internal sealed class GetTranslationStats : IEndpoint
+{
+    internal sealed record Query : IQuery<Result<TranslationStatsResponse>>;
+
+    internal sealed class Handler : IQueryHandler<Query, Result<TranslationStatsResponse>>
+    {
+        private readonly IApplicationReadDbContext _readDbContext;
+
+        public Handler(IApplicationReadDbContext readDbContext)
+        {
+            _readDbContext = readDbContext;
+        }
+
+        public async ValueTask<Result<TranslationStatsResponse>> Handle(Query query, CancellationToken cancellationToken)
+        {
+            Dictionary<TranslationStatus, int> countByStatus = await _readDbContext.Translations
+                .Where(translation => translation.RemovedInVersion == null)
+                .GroupBy(translation => translation.Status)
+                .Select(group => new { Status = group.Key, Count = group.Count() })
+                .ToDictionaryAsync(group => group.Status, group => group.Count, cancellationToken);
+
+            int total = countByStatus.Values.Sum();
+            int approved = countByStatus.GetValueOrDefault(TranslationStatus.Approved);
+
+            // "Translated" = the rows that carry Polish content. The domain only reaches Draft,
+            // Approved or NeedsReview once Polish exists (Translation.ProvideTranslation / Approve /
+            // ApplySourceChange), so summing exactly those three buckets matches the contract by
+            // construction — rather than "everything but Untranslated", which would also fold in any
+            // future status.
+            int translated =
+                countByStatus.GetValueOrDefault(TranslationStatus.Draft)
+                + approved
+                + countByStatus.GetValueOrDefault(TranslationStatus.NeedsReview);
+
+            TranslationStatsResponse stats = new(
+                Total: total,
+                Translated: translated,
+                Approved: approved,
+                Remaining: total - approved);
+
+            return Result.Success(stats);
+        }
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapGet("/api/v1/translations/stats", async (
+                IQueryHandler<Query, Result<TranslationStatsResponse>> handler,
+                CancellationToken cancellationToken) =>
+            {
+                Result<TranslationStatsResponse> result = await handler.Handle(new Query(), cancellationToken);
+
+                return result.IsSuccess
+                    ? Results.Ok(result.Value)
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(GetTranslationStats))
+            .WithTags("Translations")
+            .RequireAuthorization(AuthorizationPolicies.RequireTranslatorRole)
+            .Produces<TranslationStatsResponse>(StatusCodes.Status200OK);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/TranslationStatsResponse.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/TranslationStatsResponse.cs
@@ -1,0 +1,18 @@
+namespace LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+/// <summary>
+/// The mini-dashboard's progress counters (M3-05): a snapshot of the active (non-removed) catalog —
+/// how many fragments exist, how many carry Polish, how many are approved for distribution, and how
+/// many still need work to reach approval. Counters only, by design (YAGNI — not analytics).
+/// <list type="bullet">
+/// <item><see cref="Total"/> — every active fragment.</item>
+/// <item><see cref="Translated"/> — fragments with Polish content (draft, approved or invalidated).</item>
+/// <item><see cref="Approved"/> — fragments approved for the distributed file.</item>
+/// <item><see cref="Remaining"/> — active fragments not yet approved (<c>Total - Approved</c>).</item>
+/// </list>
+/// </summary>
+public sealed record TranslationStatsResponse(
+    int Total,
+    int Translated,
+    int Approved,
+    int Remaining);

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Dashboard/DashboardStatsLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Dashboard/DashboardStatsLoaderTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.Frontend.Components.Pages.Dashboard;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Dashboard;
+
+public sealed class DashboardStatsLoaderTests
+{
+    private const string BaseUrl = "https://localhost:5004/";
+
+    // Mirrors the JSON options the Frontend's HTTP seam uses (HttpClientApiExtensions) so the stub
+    // body deserializes through the exact same contract the loader relies on.
+    private static readonly JsonSerializerOptions ApiJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    [Fact]
+    public async Task LoadAsync_WhenApiReturnsStats_DeserializesEveryCounter()
+    {
+        TranslationStatsResponse stats = new(Total: 1500, Translated: 900, Approved: 600, Remaining: 900);
+        DashboardStatsLoader loader = CreateLoader(stats, out _);
+
+        ApiResult<TranslationStatsResponse> result = await loader.LoadAsync();
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Total.ShouldBe(1500);
+        result.Value.Translated.ShouldBe(900);
+        result.Value.Approved.ShouldBe(600);
+        result.Value.Remaining.ShouldBe(900);
+    }
+
+    [Fact]
+    public async Task LoadAsync_RequestsTheStatsEndpoint()
+    {
+        DashboardStatsLoader loader = CreateLoader(
+            new TranslationStatsResponse(0, 0, 0, 0),
+            out StubHttpMessageHandler handler);
+
+        await loader.LoadAsync();
+
+        handler.LastRequest.ShouldNotBeNull();
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
+        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/translations/stats");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenApiFails_ReturnsFailureWithProblemDetails()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.InternalServerError,
+            """{ "title": "Nie udało się wczytać statystyk.", "status": 500 }""");
+        DashboardStatsLoader loader = new(CreateClient(handler));
+
+        ApiResult<TranslationStatsResponse> result = await loader.LoadAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails.ShouldNotBeNull();
+        result.ProblemDetails!.Status.ShouldBe(500);
+    }
+
+    private static DashboardStatsLoader CreateLoader(
+        TranslationStatsResponse stats,
+        out StubHttpMessageHandler handler)
+    {
+        handler = StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(stats, ApiJsonOptions));
+        return new DashboardStatsLoader(CreateClient(handler));
+    }
+
+    private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)
+    {
+        HttpClient httpClient = new(handler)
+        {
+            BaseAddress = new Uri(BaseUrl)
+        };
+        return new TranslationSystemClient(httpClient);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Dashboard/DashboardViewTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Dashboard/DashboardViewTests.cs
@@ -1,0 +1,43 @@
+using LotroKoniecDev.Frontend.Components.Pages.Dashboard;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Dashboard;
+
+public sealed class DashboardViewTests
+{
+    [Fact]
+    public void From_CopiesEveryCounterThroughUnchanged()
+    {
+        TranslationStatsResponse stats = new(Total: 200, Translated: 150, Approved: 80, Remaining: 120);
+
+        DashboardView view = DashboardView.From(stats);
+
+        view.Total.ShouldBe(200);
+        view.Translated.ShouldBe(150);
+        view.Approved.ShouldBe(80);
+        view.Remaining.ShouldBe(120);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0)]      // empty catalog — no division by zero
+    [InlineData(100, 0, 0)]    // nothing approved yet
+    [InlineData(100, 100, 100)] // all approved
+    [InlineData(200, 100, 50)] // exact half
+    [InlineData(3, 1, 33)]     // 33.33% rounds down
+    [InlineData(3, 2, 67)]     // 66.67% rounds up
+    [InlineData(8, 1, 13)]     // 12.5% rounds away from zero to 13
+    public void From_ComputesApprovedPercent(int total, int approved, int expectedPercent)
+    {
+        TranslationStatsResponse stats = new(total, Translated: approved, approved, Remaining: total - approved);
+
+        DashboardView view = DashboardView.From(stats);
+
+        view.ApprovedPercent.ShouldBe(expectedPercent);
+    }
+
+    [Fact]
+    public void From_WhenStatsNull_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => DashboardView.From(null!));
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationStatsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationStatsTests.cs
@@ -1,0 +1,186 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
+
+[Collection("TranslationApi")]
+public sealed class GetTranslationStatsTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+    private const string SeederDisplayName = "Seed Author";
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+    private TranslatorId _seederId;
+
+    public GetTranslationStatsTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+
+        Translator seeder = Translator.Create(
+            IdentityId.Create(), DisplayName.Create(SeederDisplayName).Value, email: null, Now).Value;
+        dbContext.Translators.Add(seeder);
+
+        await dbContext.SaveChangesAsync();
+        _versionId = gameVersion.Id;
+        _seederId = seeder.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Stats_WithEmptyCatalog_ShouldReturnAllZeros()
+    {
+        // Act
+        TranslationStatsResponse stats = await StatsAsync();
+
+        // Assert
+        stats.Total.ShouldBe(0);
+        stats.Translated.ShouldBe(0);
+        stats.Approved.ShouldBe(0);
+        stats.Remaining.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Stats_WithMixedStatuses_ShouldBucketEachCounter()
+    {
+        // Arrange — one untranslated, two drafts, three approved, one invalidated (NeedsReview).
+        await SeedAsync(
+            Row(1, "a"),
+            Row(2, "b", TranslationStatus.Draft),
+            Row(3, "c", TranslationStatus.Draft),
+            Row(4, "d", TranslationStatus.Approved),
+            Row(5, "e", TranslationStatus.Approved),
+            Row(6, "f", TranslationStatus.Approved),
+            Row(7, "g", TranslationStatus.NeedsReview));
+
+        // Act
+        TranslationStatsResponse stats = await StatsAsync();
+
+        // Assert
+        stats.Total.ShouldBe(7);
+        // Translated = everything carrying Polish = drafts + approved + invalidated (all but untranslated).
+        stats.Translated.ShouldBe(6);
+        stats.Approved.ShouldBe(3);
+        // Remaining = active rows not yet approved = Total - Approved.
+        stats.Remaining.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task Stats_ShouldExcludeSoftRemovedRowsFromEveryCounter()
+    {
+        // Arrange — a removed approved row and a removed untranslated row must not count anywhere.
+        await SeedAsync(
+            Row(1, "kept", TranslationStatus.Approved),
+            Row(2, "removed-approved", TranslationStatus.Approved, removed: true),
+            Row(3, "removed-untranslated", removed: true));
+
+        // Act
+        TranslationStatsResponse stats = await StatsAsync();
+
+        // Assert
+        stats.Total.ShouldBe(1);
+        stats.Translated.ShouldBe(1);
+        stats.Approved.ShouldBe(1);
+        stats.Remaining.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Stats_WithoutToken_ShouldReturn401()
+    {
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync("/api/v1/translations/stats");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<TranslationStatsResponse> StatsAsync()
+    {
+        HttpResponseMessage response = await TranslatorClient().GetAsync("/api/v1/translations/stats");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        return (await response.Content.ReadFromJsonAsync<TranslationStatsResponse>(JsonOptions))!;
+    }
+
+    private HttpClient TranslatorClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+        return client;
+    }
+
+    private async Task SeedAsync(params Translation[] rows)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        dbContext.Translations.AddRange(rows);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private Translation Row(
+        int gossipId,
+        string source,
+        TranslationStatus status = TranslationStatus.Untranslated,
+        bool removed = false,
+        int fileId = FileId)
+    {
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(fileId, gossipId).Value,
+            TranslationSource.Create(source, null, null).Value,
+            _versionId,
+            Now).Value;
+
+        switch (status)
+        {
+            case TranslationStatus.Draft:
+                row.ProvideTranslation("Polski tekst", _seederId, Now);
+                break;
+            case TranslationStatus.Approved:
+                row.ProvideTranslation("Polski tekst", _seederId, Now);
+                row.Approve(_seederId, Now);
+                break;
+            case TranslationStatus.NeedsReview:
+                row.ProvideTranslation("Polski tekst", _seederId, Now);
+                row.ApplySourceChange(TranslationSource.Create($"{source} (reworded)", null, null).Value, _versionId, Now);
+                break;
+        }
+
+        if (removed)
+        {
+            row.MarkRemoved(_versionId, Now);
+        }
+
+        return row;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/GetTranslationStatsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/GetTranslationStatsHandlerTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Features.Translations;
+using LotroKoniecDev.TranslationSystem.API.Tests.Unit.Shared;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Translations;
+
+public sealed class GetTranslationStatsHandlerTests
+{
+    private const int FileId = 620756992;
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly GameVersionId VersionId = GameVersionId.Create();
+
+    private readonly List<TranslationReadModel> _readModels = [];
+
+    [Fact]
+    public async Task Handle_WithEmptyCatalog_ShouldReturnAllZeros()
+    {
+        // Act
+        TranslationStatsResponse stats = await HandleAsync();
+
+        // Assert
+        stats.Total.ShouldBe(0);
+        stats.Translated.ShouldBe(0);
+        stats.Approved.ShouldBe(0);
+        stats.Remaining.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Handle_WithMixedStatuses_ShouldBucketEachCounter()
+    {
+        // Arrange — 1 untranslated, 2 draft, 3 approved, 1 needs-review.
+        Given(1, TranslationStatus.Untranslated);
+        Given(2, TranslationStatus.Draft);
+        Given(3, TranslationStatus.Draft);
+        Given(4, TranslationStatus.Approved);
+        Given(5, TranslationStatus.Approved);
+        Given(6, TranslationStatus.Approved);
+        Given(7, TranslationStatus.NeedsReview);
+
+        // Act
+        TranslationStatsResponse stats = await HandleAsync();
+
+        // Assert
+        stats.Total.ShouldBe(7);
+        stats.Translated.ShouldBe(6);  // draft + approved + needs-review (all carry Polish)
+        stats.Approved.ShouldBe(3);
+        stats.Remaining.ShouldBe(4);   // total - approved
+    }
+
+    [Fact]
+    public async Task Handle_ShouldExcludeSoftRemovedRowsFromEveryCounter()
+    {
+        // Arrange — only the kept approved row may count anywhere.
+        Given(1, TranslationStatus.Approved);
+        Given(2, TranslationStatus.Approved, removed: true);
+        Given(3, TranslationStatus.Untranslated, removed: true);
+
+        // Act
+        TranslationStatsResponse stats = await HandleAsync();
+
+        // Assert
+        stats.Total.ShouldBe(1);
+        stats.Translated.ShouldBe(1);
+        stats.Approved.ShouldBe(1);
+        stats.Remaining.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoRowIsApproved_ShouldCountAllActiveRowsAsRemaining()
+    {
+        // Arrange
+        Given(1, TranslationStatus.Untranslated);
+        Given(2, TranslationStatus.Draft);
+        Given(3, TranslationStatus.NeedsReview);
+
+        // Act
+        TranslationStatsResponse stats = await HandleAsync();
+
+        // Assert
+        stats.Total.ShouldBe(3);
+        stats.Translated.ShouldBe(2);
+        stats.Approved.ShouldBe(0);
+        stats.Remaining.ShouldBe(3);
+    }
+
+    private async Task<TranslationStatsResponse> HandleAsync()
+    {
+        GetTranslationStats.Handler handler = new(new FakeReadDbContext(_readModels));
+
+        Result<TranslationStatsResponse> result =
+            await handler.Handle(new GetTranslationStats.Query(), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        return result.Value;
+    }
+
+    private void Given(int gossipId, TranslationStatus status, bool removed = false)
+        => _readModels.Add(new TranslationReadModel(
+            TranslationId.Create(),
+            FileId,
+            gossipId,
+            $"source-{gossipId}",
+            null,
+            null,
+            status == TranslationStatus.Untranslated ? null : "Polski tekst",
+            null,
+            null,
+            null,
+            status,
+            VersionId,
+            null,
+            removed ? VersionId : null,
+            Now,
+            Now));
+}


### PR DESCRIPTION
Closes #36

## M3-05: Mini-dashboard — progress counters

### What
- **API**: `GET /api/v1/translations/stats` — a no-input read-model query (mirrors `ListGameVersions`) returning `total / translated / approved / remaining` over the active (non-removed) catalog. Single `GROUP BY Status`, buckets in memory → one cheap round-trip regardless of catalog size. De-mediatorized in-house `IQueryHandler`, reads `IApplicationReadDbContext` (CQRS), behind `RequireTranslatorRole`.
- **Contract**: `TranslationStatsResponse(Total, Translated, Approved, Remaining)`.
- **Frontend**: `/dashboard` Blazor SSR page (route + nav link already existed from M3-01) — four stat cards + an approval progress bar, fed via the typed TMS client (no direct DB). Percent/counter math extracted to a pure, unit-tested `DashboardView`.

### Counter definitions (derived from the domain, not invented)
The `Translation` aggregate only reaches Draft/Approved/NeedsReview once Polish text exists:
- **Total** = non-removed rows
- **Translated** = Draft + Approved + NeedsReview (all carry Polish)
- **Approved** = Status == Approved
- **Remaining** = Total − Approved (work left to reach the distributable set)

### Acceptance criteria
- [x] Counters + progress bar correct — pinned by API unit (`FakeReadDbContext`), API integration (real PostgreSQL), and Frontend unit tests (incl. empty-catalog division-by-zero, soft-removed exclusion, rounding boundaries)
- [x] Data via API, no direct DB — Frontend goes through the typed `ITranslationSystemClient`
- [x] YAGNI — counters only, no analytics

### Tests
- API unit: `GetTranslationStatsHandlerTests` (4) — bucketing arithmetic, empty/mixed/soft-removed/no-approved
- API integration: `GetTranslationStatsTests` (4) — end-to-end vs PostgreSQL incl. 401
- Frontend unit: `DashboardViewTests` (percent matrix) + `DashboardStatsLoaderTests` (typed-client seam)

Build clean (zero warnings). code-reviewer verdict: APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)