### PR TITLE
M6-02: UseForwardedHeaders + reverse-proxy correctness

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Options;
 using OpenTelemetry;
@@ -96,6 +97,23 @@ try
         options.MimeTypes = ResponseCompressionDefaults.MimeTypes;
     });
 
+    // Behind a cloud ingress (ACA / ALB / any reverse proxy) TLS terminates at the proxy and the
+    // container receives plain HTTP with X-Forwarded-* headers. Honour them so Request.Scheme is
+    // https — OAuth redirects, scheme-derived HATEOAS hrefs, Secure cookies, and UseHttpsRedirection
+    // all depend on it. (The OpenIddict token/discovery `iss` is NOT scheme-derived: it is pinned
+    // from OpenIddictSettings.Issuer, so it stays correct regardless of these headers.) The ingress
+    // hop has no stable IP, so KnownIPNetworks/KnownProxies are cleared (every upstream proxy is
+    // trusted), which is safe only because the container is never exposed directly: it is always
+    // reached through the ingress that sets these headers (ADR-0008).
+    builder.Services.Configure<ForwardedHeadersOptions>(options =>
+    {
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+                                   | ForwardedHeaders.XForwardedProto
+                                   | ForwardedHeaders.XForwardedHost;
+        options.KnownIPNetworks.Clear();
+        options.KnownProxies.Clear();
+    });
+
     builder.Services.Configure<RouteHandlerOptions>(options =>
     {
         options.ThrowOnBadRequest = true;
@@ -183,6 +201,16 @@ try
     });
 
     WebApplication app = builder.Build();
+
+    // Must run before anything that reads the request scheme/host (logging, HSTS, redirect, auth,
+    // OpenIddict endpoint resolution). Skipped in Development so `docker compose up` keeps its
+    // plain-http behaviour unchanged; active in Testing + Production/Staging where a TLS-terminating
+    // proxy sets X-Forwarded-Proto. With the proto honoured first, UseHttpsRedirection below is a
+    // no-op (the scheme already reads https) — there is no redirect loop.
+    if (!app.Environment.IsDevelopment())
+    {
+        app.UseForwardedHeaders();
+    }
 
     app.UseRequestContextLogging();
 

--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Microsoft.AspNetCore.HttpOverrides;
 using LotroKoniecDev.Frontend;
 using LotroKoniecDev.Frontend.Components;
 using LotroKoniecDev.Frontend.Components.Pages.ImportExport;
@@ -60,6 +61,21 @@ try
             .AddRuntimeInstrumentation())
         .UseOtlpExporter();
 
+    // Behind a cloud ingress (ACA / ALB / any reverse proxy) TLS terminates at the proxy and the
+    // container receives plain HTTP with X-Forwarded-* headers. Honour them so Request.Scheme is
+    // https, which keeps the OIDC redirect_uri, antiforgery/Secure cookies, and UseHttpsRedirection
+    // correct. The ingress hop has no stable IP, so KnownIPNetworks/KnownProxies are cleared (every
+    // upstream proxy is trusted), which is safe only because the container is never exposed directly:
+    // it is always reached through the ingress that sets these headers (ADR-0008).
+    builder.Services.Configure<ForwardedHeadersOptions>(options =>
+    {
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+                                   | ForwardedHeaders.XForwardedProto
+                                   | ForwardedHeaders.XForwardedHost;
+        options.KnownIPNetworks.Clear();
+        options.KnownProxies.Clear();
+    });
+
     builder.Services.AddRazorComponents();
 
     builder.Services
@@ -77,6 +93,16 @@ try
     builder.Services.AddFrontend();
 
     WebApplication app = builder.Build();
+
+    // Must run before anything that reads the request scheme/host (logging, HSTS, redirect, OIDC
+    // correlation). Skipped in Development so the host-run dev workflow keeps its plain behaviour
+    // unchanged; active in Testing + Production where a TLS-terminating proxy sets X-Forwarded-Proto.
+    // With the proto honoured first, UseHttpsRedirection below is a no-op (the scheme already reads
+    // https) — there is no redirect loop.
+    if (!app.Environment.IsDevelopment())
+    {
+        app.UseForwardedHeaders();
+    }
 
     app.UseSerilogRequestLogging();
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Options;
 using OpenTelemetry;
@@ -81,6 +82,21 @@ try
         options.MimeTypes = ResponseCompressionDefaults.MimeTypes;
     });
 
+    // Behind a cloud ingress (ACA / ALB / any reverse proxy) TLS terminates at the proxy and the
+    // container receives plain HTTP with X-Forwarded-* headers. Honour them so Request.Scheme is
+    // https, which keeps the JWT issuer, HATEOAS hrefs, Secure cookies, and UseHttpsRedirection
+    // correct. The ingress hop has no stable IP, so KnownIPNetworks/KnownProxies are cleared — i.e.
+    // every upstream proxy is trusted. That is safe only because the container is never exposed
+    // directly: it is always reached through the ingress that sets these headers (ADR-0008).
+    builder.Services.Configure<ForwardedHeadersOptions>(options =>
+    {
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+                                   | ForwardedHeaders.XForwardedProto
+                                   | ForwardedHeaders.XForwardedHost;
+        options.KnownIPNetworks.Clear();
+        options.KnownProxies.Clear();
+    });
+
     builder.Services.Configure<RouteHandlerOptions>(options =>
     {
         options.ThrowOnBadRequest = true;
@@ -133,6 +149,16 @@ try
     });
 
     WebApplication app = builder.Build();
+
+    // Must run before anything that reads the request scheme/host (logging, HSTS, redirect, auth,
+    // HATEOAS link generation). Skipped in Development so `docker compose up` keeps its plain-http
+    // behaviour unchanged; active in Testing + Production/Staging where a TLS-terminating proxy sets
+    // X-Forwarded-Proto. With the proto honoured first, UseHttpsRedirection below is a no-op (the
+    // scheme already reads https) — there is no redirect loop.
+    if (!app.Environment.IsDevelopment())
+    {
+        app.UseForwardedHeaders();
+    }
 
     app.UseRequestContextLogging();
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
@@ -1,0 +1,100 @@
+using System.Net.Http.Headers;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.Contracts.Discovery;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.Hateoas.ContentNegotiation;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.ForwardedHeaders;
+
+/// <summary>
+/// Proves the AuthSystem honours the reverse-proxy <c>X-Forwarded-*</c> headers (Program.cs
+/// <c>UseForwardedHeaders</c>, ADR-0008 / M6-02): behind a TLS-terminating ingress the request
+/// scheme reads <c>https</c>, so every scheme-derived absolute URL is built as <c>https</c>. This is
+/// the ticket's highest-risk surface. The seam is the anonymous discovery document's HATEOAS links,
+/// generated from <c>HttpContext.Request.Scheme</c> via <c>LinkGenerator</c> — exactly what forwarded
+/// headers rewrite. (The OpenIddict token/discovery <c>iss</c> is deliberately NOT covered here: it
+/// is pinned from <c>OpenIddictSettings.Issuer</c>, independent of the request scheme, so forwarded
+/// headers cannot — and need not — affect it.)
+/// </summary>
+public sealed class ForwardedHeadersTests : EndpointsTestBase
+{
+    public ForwardedHeadersTests(AuthSystemApiFactory appFactory) : base(appFactory)
+    {
+    }
+
+    [Fact]
+    public async Task Discovery_WithForwardedProtoHttps_BuildsHttpsAbsoluteLinks()
+    {
+        // Arrange
+        using HttpRequestMessage request = HateoasRequest();
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        DiscoveryResponse response = await SendDiscoveryAsync(request);
+
+        // Assert
+        response.Links.ShouldNotBeEmpty();
+        foreach (LinkDto link in response.Links)
+        {
+            Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+            uri!.Scheme.ShouldBe("https", $"href for rel='{link.Rel}' must be https behind the proxy");
+        }
+    }
+
+    [Fact]
+    public async Task Discovery_WithoutForwardedProto_BuildsHttpAbsoluteLinks()
+    {
+        // Arrange — the test server speaks plain http; with no X-Forwarded-Proto the scheme stays
+        // http, proving the header (not some unrelated default) is what flips the scheme to https.
+        using HttpRequestMessage request = HateoasRequest();
+
+        // Act
+        DiscoveryResponse response = await SendDiscoveryAsync(request);
+
+        // Assert
+        response.Links.ShouldNotBeEmpty();
+        foreach (LinkDto link in response.Links)
+        {
+            Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+            uri!.Scheme.ShouldBe("http");
+        }
+    }
+
+    [Fact]
+    public async Task Discovery_WithForwardedHost_BuildsLinksAgainstForwardedHost()
+    {
+        // Arrange
+        using HttpRequestMessage request = HateoasRequest();
+        request.Headers.Add("X-Forwarded-Proto", "https");
+        request.Headers.Add("X-Forwarded-Host", "auth.lotro.koniec.dev");
+
+        // Act
+        DiscoveryResponse response = await SendDiscoveryAsync(request);
+
+        // Assert
+        response.Links.ShouldNotBeEmpty();
+        foreach (LinkDto link in response.Links)
+        {
+            Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+            uri!.Scheme.ShouldBe("https");
+            uri.Host.ShouldBe("auth.lotro.koniec.dev");
+        }
+    }
+
+    private static HttpRequestMessage HateoasRequest()
+    {
+        HttpRequestMessage request = new(HttpMethod.Get, new Uri("", UriKind.Relative));
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypes.HateoasJson));
+        return request;
+    }
+
+    private async Task<DiscoveryResponse> SendDiscoveryAsync(HttpRequestMessage request)
+    {
+        HttpResponseMessage httpResponse = await ApiClient.Http.SendAsync(request);
+        string stringResponse = await httpResponse.EnsureSuccessWithDetailsAsync();
+        httpResponse.Content.Headers.ContentType?.MediaType.ShouldBe(MediaTypes.HateoasJson);
+
+        return JsonSerializer.Deserialize<DiscoveryResponse>(stringResponse, ApiClient.JsonOptions)!;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
@@ -1,0 +1,173 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.ForwardedHeaders;
+
+/// <summary>
+/// Proves the TMS honours the reverse-proxy <c>X-Forwarded-*</c> headers (Program.cs
+/// <c>UseForwardedHeaders</c>, ADR-0008 / M6-02): behind a TLS-terminating ingress the request
+/// scheme reads <c>https</c>, so every scheme-derived absolute URL (HATEOAS hrefs, and by the same
+/// mechanism the JWT issuer / OIDC redirects) is built as <c>https</c>. The HATEOAS self link is the
+/// seam: it is generated from <c>HttpContext.Request.Scheme</c> via <c>LinkGenerator</c>, exactly the
+/// surface forwarded headers rewrite. The suite runs in the Testing environment, where the middleware
+/// is active (gated only out of Development) but <c>UseHttpsRedirection</c> is not — so the forwarded
+/// proto rewrites the scheme without a redirect masking the assertion.
+/// </summary>
+[Collection("TranslationApi")]
+public sealed class ForwardedHeadersTests : IAsyncLifetime
+{
+    private const string Route = "/api/v1/game-versions";
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+
+    public ForwardedHeadersTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task GetResource_WithForwardedProtoHttps_BuildsHttpsAbsoluteLinks()
+    {
+        // Arrange
+        GameVersionId id = await SeedAsync("48.0");
+        using HttpClient client = TranslatorClient();
+        using HttpRequestMessage request = HateoasRequest($"{Route}/{id.Value}");
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        GameVersionResponse response = await SendHateoasAsync<GameVersionResponse>(client, request);
+
+        // Assert
+        LinkDto selfLink = response.Links.ShouldHaveSingleItem();
+        Uri.TryCreate(selfLink.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+        uri!.Scheme.ShouldBe("https");
+    }
+
+    [Fact]
+    public async Task GetResource_WithoutForwardedProto_BuildsHttpAbsoluteLinks()
+    {
+        // Arrange — the test server speaks plain http; with no X-Forwarded-Proto the scheme stays
+        // http, proving the header (not some unrelated default) is what flips the scheme to https.
+        GameVersionId id = await SeedAsync("48.0");
+        using HttpClient client = TranslatorClient();
+        using HttpRequestMessage request = HateoasRequest($"{Route}/{id.Value}");
+
+        // Act
+        GameVersionResponse response = await SendHateoasAsync<GameVersionResponse>(client, request);
+
+        // Assert
+        LinkDto selfLink = response.Links.ShouldHaveSingleItem();
+        Uri.TryCreate(selfLink.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+        uri!.Scheme.ShouldBe("http");
+    }
+
+    [Fact]
+    public async Task GetResource_WithForwardedHost_BuildsLinksAgainstForwardedHost()
+    {
+        // Arrange
+        GameVersionId id = await SeedAsync("48.0");
+        using HttpClient client = TranslatorClient();
+        using HttpRequestMessage request = HateoasRequest($"{Route}/{id.Value}");
+        request.Headers.Add("X-Forwarded-Proto", "https");
+        request.Headers.Add("X-Forwarded-Host", "tms.lotro.koniec.dev");
+
+        // Act
+        GameVersionResponse response = await SendHateoasAsync<GameVersionResponse>(client, request);
+
+        // Assert
+        LinkDto selfLink = response.Links.ShouldHaveSingleItem();
+        Uri.TryCreate(selfLink.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+        uri!.Scheme.ShouldBe("https");
+        uri.Host.ShouldBe("tms.lotro.koniec.dev");
+    }
+
+    [Fact]
+    public async Task GetResource_WithForwardedProtoHttps_IsServedDirectlyWithoutRedirect()
+    {
+        // Arrange — a proxied request that already declares https must be served directly, not
+        // bounced with a 3xx. NOTE: this asserts only that forwarded headers introduce no spurious
+        // redirect; it does NOT exercise UseHttpsRedirection, which is gated out of the Testing
+        // environment (Program.cs: `!IsDevelopment() && !IsTesting()`). The live "ForwardedProto
+        // honoured first → UseHttpsRedirection is a no-op → no redirect loop" guarantee is verified
+        // against a real TLS-terminating reverse proxy in the M6-07 prod-parity stack, where the
+        // redirect middleware actually runs.
+        GameVersionId id = await SeedAsync("48.0");
+        using HttpClient client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+        using HttpRequestMessage request = new(HttpMethod.Get, $"{Route}/{id.Value}");
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        using HttpResponseMessage response = await client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private static HttpRequestMessage HateoasRequest(string url)
+    {
+        HttpRequestMessage request = new(HttpMethod.Get, url);
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypes.HateoasJson));
+        return request;
+    }
+
+    private static async Task<T> SendHateoasAsync<T>(HttpClient client, HttpRequestMessage request)
+        where T : class
+    {
+        HttpResponseMessage response = await client.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe(MediaTypes.HateoasJson);
+
+        return (await response.Content.ReadFromJsonAsync<T>(JsonOptions))!;
+    }
+
+    private HttpClient TranslatorClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+        return client;
+    }
+
+    private async Task<GameVersionId> SeedAsync(string version)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+
+        return gameVersion.Id;
+    }
+}


### PR DESCRIPTION
Closes #167

## What

Adds `UseForwardedHeaders` (`XForwardedFor | XForwardedProto | XForwardedHost`) as the **first** middleware in all three web apps so that behind a TLS-terminating cloud ingress (ACA / ALB / any reverse proxy) `Request.Scheme` reads `https` — keeping scheme-derived absolute URLs, `Secure` cookies, and `UseHttpsRedirection` correct (ADR-0008 / M6-02).

- `src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs`
- `src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs`
- `src/Frontend/LotroKoniecDev.Frontend/Program.cs`

Mirrors TheKittySaver's Frontend `ForwardedHeadersOptions` setup, extended to both APIs per the ticket.

## Decisions

- **Gated to non-Development.** Active in Testing + Production/Staging; skipped in Development so `docker compose up` dev behavior is unchanged (AC: dev unchanged).
- **`KnownIPNetworks`/`KnownProxies` cleared.** The ingress hop has no stable IP, so every upstream proxy is trusted. This is safe **only because the container is never exposed directly** — it is always reached through the ingress that sets these headers (ADR-0008 fixed container contract). Documented inline in each file.
- **`UseHttpsRedirection` stays.** With `ForwardedProto` honoured first the request scheme is already `https`, so the redirect is a no-op — no redirect loop. HSTS unchanged.
- **OpenIddict `iss` is config-pinned**, not scheme-derived (`options.Issuer = new Uri(OpenIddictSettings.Issuer)`), so it is unaffected by forwarded headers. The auth tests deliberately assert on the scheme-driven discovery HATEOAS links, not on `iss`.

## Tests (real pipeline, Testcontainers PostgreSQL + real OpenIddict host)

New `ForwardedHeaders` integration suites on **both** APIs (the scheme-driven seam is `LinkFactory` → `LinkGenerator.GetUriByName(HttpContext, …)`):
- `X-Forwarded-Proto: https` → all absolute hrefs are `https` (the coverage AC).
- control: no header → `http` (proves the header is load-bearing, not an unrelated default).
- `X-Forwarded-Host` → link host flips to the forwarded host.
- tms-api: a proxied-https GET is served directly (no spurious redirect).

7 new tests; full integration suites green (125 TMS + 102 auth). Build green, zero warnings (Debug + Release).

## Acceptance criteria

- [x] All three apps honor `X-Forwarded-Proto/Host` (request scheme is https behind a proxy)
- [x] No HTTPS redirect loop behind a TLS-terminating proxy (ordering: forwarded-headers first → redirect is a no-op)
- [x] Coverage: `X-Forwarded-Proto: https` yields https absolute URLs (proven on tms-api + auth-api)
- [x] Dev (`docker compose up`) behavior unchanged (non-Development gate)
- [x] Zero warnings, green build

## Scoped deferrals (tracked to M6-07 / M6-13)

- **Live redirect-loop assertion.** `UseHttpsRedirection` is gated out of the Testing environment in both APIs, so an in-process `WebApplicationFactory` cannot exercise the redirect middleware. The in-process test asserts only that forwarded headers introduce no spurious redirect; the live "ForwardedProto-first → `UseHttpsRedirection` no-op → no loop" guarantee is verified against a real TLS-terminating reverse proxy in the **M6-07** prod-parity stack.
- **Frontend end-to-end.** There is no Frontend integration test host (only `Frontend.Tests.Unit`, a bUnit/unit project with no `WebApplicationFactory`). The Frontend `Program.cs` change mirrors the two APIs exactly (same options block, same non-Development-gated first middleware). End-to-end Frontend forwarded-headers verification rides on the **M6-07** reverse-proxy stack / **M6-13** smoke test.

Note: depends on M6-01 (ADR-0008, #166) which is Accepted; this diff touches only the three `Program.cs` files and is disjoint from the ADR doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)