### PR TITLE
fix(auth): build account-email links from configured issuer, not request Host

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailVerificationLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailVerificationLinkFactory.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Settings;
+
 namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 
 internal interface IEmailVerificationLinkFactory
@@ -7,24 +10,25 @@ internal interface IEmailVerificationLinkFactory
 
 internal sealed class EmailVerificationLinkFactory : IEmailVerificationLinkFactory
 {
-    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly LinkGenerator _linkGenerator;
+    private readonly string _scheme;
+    private readonly HostString _host;
 
     public EmailVerificationLinkFactory(
-        IHttpContextAccessor httpContextAccessor,
-        LinkGenerator linkGenerator)
+        LinkGenerator linkGenerator,
+        IOptions<OpenIddictSettings> openIddictSettings)
     {
-        _httpContextAccessor = httpContextAccessor;
         _linkGenerator = linkGenerator;
+
+        // Scheme + host come from the configured issuer, never the request Host header, so a
+        // forged Host cannot poison the confirmation link that gets emailed to the account owner.
+        Uri issuer = new(openIddictSettings.Value.Issuer, UriKind.Absolute);
+        _scheme = issuer.Scheme;
+        _host = HostString.FromUriComponent(issuer);
     }
 
     public string Create(string email, string emailVerificationToken)
     {
-        if (_httpContextAccessor.HttpContext is null)
-        {
-            throw new InvalidOperationException("HttpContext is null.");
-        }
-
         if (string.IsNullOrWhiteSpace(email))
         {
             throw new ArgumentException("Email cannot be null or whitespace.", nameof(email));
@@ -36,10 +40,11 @@ internal sealed class EmailVerificationLinkFactory : IEmailVerificationLinkFacto
         }
 
         string? verificationLink = _linkGenerator.GetUriByPage(
-            _httpContextAccessor.HttpContext,
             page: "/Account/ConfirmEmail",
             handler: null,
-            values: new { email, token = emailVerificationToken });
+            values: new { email, token = emailVerificationToken },
+            scheme: _scheme,
+            host: _host);
 
         return verificationLink
             ?? throw new InvalidOperationException(

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetLinkFactory.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Settings;
+
 namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 
 internal interface IPasswordResetLinkFactory
@@ -7,24 +10,25 @@ internal interface IPasswordResetLinkFactory
 
 internal sealed class PasswordResetLinkFactory : IPasswordResetLinkFactory
 {
-    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly LinkGenerator _linkGenerator;
+    private readonly string _scheme;
+    private readonly HostString _host;
 
     public PasswordResetLinkFactory(
-        IHttpContextAccessor httpContextAccessor,
-        LinkGenerator linkGenerator)
+        LinkGenerator linkGenerator,
+        IOptions<OpenIddictSettings> openIddictSettings)
     {
-        _httpContextAccessor = httpContextAccessor;
         _linkGenerator = linkGenerator;
+
+        // Scheme + host come from the configured issuer, never the request Host header, so a
+        // forged Host cannot poison the reset link that gets emailed to the account owner.
+        Uri issuer = new(openIddictSettings.Value.Issuer, UriKind.Absolute);
+        _scheme = issuer.Scheme;
+        _host = HostString.FromUriComponent(issuer);
     }
 
     public string Create(string email, string resetToken)
     {
-        if (_httpContextAccessor.HttpContext is null)
-        {
-            throw new InvalidOperationException("HttpContext is null.");
-        }
-
         if (string.IsNullOrWhiteSpace(email))
         {
             throw new ArgumentException("Email cannot be null or whitespace.", nameof(email));
@@ -36,9 +40,11 @@ internal sealed class PasswordResetLinkFactory : IPasswordResetLinkFactory
         }
 
         string? resetLink = _linkGenerator.GetUriByPage(
-            _httpContextAccessor.HttpContext,
             page: "/Account/ResetPassword",
-            values: new { email, token = resetToken });
+            handler: null,
+            values: new { email, token = resetToken },
+            scheme: _scheme,
+            host: _host);
 
         return resetLink
             ?? throw new InvalidOperationException(

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyEmailService.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyEmailService.cs
@@ -1,0 +1,22 @@
+using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+
+#pragma warning disable CA1515
+public sealed class SpyEmailService : IEmailService
+#pragma warning restore CA1515
+{
+    public string? LastBody { get; private set; }
+
+    public Task<Result> SendAsync(
+        string receiverEmail,
+        string subject,
+        string body,
+        bool isBodyHtml = true,
+        CancellationToken cancellationToken = default)
+    {
+        LastBody = body;
+        return Task.FromResult(Result.Success());
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailLinkFactoryTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailLinkFactoryTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+public sealed class EmailLinkFactoryTests : EndpointsTestBase
+{
+    // The trusted public origin configured for the test host (AuthSystemApiFactory -> OpenIddict:Issuer).
+    private const string ConfiguredIssuerOrigin = "https://localhost:5002";
+
+    public EmailLinkFactoryTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public void PasswordResetLink_IsBuiltFromConfiguredIssuerOrigin()
+    {
+        // Arrange
+        using IServiceScope scope = Factory.Services.CreateScope();
+        IPasswordResetLinkFactory linkFactory =
+            scope.ServiceProvider.GetRequiredService<IPasswordResetLinkFactory>();
+
+        // Act
+        string link = linkFactory.Create("victim@example.com", "reset-token-123");
+
+        // Assert
+        link.ShouldStartWith($"{ConfiguredIssuerOrigin}/Account/ResetPassword");
+    }
+
+    [Fact]
+    public void EmailVerificationLink_IsBuiltFromConfiguredIssuerOrigin()
+    {
+        // Arrange
+        using IServiceScope scope = Factory.Services.CreateScope();
+        IEmailVerificationLinkFactory linkFactory =
+            scope.ServiceProvider.GetRequiredService<IEmailVerificationLinkFactory>();
+
+        // Act
+        string link = linkFactory.Create("victim@example.com", "verify-token-123");
+
+        // Assert
+        link.ShouldStartWith($"{ConfiguredIssuerOrigin}/Account/ConfirmEmail");
+    }
+
+    [Fact]
+    public async Task ForgotPassword_BuildsResetLinkFromConfiguredIssuer_WhenRequestHostIsForged()
+    {
+        // Arrange — the suite's default spy replaces the whole sender and never invokes the real
+        // link factory, so spin up a host running the real sender -> factory chain and capture the
+        // outgoing email at the SMTP boundary. This drives the actual attack seam: a forged Host
+        // header on the (anonymous) forgot-password request.
+        const string forgedHost = "evil.attacker.com";
+        SpyEmailService emailServiceSpy = new();
+
+        using WebApplicationFactory<Program> hostWithRealSender = Factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IPasswordResetEmailSender>();
+                services.AddScoped<IPasswordResetEmailSender, PasswordResetEmailSender>();
+
+                services.RemoveAll<IEmailService>();
+                services.AddSingleton<IEmailService>(emailServiceSpy);
+            });
+        });
+
+        TestApiClient apiClient = new(hostWithRealSender.CreateClient(), ApiClient.JsonOptions);
+        SpyAccountConfirmationEmailSender confirmationSpy =
+            hostWithRealSender.Services.GetRequiredService<SpyAccountConfirmationEmailSender>();
+
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserUnconfirmedAsync(apiClient, Faker, confirmationSpy);
+
+        apiClient.Http.DefaultRequestHeaders.Host = forgedHost;
+
+        // Act
+        HttpResponseMessage response = await apiClient.Http.PostAsJsonAsync(
+            new Uri("auth/forgot-password", UriKind.Relative),
+            new ForgotPasswordRequest(registerRequest.Email));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        emailServiceSpy.LastBody.ShouldNotBeNull();
+        emailServiceSpy.LastBody.ShouldContain($"{ConfiguredIssuerOrigin}/Account/ResetPassword");
+        emailServiceSpy.LastBody.ShouldNotContain(forgedHost);
+    }
+}


### PR DESCRIPTION
## Security fix — password-reset / email-confirmation link poisoning (MEDIUM)

Found by a whole-app `/security-review`. Both `PasswordResetLinkFactory` and `EmailVerificationLinkFactory` built absolute links via `LinkGenerator.GetUriByPage(httpContext, …)`, deriving scheme/host from the request `Host` header. With `AllowedHosts: "*"` and no `UseForwardedHeaders`, an attacker could `POST auth/forgot-password` with a forged `Host: evil.com` and the victim would receive a reset link pointing at `evil.com` carrying a valid token → **account takeover**. The email-confirmation link had the same flaw.

### Fix
Both factories now source scheme + host from the trusted OpenIddict issuer (`IOptions<OpenIddictSettings>`) and drop the `IHttpContextAccessor` dependency, so the link host can no longer be influenced by the request.

### Tests (AuthSystem integration)
- **Factory-level** — each factory builds the link from the configured issuer origin.
- **HTTP-level** — `POST auth/forgot-password` with `Host: evil.attacker.com` → the emitted reset link uses the issuer origin and does **not** contain the attacker host. Verified RED (against the vulnerable code) → GREEN.

### Verification
- `dotnet build LotroKoniecDev.slnx` → 0 warnings / 0 errors
- AuthSystem integration suite → **99/99** passing (96 existing + 3 new)
- `code-reviewer` agent → **APPROVE**

### Deliberately not changed
`AllowedHosts: "*"` is left as-is: tightening it would break in-network `tms-api → auth-api` calls over `http://auth-api:8080` (Host-based), and this fix removes the dependency on the `Host` header entirely. A `UseForwardedHeaders` + known-hosts allow-list is a separate, optional defense-in-depth item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
