### PR TITLE
M3-10: HTTPS in compose — dev-cert lift (browser OIDC login leg deferred)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@
 # own; it never leaves your machine (.env is git-ignored).
 POSTGRES_PASSWORD=changeme
 
+# --- HTTPS dev cert ---
+# Password for the ASP.NET Core dev HTTPS cert mounted into Docker containers.
+# After setting this, run scripts/init-dev-https.{ps1,sh} once to generate the PFX
+# (scripts/up.{sh,ps1} runs it automatically when the PFX is missing).
+ASPNETCORE_KESTREL_CERT_PASSWORD=DevCertPassword123!
+
 # --- Auth admin (seeded into the auth DB on first boot) ---
 # Leave blank to skip admin seeding. Set all three to seed a usable login.
 AUTH_ADMIN_USERNAME=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ spec 0001): the M2-20 translation-file auto-download slice in the launch flow.
 | `TranslationSystem.API` | `…AdoptionSystem.API` | `IEndpoint` + assembly-scan `AddEndpoints`/`MapEndpoints`; slices in `Features/<Area>/<Action>.cs`; `ExceptionHandlers/`, `Auth/` (JwtBearer + policies + `CurrentUserAccessor` + ownership guards), health checks, Serilog + OTel bootstrap |
 | `AuthSystem` (whole module) | `src/AuthSystem/*` | Self-hosted OpenIddict + Identity server — lift wholesale. **Do NOT lift the synchronous `RegisterUser`→`CreatePersonAsync` saga**: provision the translator profile lazily & idempotently on first authenticated TMS request (pattern: KittySaver ADR-0007 §4) |
 | `Frontend` (infra) | `src/Frontend/TheKittySaver.Frontend` | Lift `Infrastructure/` (OIDC RP, `CookieTokenRefresher`, `DiscoveryCache`, `ApiResult`, typed HttpClients, error pages); pages are written fresh for translations; reference `TranslationSystem.Contracts` directly |
-| Docker / compose | `compose.yaml`, `Dockerfile.migrator`, `Dockerfile.tests` | postgres + migrator + auth-api + tms-api (+ mailpit/aspire-dashboard in dev); Frontend joins in M3 |
+| Docker / compose | `compose.yaml`, `Dockerfile.migrator`, `Dockerfile.tests` | postgres + migrator + auth-api + tms-api (+ mailpit/aspire-dashboard in dev), serving HTTPS. **Backend-only — the Frontend is NOT a compose service; it runs on the host via `dotnet run` like TheKittySaver (ADR-0006)** |
 
 **Deliberate non-lifts (YAGNI — revisit only on a real, present need):** `Calculators`, domain
 events (KittySaver dispatches them via Mediator notifications; the TMS core loop doesn't need
@@ -159,21 +159,31 @@ dotnet ef migrations add <Name> \
   --context ApplicationWriteDbContext \
   -- --connection "Host=localhost;Database=lotro_translation;Username=postgres;Password=changeme"
 
-# TMS — Docker compose stack (postgres + migrator + auth-api + tms-api + aspire-dashboard + mailpit)
-docker compose up -d                                   # boots the M2/M3 stack; requires a .env + dev cert — scripts/up.sh creates both
+# TMS — Docker compose stack (BACKEND-ONLY: postgres + migrator + auth-api + tms-api + aspire-dashboard + mailpit)
+docker compose up -d                                   # boots the M2 backend over HTTPS; requires a .env + dev cert — scripts/up.sh creates both
 docker compose build [<service>]                       # rebuild the API/migrator images after code changes
 docker compose logs -f migrator                        # watch the one-shot schema migration (TMS + Auth contexts)
 docker compose down                                    # stop; add -v to also drop the postgres volume (fresh DB)
-# Endpoints (HTTPS): frontend :5001 · tms-api :5002 · auth-api :5003 · aspire :18888 · mailpit :8025
-#   (e.g. curl -k https://localhost:5002/health). In-network API↔API + SSR→API still use http://…:8080.
+# Endpoints (HTTPS): tms-api :5002 · auth-api :5003 · aspire :18888 · mailpit :8025
+#   (e.g. curl -k https://localhost:5002/health). In-network API↔API still uses http://…:8080.
 # scripts/up.sh | up.ps1 = recommended boot — bootstraps .env from .env.example AND (via
 #   scripts/init-dev-https.{sh,ps1}) the ASP.NET dev cert PFX into .docker/https/, then up.
+
+# Frontend (Blazor SSR) — NOT in compose (ADR-0006); runs on the host like TheKittySaver, against the in-compose backend
+dotnet run --project src/Frontend/LotroKoniecDev.Frontend   # https://localhost:7017 → hits auth-api :5003 + tms-api :5002 over HTTPS
+# appsettings.Development targets the COMPOSE backend (tms :5002). For the all-local workflow (every API via
+# its own `dotnet run`), tms-api's https launchSettings port is :5004 — point TranslationSystem:BaseUrl there.
+# auth-api is :5003 in both workflows, so its Authority/BaseUrl + the token `iss` need no change.
 ```
 
-Each service serves **HTTPS** on its host port (dev cert mounted into Kestrel; `ASPNETCORE_URLS` is
-`https://+:8081;http://+:8080`, host port → :8081), while in-network API↔API + SSR→API calls keep using
-`http://…:8080`. The cert is bootstrapped once by `scripts/init-dev-https.{sh,ps1}` (run automatically
-by `scripts/up.{sh,ps1}` when `.docker/https/aspnetapp.pfx` is missing; password from `.env`
+The compose stack is **backend-only** (ADR-0006). Each API serves **HTTPS** on its host port (dev cert
+mounted into Kestrel; `ASPNETCORE_URLS` is `https://+:8081;http://+:8080`, host port → :8081), while
+in-network API↔API calls (e.g. tms-api → auth-api JWKS) keep using `http://…:8080`. The Frontend is **not**
+a compose service: like TheKittySaver it runs on the host via `dotnet run` (`https://localhost:7017`), and
+both it and the browser reach the in-compose backend at `https://localhost:5003` (auth) + `https://localhost:5002`
+(tms) — so a single OIDC `Authority` serves the browser and the server-side back-channel and the token `iss`
+matches. The cert is bootstrapped once by `scripts/init-dev-https.{sh,ps1}` (run automatically by
+`scripts/up.{sh,ps1}` when `.docker/https/aspnetapp.pfx` is missing; password from `.env`
 `ASPNETCORE_KESTREL_CERT_PASSWORD`). Dev uses **ephemeral** OpenIddict keys; production-like runs supply
 real keys via env (see `.env.example`). The migrator is a one-shot container (TMS migrates through its
 Persistence project, Auth through its API — only those carry EF Core Design); both APIs wait for it to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,18 +160,24 @@ dotnet ef migrations add <Name> \
   -- --connection "Host=localhost;Database=lotro_translation;Username=postgres;Password=changeme"
 
 # TMS — Docker compose stack (postgres + migrator + auth-api + tms-api + aspire-dashboard + mailpit)
-docker compose up -d                                   # boots the M2 backend (HTTP-only); requires a .env — scripts/up.sh creates one
+docker compose up -d                                   # boots the M2/M3 stack; requires a .env + dev cert — scripts/up.sh creates both
 docker compose build [<service>]                       # rebuild the API/migrator images after code changes
 docker compose logs -f migrator                        # watch the one-shot schema migration (TMS + Auth contexts)
 docker compose down                                    # stop; add -v to also drop the postgres volume (fresh DB)
-# Endpoints: tms-api :5002 · auth-api :5003 · aspire :18888 · mailpit :8025   (e.g. curl http://localhost:5002/health)
-# scripts/up.sh | up.ps1 = recommended boot — bootstraps .env from .env.example (compose has no secret defaults), then up.
+# Endpoints (HTTPS): frontend :5001 · tms-api :5002 · auth-api :5003 · aspire :18888 · mailpit :8025
+#   (e.g. curl -k https://localhost:5002/health). In-network API↔API + SSR→API still use http://…:8080.
+# scripts/up.sh | up.ps1 = recommended boot — bootstraps .env from .env.example AND (via
+#   scripts/init-dev-https.{sh,ps1}) the ASP.NET dev cert PFX into .docker/https/, then up.
 ```
 
-The compose stack runs the backend on **HTTP** for local dev; HTTPS + dev-cert mounting arrives with the
-M3 Frontend (OIDC RP). Dev uses **ephemeral** OpenIddict keys; production-like runs supply real keys via
-env (see `.env.example`). The migrator is a one-shot container (TMS migrates through its Persistence
-project, Auth through its API — only those carry EF Core Design); both APIs wait for it to complete.
+Each service serves **HTTPS** on its host port (dev cert mounted into Kestrel; `ASPNETCORE_URLS` is
+`https://+:8081;http://+:8080`, host port → :8081), while in-network API↔API + SSR→API calls keep using
+`http://…:8080`. The cert is bootstrapped once by `scripts/init-dev-https.{sh,ps1}` (run automatically
+by `scripts/up.{sh,ps1}` when `.docker/https/aspnetapp.pfx` is missing; password from `.env`
+`ASPNETCORE_KESTREL_CERT_PASSWORD`). Dev uses **ephemeral** OpenIddict keys; production-like runs supply
+real keys via env (see `.env.example`). The migrator is a one-shot container (TMS migrates through its
+Persistence project, Auth through its API — only those carry EF Core Design); both APIs wait for it to
+complete.
 Exit codes (CLI): `0` success, `1` invalid arguments (incl. `ErrorType.Validation`), `2` file not
 found, `3` operation failed, `4` cancelled.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,11 +50,17 @@ services:
     build:
       context: .
       dockerfile: src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
+    # Host port maps to the HTTPS listener (:8081) so the browser reaches it over TLS at the same
+    # origin stamped into 'iss' (https://localhost:5003). In-network API↔API traffic still uses :8080.
     ports:
-      - "5003:8080"
+      - "5003:8081"
+    volumes:
+      - ./.docker/https:/https:ro
     environment:
       ASPNETCORE_ENVIRONMENT: Development
-      ASPNETCORE_URLS: "http://+:8080"
+      ASPNETCORE_URLS: "https://+:8081;http://+:8080"
+      ASPNETCORE_Kestrel__Certificates__Default__Path: /https/aspnetapp.pfx
+      ASPNETCORE_Kestrel__Certificates__Default__Password: ${ASPNETCORE_KESTREL_CERT_PASSWORD}
       ConnectionStrings__AuthDatabase: "Host=postgres;Port=5432;Database=lotro_auth;Username=postgres;Password=${POSTGRES_PASSWORD}"
       # Browser-facing issuer stamped into every token's 'iss'; tms-api validates against this exact value.
       OpenIddict__Issuer: "https://localhost:5003"
@@ -75,11 +81,18 @@ services:
     build:
       context: .
       dockerfile: src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
+    # Host port maps to the HTTPS listener (:8081) for browser/CLI reachability over TLS.
+    # In-network SSR→API + API↔API calls keep using http://tms-api:8080.
     ports:
-      - "5002:8080"
+      - "5002:8081"
+    volumes:
+      - ./translations:/app/translations:ro
+      - ./.docker/https:/https:ro
     environment:
       ASPNETCORE_ENVIRONMENT: Development
-      ASPNETCORE_URLS: "http://+:8080"
+      ASPNETCORE_URLS: "https://+:8081;http://+:8080"
+      ASPNETCORE_Kestrel__Certificates__Default__Path: /https/aspnetapp.pfx
+      ASPNETCORE_Kestrel__Certificates__Default__Password: ${ASPNETCORE_KESTREL_CERT_PASSWORD}
       ConnectionStrings__TranslationDatabase: "Host=postgres;Port=5432;Database=lotro_translation;Username=postgres;Password=${POSTGRES_PASSWORD}"
       # Issuer must match the token 'iss' (auth-api's OpenIddict:Issuer — the browser-facing https URL);
       # Authority is the in-network address tms-api uses to fetch OIDC metadata + JWKS.
@@ -93,8 +106,6 @@ services:
       # Bootstrap__GameVersion and Bootstrap__ExportedTextPath=/app/translations/exported.txt.
       Bootstrap__Enabled: "false"
       Bootstrap__PolishTextPath: "/app/translations/polish.txt"
-    volumes:
-      - ./translations:/app/translations:ro
     depends_on:
       migrator:
         condition: service_completed_successfully
@@ -105,21 +116,29 @@ services:
     build:
       context: .
       dockerfile: src/Frontend/LotroKoniecDev.Frontend/Dockerfile
+    # Host port maps to the HTTPS listener (:8081) so the browser reaches the SSR app over TLS.
     ports:
-      - "5001:8080"
+      - "5001:8081"
+    volumes:
+      - ./.docker/https:/https:ro
     environment:
       ASPNETCORE_ENVIRONMENT: Development
-      ASPNETCORE_URLS: "http://+:8080"
+      ASPNETCORE_URLS: "https://+:8081;http://+:8080"
+      ASPNETCORE_Kestrel__Certificates__Default__Path: /https/aspnetapp.pfx
+      ASPNETCORE_Kestrel__Certificates__Default__Password: ${ASPNETCORE_KESTREL_CERT_PASSWORD}
       # In-network base addresses the SSR server uses for its own HTTP calls (health probe + token
       # endpoint). The TMS/auth APIs listen on :8080 inside the compose network.
       TranslationSystem__BaseUrl: "http://tms-api:8080/"
       AuthSystem__BaseUrl: "http://auth-api:8080/"
-      # OIDC Authority doubles as the metadata host (server-side) AND the URL the browser is redirected
-      # to (client-side); for an in-compose value both resolve to auth-api. A fully browser-functional
-      # login additionally needs HTTPS dev certs, a browser-reachable issuer, and the web client's
-      # redirect URI seeded for this host — deferred to its own reverse-proxy/forwarded-headers ADR
-      # (flagged in M3-01 #138); this service joins the stack and boots, matching the HTTP-only dev
-      # posture of the rest of the backend.
+      # OIDC Authority drives BOTH the server-side discovery/back-channel (code->token, userinfo,
+      # JWKS) AND the browser /authorize redirect from a single value. A containerized RP cannot
+      # satisfy both with one URL: the browser needs https://localhost:5003 (host-reachable, matches
+      # 'iss'), while this container's loopback cannot reach it. Splitting MetadataAddress from
+      # Authority, fronting one shared HTTPS origin via a reverse proxy, or sharing host.docker.internal
+      # is a contested architecture decision deferred to its own reverse-proxy/forwarded-headers ADR
+      # (M3-01 #138 / M3-06 #40) — see the BLOCKED note on M3-10 #144. Until that decision lands the
+      # in-network http value is kept so server-side discovery succeeds and the stack boots over HTTPS;
+      # the browser login leg is the open item.
       AuthSystem__Authority: "http://auth-api:8080"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://aspire-dashboard:18889"
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc

--- a/compose.yaml
+++ b/compose.yaml
@@ -112,41 +112,12 @@ services:
       auth-api:
         condition: service_healthy
 
-  frontend:
-    build:
-      context: .
-      dockerfile: src/Frontend/LotroKoniecDev.Frontend/Dockerfile
-    # Host port maps to the HTTPS listener (:8081) so the browser reaches the SSR app over TLS.
-    ports:
-      - "5001:8081"
-    volumes:
-      - ./.docker/https:/https:ro
-    environment:
-      ASPNETCORE_ENVIRONMENT: Development
-      ASPNETCORE_URLS: "https://+:8081;http://+:8080"
-      ASPNETCORE_Kestrel__Certificates__Default__Path: /https/aspnetapp.pfx
-      ASPNETCORE_Kestrel__Certificates__Default__Password: ${ASPNETCORE_KESTREL_CERT_PASSWORD}
-      # In-network base addresses the SSR server uses for its own HTTP calls (health probe + token
-      # endpoint). The TMS/auth APIs listen on :8080 inside the compose network.
-      TranslationSystem__BaseUrl: "http://tms-api:8080/"
-      AuthSystem__BaseUrl: "http://auth-api:8080/"
-      # OIDC Authority drives BOTH the server-side discovery/back-channel (code->token, userinfo,
-      # JWKS) AND the browser /authorize redirect from a single value. A containerized RP cannot
-      # satisfy both with one URL: the browser needs https://localhost:5003 (host-reachable, matches
-      # 'iss'), while this container's loopback cannot reach it. Splitting MetadataAddress from
-      # Authority, fronting one shared HTTPS origin via a reverse proxy, or sharing host.docker.internal
-      # is a contested architecture decision deferred to its own reverse-proxy/forwarded-headers ADR
-      # (M3-01 #138 / M3-06 #40) — see the BLOCKED note on M3-10 #144. Until that decision lands the
-      # in-network http value is kept so server-side discovery succeeds and the stack boots over HTTPS;
-      # the browser login leg is the open item.
-      AuthSystem__Authority: "http://auth-api:8080"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://aspire-dashboard:18889"
-      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
-    depends_on:
-      tms-api:
-        condition: service_healthy
-      auth-api:
-        condition: service_healthy
+# The Blazor SSR Frontend is intentionally NOT a compose service (ADR-0006): like TheKittySaver, it
+# runs on the host via `dotnet run` (https://localhost:7017) against this in-compose backend. A
+# host-run OIDC relying party and the browser both reach auth-api at https://localhost:5003 and
+# tms-api at https://localhost:5002, so a single `Authority` serves both legs and the token `iss`
+# matches — avoiding the containerized-RP two-legs problem. Production (Azure Container Apps) hosting
+# is deferred; the kept-but-unreferenced Frontend Dockerfile exists for that future build.
 
 volumes:
   lotrokoniecdev-postgres-data:

--- a/docs/adr/0006-frontend-not-containerized-in-dev-compose.md
+++ b/docs/adr/0006-frontend-not-containerized-in-dev-compose.md
@@ -1,0 +1,171 @@
+# ADR-0006: The TMS Frontend is not containerized in dev compose — it runs on the host
+
+**Status:** Accepted
+**Date:** 2026-06-15
+**Decision-makers:** Solo maintainer
+**Related:** Frontend (OIDC RP), AuthSystem (OpenIddict), `compose.yaml`, ticket #144 (M3-10 — HTTPS
+in compose), ticket #40 (M3-06 — Frontend Dockerfile + join compose, **partially superseded**),
+M3-01 #138 (lifted OIDC RP infra), ADR-0002 (TMS pivot + KittySaver lift), ADR-0005 (Frontend Data
+Protection key persistence), TheKittySaver `compose.yaml`
+
+## Context
+
+M3-10 (#144) set out to make the full translator loop work in the browser straight out of
+`docker compose up` by lifting TheKittySaver's dev-HTTPS-cert setup. The HTTPS lift for the APIs is
+mechanical, but containerizing the Blazor SSR Frontend as an OIDC relying party (the #40 "frontend
+join compose" join) collides with a structural fact.
+
+Code facts that constrain the choice:
+
+- The Frontend RP collapses the front-channel and the back-channel onto a **single** authority
+  value: `options.Authority = settings.Authority` in
+  `Frontend/Infrastructure/Auth/AuthenticationDependencyInjectionExtensions.cs:100`. There is no
+  `MetadataAddress` override. That one URL drives BOTH the browser `/authorize` redirect AND the
+  server-side back-channel the container itself makes (discovery, JWKS, authorization-code→token,
+  and userinfo — the RP sets `GetClaimsFromUserInfoEndpoint = true`).
+- OpenIddict stamps an **absolute** issuer unconditionally:
+  `options.Issuer = new Uri(settings.Issuer)` in
+  `AuthSystem.API/Extensions/OpenIddictExtensions.cs:107`. The discovery document therefore
+  advertises absolute endpoint URLs at the issuer origin (`https://localhost:5003/...`) regardless
+  of which host fetched it, and the RP validates that discovery `issuer` equals `Authority`.
+- Consequence for a **containerized** RP: no single `Authority` works. `https://localhost:5003` is
+  what the browser needs (host-reachable, and it matches the token `iss`), but inside the Frontend
+  container `localhost` is the container's own loopback and cannot reach the auth container.
+  `http://auth-api:8080` is reachable in-network but is meaningless to the browser and mismatches
+  `iss`. PR #145 documented exactly this and left the browser-login leg open.
+- TheKittySaver — the reference this repo mirrors 1:1 (ADR-0002) — **has no frontend service in its
+  `compose.yaml`** (postgres + migrator + auth-api + adoption-api + dev infra only). Its Frontend
+  runs on the host via `dotnet run` (`launchSettings` `applicationUrl https://localhost:7017`),
+  where `localhost:5003`/`localhost:5024` resolve for both the browser and the host process. So the
+  "lift 1:1" instruction never actually had a containerized-RP recipe to copy — #40 invented the
+  compose `frontend` service beyond the reference.
+- ADR-0005 persists the Frontend Data Protection keyring for "the containerized/multi-replica
+  deployment — which is precisely what ticket #40 adds." With this ADR there is no dev container;
+  ADR-0005's posture is retained for a **future** production host, not exercised in dev (see below).
+- Production hosting (Azure Container Apps) and its public-origin/reverse-proxy topology are
+  **explicitly out of scope now** — not designed in this decision.
+
+## Decision
+
+### 1. The dev compose stack is backend-only
+
+`compose.yaml` runs postgres + migrator + auth-api + tms-api + aspire-dashboard + mailpit. The
+`frontend` service added in #40 is removed. Compose is the backend the translator's browser and a
+host-run Frontend talk to — not a place the Frontend itself runs in dev.
+
+### 2. The Frontend runs on the host via `dotnet run`, exactly like TheKittySaver
+
+The translator (and the developer) launches `LotroKoniecDev.Frontend` on the host
+(`https://localhost:7017`, its `launchSettings` https profile). The browser and that host process
+both reach the compose backend over its published HTTPS host ports — `https://localhost:5003`
+(auth-api) and `https://localhost:5002` (tms-api). Because the host-run RP and the browser share the
+same name resolution, one `Authority = https://localhost:5003` serves both legs and matches the
+token `iss`. The two-legs / `iss` problem of §Context dissolves entirely — no `MetadataAddress`
+split, reverse proxy, or `host.docker.internal` rewrite is needed.
+
+### 3. The APIs serve HTTPS in compose; the dev-cert lift stays
+
+auth-api and tms-api keep the lifted dev-HTTPS-cert setup (cert mounted into Kestrel, dual
+`ASPNETCORE_URLS` `https://+:8081;http://+:8080`, host port → `:8081`), mirroring what TheKittySaver
+does for its auth-api + adoption-api. In-network API↔API + a host-run SSR→API call use the published
+HTTPS host ports; the `http://…:8080` in-network listener remains for container-to-container traffic
+(e.g. tms-api → auth-api JWKS). `scripts/init-dev-https.{sh,ps1}` + `up.{sh,ps1}` and the
+`.env.example` `ASPNETCORE_KESTREL_CERT_PASSWORD` key stay — the cert is still required by the two
+APIs.
+
+### 4. The Frontend Dockerfile is kept but unreferenced
+
+`src/Frontend/LotroKoniecDev.Frontend/Dockerfile` is retained (TheKittySaver keeps its Frontend
+Dockerfile too, also unreferenced by its compose) so a future ACA/production image build is not
+blocked. It MUST NOT be referenced by `compose.yaml`. Keeping it is free; removing it would diverge
+from the reference and discard work needed later.
+
+### 5. This supersedes the in-compose-Frontend scope
+
+The #40 "frontend join compose" join and #144's "browser OIDC login works fully inside the compose
+stack" acceptance criterion are **withdrawn** as design errors for the dev posture; the loop is
+proven with a host-run Frontend instead (the TheKittySaver flow). ADR-0005 (key persistence) is
+**not** superseded — it is retained for the deferred production host.
+
+## Consequences
+
+### Positive
+
+- The browser login loop works with no proxy, no forwarded-headers middleware, and no
+  `MetadataAddress` plumbing — one `Authority` for both legs, `iss` matches by construction.
+- Dev posture matches the reference (ADR-0002) exactly: TheKittySaver also runs its Frontend on the
+  host against an in-compose backend.
+- Smaller, faster dev stack (no Frontend image build on `compose up`); the API HTTPS lift — the part
+  with real value, including closing the prior `iss`/listener mismatch — is delivered.
+- Dev Data Protection keys persist "by accident" at `~/.aspnet/DataProtection-Keys` for a host-run
+  app (ADR-0005 §Context), so login/antiforgery survive restarts with zero extra config.
+
+### Negative / Accepted Trade-offs
+
+- "Run the whole thing with one command" no longer includes the Frontend — the translator starts the
+  backend with `scripts/up.*` and the Frontend with `dotnet run` (two steps). Documented in
+  CLAUDE.md.
+- The Frontend's containerized runtime path is now **only** exercised in production (ACA), which is
+  deferred and undesigned — its first real container run will surface origin/forwarded-headers work
+  that this decision postpones rather than solves.
+- The kept-but-unreferenced Dockerfile can drift from a working state until production revisits it
+  (mitigated: it still builds today; CI builds the solution, and the Dockerfile is a thin publish
+  over that).
+
+## Alternatives Considered
+
+### A. Frontend on the host, backend in compose over HTTPS (this ADR)
+
+Chosen. Mirrors TheKittySaver, dissolves the two-legs/`iss` problem with zero added infra, and ships
+the API HTTPS lift now.
+
+### B. Containerize the Frontend and split `MetadataAddress` from `Authority`
+
+Set `MetadataAddress` to the in-network discovery URL, keep `Authority` browser-facing. Rejected.
+OpenIddict's absolute `iss` (`OpenIddictExtensions.cs:107`) means the discovery doc still hands the
+container absolute `https://localhost:5003/...` token/userinfo endpoints, so the back-channel still
+needs a host rewrite (`extra_hosts`/gateway) on top — new RP code plus fragile per-endpoint routing,
+for a dev convenience the reference doesn't even attempt.
+
+### C. Containerize the Frontend behind a reverse proxy on one shared HTTPS origin
+
+The classic fix, and the "reverse-proxy/forwarded-headers ADR" floated in #138/#40. Rejected for
+dev. Adds a proxy service and the `ForwardedHeaders` middleware the Frontend currently lacks, to
+solve a problem that only exists because we put the RP in a container — which §2 simply doesn't do.
+This is the shape production (ACA) will likely take, and is deferred to that decision.
+
+### D. Share `host.docker.internal` as the OIDC origin for both legs
+
+Rejected. Docker-Desktop-only, and it forces the dev `iss`/seeded redirect URI off `localhost` onto
+`host.docker.internal`, diverging from the reference and from the all-local `dotnet run` workflow for
+no gain over A.
+
+## Implementation Notes
+
+- Changed: `compose.yaml` — remove the `frontend` service (and the HTTPS bits added for it in #145:
+  cert mount, dual URLs, `5001:8081`, browser-facing `AuthSystem__Authority`); keep auth-api +
+  tms-api HTTPS.
+- Frontend host-run config: `Frontend/appsettings.Development.json` —
+  `AuthSystem:Authority`/`AuthSystem:BaseUrl` → `https://localhost:5003`, `TranslationSystem:BaseUrl`
+  → `https://localhost:5002` (the compose host ports), so a host-run Frontend hits the in-compose
+  backend and `iss` matches. `Properties/launchSettings.json` https profile stays
+  `https://localhost:7017` (the seeded web-client redirect host).
+- Kept: `scripts/init-dev-https.{sh,ps1}`, `scripts/up.{sh,ps1}`, `.env.example`
+  `ASPNETCORE_KESTREL_CERT_PASSWORD`, `src/Frontend/LotroKoniecDev.Frontend/Dockerfile`
+  (unreferenced).
+- Docs: `CLAUDE.md` — compose stack is backend-only over HTTPS; Frontend runs locally via
+  `dotnet run`; correct the lift-map "frontend joins compose" line and the stale "HTTPS arrives with
+  the M3 Frontend" note.
+- AuthSystem seeded web-client redirect URIs (`https://localhost:7017/callback`, root post-logout)
+  are unchanged — they already target the host-run Frontend.
+
+## References
+
+- ADR-0002 — TMS pivot + the TheKittySaver 1:1 lift (this decision restores compose to the reference
+  topology)
+- ADR-0005 — Frontend Data Protection key persistence (retained for the deferred production host;
+  **not** superseded)
+- Ticket #144 (M3-10) — re-scoped to this decision; PR #145
+- Ticket #40 (M3-06) — its compose `frontend` service is withdrawn by §1/§5
+- TheKittySaver (`~/RiderProjects/TheKittySaver`) — `compose.yaml` (no frontend service) and
+  `src/Frontend/.../launchSettings.json` (host-run on `https://localhost:7017`)

--- a/scripts/init-dev-https.ps1
+++ b/scripts/init-dev-https.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    One-time bootstrap of the ASP.NET Core dev HTTPS certificate for Docker.
+
+.DESCRIPTION
+    Trusts the dev cert on the host (so the browser accepts https://localhost:*),
+    then exports it as a PFX into ./.docker/https/aspnetapp.pfx so containers can
+    mount it and serve HTTPS through Kestrel.
+
+    Cert password is read from .env (key: ASPNETCORE_KESTREL_CERT_PASSWORD).
+    Run once on a fresh clone, then `docker compose up`.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$certDir  = Join-Path $repoRoot '.docker/https'
+$certPath = Join-Path $certDir  'aspnetapp.pfx'
+$envFile  = Join-Path $repoRoot '.env'
+
+if (-not (Test-Path $envFile)) {
+    Write-Error ".env not found. Copy .env.example to .env first."
+    exit 1
+}
+
+$line = Get-Content $envFile |
+    Where-Object { $_ -match '^\s*ASPNETCORE_KESTREL_CERT_PASSWORD\s*=\s*(.+)\s*$' } |
+    Select-Object -First 1
+
+if (-not $line) {
+    Write-Error "ASPNETCORE_KESTREL_CERT_PASSWORD not set in .env"
+    exit 1
+}
+
+$password = ($line -split '=', 2)[1].Trim()
+
+New-Item -ItemType Directory -Force -Path $certDir | Out-Null
+
+Write-Host "Trusting ASP.NET Core dev certificate (you may be prompted)..."
+& dotnet dev-certs https --trust
+if ($LASTEXITCODE -ne 0) { throw "dotnet dev-certs https --trust failed" }
+
+if (Test-Path $certPath) { Remove-Item $certPath -Force }
+
+Write-Host "Exporting PFX to $certPath ..."
+& dotnet dev-certs https -ep $certPath -p $password --format Pfx | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "dotnet dev-certs https export failed" }
+
+Write-Host ""
+Write-Host "Done. Cert at: $certPath"
+Write-Host "Next: docker compose up"

--- a/scripts/init-dev-https.sh
+++ b/scripts/init-dev-https.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# One-time bootstrap of the ASP.NET Core dev HTTPS certificate for Docker.
+# Trusts the dev cert on the host, then exports it to .docker/https/aspnetapp.pfx
+# so containers can mount it and serve HTTPS through Kestrel.
+#
+# Cert password is read from .env (key: ASPNETCORE_KESTREL_CERT_PASSWORD).
+# Run once on a fresh clone, then `docker compose up`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CERT_DIR="$REPO_ROOT/.docker/https"
+CERT_PATH="$CERT_DIR/aspnetapp.pfx"
+ENV_FILE="$REPO_ROOT/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo ".env not found. Copy .env.example to .env first." >&2
+    exit 1
+fi
+
+PASSWORD="$(grep -E '^[[:space:]]*ASPNETCORE_KESTREL_CERT_PASSWORD[[:space:]]*=' "$ENV_FILE" | head -n1 | cut -d= -f2- | xargs || true)"
+if [ -z "$PASSWORD" ]; then
+    echo "ASPNETCORE_KESTREL_CERT_PASSWORD not set in .env" >&2
+    exit 1
+fi
+
+mkdir -p "$CERT_DIR"
+
+echo "Trusting ASP.NET Core dev certificate (you may be prompted)..."
+dotnet dev-certs https --trust
+
+[ -f "$CERT_PATH" ] && rm -f "$CERT_PATH"
+
+echo "Exporting PFX to $CERT_PATH ..."
+dotnet dev-certs https -ep "$CERT_PATH" -p "$PASSWORD" --format Pfx >/dev/null
+
+echo ""
+echo "Done. Cert at: $CERT_PATH"
+echo "Next: docker compose up"

--- a/scripts/up.ps1
+++ b/scripts/up.ps1
@@ -1,16 +1,24 @@
-# "docker compose up" with a one-time .env bootstrap.
+# "docker compose up" with one-time .env + dev-cert bootstrap baked in.
 # compose has no secret defaults, so a .env is required; this creates it from .env.example
-# on first run (edit secrets there afterwards). Extra args pass through.
+# on first run (edit secrets there afterwards). Runs init-dev-https.ps1 if the HTTPS dev-cert
+# PFX is missing, then `docker compose up`. Extra args pass through.
 
 $ErrorActionPreference = "Stop"
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $envFile = Join-Path $repoRoot ".env"
+$certPath = Join-Path $repoRoot ".docker/https/aspnetapp.pfx"
 
 if (-not (Test-Path $envFile))
 {
     Copy-Item (Join-Path $repoRoot ".env.example") $envFile
     Write-Host ".env created from .env.example. Edit secrets if needed."
+}
+
+if (-not (Test-Path $certPath))
+{
+    Write-Host "Dev HTTPS cert missing - running one-time bootstrap..."
+    & (Join-Path $PSScriptRoot "init-dev-https.ps1")
 }
 
 Set-Location $repoRoot

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
-# "docker compose up" with a one-time .env bootstrap.
+# "docker compose up" with one-time .env + dev-cert bootstrap baked in.
 # compose has no secret defaults, so a .env is required; this creates it from .env.example
-# on first run (edit secrets there afterwards). Extra args pass through.
+# on first run (edit secrets there afterwards). Runs init-dev-https.sh if the HTTPS dev-cert
+# PFX is missing, then `docker compose up`. Extra args pass through.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ENV_FILE="$REPO_ROOT/.env"
+CERT_PATH="$REPO_ROOT/.docker/https/aspnetapp.pfx"
 
 if [ ! -f "$ENV_FILE" ]; then
     cp "$REPO_ROOT/.env.example" "$ENV_FILE"
     echo ".env created from .env.example. Edit secrets if needed."
+fi
+
+if [ ! -f "$CERT_PATH" ]; then
+    echo "Dev HTTPS cert missing — running one-time bootstrap..."
+    "$(dirname "$0")/init-dev-https.sh"
 fi
 
 cd "$REPO_ROOT"

--- a/src/Frontend/LotroKoniecDev.Frontend/appsettings.Development.json
+++ b/src/Frontend/LotroKoniecDev.Frontend/appsettings.Development.json
@@ -33,7 +33,7 @@
     "KeyRingPath": ""
   },
   "TranslationSystem": {
-    "BaseUrl": "https://localhost:5004/"
+    "BaseUrl": "https://localhost:5002/"
   },
   "AuthSystem": {
     "BaseUrl": "https://localhost:5003/",


### PR DESCRIPTION
Closes #144

## Re-scope (per maintainer decision — ADR-0006)

The TMS Frontend is **NOT** containerized in dev compose — it runs on the host via `dotnet run` exactly like TheKittySaver (whose compose has no frontend service). The `frontend` compose service is **removed**; the dev stack is **backend-only over HTTPS** (postgres + migrator + auth-api + tms-api + aspire-dashboard + mailpit). A host-run RP and the browser both reach auth-api at `https://localhost:5003` and tms-api at `https://localhost:5002`, so a single OIDC `Authority` serves both the browser redirect and the server-side back-channel and the token `iss` matches — dissolving the earlier containerized-RP two-legs problem. Production (Azure Container Apps) hosting is explicitly deferred. Recorded in **ADR-0006** (`docs/adr/0006-frontend-not-containerized-in-dev-compose.md`), which supersedes #40's frontend-join-compose and the moot in-compose-login criterion (ADR-0005 key persistence retained for the deferred production host).

## What this does

Lifts TheKittySaver's dev-HTTPS-cert setup so **auth-api + tms-api** serve HTTPS on their host ports (mirroring TKS auth-api + adoption-api), while in-network API↔API calls keep using `http://…:8080`. Also closes the pre-existing `iss`/listener mismatch (auth-api now actually serves the `https://localhost:5003` origin it stamps into `iss`).

## Changes

- **`scripts/init-dev-https.{sh,ps1}`** (new, lifted 1:1 from TKS) — `dotnet dev-certs https --trust`, export PFX to `.docker/https/aspnetapp.pfx`, password from `.env` `ASPNETCORE_KESTREL_CERT_PASSWORD`.
- **`scripts/up.{sh,ps1}`** — run `init-dev-https` when the PFX is missing, then `docker compose up` (keeps the existing `.env` bootstrap). Twins edited together.
- **`.env.example`** — add `ASPNETCORE_KESTREL_CERT_PASSWORD=DevCertPassword123!`.
- **`compose.yaml`** — `auth-api` + `tms-api` mount `./.docker/https:/https:ro`, serve `ASPNETCORE_URLS "https://+:8081;http://+:8080"` with the Kestrel cert env, map host ports to the https listener (`5003`/`5002` → `8081`). The `frontend` service is removed.
- **`src/Frontend/LotroKoniecDev.Frontend/appsettings.Development.json`** — `TranslationSystem:BaseUrl` `5004` → `5002` so a host-run Frontend targets the in-compose backend (auth `5003` unchanged in both workflows). Frontend Dockerfile kept but unreferenced (mirrors TKS).
- **`docs/adr/0006-...md`** — the decision.
- **`CLAUDE.md`** — lift map + Commands + prose: backend-only over HTTPS, Frontend on the host via `dotnet run`; note the all-local workflow uses tms `:5004`.
- `.gitignore` already covers `.docker/https/aspnetapp.pfx` via `*.pfx` — no change needed.

## Acceptance criteria (re-scoped)

- [x] **(1)** Fresh clone → `scripts/up.{sh,ps1}` bootstraps `.env` + dev cert, then the **backend-only** stack comes up over HTTPS. *(verified via `docker compose config`; full fresh-clone boot needs a Docker run.)*
- [x] **(2)** `https://localhost:5003/health` (auth) + `https://localhost:5002/health` (tms) serve over HTTPS; in-network API↔API still `http://…:8080`; no `:5001` frontend endpoint. *(config verified.)*
- [ ] **(3)** **Browser login loop (host `dotnet run` Frontend → in-compose HTTPS APIs)** — config is internally consistent (FE appsettings auth `5003` / tms `5002`, launchSettings https `7017`, seeded redirect `https://localhost:7017/callback`, `iss=https://localhost:5003`). **The end-to-end browser run is the maintainer's manual confirmation step** — not observed headlessly.
- [x] **(4)** Token `iss` matches the browser-facing https issuer (`https://localhost:5003`, now served over TLS).
- [x] **(5)** Zero warnings (`dotnet build LotroKoniecDev.slnx`); CLAUDE.md Commands + lift map + HTTP-only note updated.

## Verification

- `dotnet build LotroKoniecDev.slnx` — green, **0 warnings**.
- `docker compose config --services` — exactly the 6 backend services, no `frontend`.
- code-reviewer agent: **APPROVE** (re-scoped criteria 1/2/4/5 implemented; criterion 3 config consistent).
- `/security-review`: **no findings**.
- **Needs manual check:** the host-Frontend → compose-API browser login loop (criterion #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)