### PR TITLE
M3-06: Frontend Dockerfile + join compose + bUnit component tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,6 +56,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="Spectre.Console" Version="0.53.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/compose.yaml
+++ b/compose.yaml
@@ -101,5 +101,33 @@ services:
       auth-api:
         condition: service_healthy
 
+  frontend:
+    build:
+      context: .
+      dockerfile: src/Frontend/LotroKoniecDev.Frontend/Dockerfile
+    ports:
+      - "5001:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: "http://+:8080"
+      # In-network base addresses the SSR server uses for its own HTTP calls (health probe + token
+      # endpoint). The TMS/auth APIs listen on :8080 inside the compose network.
+      TranslationSystem__BaseUrl: "http://tms-api:8080/"
+      AuthSystem__BaseUrl: "http://auth-api:8080/"
+      # OIDC Authority doubles as the metadata host (server-side) AND the URL the browser is redirected
+      # to (client-side); for an in-compose value both resolve to auth-api. A fully browser-functional
+      # login additionally needs HTTPS dev certs, a browser-reachable issuer, and the web client's
+      # redirect URI seeded for this host — deferred to its own reverse-proxy/forwarded-headers ADR
+      # (flagged in M3-01 #138); this service joins the stack and boots, matching the HTTP-only dev
+      # posture of the rest of the backend.
+      AuthSystem__Authority: "http://auth-api:8080"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://aspire-dashboard:18889"
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+    depends_on:
+      tms-api:
+        condition: service_healthy
+      auth-api:
+        condition: service_healthy
+
 volumes:
   lotrokoniecdev-postgres-data:

--- a/docs/adr/0005-frontend-data-protection-key-persistence.md
+++ b/docs/adr/0005-frontend-data-protection-key-persistence.md
@@ -1,0 +1,133 @@
+# ADR-0005: Persist Frontend Data Protection keys to a shared filesystem volume
+
+**Status:** Accepted
+**Date:** 2026-06-15
+**Decision-makers:** Solo maintainer
+**Related:** ticket #40 (M3-06 — Frontend Dockerfile + join compose), M3-01 #138 (lifted OIDC RP
+infra), M3-02 #139 (auth session UX), TheKittySaver ADR-0006 (the lifted decision — same
+data-protection posture), `Infrastructure/Auth/DataProtectionDependencyInjectionExtensions.cs`
+(the registration this ADR records)
+
+## Context
+
+`LotroKoniecDev.Frontend` (Blazor SSR) relies on ASP.NET Core **Data Protection** for every piece of
+client-held crypto material it issues:
+
+- the auth cookie `.lotrokoniecdev.auth`
+  (`AuthenticationDependencyInjectionExtensions.cs`), which carries the OIDC tokens via
+  `SaveTokens = true`;
+- the **antiforgery** tokens behind every mutation form — the Frontend is pure SSR, so every
+  `<form method="post">` surface (logout in `NavMenu.razor`, save / approve in `Editor.razor`)
+  depends on them;
+- the transient **OIDC correlation + nonce** cookies written during the login handshake.
+
+All three are encrypted/signed with the Data Protection keyring. The framework default keyring is
+**ephemeral and process-local** in a container: its default location lives under a home directory
+that is not persisted across `docker run` / image rebuild, so every redeploy mints a brand-new
+keyring. Past a single instance the same fault is structural — each replica generates its own
+keyring, so a cookie minted by replica A is undecryptable by replica B.
+
+A rotated/forked keyring breaks all three surfaces at once:
+
+| Surface | Failure when the keyring is not shared/persisted |
+|---|---|
+| `.lotrokoniecdev.auth` | Existing cookie can't be unprotected → silent mass logout on every deploy; load-balanced requests randomly 302 to login |
+| Antiforgery | POST tokens minted under the old key fail validation → every form submit 400s until the page is reloaded |
+| OIDC correlation/nonce | A login that starts on one key/replica and finishes on another fails with "Correlation failed" — login itself becomes flaky |
+
+Two constraints frame the choice:
+
+- **The Frontend is deliberately database-less.** Its csproj references no EF, no Npgsql, no Redis;
+  its contract with the backend is *typed HTTP clients, nothing else* (M3-01). Introducing a DB or
+  Redis purely to store keys would breach that boundary.
+- **Dev already persists keys by accident.** When the Frontend runs on the host via `dotnet run`
+  its default keyring at `~/.aspnet/DataProtection-Keys` survives restarts. The gap is exclusively
+  the containerized/multi-replica deployment — which is precisely what ticket #40 adds (the
+  Frontend Dockerfile + its `compose.yaml` service).
+
+This is the lifted twin of TheKittySaver ADR-0006; the registration code is a near 1:1 lift. It is
+**not** a contested business decision — it records the deployment posture the lifted infra already
+implements, made concrete now that #40 ships the container.
+
+## Decision
+
+### 1. Persist the keyring to the filesystem; path supplied by configuration
+
+`AddDataProtection().PersistKeysToFileSystem(new DirectoryInfo(path))` is registered when a keyring
+path is configured (`DataProtection:KeyRingPath`). The path is mounted to a Docker/host **volume**,
+so the keyring outlives container recreation. Filesystem is chosen over Redis/DB because it adds no
+new runtime component and no in-process data dependency to a database-less app.
+
+### 2. Pin a stable application name
+
+`SetApplicationName("LotroKoniecDev.Frontend")` in **every** environment. The application name is
+part of the Data Protection purpose/isolation; its default is the content-root path, which differs
+between host-dev and the container (`/app`) and is identical across replicas only by luck. Pinning
+one stable name is what makes a key created by one instance/path usable by another — without it a
+shared volume still yields per-path key isolation and the cookies stay mutually unreadable.
+
+### 3. Dev falls back to the framework default; only containers mount a path
+
+When `DataProtection:KeyRingPath` is empty, `PersistKeysToFileSystem` is **not** called — the
+host-dev default location already persists, and hardcoding a container path into dev would be wrong.
+The dev `compose.yaml` runs the Frontend under `ASPNETCORE_ENVIRONMENT=Development` and does **not**
+mount a keyring, so it intentionally uses the in-container ephemeral default: acceptable for a local
+smoke stack with no real sessions to preserve.
+
+### 4. Fail fast outside Development when the path is missing
+
+Outside Development, an empty `DataProtection:KeyRingPath` throws at startup. An ephemeral keyring in
+production is never intended — it silently invalidates every auth cookie / antiforgery token / OIDC
+correlation cookie on each deploy and makes multi-replica impossible. Loud over silent: the
+deployment is forced to mount a shared volume and point the keyring at it.
+
+### 5. The Dockerfile prepares the mount point but declares no `VOLUME`
+
+`src/Frontend/LotroKoniecDev.Frontend/Dockerfile` creates `/keys` owned by the non-root `app` user
+as the conventional mount point and documents the requirement. It deliberately omits a `VOLUME`
+instruction: an anonymous volume would silently mask a missing real mount and re-introduce the
+ephemeral-key failure under a false sense of safety. A named volume covers single-host
+restart/scale; multi-host needs a `ReadWriteMany` backend (NFS/EFS/Azure Files).
+
+## Consequences
+
+### Positive
+
+- Live sessions survive deploys and scale-out — no mass logout, no flaky login, no form 400s from a
+  rotated keyring.
+- No new runtime component: the database-less Frontend stays database-less.
+- The non-dev startup guard makes a mis-deploy fail immediately and legibly instead of degrading in
+  production.
+
+### Negative / Accepted trade-offs
+
+- The deployment must provision and mount a persistent volume and set `DataProtection:KeyRingPath` —
+  a one-line orchestration requirement, enforced by the startup guard.
+- Multi-host deployments need a shared (RWX) filesystem; a plain per-host named volume is
+  single-host only. Documented in the Dockerfile and here; revisit if/when multi-host is real
+  (YAGNI today).
+- The dev compose keyring is ephemeral by choice — restarting the `frontend` container logs out any
+  in-progress dev session. Acceptable for a local smoke stack.
+
+## Alternatives considered
+
+- **Store keys in Redis / a database.** Rejected — adds a runtime component and an in-process data
+  dependency to an app whose entire contract is "HTTP clients, nothing else"; filesystem + a mounted
+  volume achieves the same persistence with zero new infrastructure.
+- **Leave the framework default.** Rejected — ephemeral and process-local in a container; breaks all
+  three crypto surfaces on every deploy and is structurally impossible across replicas.
+- **Declare a `VOLUME /keys` in the Dockerfile.** Rejected — an anonymous volume masks a missing
+  real mount, so a misconfigured deploy would *look* fine while still minting a fresh keyring per
+  container. Preparing the directory without `VOLUME` keeps the missing-mount failure visible.
+
+## References
+
+- TheKittySaver `docs/adr/0006-frontend-data-protection-key-persistence.md` — the lifted decision
+  (same posture, near-identical registration code)
+- `src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DataProtectionDependencyInjectionExtensions.cs`
+  — the registration (stable application name, conditional `PersistKeysToFileSystem`, non-dev guard)
+- `src/Frontend/LotroKoniecDev.Frontend/Settings/DataProtectionSettings.cs` — the `KeyRingPath`
+  option and its semantics
+- `src/Frontend/LotroKoniecDev.Frontend/Dockerfile` — the `/keys` mount point + the "no `VOLUME`"
+  rationale
+- Ticket #40 (M3-06); M3-01 #138 (lifted OIDC RP infra)

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/PlaceholderAnalyzer.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/PlaceholderAnalyzer.cs
@@ -6,8 +6,8 @@ namespace LotroKoniecDev.Frontend.Components.Pages.Editor;
 /// so the page can highlight the markers without an interactive layer. The token is the inter-context
 /// file contract (a piece separator); the Frontend owns its own copy as a constant rather than
 /// referencing the frozen patcher, exactly as each bounded context owns its own parser. Kept isolated
-/// so the count / comparison / segmentation rules are unit-testable without rendering the component
-/// (the Frontend has no bUnit).
+/// so the count / comparison / segmentation rules are unit-testable directly, without paying the cost
+/// of rendering the component (the editor's render-level highlighting is covered separately by bUnit).
 /// </summary>
 internal static class PlaceholderAnalyzer
 {

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/TranslationEditorLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/TranslationEditorLoader.cs
@@ -10,8 +10,8 @@ namespace LotroKoniecDev.Frontend.Components.Pages.Editor;
 /// Drives the side-by-side editor's three TMS calls through the typed client: load one translation
 /// (<c>GET /api/v1/translations/{id}</c>), save the Polish (<c>PUT /api/v1/translations</c>, #100) and
 /// approve it (<c>POST /api/v1/translations/{id}/approve</c>, #101). Kept as a thin injectable seam so
-/// the editor's load / save / approve behavior is unit-testable end-to-end over a stubbed HTTP handler
-/// (the Frontend has no bUnit for component-level rendering tests).
+/// the editor's load / save / approve behavior is unit-testable end-to-end over a stubbed HTTP handler,
+/// and so a bUnit render test can drive the editor through a substituted loader.
 /// </summary>
 internal sealed class TranslationEditorLoader
 {

--- a/src/Frontend/LotroKoniecDev.Frontend/Dockerfile
+++ b/src/Frontend/LotroKoniecDev.Frontend/Dockerfile
@@ -1,0 +1,49 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+COPY ["Directory.Build.props", "./"]
+COPY ["Directory.Packages.props", "./"]
+COPY [".editorconfig", "./"]
+COPY ["src/Frontend/LotroKoniecDev.Frontend/LotroKoniecDev.Frontend.csproj", "src/Frontend/LotroKoniecDev.Frontend/"]
+COPY ["src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/LotroKoniecDev.TranslationSystem.Contracts.csproj", "src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/"]
+COPY ["src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/LotroKoniecDev.TranslationSystem.Primitives.csproj", "src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/"]
+COPY ["src/SharedKernel/LotroKoniecDev.SharedKernel/LotroKoniecDev.SharedKernel.csproj", "src/SharedKernel/LotroKoniecDev.SharedKernel/"]
+COPY ["src/Utilities/LotroKoniecDev.Hateoas.Abstractions/LotroKoniecDev.Hateoas.Abstractions.csproj", "src/Utilities/LotroKoniecDev.Hateoas.Abstractions/"]
+COPY ["src/Utilities/LotroKoniecDev.Options/LotroKoniecDev.Options.csproj", "src/Utilities/LotroKoniecDev.Options/"]
+
+RUN dotnet restore "src/Frontend/LotroKoniecDev.Frontend/LotroKoniecDev.Frontend.csproj"
+ARG CACHEBUST=0
+COPY . .
+WORKDIR "/src/src/Frontend/LotroKoniecDev.Frontend"
+RUN dotnet build "./LotroKoniecDev.Frontend.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./LotroKoniecDev.Frontend.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+
+# Data Protection keyring mount point (ADR-0005). A non-dev deployment MUST mount a shared/persistent
+# volume here and set DataProtection__KeyRingPath=/keys, or the startup guard fails fast. A named
+# volume covers single-host restart/scale; multi-host needs ReadWriteMany (NFS/EFS/Azure Files). No
+# VOLUME instruction on purpose: an anonymous volume would silently mask a missing mount. The dev
+# compose runs under Development, where an empty keyring path is valid (host-default location), so
+# this directory is unused there.
+USER root
+RUN mkdir -p /keys && chown app:app /keys
+USER app
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8080/ || exit 1
+
+ENTRYPOINT ["dotnet", "LotroKoniecDev.Frontend.dll"]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/NavMenuTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/NavMenuTests.cs
@@ -1,0 +1,82 @@
+using AngleSharp.Dom;
+using Bunit.Rendering;
+using Bunit.TestDoubles;
+using LotroKoniecDev.Frontend.Components.Layout;
+using LotroKoniecDev.Frontend.Infrastructure.Auth;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Layout;
+
+/// <summary>
+/// Renders <see cref="NavMenu"/> through bUnit to lock the two authentication states down at the markup
+/// level: an anonymous visitor is offered the login link, an authenticated translator is shown their
+/// name plus a logout form. The link targets are the auth module's canonical paths, so a future rename
+/// of those constants surfaces here instead of as a dead button in the browser.
+/// </summary>
+public sealed class NavMenuTests : BunitContext
+{
+    public NavMenuTests()
+    {
+        // The authenticated branch renders an <AntiforgeryToken/> inside the logout form.
+        Services.AddAntiforgery();
+    }
+
+    [Fact]
+    public void Render_WhenAnonymous_ShowsTheLoginLinkAndNoLogoutForm()
+    {
+        this.AddAuthorization().SetNotAuthorized();
+
+        IRenderedComponent<NavMenu> component = RenderNavMenu();
+
+        IElement loginLink = component.Find("a.btn-primary");
+        loginLink.GetAttribute("href").ShouldBe(AuthenticationDependencyInjectionExtensions.LoginPath);
+        component.FindAll("form").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenAuthenticated_ShowsTheUserNameAndALogoutFormPostingToTheLogoutPath()
+    {
+        this.AddAuthorization().SetAuthorized("Frodo");
+
+        IRenderedComponent<NavMenu> component = RenderNavMenu();
+
+        component.Find("span.auth-user").TextContent.ShouldBe("Frodo");
+
+        IElement logoutForm = component.Find("form");
+        logoutForm.GetAttribute("method").ShouldBe("post");
+        logoutForm.GetAttribute("action").ShouldBe(AuthenticationDependencyInjectionExtensions.LogoutPath);
+        component.FindAll("a.btn-primary").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_Always_ShowsTheCoreNavigationLinksInOrder()
+    {
+        this.AddAuthorization().SetNotAuthorized();
+
+        IRenderedComponent<NavMenu> component = RenderNavMenu();
+
+        string[] navTargets = component
+            .FindAll("nav.sidebar-nav a")
+            .Select(anchor => anchor.GetAttribute("href")!)
+            .ToArray();
+
+        navTargets.ShouldBe(["/", "/translations", "/import-export", "/dashboard"]);
+    }
+
+    /// <summary>
+    /// Hosts <see cref="NavMenu"/> inside a render fragment and resolves it via
+    /// <c>FindComponent</c>. The component's <see cref="Microsoft.AspNetCore.Components.Authorization.AuthorizeView"/>
+    /// resolves asynchronously, which the typed <c>Render&lt;NavMenu&gt;</c> discovery does not see on its
+    /// first synchronous pass for a parameterless component; the fragment seam renders it reliably.
+    /// </summary>
+    private IRenderedComponent<NavMenu> RenderNavMenu()
+    {
+        IRenderedComponent<ContainerFragment> fragment = Render(builder =>
+        {
+            builder.OpenComponent<NavMenu>(0);
+            builder.CloseComponent();
+        });
+
+        return fragment.FindComponent<NavMenu>();
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
@@ -1,0 +1,157 @@
+using AngleSharp.Dom;
+using Bunit.TestDoubles;
+using LotroKoniecDev.Frontend.Components.Pages.Editor;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using EditorComponent = LotroKoniecDev.Frontend.Components.Pages.Editor.Editor;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Editor;
+
+/// <summary>
+/// Renders the side-by-side <see cref="EditorComponent"/> through bUnit over a stubbed TMS client,
+/// locking down the render wiring the pure <see cref="PlaceholderAnalyzer"/> tests cannot reach: that
+/// every <c>&lt;--DO_NOT_TOUCH!--&gt;</c> marker in the English source is wrapped in a highlight span,
+/// and that a placeholder-count mismatch between source and the persisted Polish surfaces the advisory
+/// warning (the M3-04 placeholder validation feature). The authenticated-but-non-approver state keeps
+/// the assertions on the highlighting path.
+/// </summary>
+public sealed class EditorTests : BunitContext
+{
+    private const string Token = "<--DO_NOT_TOUCH!-->";
+
+    private readonly ITranslationSystemClient _client = Substitute.For<ITranslationSystemClient>();
+
+    public EditorTests()
+    {
+        Services.AddAntiforgery();
+        Services.AddSingleton(_client);
+        Services.AddScoped<TranslationEditorLoader>();
+        this.AddAuthorization().SetAuthorized("Frodo");
+    }
+
+    [Fact]
+    public void Render_WhenSourceHasMarkers_HighlightsEveryPlaceholderMarkerInTheEnglishSource()
+    {
+        StubLoad(BuildDetail(
+            sourceText: $"You gained {Token} of {Token}.",
+            translatedText: $"Zdobyto {Token} z {Token}."));
+
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        IReadOnlyList<IElement> highlights = component.FindAll(".editor-source .ph-token");
+        highlights.Count.ShouldBe(2);
+        highlights.ShouldAllBe(span => span.TextContent == Token);
+    }
+
+    [Fact]
+    public void Render_WhenSourceHasNoMarkers_RendersTheSourceWithoutAnyHighlightSpans()
+    {
+        StubLoad(BuildDetail(sourceText: "Plain English line.", translatedText: "Zwykły polski."));
+
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        component.Find(".editor-source").TextContent.ShouldBe("Plain English line.");
+        component.FindAll(".editor-source .ph-token").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenTranslationDropsAMarker_ShowsThePlaceholderMismatchWarning()
+    {
+        StubLoad(BuildDetail(
+            sourceText: $"You have {Token} of {Token} items.",
+            translatedText: $"Masz {Token} przedmiotów."));
+
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        IElement warning = component.Find(".status-warning");
+        warning.TextContent.ShouldContain("Liczba znaczników się nie zgadza");
+    }
+
+    [Fact]
+    public void Render_WhenPlaceholderCountsMatch_DoesNotShowTheMismatchWarning()
+    {
+        StubLoad(BuildDetail(
+            sourceText: $"You gained {Token} reputation.",
+            translatedText: $"Zdobyto {Token} reputacji."));
+
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        component.FindAll(".status-warning").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenTheRowFailsToLoad_RendersTheLoadErrorInsteadOfTheEditorGrid()
+    {
+        _client
+            .GetApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Nie znaleziono." }));
+
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        component.Find(".status-down").TextContent.ShouldContain("Nie znaleziono.");
+        component.FindAll(".editor-grid").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenRowWasInvalidatedByAnUpdate_ShowsTheSupersededEnglishWithItsOwnHighlighting()
+    {
+        // spec 0001 re-review path: a game update superseded the English; the editor keeps the previous
+        // version visible for comparison, highlighting its placeholders just like the current source.
+        StubLoad(BuildDetail(
+            sourceText: $"You gained {Token} renown.",
+            translatedText: $"Zdobyto {Token} sławy.",
+            previousSourceText: $"You earned {Token} renown."));
+
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        IElement superseded = component.Find(".editor-superseded .editor-source");
+        superseded.TextContent.ShouldBe("You earned <--DO_NOT_TOUCH!--> renown.");
+        superseded.QuerySelectorAll(".ph-token").Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Render_WhenRowHasNoPreviousSource_DoesNotRenderTheSupersededBlock()
+    {
+        StubLoad(BuildDetail(
+            sourceText: $"You gained {Token} renown.",
+            translatedText: $"Zdobyto {Token} sławy."));
+
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        component.FindAll(".editor-superseded").ShouldBeEmpty();
+    }
+
+    private IRenderedComponent<EditorComponent> RenderEditor() =>
+        Render<EditorComponent>(parameters => parameters.Add(component => component.Id, Guid.NewGuid()));
+
+    private void StubLoad(TranslationDetailResponse detail)
+    {
+        _client
+            .GetApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(detail));
+    }
+
+    private static TranslationDetailResponse BuildDetail(
+        string sourceText,
+        string? translatedText,
+        string? previousSourceText = null) =>
+        new(
+            new TranslationId(Guid.NewGuid()),
+            FileId: 620756992,
+            GossipId: 1002,
+            SourceText: sourceText,
+            ArgsOrder: null,
+            ArgsId: null,
+            TranslatedText: translatedText,
+            PreviousSourceText: previousSourceText,
+            Submitter: null,
+            Approver: null,
+            Status: TranslationStatus.Draft,
+            CreatedAt: DateTimeOffset.UnixEpoch,
+            UpdatedAt: DateTimeOffset.UnixEpoch);
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="bunit" />
         <PackageReference Include="coverlet.collector">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -25,6 +26,7 @@
     <ItemGroup>
         <Using Include="Xunit" />
         <Using Include="Shouldly" />
+        <Using Include="Bunit" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Closes #40

## M3-06: Frontend Dockerfile + join compose + frontend tests

- **Dockerfile** (`src/Frontend/LotroKoniecDev.Frontend/Dockerfile`) — multi-stage (sdk build/publish → aspnet runtime), mirrors the TMS/Auth API Dockerfiles; non-root `app` user, curl-backed healthcheck on `/` (anonymous Home page), `/keys` Data Protection keyring mount point documented per ADR-0005 (no `VOLUME` on purpose).
- **compose** — new `frontend` service alongside postgres/migrator/auth-api/tms-api: in-network base URLs to `tms-api`/`auth-api`, OTel → aspire, `depends_on` both APIs healthy, host port `5001:8080`. Boots in the HTTP-only dev posture of the rest of the backend; a fully browser-functional OIDC login (HTTPS dev certs, browser-reachable issuer, redirect-URI seeding) is deliberately deferred to its own reverse-proxy/forwarded-headers ADR (flagged in M3-01 #138) — outside this ticket's acceptance criteria.
- **bUnit tests** — added `bunit` 2.7.2 to the catalog; test project switched to `Microsoft.NET.Sdk.Razor`. New render tests: `NavMenu` (anonymous vs authenticated auth states + nav-link set), `Editor` (placeholder highlighting, count-mismatch warning, the spec-0001 superseded-source re-review block present/absent, and the load-error path).
- **ADR-0005** — records the Frontend Data Protection key-persistence posture (lifted twin of TheKittySaver ADR-0006).

### Acceptance criteria
- [x] `docker compose up` includes the Frontend — `docker compose config` validates the wired `frontend` service.
- [x] Key components tested — 10 bUnit tests (NavMenu + Editor) over the rendered DOM.

### Verification
- `dotnet build LotroKoniecDev.slnx` — green, 0 warnings.
- Frontend test project — 147 passing (137 pre-existing + 10 new bUnit).
- code-reviewer agent: APPROVE. `/security-review`: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)