### PR TITLE
M6-03: CORS from configuration (multi-origin, per-environment)

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -15,6 +15,7 @@ using LotroKoniecDev.AuthSystem.API;
 using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.API.Health;
 using LotroKoniecDev.AuthSystem.API.Middleware;
+using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Persistence.Settings;
 
 Log.Logger = new LoggerConfiguration()
@@ -119,6 +120,21 @@ try
         options.ThrowOnBadRequest = true;
     });
 
+    // CORS origins are environment-injected, not baked into code (ADR-0008 §3, M6-03): the production
+    // policy admits only the configured browser origins, validated at startup so a missing or
+    // malformed origin aborts boot in Staging/Production (CorsSettingsValidator) instead of silently
+    // blocking the browser. Development uses the permissive policy below and ignores this list.
+    // AllowCredentials() (required for the cookie/OIDC auth flows) is preserved — it pairs with the
+    // explicit WithOrigins list, never with AllowAnyOrigin (which the framework would reject).
+    builder.Services.AddOptions<CorsSettings>()
+        .BindConfiguration(CorsSettings.ConfigurationSection)
+        .ValidateOnStart();
+    builder.Services.AddSingleton<IValidateOptions<CorsSettings>, CorsSettingsValidator>();
+
+    string[] allowedCorsOrigins = builder.Configuration
+        .GetSection(CorsSettings.ConfigurationSection)
+        .Get<CorsSettings>()?.AllowedOrigins ?? [];
+
     const string localCorsPolicy = "DevelopmentPolicy";
     const string productionCorsPolicy = "ProductionPolicy";
 
@@ -134,7 +150,7 @@ try
         options.AddPolicy(productionCorsPolicy, corsBuilder =>
         {
             corsBuilder
-                .WithOrigins("https://lotro.koniec.dev")
+                .WithOrigins(allowedCorsOrigins)
                 .WithHeaders("Authorization", "Content-Type", "X-Requested-With", "Accept")
                 .WithMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .AllowCredentials();
@@ -236,11 +252,12 @@ try
     app.UseRouting();
     app.UseGlobalNoCache();
 
-    string corsPolicy = app.Environment.EnvironmentName switch
-    {
-        EnvironmentsExtensions.ProductionName => productionCorsPolicy,
-        _ => localCorsPolicy
-    };
+    // Only Development gets the permissive AllowAnyOrigin policy; every deployed environment
+    // (Staging + Production, ADR-0008 §1) serves the restrictive configured-origins policy, so a
+    // staging origin is never silently waved through.
+    string corsPolicy = app.Environment.IsDevelopment()
+        ? localCorsPolicy
+        : productionCorsPolicy;
     app.UseCors(corsPolicy);
 
     app.UseAuthentication();

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/CorsSettings.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/CorsSettings.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.AuthSystem.API.Settings;
+
+/// <summary>
+/// Browser origins the production CORS policy admits, injected per environment (ADR-0008 §3).
+/// An empty list is valid only in Development/Testing — those use the permissive AllowAnyOrigin
+/// policy and never read this list; Staging/Production require at least one bare http(s) origin,
+/// enforced at startup by <see cref="CorsSettingsValidator"/>.
+/// </summary>
+internal sealed class CorsSettings
+{
+    public const string ConfigurationSection = "Cors";
+
+    public string[] AllowedOrigins { get; init; } = [];
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/CorsSettingsValidator.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/CorsSettingsValidator.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+
+namespace LotroKoniecDev.AuthSystem.API.Settings;
+
+/// <summary>
+/// Fails fast at startup when the configured CORS origins are missing or malformed in a deployed
+/// environment (Staging/Production), naming the offending key (ADR-0008 §3, M6-03). Development
+/// uses the permissive AllowAnyOrigin policy and Testing runs same-origin in-memory, so neither
+/// supplies origins — both skip validation, mirroring <c>OpenIddictSettingsValidator</c>.
+/// </summary>
+internal sealed class CorsSettingsValidator : IValidateOptions<CorsSettings>
+{
+    private readonly IWebHostEnvironment _environment;
+
+    public CorsSettingsValidator(IWebHostEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    public ValidateOptionsResult Validate(string? name, CorsSettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (_environment.IsDevelopment() || _environment.IsEnvironment(EnvironmentsExtensions.TestingName))
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        List<string> errors = [];
+
+        if (options.AllowedOrigins.Length == 0)
+        {
+            errors.Add(
+                $"{CorsSettings.ConfigurationSection}:{nameof(CorsSettings.AllowedOrigins)} must contain at least one " +
+                $"origin in {_environment.EnvironmentName}. Inject it via the " +
+                $"{CorsSettings.ConfigurationSection}__{nameof(CorsSettings.AllowedOrigins)}__0 environment variable " +
+                "(e.g. https://lotro.koniec.dev).");
+        }
+
+        foreach (string origin in options.AllowedOrigins)
+        {
+            if (!BeBareHttpOrigin(origin))
+            {
+                errors.Add(
+                    $"{CorsSettings.ConfigurationSection}:{nameof(CorsSettings.AllowedOrigins)} entry '{origin}' must be " +
+                    "a bare absolute http(s) origin — lowercase scheme and host, no default port, and no userinfo, " +
+                    "path, query, or trailing slash (e.g. https://lotro.koniec.dev).");
+            }
+        }
+
+        return errors.Count > 0
+            ? ValidateOptionsResult.Fail(errors)
+            : ValidateOptionsResult.Success;
+    }
+
+    /// <summary>
+    /// A CORS origin is the scheme+host(+non-default-port) only — the browser's <c>Origin</c> header
+    /// carries no userinfo, path, query, or trailing slash and is always lowercase, so e.g.
+    /// <c>WithOrigins("https://x/")</c> or <c>"https://u:p@x"</c> would silently never match.
+    /// Requiring the value to equal its own (userinfo-free) authority part rejects those
+    /// misconfigurations at boot.
+    /// </summary>
+    private static bool BeBareHttpOrigin(string? value)
+    {
+        return value is not null
+               && Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+               && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+               && string.IsNullOrEmpty(uri.UserInfo)
+               && string.Equals(value, uri.GetLeftPart(UriPartial.Authority), StringComparison.Ordinal);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
@@ -17,6 +17,7 @@ using LotroKoniecDev.TranslationSystem.API.Extensions;
 using LotroKoniecDev.TranslationSystem.API.Features.Bootstrap;
 using LotroKoniecDev.TranslationSystem.API.Health;
 using LotroKoniecDev.TranslationSystem.API.Middleware;
+using LotroKoniecDev.TranslationSystem.API.Settings;
 using LotroKoniecDev.TranslationSystem.Persistence.Settings;
 
 Log.Logger = new LoggerConfiguration()
@@ -102,6 +103,19 @@ try
         options.ThrowOnBadRequest = true;
     });
 
+    // CORS origins are environment-injected, not baked into code (ADR-0008 §3, M6-03): the production
+    // policy admits only the configured browser origins, validated at startup so a missing or
+    // malformed origin aborts boot in Staging/Production (CorsSettingsValidator) instead of silently
+    // blocking the browser. Development uses the permissive policy below and ignores this list.
+    builder.Services.AddOptions<CorsSettings>()
+        .BindConfiguration(CorsSettings.ConfigurationSection)
+        .ValidateOnStart();
+    builder.Services.AddSingleton<IValidateOptions<CorsSettings>, CorsSettingsValidator>();
+
+    string[] allowedCorsOrigins = builder.Configuration
+        .GetSection(CorsSettings.ConfigurationSection)
+        .Get<CorsSettings>()?.AllowedOrigins ?? [];
+
     const string localCorsPolicy = "DevelopmentPolicy";
     const string productionCorsPolicy = "ProductionPolicy";
 
@@ -117,7 +131,7 @@ try
         options.AddPolicy(productionCorsPolicy, corsBuilder =>
         {
             corsBuilder
-                .WithOrigins("https://lotro.koniec.dev")
+                .WithOrigins(allowedCorsOrigins)
                 .WithHeaders("Authorization", "Content-Type", "X-Requested-With", "Accept")
                 .WithMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
         });
@@ -184,11 +198,12 @@ try
     app.UseRouting();
     app.UseGlobalNoCache();
 
-    string corsPolicy = app.Environment.EnvironmentName switch
-    {
-        EnvironmentsExtensions.ProductionName => productionCorsPolicy,
-        _ => localCorsPolicy
-    };
+    // Only Development gets the permissive AllowAnyOrigin policy; every deployed environment
+    // (Staging + Production, ADR-0008 §1) serves the restrictive configured-origins policy, so a
+    // staging origin is never silently waved through.
+    string corsPolicy = app.Environment.IsDevelopment()
+        ? localCorsPolicy
+        : productionCorsPolicy;
     app.UseCors(corsPolicy);
 
     app.UseAuthentication();

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Settings/CorsSettings.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Settings/CorsSettings.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.TranslationSystem.API.Settings;
+
+/// <summary>
+/// Browser origins the production CORS policy admits, injected per environment (ADR-0008 §3).
+/// An empty list is valid only in Development/Testing — those use the permissive AllowAnyOrigin
+/// policy and never read this list; Staging/Production require at least one bare http(s) origin,
+/// enforced at startup by <see cref="CorsSettingsValidator"/>.
+/// </summary>
+internal sealed class CorsSettings
+{
+    public const string ConfigurationSection = "Cors";
+
+    public string[] AllowedOrigins { get; init; } = [];
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Settings/CorsSettingsValidator.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Settings/CorsSettingsValidator.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+
+namespace LotroKoniecDev.TranslationSystem.API.Settings;
+
+/// <summary>
+/// Fails fast at startup when the configured CORS origins are missing or malformed in a deployed
+/// environment (Staging/Production), naming the offending key (ADR-0008 §3, M6-03). Development
+/// uses the permissive AllowAnyOrigin policy and Testing runs same-origin in-memory, so neither
+/// supplies origins — both skip validation, mirroring <c>OpenIddictSettingsValidator</c>.
+/// </summary>
+internal sealed class CorsSettingsValidator : IValidateOptions<CorsSettings>
+{
+    private readonly IWebHostEnvironment _environment;
+
+    public CorsSettingsValidator(IWebHostEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    public ValidateOptionsResult Validate(string? name, CorsSettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (_environment.IsDevelopment() || _environment.IsEnvironment(EnvironmentsExtensions.TestingName))
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        List<string> errors = [];
+
+        if (options.AllowedOrigins.Length == 0)
+        {
+            errors.Add(
+                $"{CorsSettings.ConfigurationSection}:{nameof(CorsSettings.AllowedOrigins)} must contain at least one " +
+                $"origin in {_environment.EnvironmentName}. Inject it via the " +
+                $"{CorsSettings.ConfigurationSection}__{nameof(CorsSettings.AllowedOrigins)}__0 environment variable " +
+                "(e.g. https://lotro.koniec.dev).");
+        }
+
+        foreach (string origin in options.AllowedOrigins)
+        {
+            if (!BeBareHttpOrigin(origin))
+            {
+                errors.Add(
+                    $"{CorsSettings.ConfigurationSection}:{nameof(CorsSettings.AllowedOrigins)} entry '{origin}' must be " +
+                    "a bare absolute http(s) origin — lowercase scheme and host, no default port, and no userinfo, " +
+                    "path, query, or trailing slash (e.g. https://lotro.koniec.dev).");
+            }
+        }
+
+        return errors.Count > 0
+            ? ValidateOptionsResult.Fail(errors)
+            : ValidateOptionsResult.Success;
+    }
+
+    /// <summary>
+    /// A CORS origin is the scheme+host(+non-default-port) only — the browser's <c>Origin</c> header
+    /// carries no userinfo, path, query, or trailing slash and is always lowercase, so e.g.
+    /// <c>WithOrigins("https://x/")</c> or <c>"https://u:p@x"</c> would silently never match.
+    /// Requiring the value to equal its own (userinfo-free) authority part rejects those
+    /// misconfigurations at boot.
+    /// </summary>
+    private static bool BeBareHttpOrigin(string? value)
+    {
+        return value is not null
+               && Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+               && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+               && string.IsNullOrEmpty(uri.UserInfo)
+               && string.Equals(value, uri.GetLeftPart(UriPartial.Authority), StringComparison.Ordinal);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/CorsSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/CorsSettingsValidatorTests.cs
@@ -1,0 +1,102 @@
+using LotroKoniecDev.AuthSystem.API.Settings;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Settings;
+
+/// <summary>
+/// Pure unit coverage for the AuthSystem CORS startup guard (M6-03). It lives in the integration
+/// project only because the AuthSystem has no API unit project; it instantiates no factory and
+/// starts no container.
+/// </summary>
+public sealed class CorsSettingsValidatorTests
+{
+    private const string Production = "Production";
+    private const string Staging = "Staging";
+    private const string Development = "Development";
+    private const string Testing = "Testing";
+
+    [Theory]
+    [InlineData(Development)]
+    [InlineData(Testing)]
+    public void Validate_NonDeployedEnvironmentWithNoOrigins_Succeeds(string environmentName)
+    {
+        CorsSettingsValidator validator = CreateValidator(environmentName);
+        CorsSettings settings = new() { AllowedOrigins = [] };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(Production)]
+    [InlineData(Staging)]
+    public void Validate_DeployedEnvironmentWithNoOrigins_FailsNamingTheKey(string environmentName)
+    {
+        CorsSettingsValidator validator = CreateValidator(environmentName);
+        CorsSettings settings = new() { AllowedOrigins = [] };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure => failure.Contains("Cors:AllowedOrigins", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ProductionWithMultipleValidOrigins_Succeeds()
+    {
+        CorsSettingsValidator validator = CreateValidator(Production);
+        CorsSettings settings = new()
+        {
+            AllowedOrigins = ["https://lotro.koniec.dev", "https://staging.lotro.koniec.dev"]
+        };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://lotro.koniec.dev")]
+    [InlineData("https://lotro.koniec.dev/")]
+    [InlineData("https://lotro.koniec.dev/api")]
+    [InlineData("https://user:pass@lotro.koniec.dev")]
+    public void Validate_ProductionWithMalformedOrigin_FailsNamingTheKey(string? origin)
+    {
+        CorsSettingsValidator validator = CreateValidator(Production);
+        // origin! — a sparse/explicit-null config binding can place a null element into the array;
+        // the validator must reject it, so the test deliberately passes one.
+        CorsSettings settings = new() { AllowedOrigins = [origin!] };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure => failure.Contains("Cors:AllowedOrigins", StringComparison.Ordinal));
+    }
+
+    private static CorsSettingsValidator CreateValidator(string environmentName)
+        => new(new FakeWebHostEnvironment(environmentName));
+}
+
+file sealed class FakeWebHostEnvironment : IWebHostEnvironment
+{
+    public FakeWebHostEnvironment(string environmentName)
+    {
+        EnvironmentName = environmentName;
+    }
+
+    public string EnvironmentName { get; set; }
+    public string ApplicationName { get; set; } = "auth-tests";
+    public string ContentRootPath { get; set; } = string.Empty;
+    public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    public string WebRootPath { get; set; } = string.Empty;
+    public IFileProvider WebRootFileProvider { get; set; } = null!;
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Settings/CorsSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Settings/CorsSettingsValidatorTests.cs
@@ -1,0 +1,122 @@
+using LotroKoniecDev.TranslationSystem.API.Settings;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Settings;
+
+public sealed class CorsSettingsValidatorTests
+{
+    private const string Production = "Production";
+    private const string Staging = "Staging";
+    private const string Development = "Development";
+    private const string Testing = "Testing";
+
+    [Theory]
+    [InlineData(Development)]
+    [InlineData(Testing)]
+    public void Validate_NonDeployedEnvironmentWithNoOrigins_Succeeds(string environmentName)
+    {
+        CorsSettingsValidator validator = CreateValidator(environmentName);
+        CorsSettings settings = new() { AllowedOrigins = [] };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_DevelopmentWithMalformedOrigin_Succeeds()
+    {
+        // Development never reads the list (permissive AllowAnyOrigin policy), so even a malformed
+        // value must not block boot — the skip is unconditional, not "skip only when empty".
+        CorsSettingsValidator validator = CreateValidator(Development);
+        CorsSettings settings = new() { AllowedOrigins = ["not-a-url"] };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(Production)]
+    [InlineData(Staging)]
+    public void Validate_DeployedEnvironmentWithNoOrigins_FailsNamingTheKey(string environmentName)
+    {
+        CorsSettingsValidator validator = CreateValidator(environmentName);
+        CorsSettings settings = new() { AllowedOrigins = [] };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure => failure.Contains("Cors:AllowedOrigins", StringComparison.Ordinal));
+        result.Failures.ShouldContain(failure => failure.Contains(environmentName, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ProductionWithSingleValidOrigin_Succeeds()
+    {
+        CorsSettingsValidator validator = CreateValidator(Production);
+        CorsSettings settings = new() { AllowedOrigins = ["https://lotro.koniec.dev"] };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ProductionWithMultipleValidOrigins_Succeeds()
+    {
+        CorsSettingsValidator validator = CreateValidator(Production);
+        CorsSettings settings = new()
+        {
+            AllowedOrigins = ["https://lotro.koniec.dev", "https://staging.lotro.koniec.dev", "http://localhost:7017"]
+        };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    [InlineData("/relative/path")]
+    [InlineData("ftp://lotro.koniec.dev")]
+    [InlineData("https://lotro.koniec.dev/")]
+    [InlineData("https://lotro.koniec.dev/api")]
+    [InlineData("https://user:pass@lotro.koniec.dev")]
+    public void Validate_ProductionWithMalformedOrigin_FailsNamingTheKey(string? origin)
+    {
+        CorsSettingsValidator validator = CreateValidator(Production);
+        // origin! — a sparse/explicit-null config binding can place a null element into the array;
+        // the validator must reject it, so the test deliberately passes one.
+        CorsSettings settings = new() { AllowedOrigins = [origin!] };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure => failure.Contains("Cors:AllowedOrigins", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ProductionWithOneValidAndOneMalformedOrigin_Fails()
+    {
+        CorsSettingsValidator validator = CreateValidator(Production);
+        CorsSettings settings = new() { AllowedOrigins = ["https://lotro.koniec.dev", "https://bad.example/path"] };
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+    }
+
+    private static CorsSettingsValidator CreateValidator(string environmentName)
+    {
+        IWebHostEnvironment environment = Substitute.For<IWebHostEnvironment>();
+        environment.EnvironmentName.Returns(environmentName);
+        return new CorsSettingsValidator(environment);
+    }
+}


### PR DESCRIPTION
## Summary
Replace the hardcoded `https://lotro.koniec.dev` CORS origin in both APIs with an environment-injected `Cors:AllowedOrigins` list (ADR-0008 §3). Adding or changing an origin is now config-only (env var), and multiple origins (staging + prod) are supported per environment.

## Changes
- **`CorsSettings`** (bound from the `Cors` section) + **`CorsSettingsValidator`** added to both `AuthSystem.API` and `TranslationSystem.API`. The production policy now admits the configured origins via `WithOrigins(allowedCorsOrigins)`.
- Validator **fails fast at startup** (`ValidateOnStart`) in Staging/Production when origins are missing or not a bare `http(s)` origin — naming the offending key. Development/Testing skip validation and use the permissive `AllowAnyOrigin` policy.
- Policy selection flipped to `IsDevelopment() ? permissive : restrictive`, so **Staging** also gets the locked-down policy (previously Production-only).
- Auth preserves **`AllowCredentials()`** paired with the explicit origin list (never with `AllowAnyOrigin`).
- Unit tests for both validators: environment gating, multi-origin, and the bare-origin unhappy-path matrix.

## Acceptance criteria
- [x] No hardcoded origin remains in code
- [x] Adding/changing an origin is config-only (env var)
- [x] Multiple origins supported (staging + prod)
- [x] Non-Development boot fails fast if origins missing
- [x] Zero warnings, green build

## Verification
- `dotnet build LotroKoniecDev.slnx` → 0 Warnings, 0 Errors
- AuthSystem CORS validator tests: 12/12 passed · TranslationSystem CORS validator tests: 16/16 passed

> Wiring concrete staging/prod origin values into `compose.prod`/the runbook is deferred to the later prod-settings infra ticket (#171/#172 per ADR-0008) — this PR establishes the `Cors:AllowedOrigins` contract the deployment honors.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)