### PR TITLE
M6-04: Data Protection key persistence in auth-api

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
@@ -35,6 +35,14 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 
+# Data Protection keyring mount point (M6-04, ADR-0005). A non-dev deployment MUST mount a
+# shared/persistent volume here and set DataProtection__KeyRingPath=/keys, or the startup guard
+# fails fast. A named volume covers single-host restart/scale; multi-host needs ReadWriteMany
+# (NFS/EFS/Azure Files). No VOLUME instruction on purpose: an anonymous volume would silently mask
+# a missing mount. The dev compose runs under Development, where an empty keyring path is valid
+# (host-default location), so this directory is unused there.
+USER root
+RUN mkdir -p /keys && chown app:app /keys
 USER app
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/DataProtectionExtensions.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/DataProtectionExtensions.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.DataProtection;
+using LotroKoniecDev.AuthSystem.API.Settings;
+
+namespace LotroKoniecDev.AuthSystem.API.Extensions;
+
+/// <summary>
+/// Configures ASP.NET Core Data Protection for auth-api (M6-04, mirrors the Frontend posture in
+/// ADR-0005): a stable application name in every environment (so a key minted by one instance/path
+/// is readable by another), and filesystem key persistence only when a keyring path is configured.
+/// Data Protection protects the Identity login cookie, Razor antiforgery on the login/account
+/// pages, and the Identity password-reset / email-confirmation tokens — all silently invalidated on
+/// every deploy (and immediately across replicas) by an ephemeral, process-local keyring.
+/// </summary>
+internal static class DataProtectionExtensions
+{
+    private const string ApplicationName = "LotroKoniecDev.AuthSystem";
+
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        /// Pins a stable application name and persists the keyring to the filesystem when a path is
+        /// configured. The keyring path is read straight from configuration at registration time —
+        /// Data Protection is set up before the DI container is built, so there is no validated
+        /// options instance to resolve yet, and binding <see cref="IServiceProvider"/> here would
+        /// trip ASP0000. The non-dev guard therefore lives here (not in an
+        /// <see cref="Microsoft.Extensions.Options.IValidateOptions{TOptions}"/>) so it fires
+        /// before the host is built.
+        /// </summary>
+        public IServiceCollection AddAuthDataProtection(IConfiguration configuration, IHostEnvironment environment)
+        {
+            DataProtectionSettings settings = configuration
+                .GetSection(DataProtectionSettings.ConfigurationSection)
+                .Get<DataProtectionSettings>() ?? new DataProtectionSettings();
+
+            GuardKeyRingPath(settings, environment);
+
+            IDataProtectionBuilder builder = services
+                .AddDataProtection()
+                .SetApplicationName(ApplicationName);
+
+            if (!string.IsNullOrWhiteSpace(settings.KeyRingPath))
+            {
+                builder.PersistKeysToFileSystem(new DirectoryInfo(settings.KeyRingPath));
+            }
+
+            return services;
+        }
+    }
+
+    /// <summary>
+    /// Loud over silent: a keyring path is mandatory outside Development/Testing. Development uses
+    /// the host-default location (which already persists), and Testing is an in-memory harness with
+    /// no real sessions to preserve — both legitimately leave the path empty, mirroring the
+    /// CORS startup guard's environment posture. Every deployed environment must mount a shared
+    /// volume and point the keyring at it; otherwise each deploy/scale-out logs all users out and
+    /// breaks antiforgery + password-reset/email-confirmation links.
+    /// </summary>
+    public static void GuardKeyRingPath(DataProtectionSettings settings, IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        if (environment.IsDevelopment() || environment.IsTesting())
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.KeyRingPath))
+        {
+            throw new InvalidOperationException(
+                $"{DataProtectionSettings.ConfigurationSection}:{nameof(DataProtectionSettings.KeyRingPath)} "
+                + $"must be set in {environment.EnvironmentName}. Mount a shared/persistent volume and point the "
+                + "keyring at it (e.g. DataProtection__KeyRingPath=/keys); otherwise every deploy/scale-out logs "
+                + "all users out and breaks antiforgery + password-reset/email-confirmation links.");
+        }
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -55,6 +55,13 @@ try
 
     builder.Services.AddAuthSystem(builder.Environment);
 
+    // Configured before the host is built and read straight from configuration (M6-04, mirrors the
+    // Frontend posture in ADR-0005): the keyring must be persistent and the application name pinned
+    // so the Identity login cookie, Razor antiforgery, and password-reset/email-confirmation tokens
+    // survive restarts and are shared across replicas. Registered before AddAuthentication, which
+    // depends on the configured keyring to protect its cookie.
+    builder.Services.AddAuthDataProtection(builder.Configuration, builder.Environment);
+
     builder.Services.AddAuthentication(options =>
     {
         options.DefaultScheme = OpenIddict.Validation.AspNetCore.OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme;

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/DataProtectionSettings.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/DataProtectionSettings.cs
@@ -1,0 +1,19 @@
+namespace LotroKoniecDev.AuthSystem.API.Settings;
+
+/// <summary>
+/// Filesystem directory the ASP.NET Core Data Protection keyring is persisted to (mounted to a
+/// shared volume in container deployments). Data Protection protects the Identity login cookie
+/// (<c>LotroKoniecDev.Auth</c>), the Razor antiforgery tokens on the login/account pages, and the
+/// Identity data-protector tokens (email-confirmation / password-reset links). Empty is valid in
+/// Development: the framework default location at <c>~/.aspnet/DataProtection-Keys</c> already
+/// persists across host restarts, so dev must not hardcode a container path. A non-dev startup
+/// guard rejects an empty value — an ephemeral keyring in a deployed environment mass-logs-out
+/// users and breaks antiforgery + reset/confirm links on every deploy (and immediately with more
+/// than one replica), because every protected payload becomes unreadable.
+/// </summary>
+internal sealed class DataProtectionSettings
+{
+    public const string ConfigurationSection = "DataProtection";
+
+    public string? KeyRingPath { get; init; }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.Development.json
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.Development.json
@@ -24,6 +24,9 @@
       "PostLogoutRedirectUris": ["https://localhost:7017"]
     }
   },
+  "DataProtection": {
+    "KeyRingPath": ""
+  },
   "AdminUser": {
     "Username": "admin",
     "Email": "",

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.json
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.json
@@ -29,6 +29,9 @@
       ]
     }
   },
+  "DataProtection": {
+    "KeyRingPath": ""
+  },
   "AdminUser": {
     "Username": "",
     "Email": "",

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/DataProtectionGuardTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/DataProtectionGuardTests.cs
@@ -1,0 +1,79 @@
+using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Settings;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Settings;
+
+/// <summary>
+/// Pure unit coverage for the AuthSystem Data Protection keyring startup guard (M6-04). It lives in
+/// the integration project only because the AuthSystem has no API unit project; it instantiates no
+/// factory and starts no container.
+/// </summary>
+public sealed class DataProtectionGuardTests
+{
+    private const string Production = "Production";
+    private const string Staging = "Staging";
+    private const string Development = "Development";
+    private const string Testing = "Testing";
+
+    [Theory]
+    [InlineData(Development)]
+    [InlineData(Testing)]
+    public void GuardKeyRingPath_NonDeployedEnvironmentWithEmptyPath_DoesNotThrow(string environmentName)
+    {
+        DataProtectionSettings settings = new() { KeyRingPath = null };
+
+        Action act = () => DataProtectionExtensions.GuardKeyRingPath(settings, new FakeWebHostEnvironment(environmentName));
+
+        act.ShouldNotThrow();
+    }
+
+    [Theory]
+    [InlineData(Production, null)]
+    [InlineData(Production, "")]
+    [InlineData(Production, "   ")]
+    [InlineData(Staging, null)]
+    [InlineData(Staging, "")]
+    [InlineData(Staging, "   ")]
+    public void GuardKeyRingPath_DeployedEnvironmentWithMissingPath_ThrowsNamingTheKey(
+        string environmentName,
+        string? keyRingPath)
+    {
+        DataProtectionSettings settings = new() { KeyRingPath = keyRingPath };
+
+        Action act = () => DataProtectionExtensions.GuardKeyRingPath(settings, new FakeWebHostEnvironment(environmentName));
+
+        InvalidOperationException exception = act.ShouldThrow<InvalidOperationException>();
+        exception.Message.ShouldContain("DataProtection:KeyRingPath");
+        exception.Message.ShouldContain(environmentName);
+    }
+
+    [Theory]
+    [InlineData(Production)]
+    [InlineData(Staging)]
+    public void GuardKeyRingPath_DeployedEnvironmentWithPath_DoesNotThrow(string environmentName)
+    {
+        DataProtectionSettings settings = new() { KeyRingPath = "/keys" };
+
+        Action act = () => DataProtectionExtensions.GuardKeyRingPath(settings, new FakeWebHostEnvironment(environmentName));
+
+        act.ShouldNotThrow();
+    }
+}
+
+file sealed class FakeWebHostEnvironment : IWebHostEnvironment
+{
+    public FakeWebHostEnvironment(string environmentName)
+    {
+        EnvironmentName = environmentName;
+    }
+
+    public string EnvironmentName { get; set; }
+    public string ApplicationName { get; set; } = "auth-tests";
+    public string ContentRootPath { get; set; } = string.Empty;
+    public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    public string WebRootPath { get; set; } = string.Empty;
+    public IFileProvider WebRootFileProvider { get; set; } = null!;
+}


### PR DESCRIPTION
Closes #169

## What & why
auth-api did not persist the ASP.NET Core Data Protection keyring. DP protects the Identity login cookie (`LotroKoniecDev.Auth`), Razor antiforgery on the login/account pages, and the Identity password-reset / email-confirmation tokens. On an ephemeral container FS every restart rotated those keys → users logged out, antiforgery + reset/confirm links broke; with >1 replica they broke immediately. This mirrors the already-shipped Frontend pattern (ADR-0005).

## Changes
- **`Settings/DataProtectionSettings.cs`** — `internal sealed`, `init`-only `KeyRingPath` (mirrors the Frontend settings shape).
- **`Extensions/DataProtectionExtensions.cs`** — `AddAuthDataProtection(IConfiguration, IHostEnvironment)`: pins a stable application name (`LotroKoniecDev.AuthSystem`) and persists keys to the configured path via `PersistKeysToFileSystem`. The fail-fast guard is extracted as a unit-testable `GuardKeyRingPath` static (DP must be configured pre-container, so an `IValidateOptions` would run too late / ASP0000).
- **`Program.cs`** — registered before `AddAuthentication` (the cookie handler depends on the configured keyring).
- **`Dockerfile`** — `/keys` mount point owned by `app` (`USER root` → `mkdir -p /keys && chown app:app /keys` → `USER app`), no `VOLUME` so a missing mount stays visible. Byte-for-byte mirror of the Frontend.
- **`appsettings.json` / `appsettings.Development.json`** — `DataProtection:KeyRingPath: ""` (dev falls back to the host-default keyring location).
- **`DataProtectionGuardTests.cs`** — pure unit test (lives in the Integration project because auth-api has no API unit project, mirroring `CorsSettingsValidatorTests`); boundary matrix over {Development, Testing, Production, Staging} × {null, "", "   ", "/keys"}.

## Key decision
The fail-fast guard skips **Development AND Testing** (the Frontend only skips Development). The auth integration suite boots the full host via `WebApplicationFactory` under environment `Testing` with no `KeyRingPath`, and the existing `CorsSettingsValidator` (M6-03) sets the exact precedent. Verified: 23 host-booting integration tests still pass with DP registered.

## Scope note
The ticket's `compose.prod.yaml` wiring + runbook bullets are cross-referenced to **M6-07** (a separate ticket); `compose.prod.yaml` does not exist yet and the Frontend keyring is likewise not wired into dev `compose.yaml` (ADR-0005 §3). They fall outside this ticket's acceptance criteria and are deliberately deferred.

## Verification
- `dotnet build LotroKoniecDev.slnx` → 0 warnings, 0 errors.
- `DataProtectionGuardTests` → 10/10 pass; representative host-booting integration tests → 23/23 pass.
- code-reviewer agent: **APPROVE** (every AC met, full edge-case matrix). Security review: no HIGH/MEDIUM findings (net security improvement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)