### PR TITLE
M3-11: Pure-SSR guard — check-ssr-purity.sh + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # Same Static-SSR gate as pr-verify — backstops direct pushes to main.
+      - name: Pure-SSR guard
+        run: ./scripts/check-ssr-purity.sh
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # Fast, dependency-free gate: the Frontend must stay Static SSR. Runs before
+      # the .NET setup so a stray @rendermode/@onclick fails in seconds, not minutes.
+      - name: Pure-SSR guard
+        run: ./scripts/check-ssr-purity.sh
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,12 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 - **Right-size the design — YAGNI by default.** Before proposing an abstraction, cache, config
   knob, queue, or new infra, check it solves a **real, present** need from the current
   spec/ticket — not a hypothetical future. Pick the simple path and note the trade-off in one line.
+- **Frontend is Static SSR — enforced, not just documented.** No WebAssembly, no SignalR circuit,
+  no per-user server state; forms post via `<form method="post" @formname @onsubmit>` (the SSR
+  `@onsubmit` special-case) or `<EditForm OnValidSubmit>` — never interactive `@on*` handlers,
+  `@rendermode`, `StateHasChanged`, or `AddInteractive*`. `scripts/check-ssr-purity.sh` (with a
+  `.ps1` twin for local Windows devs) gates this in **both** `pr-verify` and `ci`, before
+  `setup-dotnet`. Genuinely need interactivity? That's an ADR-first architecture change.
 - **Git is rebase-based, and branches are never deleted.** Integrate a feature branch off `main`
   with `git rebase main` — never `git merge main`; no merge commits in feature branches (remote
   `main` is squash-only, so history stays linear). After a PR's squash commit lands on `main`,

--- a/scripts/check-ssr-purity.ps1
+++ b/scripts/check-ssr-purity.ps1
@@ -1,0 +1,78 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Pure-SSR guard for the Frontend (PowerShell twin of check-ssr-purity.sh).
+
+.DESCRIPTION
+    The Frontend is Static SSR on purpose: no WebAssembly download, no SignalR circuit,
+    no per-user server state. A single stray @rendermode, @onclick or StateHasChanged
+    silently flips a page into interactive mode and quietly breaks that guarantee.
+    CLAUDE.md states the rule in prose; this script enforces it. CI runs the .sh; this
+    .ps1 is the local twin for Windows devs — keep the two in sync.
+
+    Lifted from TheKittySaver with ONE deliberate deviation: @onsubmit is allowed. It is
+    the documented Static-SSR special exception — "always functional, regardless of render
+    mode" — and is how Editor.razor posts forms (<form method="post" @formname @onsubmit>).
+    Every other @on* handler (onclick/onchange/oninput/...) is dead in SSR and stays forbidden.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot    = Split-Path -Parent $PSScriptRoot
+$frontendDir = Join-Path $repoRoot 'src/Frontend'
+
+if (-not (Test-Path $frontendDir)) {
+    Write-Error "Pure-SSR guard: Frontend directory not found at $frontendDir"
+    exit 2
+}
+
+# obj/ and bin/ are build output, not source — never scan them (mirrors the .sh --exclude-dir).
+$files = Get-ChildItem -Path $frontendDir -Recurse -File -Include '*.razor', '*.cs' |
+    Where-Object { $_.FullName -notmatch '[\\/](obj|bin)[\\/]' }
+$script:fail = $false
+
+function Test-SsrPurity {
+    # -Pattern flags a violation; -AllowPattern (optional) is an SSR-valid token (e.g. @onsubmit)
+    # stripped before re-testing, so it can't mask a real handler sharing the line.
+    param(
+        [Parameter(Mandatory)][string] $Pattern,
+        [Parameter(Mandatory)][string] $Message,
+        [string] $AllowPattern
+    )
+
+    $hits = $files | Select-String -Pattern $Pattern -CaseSensitive
+    if ($AllowPattern) {
+        # Strip the SSR-valid token, then re-test: a line matching ONLY via the allowed
+        # token drops out; a line also carrying a real handler is still flagged.
+        $hits = $hits | Where-Object { ($_.Line -creplace $AllowPattern, '') -cmatch $Pattern }
+    }
+
+    if ($hits) {
+        $script:fail = $true
+        Write-Host "X $Message"
+        foreach ($hit in $hits) {
+            Write-Host ("    {0}:{1}:{2}" -f $hit.Path, $hit.LineNumber, $hit.Line.Trim())
+        }
+        Write-Host ""
+    }
+}
+
+Test-SsrPurity -Pattern '@rendermode' `
+    -Message 'Render-mode directive forces a component into interactive mode. Remove it - SSR renders on the server.'
+Test-SsrPurity -Pattern '@on[a-z]+\s*[=:]' `
+    -Message 'Blazor event handler (@onclick / @onchange / @oninput ...) does nothing in SSR. Use <form method="post" @onsubmit> or <EditForm OnValidSubmit>.' `
+    -AllowPattern '@onsubmit\s*[=:]'
+Test-SsrPurity -Pattern 'StateHasChanged' `
+    -Message 'StateHasChanged only works in interactive mode. In SSR the next request re-renders the page - delete the call.'
+Test-SsrPurity -Pattern 'AddInteractiveServerComponents|AddInteractiveWebAssemblyComponents|AddInteractiveServerRenderMode|AddInteractiveWebAssemblyRenderMode' `
+    -Message 'Interactive Blazor registered in Program.cs. Keep only AddRazorComponents() and MapRazorComponents<App>().'
+
+if ($script:fail) {
+    Write-Host "----------------------------------------------------------------------"
+    Write-Host "Pure-SSR guard FAILED - the Frontend must stay Static SSR."
+    Write-Host "See CLAUDE.md -> 'Frontend is Static SSR'. Genuinely need interactivity?"
+    Write-Host "That is an architecture change - write an ADR first (docs/adr/, /adr)."
+    exit 1
+}
+
+Write-Host "OK Pure-SSR guard passed - Frontend is clean."

--- a/scripts/check-ssr-purity.sh
+++ b/scripts/check-ssr-purity.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Pure-SSR guard for the Frontend.
+#
+# The Frontend is Static SSR on purpose: no WebAssembly download, no SignalR circuit,
+# no per-user server state. A single stray @rendermode, @onclick or StateHasChanged
+# silently flips a page into interactive mode and quietly breaks that guarantee.
+# CLAUDE.md states this rule in prose; THIS script is the machine that enforces it,
+# so the rule can't rot. Run it before pushing; CI (pr-verify + ci) runs it on every PR.
+#
+# Lifted from TheKittySaver with ONE deliberate deviation: @onsubmit is allowed.
+# It is the documented Static-SSR special exception — "always functional, regardless of
+# render mode" (MS docs: aspnet/core/blazor/components/class-libraries-and-static-server-side-rendering)
+# — and is how Editor.razor posts forms (<form method="post" @formname @onsubmit>).
+# KittySaver uses <EditForm> so its broad @on* regex never sees this; we use plain forms.
+# Every other @on* handler (onclick/onchange/oninput/…) is dead in SSR and stays forbidden.
+# Keep this in sync with its check-ssr-purity.ps1 twin (run locally on Windows).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FRONTEND_DIR="$REPO_ROOT/src/Frontend"
+
+if [ ! -d "$FRONTEND_DIR" ]; then
+    echo "Pure-SSR guard: Frontend directory not found at $FRONTEND_DIR" >&2
+    exit 2
+fi
+
+fail=0
+
+check() {
+    # $1 = grep -E pattern to flag, $2 = plain explanation of what to do instead,
+    # $3 = optional grep -E allow-pattern: a token that IS valid in SSR (e.g. @onsubmit).
+    #      It is stripped from each candidate line and $1 re-tested — so a line matching
+    #      ONLY via the allowed token drops out, while a line that also carries a real
+    #      violation (e.g. @onclick beside @onsubmit on one element) is still flagged.
+    # obj/ and bin/ are build output, not source — never scan them (in CI this runs before
+    # restore/build, but a local run after a build would otherwise hit generated *.g.cs).
+    local matches
+    matches="$(grep -rnE "$1" --include='*.razor' --include='*.cs' --exclude-dir=obj --exclude-dir=bin "$FRONTEND_DIR" 2>/dev/null || true)"
+    if [ -n "$matches" ] && [ -n "${3:-}" ]; then
+        matches="$(printf '%s\n' "$matches" | sed -E "s/$3//g" | grep -E "$1" || true)"
+    fi
+    if [ -n "$matches" ]; then
+        fail=1
+        printf '✗ %s\n' "$2"
+        echo "$matches" | sed 's/^/    /'
+        echo
+    fi
+}
+
+check '@rendermode' \
+    'Render-mode directive forces a component into interactive mode. Remove it — SSR renders on the server.'
+check '@on[a-z]+[[:space:]]*[=:]' \
+    'Blazor event handler (@onclick / @onchange / @oninput …) does nothing in SSR. Use <form method="post" @onsubmit> or <EditForm OnValidSubmit>.' \
+    '@onsubmit[[:space:]]*[=:]'
+check 'StateHasChanged' \
+    'StateHasChanged only works in interactive mode. In SSR the next request re-renders the page — delete the call.'
+check 'AddInteractiveServerComponents|AddInteractiveWebAssemblyComponents|AddInteractiveServerRenderMode|AddInteractiveWebAssemblyRenderMode' \
+    'Interactive Blazor registered in Program.cs. Keep only AddRazorComponents() and MapRazorComponents<App>().'
+
+if [ "$fail" -ne 0 ]; then
+    echo "──────────────────────────────────────────────────────────────────────"
+    echo "Pure-SSR guard FAILED — the Frontend must stay Static SSR."
+    echo "See CLAUDE.md → 'Frontend is Static SSR'. Genuinely need interactivity?"
+    echo "That is an architecture change — write an ADR first (docs/adr/, /adr)."
+    exit 1
+fi
+
+echo "✓ Pure-SSR guard passed — Frontend is clean."


### PR DESCRIPTION
Closes #156

## What

Adds a machine-enforced SSR-purity guard so a stray `@rendermode`, `@onclick`, `@bind`, or `StateHasChanged` fails CI in seconds — before `setup-dotnet` even runs.

## Changes

1. **`scripts/check-ssr-purity.sh`** + **`.ps1` twin** — grep the Frontend for interactive markers; exit non-zero on first violation.
2. **CI wiring** — "Pure-SSR guard" step added to both `pr-verify.yml` and `ci.yml`, before `setup-dotnet`.
3. **`CLAUDE.md`** — documents the enforcement rule.