### PR TITLE
M2-23: TMS real-process E2E tests (Testcontainers, mirror KittySaver)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,50 @@
+name: E2E
+
+# Heaviest possible job: the E2ETestFixture builds the auth/tms/migrator Docker images and spins up the
+# full stack (Postgres + migrator + both APIs) via Testcontainers, then drives the core loop over real HTTP
+# with real auth-api tokens. Manual only — never on push/PR — so it costs nothing routinely. The project is
+# named `...E2E.Tests` (not `*.Tests.Unit`/`*.Tests.Integration`), so pr-verify/ci skip it by convention.
+# Run from the Actions tab or `gh workflow run e2e.yml`.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E (full stack via Testcontainers)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.100'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore tests/LotroKoniecDev.TranslationSystem.E2E.Tests/LotroKoniecDev.TranslationSystem.E2E.Tests.csproj
+
+      - name: Build
+        run: dotnet build tests/LotroKoniecDev.TranslationSystem.E2E.Tests/LotroKoniecDev.TranslationSystem.E2E.Tests.csproj --configuration Release --no-restore
+
+      # The fixture shells out to `docker build` for the three images (the ubuntu runner has Docker preinstalled),
+      # then boots the stack via Testcontainers — no SKIP_DOCKER_BUILD, no pre-built images.
+      - name: Run E2E Tests
+        run: dotnet test tests/LotroKoniecDev.TranslationSystem.E2E.Tests/LotroKoniecDev.TranslationSystem.E2E.Tests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -45,6 +45,7 @@
     <Project Path="tests/LotroKoniecDev.SharedKernel.Tests.Unit/LotroKoniecDev.SharedKernel.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj" />
     <Project Path="tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj" />
+    <Project Path="tests/LotroKoniecDev.TranslationSystem.E2E.Tests/LotroKoniecDev.TranslationSystem.E2E.Tests.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.E2E/LotroKoniecDev.Tests.E2E.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Infrastructure/LotroKoniecDev.Tests.Infrastructure.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj" />

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -7,8 +7,13 @@ dotnet test                                            # everything runnable on 
 dotnet test tests/LotroKoniecDev.Tests.Unit            # unit only — always green, every OS
 dotnet test tests/LotroKoniecDev.Tests.Infrastructure  # real-infrastructure tests
 dotnet test tests/LotroKoniecDev.Tests.E2E             # full CLI pipeline — auto-skips off-Windows
+dotnet test tests/LotroKoniecDev.TranslationSystem.E2E.Tests  # real-process TMS stack — REQUIRES Docker (builds 3 images)
 dotnet test --filter "FullyQualifiedName~Fragment"     # filter by name
 ```
+
+> **Heads-up on bare `dotnet test`:** the TMS real-process E2E suite runs whenever the whole solution is
+> tested and **requires a running Docker daemon** (it builds the auth/tms/migrator images and boots the
+> stack). It is off the PR/CI gate by name (below); target a specific project when you don't have Docker.
 
 ## Mutation Testing (Stryker.NET)
 
@@ -87,6 +92,26 @@ output belongs here, never in `Tests.Unit`. Targets `net10.0-windows`: builds ev
 Full-pipeline tests driving the CLI (`ExportE2ETests`, `PatchE2ETests`, `RoundtripE2ETests`,
 `ErrorPathE2ETests`) against a real DAT. They use `SkippableFact` and **skip automatically**
 off-Windows or without a DAT available — `Skipped` on macOS is expected, not a failure.
+
+## TMS Real-Process E2E Tests (LotroKoniecDev.TranslationSystem.E2E.Tests)
+
+A Testcontainers-driven suite that mirrors TheKittySaver's `E2E.Tests`: `E2ETestFixture` builds the
+`auth`/`tms`/`migrator` Docker images (`SKIP_DOCKER_BUILD=true` to reuse pre-built ones), spins up a private
+network with `postgres:17-alpine` (+ the bind-mounted `scripts/init-postgres.sh` for the second `lotro_auth`
+DB), runs the one-shot migrator, then boots `auth-api` (env `Testing` → password-grant `lotrokoniecdev-test`
+client + seeded Admin) and `tms-api` on `http://+:8080`, waiting on `/health/live`. Tests drive the loop over
+real HTTP with **real auth-api tokens validated by tms-api via live JWKS + lazy translator provisioning** — the
+layer the in-process `*.Tests.Integration` suite fakes by forging HS256 tokens.
+
+- `AuthFlowE2ETests` — real Admin token accepted + first write lazily provisions the translator; a registered
+  Translator's token is accepted; no/garbage token → 401.
+- `CoreLoopE2ETests` — register version → import → list → upsert → approve → download (+ ETag/304).
+- `UpdateCycleE2ETests` — a later import reword's an approved row's source → invalidated + dropped from the file.
+
+**Requires Docker; off the PR gate by name** — the project is `...E2E.Tests` (not `*.Tests.Unit` /
+`*.Tests.Integration`), so the `pr-verify.yml`/`ci.yml` test-discovery globs skip it. It runs only via
+`.github/workflows/e2e.yml` (`workflow_dispatch`) or a local `dotnet test` of the project. It IS compiled by the
+solution build, so the zero-warning gate still covers it.
 
 ## Conventions
 

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/AuthApiClient.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/AuthApiClient.cs
@@ -1,0 +1,64 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.E2E.Tests.Clients.Responses;
+using LotroKoniecDev.TranslationSystem.E2E.Tests.Extensions;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests.Clients;
+
+/// <summary>
+/// Talks to the running auth-api over real HTTP: registration and the OAuth2 password grant
+/// (the <c>lotrokoniecdev-test</c> client, live only under the <c>Testing</c> environment).
+/// </summary>
+public sealed class AuthApiClient : IDisposable
+{
+    private const string PasswordGrantScope = "email profile roles api";
+
+    private readonly HttpClient _client;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public AuthApiClient(string baseUrl, JsonSerializerOptions jsonOptions)
+    {
+        _client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        _jsonOptions = jsonOptions;
+    }
+
+    public async Task<IdentityId> RegisterAsync(RegisterRequest request)
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("auth/register", request, _jsonOptions);
+        string content = await response.EnsureSuccessWithDetailsAsync();
+        return JsonSerializer.Deserialize<IdentityId>(content, _jsonOptions);
+    }
+
+    public async Task<HttpResponseMessage> RegisterRawAsync(RegisterRequest request) =>
+        await _client.PostAsJsonAsync("auth/register", request, _jsonOptions);
+
+    public async Task<TokenResponse> LoginAsync(string username, string password)
+    {
+        HttpResponseMessage response = await PostPasswordGrantAsync(username, password);
+        await response.EnsureSuccessWithDetailsAsync();
+        return await response.Content.ReadFromJsonAsync<TokenResponse>(_jsonOptions)
+               ?? throw new InvalidOperationException("Null response from the token endpoint.");
+    }
+
+    public async Task<HttpResponseMessage> LoginRawAsync(string username, string password) =>
+        await PostPasswordGrantAsync(username, password);
+
+    private async Task<HttpResponseMessage> PostPasswordGrantAsync(string username, string password)
+    {
+        Dictionary<string, string> parameters = new()
+        {
+            ["grant_type"] = "password",
+            ["username"] = username,
+            ["password"] = password,
+            ["client_id"] = E2ETestFixture.TestClientId,
+            ["scope"] = PasswordGrantScope
+        };
+
+        using FormUrlEncodedContent content = new(parameters);
+        return await _client.PostAsync(new Uri("connect/token", UriKind.Relative), content);
+    }
+
+    public void Dispose() => _client.Dispose();
+}

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/Responses/TokenResponse.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/Responses/TokenResponse.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests.Clients.Responses;
+
+/// <summary>
+/// The OAuth2 token endpoint response (<c>connect/token</c>) shape, mapped from the
+/// snake_case OpenIddict JSON payload.
+/// </summary>
+public sealed record TokenResponse(
+    [property: JsonPropertyName("access_token")] string AccessToken,
+    [property: JsonPropertyName("token_type")] string TokenType,
+    [property: JsonPropertyName("expires_in")] int ExpiresIn,
+    [property: JsonPropertyName("refresh_token")] string? RefreshToken,
+    [property: JsonPropertyName("scope")] string Scope);

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/TranslationSystemApiClient.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/TranslationSystemApiClient.cs
@@ -1,0 +1,103 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Import;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.E2E.Tests.Extensions;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests.Clients;
+
+/// <summary>
+/// Talks to the running tms-api over real HTTP with an optional bearer token. Happy-path methods unwrap the
+/// typed response (and surface the API's problem details on failure); the <c>Raw</c> variants return the
+/// <see cref="HttpResponseMessage"/> so tests can assert status codes (204, 304, 401) and headers (ETag).
+/// </summary>
+public sealed class TranslationSystemApiClient : IDisposable
+{
+    private const string TranslationsRoute = "/api/v1/translations";
+    private const string GameVersionsRoute = "/api/v1/game-versions";
+
+    private readonly HttpClient _client;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public TranslationSystemApiClient(string baseUrl, JsonSerializerOptions jsonOptions, string? bearerToken)
+    {
+        _client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        _jsonOptions = jsonOptions;
+
+        if (!string.IsNullOrEmpty(bearerToken))
+        {
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+        }
+    }
+
+    public async Task<GameVersionResponse> RegisterGameVersionAsync(string version)
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            GameVersionsRoute, new RegisterGameVersionRequest(version), _jsonOptions);
+        string content = await response.EnsureSuccessWithDetailsAsync();
+        return Deserialize<GameVersionResponse>(content);
+    }
+
+    public async Task<ImportSummary> ImportAsync(Guid gameVersionId, params string[] lines)
+    {
+        using ByteArrayContent fileContent = new(Encoding.UTF8.GetBytes(string.Join('\n', lines)));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        using MultipartFormDataContent form = new() { { fileContent, "file", "exported.txt" } };
+
+        HttpResponseMessage response = await _client.PostAsync(
+            new Uri($"{GameVersionsRoute}/{gameVersionId}/import", UriKind.Relative), form);
+        string content = await response.EnsureSuccessWithDetailsAsync();
+        return Deserialize<ImportSummary>(content);
+    }
+
+    public async Task<PaginationResponse<TranslationListItemResponse>> ListTranslationsAsync()
+    {
+        HttpResponseMessage response = await _client.GetAsync(new Uri(TranslationsRoute, UriKind.Relative));
+        string content = await response.EnsureSuccessWithDetailsAsync();
+        return Deserialize<PaginationResponse<TranslationListItemResponse>>(content);
+    }
+
+    public async Task<HttpResponseMessage> ListTranslationsRawAsync() =>
+        await _client.GetAsync(new Uri(TranslationsRoute, UriKind.Relative));
+
+    public async Task<TranslationDetailResponse> GetTranslationAsync(Guid id)
+    {
+        HttpResponseMessage response = await _client.GetAsync(new Uri($"{TranslationsRoute}/{id}", UriKind.Relative));
+        string content = await response.EnsureSuccessWithDetailsAsync();
+        return Deserialize<TranslationDetailResponse>(content);
+    }
+
+    public async Task<TranslationDetailResponse> UpsertAsync(int fileId, long gossipId, string translatedText)
+    {
+        HttpResponseMessage response = await _client.PutAsJsonAsync(
+            TranslationsRoute, new UpsertTranslationRequest(fileId, gossipId, translatedText), _jsonOptions);
+        string content = await response.EnsureSuccessWithDetailsAsync();
+        return Deserialize<TranslationDetailResponse>(content);
+    }
+
+    public async Task<HttpResponseMessage> ApproveRawAsync(Guid id) =>
+        await _client.PostAsync(new Uri($"{TranslationsRoute}/{id}/approve", UriKind.Relative), content: null);
+
+    public async Task<HttpResponseMessage> DownloadFileRawAsync(string language, EntityTagHeaderValue? ifNoneMatch = null)
+    {
+        using HttpRequestMessage request = new(
+            HttpMethod.Get, new Uri($"/api/v1/translation-files/{language}", UriKind.Relative));
+
+        if (ifNoneMatch is not null)
+        {
+            request.Headers.IfNoneMatch.Add(ifNoneMatch);
+        }
+
+        return await _client.SendAsync(request);
+    }
+
+    private T Deserialize<T>(string content) =>
+        JsonSerializer.Deserialize<T>(content, _jsonOptions)
+        ?? throw new InvalidOperationException($"Null response deserializing {typeof(T).Name}.");
+
+    public void Dispose() => _client.Dispose();
+}

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Bogus;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.E2E.Tests.Clients;
+using LotroKoniecDev.TranslationSystem.E2E.Tests.Clients.Responses;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests;
+
+[Collection("E2E")]
+public abstract class E2ETestBase : IAsyncLifetime
+{
+    protected static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private const string TranslatorPassword = "TranslatorPass123!";
+
+    private readonly List<IDisposable> _disposables = [];
+
+    protected E2ETestFixture Fixture { get; }
+    protected AuthApiClient AuthApi { get; }
+    protected Faker Faker { get; } = new();
+
+    protected E2ETestBase(E2ETestFixture fixture)
+    {
+        Fixture = fixture;
+        AuthApi = new AuthApiClient(fixture.AuthApiBaseUrl, JsonOptions);
+        _disposables.Add(AuthApi);
+    }
+
+    /// <summary>Each test starts from an empty translation catalog so row counts and file ETags are deterministic.</summary>
+    public virtual async Task InitializeAsync() => await Fixture.ResetTranslationDataAsync();
+
+    /// <summary>Creates a tms-api client carrying the given bearer token (anonymous when null); disposed with the test.</summary>
+    protected TranslationSystemApiClient CreateTmsClient(string? bearerToken = null)
+    {
+        TranslationSystemApiClient client = new(Fixture.TmsApiBaseUrl, JsonOptions, bearerToken);
+        _disposables.Add(client);
+        return client;
+    }
+
+    /// <summary>Logs in the seeded admin (Admin role, email pre-confirmed) via the password grant and returns its access token.</summary>
+    protected async Task<string> LoginAsAdminAsync()
+    {
+        TokenResponse token = await AuthApi.LoginAsync(E2ETestFixture.AdminUsername, E2ETestFixture.AdminPassword);
+        return token.AccessToken;
+    }
+
+    /// <summary>Registers a fresh user (granted the Translator role, email auto-confirmed) and logs it in.</summary>
+    protected async Task<RegisteredTranslator> RegisterAndLoginTranslatorAsync()
+    {
+        string username = $"translator_{Faker.Random.AlphaNumeric(10)}";
+        string email = $"{username}@lotro.koniec.dev";
+
+        RegisterRequest request = new(
+            username,
+            email,
+            TranslatorPassword,
+            "+48500100200",
+            AcceptedPrivacyPolicy: true,
+            AcceptedDataProcessingConsent: true);
+
+        IdentityId identityId = await AuthApi.RegisterAsync(request);
+        TokenResponse token = await AuthApi.LoginAsync(username, TranslatorPassword);
+        return new RegisteredTranslator(identityId, username, email, token.AccessToken);
+    }
+
+    public virtual Task DisposeAsync()
+    {
+        foreach (IDisposable disposable in _disposables)
+        {
+            disposable.Dispose();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    protected sealed record RegisteredTranslator(IdentityId IdentityId, string Username, string Email, string AccessToken);
+}

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
@@ -1,0 +1,291 @@
+using System.Diagnostics;
+using System.Globalization;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Testcontainers.PostgreSql;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests;
+
+/// <summary>
+/// Boots the full TMS backend the way it ships — Postgres + the one-shot migrator + auth-api + tms-api —
+/// as real containers on a private Docker network, so the suite exercises the core loop over actual HTTP
+/// through real JWT issuance, JWKS validation and lazy translator provisioning. This is the layer the
+/// in-process integration tests cannot reach (they forge HS256 tokens and disable JWKS discovery).
+/// </summary>
+public sealed class E2ETestFixture : IAsyncLifetime
+{
+    private const string MigratorImage = "lotrokoniecdev-migrator:e2e";
+    private const string AuthImage = "lotrokoniecdev-auth:e2e";
+    private const string TmsImage = "lotrokoniecdev-tms:e2e";
+
+    /// <summary>Image name → Dockerfile path (relative to the solution root), built in order if not present.</summary>
+    private static readonly (string Image, string Dockerfile)[] DockerImages =
+    [
+        (AuthImage, "src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile"),
+        (TmsImage, "src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile"),
+        (MigratorImage, "Dockerfile.migrator")
+    ];
+
+    private const string TranslationDatabaseName = "lotro_translation";
+    private const string AuthDatabaseName = "lotro_auth";
+    private const string PostgresUser = "postgres";
+    private const string PostgresPassword = "e2e-postgres-password";
+
+    /// <summary>The audience tms-api validates; matches the resource the auth token endpoint stamps on the JWT.</summary>
+    private const string Audience = "lotrokoniecdev-api";
+    private const string ApiClientSecret = "e2e-test-api-client-secret-min-32-characters";
+
+    /// <summary>
+    /// Seeded by auth-api on startup from <c>AdminUser__*</c> config, with <c>EmailConfirmed = true</c> and the
+    /// <c>Admin</c> role — so a password-grant login yields a real Admin token without the email-confirmation dance.
+    /// </summary>
+    public const string AdminUsername = "e2e-admin";
+    public const string AdminEmail = "e2e-admin@lotro.koniec.dev";
+    public const string AdminPassword = "E2eAdminPass123!";
+
+    /// <summary>The public, password-grant OpenIddict client seeded only under the <c>Testing</c> environment.</summary>
+    public const string TestClientId = "lotrokoniecdev-test";
+
+    private INetwork _network = null!;
+    private PostgreSqlContainer _postgres = null!;
+    private IContainer _migrator = null!;
+    private IContainer _authApi = null!;
+    private IContainer _tmsApi = null!;
+
+    public string AuthApiBaseUrl => $"http://localhost:{_authApi.GetMappedPublicPort(8080)}";
+    public string TmsApiBaseUrl => $"http://localhost:{_tmsApi.GetMappedPublicPort(8080)}";
+
+    private static string TranslationConnectionString => BuildInternalConnectionString(TranslationDatabaseName);
+    private static string AuthConnectionString => BuildInternalConnectionString(AuthDatabaseName);
+
+    public async Task InitializeAsync()
+    {
+        await BuildDockerImagesAsync();
+
+        _network = new NetworkBuilder()
+            .WithName($"e2e-{Guid.NewGuid():N}")
+            .Build();
+        await _network.CreateAsync();
+
+        // Postgres' POSTGRES_DB creates lotro_translation on first boot; the bind-mounted init script
+        // adds the second database (lotro_auth) the AuthSystem needs — identical to the compose stack.
+        string initScriptPath = Path.Combine(FindSolutionDirectory(), "scripts", "init-postgres.sh");
+        _postgres = new PostgreSqlBuilder("postgres:17-alpine")
+            .WithNetwork(_network)
+            .WithNetworkAliases("postgres")
+            .WithUsername(PostgresUser)
+            .WithPassword(PostgresPassword)
+            .WithDatabase(TranslationDatabaseName)
+            .WithBindMount(initScriptPath, "/docker-entrypoint-initdb.d/10-init-databases.sh")
+            .Build();
+        await _postgres.StartAsync();
+
+        await RunMigratorAsync();
+        await StartApiContainersAsync();
+    }
+
+    /// <summary>
+    /// Truncates the translation lifecycle tables so each loop test starts from an empty catalog and can assert
+    /// exact counts. Runs <c>psql</c> inside the Postgres container (local-socket trust), mirroring the in-process
+    /// <c>CoreLoopTests</c> reset; the <c>Translators</c> table is intentionally left (the provisioner is idempotent).
+    /// </summary>
+    public async Task ResetTranslationDataAsync()
+    {
+        ExecResult result = await _postgres.ExecAsync(
+        [
+            "psql", "-v", "ON_ERROR_STOP=1", "-U", PostgresUser, "-d", TranslationDatabaseName,
+            "-c", "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;"
+        ]);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Failed to reset translation data (exit code {result.ExitCode}).\nStdout:\n{result.Stdout}\nStderr:\n{result.Stderr}");
+        }
+    }
+
+    public async Task<string> GetAuthApiLogsAsync()
+    {
+        (string? stdout, string? stderr) = await _authApi.GetLogsAsync();
+        return $"=== Auth API Stdout ===\n{stdout}\n=== Auth API Stderr ===\n{stderr}";
+    }
+
+    public async Task<string> GetTmsApiLogsAsync()
+    {
+        (string? stdout, string? stderr) = await _tmsApi.GetLogsAsync();
+        return $"=== TMS API Stdout ===\n{stdout}\n=== TMS API Stderr ===\n{stderr}";
+    }
+
+    private async Task RunMigratorAsync()
+    {
+        // One-shot: migrates the TMS context (via Persistence) then the Auth context (via the Auth API),
+        // exactly as the compose migrator does. Mirrors compose env — connection strings only.
+        _migrator = new ContainerBuilder(MigratorImage)
+            .WithNetwork(_network)
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
+            .WithEnvironment("ConnectionStrings__TranslationDatabase", TranslationConnectionString)
+            .WithEnvironment("ConnectionStrings__AuthDatabase", AuthConnectionString)
+            .Build();
+
+        await _migrator.StartAsync();
+
+        long exitCode = await _migrator.GetExitCodeAsync();
+        if (exitCode != 0)
+        {
+            (string? stdout, string? stderr) = await _migrator.GetLogsAsync();
+            throw new InvalidOperationException(
+                $"Migrator failed with exit code {exitCode}.\nStdout:\n{stdout}\nStderr:\n{stderr}");
+        }
+    }
+
+    private async Task StartApiContainersAsync()
+    {
+        // No RegisterUser->CreatePerson saga is lifted (the translator profile is provisioned lazily on the first
+        // authenticated TMS request), so there is no auth->tms startup dependency. auth-api is started first only
+        // because tms-api fetches its JWKS from it; the seeded admin must also be live before any test logs in.
+        _authApi = new ContainerBuilder(AuthImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases("auth-api")
+            .WithPortBinding(8080, true)
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Testing")
+            .WithEnvironment("ASPNETCORE_URLS", "http://+:8080")
+            .WithEnvironment("ConnectionStrings__AuthDatabase", AuthConnectionString)
+            // The token iss; tms-api validates against this and fetches its JWKS from the same in-network address.
+            .WithEnvironment("OpenIddict__Issuer", "http://auth-api:8080")
+            .WithEnvironment("OpenIddict__ApiClientSecret", ApiClientSecret)
+            // The seeder dereferences WebClient.RedirectUris[0] in non-production, so at least one URI is required.
+            .WithEnvironment("OpenIddict__WebClient__RedirectUris__0", "http://localhost:8080/callback")
+            .WithEnvironment("OpenIddict__WebClient__PostLogoutRedirectUris__0", "http://localhost:8080")
+            .WithEnvironment("AdminUser__Username", AdminUsername)
+            .WithEnvironment("AdminUser__Email", AdminEmail)
+            .WithEnvironment("AdminUser__Password", AdminPassword)
+            // No mailpit in this network: the confirmation-email send fails fast and registration auto-confirms,
+            // so a freshly-registered translator can log in without the email round-trip.
+            .WithEnvironment("Email__Host", "localhost")
+            .WithEnvironment("Email__Port", "2525")
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(request => request.ForPath("/health/live").ForPort(8080)))
+            .Build();
+
+        await _authApi.StartAsync();
+
+        _tmsApi = new ContainerBuilder(TmsImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases("tms-api")
+            .WithPortBinding(8080, true)
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
+            .WithEnvironment("ASPNETCORE_URLS", "http://+:8080")
+            .WithEnvironment("ConnectionStrings__TranslationDatabase", TranslationConnectionString)
+            .WithEnvironment("Auth__Issuer", "http://auth-api:8080")
+            .WithEnvironment("Auth__Authority", "http://auth-api:8080")
+            .WithEnvironment("Auth__Audience", Audience)
+            .WithEnvironment("Bootstrap__Enabled", "false")
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(request => request.ForPath("/health/live").ForPort(8080)))
+            .Build();
+
+        await _tmsApi.StartAsync();
+    }
+
+    private static string BuildInternalConnectionString(string database) =>
+        $"Host=postgres;Port=5432;Database={database};Username={PostgresUser};Password={PostgresPassword}";
+
+    private static async Task BuildDockerImagesAsync()
+    {
+        // CI pre-builds the images and sets SKIP_DOCKER_BUILD=true; locally the suite builds them on demand.
+        if (Environment.GetEnvironmentVariable("SKIP_DOCKER_BUILD") == "true")
+        {
+            Console.WriteLine("Skipping Docker image build (SKIP_DOCKER_BUILD=true).");
+            return;
+        }
+
+        string solutionDir = FindSolutionDirectory();
+        string cacheBust = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+
+        foreach ((string imageName, string dockerfile) in DockerImages)
+        {
+            Console.WriteLine($"Building Docker image: {imageName}...");
+
+            using Process process = new();
+            process.StartInfo = new ProcessStartInfo
+            {
+                FileName = "docker",
+                Arguments = $"build --build-arg CACHEBUST={cacheBust} -f {dockerfile} -t {imageName} .",
+                WorkingDirectory = solutionDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            process.Start();
+
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+
+            await process.WaitForExitAsync();
+
+            string stderr = await stderrTask;
+
+            if (process.ExitCode != 0)
+            {
+                string stdout = await stdoutTask;
+                throw new InvalidOperationException(
+                    $"Failed to build Docker image '{imageName}' (exit code {process.ExitCode}).\n" +
+                    $"Dockerfile: {dockerfile}\n" +
+                    $"Working directory: {solutionDir}\n" +
+                    $"Stdout:\n{stdout}\n" +
+                    $"Stderr:\n{stderr}");
+            }
+
+            Console.WriteLine($"Successfully built: {imageName}");
+        }
+    }
+
+    private static string FindSolutionDirectory()
+    {
+        DirectoryInfo? directory = new(Directory.GetCurrentDirectory());
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "LotroKoniecDev.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find the solution directory (LotroKoniecDev.slnx). Started from: {Directory.GetCurrentDirectory()}");
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_tmsApi is not null)
+        {
+            await _tmsApi.DisposeAsync();
+        }
+
+        if (_authApi is not null)
+        {
+            await _authApi.DisposeAsync();
+        }
+
+        if (_migrator is not null)
+        {
+            await _migrator.DisposeAsync();
+        }
+
+        if (_postgres is not null)
+        {
+            await _postgres.DisposeAsync();
+        }
+
+        if (_network is not null)
+        {
+            await _network.DeleteAsync();
+        }
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Extensions/HttpResponseMessageExtensions.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Extensions/HttpResponseMessageExtensions.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests.Extensions;
+
+internal static class HttpResponseMessageExtensions
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    /// <summary>
+    /// Returns the response body on success; on failure throws an <see cref="HttpRequestException"/>
+    /// whose message unpacks the RFC-7807 problem details, so a failing E2E call reports the API's
+    /// own error instead of a bare status code.
+    /// </summary>
+    public static async Task<string> EnsureSuccessWithDetailsAsync(this HttpResponseMessage response)
+    {
+        if (response.StatusCode is HttpStatusCode.NoContent)
+        {
+            return string.Empty;
+        }
+
+        string content = await response.Content.ReadAsStringAsync();
+
+        if (response.IsSuccessStatusCode)
+        {
+            return content;
+        }
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            throw new HttpRequestException(
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.StatusCode}). " +
+                $"Response body was empty. RequestUri: {response.RequestMessage?.RequestUri}");
+        }
+
+        ProblemDetailsDto? problemDetails = JsonSerializer.Deserialize<ProblemDetailsDto>(content, JsonOptions);
+
+        if (problemDetails is not null && !string.IsNullOrEmpty(problemDetails.Title))
+        {
+            string errorMessage =
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.StatusCode}).\n" +
+                $"Title: {problemDetails.Title}\n" +
+                $"Detail: {problemDetails.Detail}\n" +
+                $"Type: {problemDetails.Type}\n";
+
+            if (!(problemDetails.Extensions?.Count > 0))
+            {
+                throw new HttpRequestException(errorMessage);
+            }
+
+            errorMessage += "Extensions:\n";
+            foreach (KeyValuePair<string, JsonElement> extension in problemDetails.Extensions)
+            {
+                errorMessage += $"  {extension.Key}: {extension.Value}\n";
+            }
+
+            throw new HttpRequestException(errorMessage);
+        }
+
+        throw new HttpRequestException(
+            $"Response status code does not indicate success: {(int)response.StatusCode} ({response.StatusCode}).\n" +
+            $"Content: {content}");
+    }
+
+    [SuppressMessage("Major Code Smell", "S3459:Unassigned members should be removed",
+        Justification = "Deserialization DTO — properties are assigned by System.Text.Json.")]
+    private sealed class ProblemDetailsDto
+    {
+        public string? Type { get; init; }
+        public string? Title { get; init; }
+        public int? Status { get; init; }
+        public string? Detail { get; init; }
+        public string? Instance { get; init; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? Extensions { get; init; }
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/LotroKoniecDev.TranslationSystem.E2E.Tests.csproj
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/LotroKoniecDev.TranslationSystem.E2E.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Bogus" />
+        <PackageReference Include="coverlet.collector">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="Testcontainers" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\AuthSystem\LotroKoniecDev.AuthSystem.Contracts\LotroKoniecDev.AuthSystem.Contracts.csproj" />
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.Contracts\LotroKoniecDev.TranslationSystem.Contracts.csproj" />
+        <ProjectReference Include="..\..\src\SharedKernel\LotroKoniecDev.SharedKernel\LotroKoniecDev.SharedKernel.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/TestCollection.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/TestCollection.cs
@@ -1,0 +1,4 @@
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests;
+
+[CollectionDefinition("E2E")]
+public sealed class E2ETestCollection : ICollectionFixture<E2ETestFixture>;

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/AuthFlowE2ETests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/AuthFlowE2ETests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.E2E.Tests.Clients;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests.Tests;
+
+/// <summary>
+/// Proves the layer the in-process integration tests cannot reach: a JWT minted by the real auth-api
+/// (OAuth2 password grant) is accepted by a separate tms-api process after it validates the signature
+/// against the live JWKS endpoint, and that the first authenticated write lazily provisions the translator.
+/// </summary>
+public sealed class AuthFlowE2ETests : E2ETestBase
+{
+    private const int FileId = 620_756_992;
+
+    private readonly ITestOutputHelper _output;
+
+    public AuthFlowE2ETests(E2ETestFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task RealAdminToken_FromAuthApi_IsAcceptedByTmsApi_AndProvisionsTranslatorOnFirstWrite()
+    {
+        try
+        {
+            string adminToken = await LoginAsAdminAsync();
+            adminToken.ShouldNotBeNullOrWhiteSpace();
+
+            TranslationSystemApiClient admin = CreateTmsClient(adminToken);
+
+            GameVersionResponse version = await admin.RegisterGameVersionAsync("48.0");
+            await admin.ImportAsync(version.Id.Value, $"{FileId}||1||English one||NULL||NULL||1");
+
+            TranslationDetailResponse edited = await admin.UpsertAsync(FileId, gossipId: 1, translatedText: "Polski jeden");
+
+            edited.Status.ShouldBe(TranslationStatus.Draft);
+            edited.Submitter.ShouldNotBeNull("the first authenticated write must lazily provision a translator and stamp it");
+            edited.Submitter.DisplayName.ShouldNotBeNullOrWhiteSpace();
+        }
+        catch (Exception)
+        {
+            _output.WriteLine(await Fixture.GetAuthApiLogsAsync());
+            _output.WriteLine(await Fixture.GetTmsApiLogsAsync());
+            throw;
+        }
+    }
+
+    [Fact]
+    public async Task RegisteredTranslator_RealToken_IsAcceptedByTmsApi()
+    {
+        try
+        {
+            RegisteredTranslator translator = await RegisterAndLoginTranslatorAsync();
+            translator.AccessToken.ShouldNotBeNullOrWhiteSpace();
+
+            TranslationSystemApiClient client = CreateTmsClient(translator.AccessToken);
+
+            HttpResponseMessage response = await client.ListTranslationsRawAsync();
+
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+        catch (Exception)
+        {
+            _output.WriteLine(await Fixture.GetAuthApiLogsAsync());
+            _output.WriteLine(await Fixture.GetTmsApiLogsAsync());
+            throw;
+        }
+    }
+
+    [Fact]
+    public async Task TmsApi_RejectsProtectedEndpoint_WithoutToken()
+    {
+        TranslationSystemApiClient anonymous = CreateTmsClient();
+
+        HttpResponseMessage response = await anonymous.ListTranslationsRawAsync();
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task TmsApi_RejectsProtectedEndpoint_WithMalformedToken()
+    {
+        TranslationSystemApiClient client = CreateTmsClient("not-a-real-jwt");
+
+        HttpResponseMessage response = await client.ListTranslationsRawAsync();
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/CoreLoopE2ETests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/CoreLoopE2ETests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using System.Net.Http.Headers;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Import;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.E2E.Tests.Clients;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests.Tests;
+
+/// <summary>
+/// Drives the whole M2 core loop through the public HTTP endpoints of the containerised tms-api — register a
+/// game version, import the English baseline, list, translate, approve, distribute — with a real Admin token
+/// from auth-api (Admin also satisfies the translator policy), proving the assembled slices compose end-to-end
+/// over the network and that the distributed file is ETag-cacheable.
+/// </summary>
+public sealed class CoreLoopE2ETests : E2ETestBase
+{
+    private const int FileId = 620_756_992;
+    private const string Language = "pl";
+
+    private readonly ITestOutputHelper _output;
+
+    public CoreLoopE2ETests(E2ETestFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task CoreLoop_RegisterImportEditApproveDownload_FlowsThroughEndpointsAndCaches()
+    {
+        try
+        {
+            string adminToken = await LoginAsAdminAsync();
+            TranslationSystemApiClient admin = CreateTmsClient(adminToken);
+            TranslationSystemApiClient anonymous = CreateTmsClient();
+
+            // Register a game version, then import the English baseline against it.
+            GameVersionResponse version = await admin.RegisterGameVersionAsync("48.0");
+            ImportSummary import = await admin.ImportAsync(version.Id.Value, Line(1, "English one"), Line(2, "English two"));
+            import.Added.ShouldBe(2);
+
+            // The catalog now lists two untranslated rows.
+            PaginationResponse<TranslationListItemResponse> list = await admin.ListTranslationsAsync();
+            list.TotalCount.ShouldBe(2);
+            list.Items.ShouldAllBe(item => item.Status == TranslationStatus.Untranslated);
+
+            // Translate row 1 -> Draft (lazily provisioning the translator), then approve it -> published.
+            TranslationDetailResponse edited = await admin.UpsertAsync(FileId, gossipId: 1, translatedText: "Polski jeden");
+            edited.Status.ShouldBe(TranslationStatus.Draft);
+            edited.Submitter.ShouldNotBeNull();
+
+            HttpResponseMessage approve = await admin.ApproveRawAsync(edited.Id.Value);
+            approve.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+            // Download the distributed file (anonymous): the approved row is in, the untranslated one is out.
+            HttpResponseMessage download = await anonymous.DownloadFileRawAsync(Language);
+            download.StatusCode.ShouldBe(HttpStatusCode.OK);
+            download.Headers.ETag.ShouldNotBeNull();
+            EntityTagHeaderValue etag = download.Headers.ETag!;
+
+            string file = await download.Content.ReadAsStringAsync();
+            file.ShouldContain($"{FileId}||1||Polski jeden||NULL||NULL||1");
+            file.ShouldNotContain($"{FileId}||2||");
+
+            // The download is cacheable: a conditional re-request with the held ETag is a 304.
+            HttpResponseMessage conditional = await anonymous.DownloadFileRawAsync(Language, etag);
+            conditional.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        }
+        catch (Exception)
+        {
+            _output.WriteLine(await Fixture.GetAuthApiLogsAsync());
+            _output.WriteLine(await Fixture.GetTmsApiLogsAsync());
+            throw;
+        }
+    }
+
+    private static string Line(int gossipId, string text) => $"{FileId}||{gossipId}||{text}||NULL||NULL||1";
+}

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/UpdateCycleE2ETests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/UpdateCycleE2ETests.cs
@@ -1,0 +1,76 @@
+using System.Net.Http.Headers;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Import;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.E2E.Tests.Clients;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests.Tests;
+
+/// <summary>
+/// Proves the M2 update lifecycle over real HTTP: when a later game version reword's an already-approved row's
+/// English source, the second import invalidates that row (NeedsReview, superseded source kept) and drops it
+/// from the regenerated distributed file under a fresh ETag.
+/// </summary>
+public sealed class UpdateCycleE2ETests : E2ETestBase
+{
+    private const int FileId = 620_756_992;
+    private const string Language = "pl";
+
+    private readonly ITestOutputHelper _output;
+
+    public UpdateCycleE2ETests(E2ETestFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task UpdateCycle_SecondImportRewordsApprovedRow_InvalidatesAndDropsItFromDownload()
+    {
+        try
+        {
+            string adminToken = await LoginAsAdminAsync();
+            TranslationSystemApiClient admin = CreateTmsClient(adminToken);
+            TranslationSystemApiClient anonymous = CreateTmsClient();
+
+            // Baseline: import, translate + approve row 1, so it is in the distributed file.
+            GameVersionResponse firstVersion = await admin.RegisterGameVersionAsync("48.0");
+            await admin.ImportAsync(firstVersion.Id.Value, Line(1, "English one"), Line(2, "English two"));
+            TranslationDetailResponse edited = await admin.UpsertAsync(FileId, gossipId: 1, translatedText: "Polski jeden");
+            await admin.ApproveRawAsync(edited.Id.Value);
+
+            HttpResponseMessage firstDownload = await anonymous.DownloadFileRawAsync(Language);
+            (await firstDownload.Content.ReadAsStringAsync()).ShouldContain($"{FileId}||1||Polski jeden||NULL||NULL||1");
+            firstDownload.Headers.ETag.ShouldNotBeNull();
+            EntityTagHeaderValue firstEtag = firstDownload.Headers.ETag!;
+
+            // A game update reword's row 1's English source on the next version's import.
+            GameVersionResponse secondVersion = await admin.RegisterGameVersionAsync("48.1");
+            ImportSummary update = await admin.ImportAsync(
+                secondVersion.Id.Value, Line(1, "English one reworded"), Line(2, "English two"));
+            update.SourceChanged.ShouldBe(1);
+            update.Invalidated.ShouldBe(1);
+            update.Unchanged.ShouldBe(1);
+
+            // Row 1 is now NeedsReview, with its superseded English kept for side-by-side review.
+            TranslationDetailResponse row1 = await admin.GetTranslationAsync(edited.Id.Value);
+            row1.Status.ShouldBe(TranslationStatus.NeedsReview);
+            row1.PreviousSourceText.ShouldBe("English one");
+
+            // The invalidated row drops out of the freshly regenerated distributed file (new ETag).
+            HttpResponseMessage secondDownload = await anonymous.DownloadFileRawAsync(Language);
+            secondDownload.Headers.ETag.ShouldNotBe(firstEtag);
+            (await secondDownload.Content.ReadAsStringAsync()).ShouldNotContain($"{FileId}||1||");
+        }
+        catch (Exception)
+        {
+            _output.WriteLine(await Fixture.GetAuthApiLogsAsync());
+            _output.WriteLine(await Fixture.GetTmsApiLogsAsync());
+            throw;
+        }
+    }
+
+    private static string Line(int gossipId, string text) => $"{FileId}||{gossipId}||{text}||NULL||NULL||1";
+}


### PR DESCRIPTION
New tests/LotroKoniecDev.TranslationSystem.E2E.Tests suite that boots the full
backend (postgres + migrator + auth-api + tms-api) as real containers via
Testcontainers and drives the M2 core loop over real HTTP with real auth-api
tokens validated by tms-api through live JWKS + lazy translator provisioning —
the layer the in-process integration tests fake with forged HS256 tokens.

- E2ETestFixture: builds the auth/tms/migrator images, private network,
  postgres:17-alpine + init-postgres.sh (second DB), one-shot migrator,
  auth-api (Testing -> password-grant test client + seeded admin) + tms-api on
  http://+:8080 with /health/live waits, and a psql TRUNCATE reset per test.
- AuthFlowE2ETests (real admin token + lazy provisioning, registered translator,
  401 negatives), CoreLoopE2ETests, UpdateCycleE2ETests + typed clients.
- .github/workflows/e2e.yml (workflow_dispatch only); off the PR/CI gate by name
  (...E2E.Tests matches neither the *.Tests.Unit nor *.Tests.Integration glob).

Closes #150

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
