### PR TITLE
M2-22: Stryker.NET mutation gate (Domain + SharedKernel)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.14.2",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": true
+    }
+  }
+}

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -1,0 +1,79 @@
+name: Mutation Testing
+
+# Stryker.NET mutation gate on the purest, highest-value layers (Domain / SharedKernel and their
+# dependencies). Heavy job (~up to 30 min/leg) — path-filtered so it only runs when the mutated
+# code or its config actually changes in a PR. Also runnable on demand via the Actions tab /
+# `gh workflow run mutation-test.yml`. Unlike TheKittySaver (post-merge on main), this is a PR gate:
+# `break: 67` makes `dotnet stryker` exit non-zero — and the leg go red — when the score drops below it.
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/**'
+      - 'src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/**'
+      - 'src/SharedKernel/**'
+      - 'tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/**'
+      - 'tests/LotroKoniecDev.SharedKernel.Tests.Unit/**'
+      - '.config/dotnet-tools.json'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - '.github/workflows/mutation-test.yml'
+  workflow_dispatch:
+
+# A new push to the same PR cancels the in-progress run (both matrix legs) instead of paying for both.
+concurrency:
+  group: mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  stryker:
+    name: Stryker.NET (${{ matrix.name }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      # One weak leg must not cancel the other — we want both reports every run.
+      fail-fast: false
+      matrix:
+        include:
+          - name: Domain
+            working-directory: tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit
+          - name: SharedKernel
+            working-directory: tests/LotroKoniecDev.SharedKernel.Tests.Unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.100'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj', '.config/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Restore packages
+        run: dotnet restore
+
+      - name: Run Stryker
+        working-directory: ${{ matrix.working-directory }}
+        run: dotnet stryker
+
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: stryker-report-${{ matrix.name }}-${{ github.run_number }}
+          path: ${{ matrix.working-directory }}/StrykerOutput/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -501,3 +501,6 @@ data/
 
 # Intel / test snapshots (DAT backups, exports, diffs — too large for git)
 intel/
+
+# Stryker.NET mutation testing output
+StrykerOutput/

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -10,6 +10,25 @@ dotnet test tests/LotroKoniecDev.Tests.E2E             # full CLI pipeline — a
 dotnet test --filter "FullyQualifiedName~Fragment"     # filter by name
 ```
 
+## Mutation Testing (Stryker.NET)
+
+Mutation testing runs on the two purest, highest-value layers — `TranslationSystem.Domain` and
+`SharedKernel` — as a **PR gate** (`.github/workflows/mutation-test.yml`: path-filtered +
+`workflow_dispatch`, matrix over both targets). The tool is pinned in `.config/dotnet-tools.json`;
+each target carries its own `stryker-config.json`.
+
+```bash
+dotnet tool restore                                            # once — restores dotnet-stryker (pinned)
+
+# Run from each test project directory; writes ./StrykerOutput/ (gitignored) with the HTML report:
+( cd tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit && dotnet stryker )
+( cd tests/LotroKoniecDev.SharedKernel.Tests.Unit            && dotnet stryker )
+```
+
+Thresholds are high 80 / low 70 / **break 67** — `break` fails the run (and the CI leg) when the
+mutation score drops below it. `break: 67` is a calibrated starting point, not dogma; adjust it in the
+per-project `stryker-config.json` after reviewing the baseline report.
+
 ## Framework & Libraries
 
 - **xUnit** — test framework (`Fact`, `Theory`, `InlineData`)

--- a/tests/LotroKoniecDev.SharedKernel.Tests.Unit/stryker-config.json
+++ b/tests/LotroKoniecDev.SharedKernel.Tests.Unit/stryker-config.json
@@ -1,0 +1,29 @@
+{
+  "stryker-config": {
+    "project": "LotroKoniecDev.SharedKernel.csproj",
+    "test-projects": [
+      "LotroKoniecDev.SharedKernel.Tests.Unit.csproj"
+    ],
+    "mutate": [
+      "**/*.cs",
+      "!**/obj/**/*.cs",
+      "!**/bin/**/*.cs",
+      "!**/*.g.cs",
+      "!**/*.g.i.cs",
+      "!**/Generated/**/*.cs",
+      "!**/Messaging/**/*.cs",
+      "!**/*DependencyInjection.cs"
+    ],
+    "reporters": [
+      "html",
+      "json",
+      "progress",
+      "cleartext"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 70,
+      "break": 67
+    }
+  }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/stryker-config.json
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/stryker-config.json
@@ -1,0 +1,29 @@
+{
+  "stryker-config": {
+    "project": "LotroKoniecDev.TranslationSystem.Domain.csproj",
+    "test-projects": [
+      "LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj"
+    ],
+    "mutate": [
+      "**/*.cs",
+      "!**/obj/**/*.cs",
+      "!**/bin/**/*.cs",
+      "!**/*.g.cs",
+      "!**/*.g.i.cs",
+      "!**/Generated/**/*.cs",
+      "!**/Core/Errors/**/*.cs",
+      "!**/*DependencyInjection.cs"
+    ],
+    "reporters": [
+      "html",
+      "json",
+      "progress",
+      "cleartext"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 70,
+      "break": 67
+    }
+  }
+}


### PR DESCRIPTION
Closes #149

## What

Stryker.NET mutation-testing gate, mirroring TheKittySaver's setup, scoped to the two purest,
highest-value layers — `TranslationSystem.Domain` and `SharedKernel`.

- `.config/dotnet-tools.json` — `dotnet-stryker` 4.14.2 (`isRoot`, `rollForward`), 1:1 KittySaver.
- `tests/.../Domain.Tests.Unit/stryker-config.json` — project `…Domain.csproj`; excludes obj/bin/
  generated, `Core/Errors`, `*DependencyInjection.cs`; reporters html/json/progress/cleartext;
  thresholds high 80 / low 70 / break 67.
- `tests/.../SharedKernel.Tests.Unit/stryker-config.json` — project `…SharedKernel.csproj`; same base
  + excludes `Messaging/` (empty marker interfaces) and DI.
- `.github/workflows/mutation-test.yml` — `pull_request` (path-filtered to Domain/Primitives/
  SharedKernel + their tests + the Stryker config/manifest/props) + `workflow_dispatch`; matrix
  `[Domain, SharedKernel]` (`fail-fast: false`); `dotnet tool restore` → `dotnet stryker`; uploads each
  leg's HTML report as an artifact; concurrency cancel-in-progress.
- `.gitignore`: `StrykerOutput/`. `tests/CLAUDE.md`: how-to-run-locally note.

## Deviation from KittySaver

KittySaver runs Stryker post-merge on `main`; here it is a **PR gate** — `break: 67` makes
`dotnet stryker` exit non-zero, turning the matrix leg red when the score drops below the floor.

## Local baseline (calibration)

| Target | Mutation score | Killed | Survived | Timeout | Result |
|---|---|---|---|---|---|
| Domain | **81.29 %** | 124 | 25 | 2 | ✅ above break |
| SharedKernel | **80.77 %** | 81 | 13 | 3 | ✅ above break |

Both legs sit above even the `high: 80` threshold, so `break: 67` carries comfortable headroom — kept
as the agreed starting floor (not dogma; raise it in the per-project config once the team wants a
tighter ratchet). The 25/13 surviving + a few no-coverage mutants are improvement opportunities, not
gate failures, and are left for a follow-up — this PR sets up the gate, it doesn't chase 100 %.

## Note

The workflow goes red below the floor, but **blocking merge** on it is a separate branch-protection
toggle (add "Stryker.NET (Domain)" / "Stryker.NET (SharedKernel)" to required checks) — not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
