### PR TITLE
M6-05: fail-fast configuration validation at startup (#170)

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -74,9 +74,13 @@ internal static class ApiDependencyInjection
             services.AddScoped<IPasswordResetEmailSender, PasswordResetEmailSender>();
             services.AddScoped<IAccountConfirmationEmailSender, AccountConfirmationEmailSender>();
 
+            // Fail-fast startup validation of the OpenIddict server config (ADR-0008 §3, M6-05): the
+            // OpenIddictSettingsValidator enforces the production key material / issuer and names the
+            // offending key + environment. No ValidateDataAnnotations() — the settings carry no
+            // DataAnnotations attributes (the `required` issuer is a binder constraint), so that call
+            // validated nothing.
             services.AddOptions<OpenIddictSettings>()
                 .BindConfiguration(OpenIddictSettings.ConfigurationSection)
-                .ValidateDataAnnotations()
                 .ValidateOnStart();
 
             services.AddSingleton<IValidateOptions<OpenIddictSettings>, OpenIddictSettingsValidator>();

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/OpenIddictSettingsValidator.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/OpenIddictSettingsValidator.cs
@@ -1,14 +1,29 @@
 using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Extensions;
 
 namespace LotroKoniecDev.AuthSystem.API.Settings;
 
-internal sealed class OpenIddictSettingsValidator(IWebHostEnvironment environment)
-    : IValidateOptions<OpenIddictSettings>
+/// <summary>
+/// Fails fast at startup when the OpenIddict server is misconfigured in a deployed environment
+/// (Staging/Production), naming the offending key and the environment (ADR-0008 §3, M6-05).
+/// Development and Testing mint ephemeral signing/encryption keys (see <c>OpenIddictExtensions</c>),
+/// so the production key material is intentionally absent there and validation is skipped — mirroring
+/// <see cref="CorsSettingsValidator"/> and the Data Protection keyring guard.
+/// </summary>
+internal sealed class OpenIddictSettingsValidator : IValidateOptions<OpenIddictSettings>
 {
+    private readonly IWebHostEnvironment _environment;
+
+    public OpenIddictSettingsValidator(IWebHostEnvironment environment)
+    {
+        _environment = environment;
+    }
+
     public ValidateOptionsResult Validate(string? name, OpenIddictSettings options)
     {
-        // In development/testing, ephemeral keys are used - no validation needed
-        if (environment.IsDevelopment() || environment.IsEnvironment("Testing"))
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (_environment.IsDevelopment() || _environment.IsTesting())
         {
             return ValidateOptionsResult.Success;
         }
@@ -17,30 +32,69 @@ internal sealed class OpenIddictSettingsValidator(IWebHostEnvironment environmen
 
         if (string.IsNullOrWhiteSpace(options.EncryptionKey.Key))
         {
-            errors.Add("EncryptionKey.Key must be set in production. Generate a 256-bit (32-byte) key and base64 encode it.");
+            errors.Add(
+                $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.EncryptionKey)}:"
+                + $"{nameof(EncryptionKeySettings.Key)} must be set in {_environment.EnvironmentName}. Generate a "
+                + "256-bit (32-byte) key and base64-encode it, then inject it via the "
+                + $"{OpenIddictSettings.ConfigurationSection}__{nameof(OpenIddictSettings.EncryptionKey)}__"
+                + $"{nameof(EncryptionKeySettings.Key)} environment variable.");
         }
 
         if (string.IsNullOrWhiteSpace(options.SigningKey.RsaPrivateKeyXml))
         {
-            errors.Add("SigningKey.RsaPrivateKeyXml must be set in production. Generate an RSA key pair and base64 encode the XML.");
+            errors.Add(
+                $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.SigningKey)}:"
+                + $"{nameof(SigningKeySettings.RsaPrivateKeyXml)} must be set in {_environment.EnvironmentName}. "
+                + "Generate an RSA key pair and base64-encode its XML, then inject it via the "
+                + $"{OpenIddictSettings.ConfigurationSection}__{nameof(OpenIddictSettings.SigningKey)}__"
+                + $"{nameof(SigningKeySettings.RsaPrivateKeyXml)} environment variable.");
         }
 
         if (string.IsNullOrWhiteSpace(options.ApiClientSecret))
         {
-            errors.Add("ApiClientSecret must be set in production.");
+            errors.Add(
+                $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.ApiClientSecret)} must be set "
+                + $"in {_environment.EnvironmentName}. Use a strong, randomly generated secret of at least "
+                + $"{MinimumApiClientSecretLength} characters.");
         }
-        else if (options.ApiClientSecret.Length < 32)
+        else if (options.ApiClientSecret.Length < MinimumApiClientSecretLength)
         {
-            errors.Add("ApiClientSecret must be at least 32 characters for security.");
+            errors.Add(
+                $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.ApiClientSecret)} must be at "
+                + $"least {MinimumApiClientSecretLength} characters in {_environment.EnvironmentName} for security.");
         }
 
-        if (options.Issuer.Contains("localhost", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrWhiteSpace(options.Issuer))
         {
-            errors.Add("Issuer cannot contain 'localhost' in production.");
+            errors.Add(
+                $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.Issuer)} must be set in "
+                + $"{_environment.EnvironmentName}. Inject the public token issuer URL via the "
+                + $"{OpenIddictSettings.ConfigurationSection}__{nameof(OpenIddictSettings.Issuer)} environment "
+                + "variable (e.g. https://auth.lotro.koniec.dev).");
+        }
+        else if (!BeAbsoluteHttpUrl(options.Issuer))
+        {
+            errors.Add(
+                $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.Issuer)} must be an absolute "
+                + $"http(s) URL in {_environment.EnvironmentName} (e.g. https://auth.lotro.koniec.dev).");
+        }
+        else if (options.Issuer.Contains("localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add(
+                $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.Issuer)} cannot contain "
+                + $"'localhost' in {_environment.EnvironmentName}.");
         }
 
         return errors.Count > 0
             ? ValidateOptionsResult.Fail(errors)
             : ValidateOptionsResult.Success;
+    }
+
+    private const int MinimumApiClientSecretLength = 32;
+
+    private static bool BeAbsoluteHttpUrl(string value)
+    {
+        return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+               && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
     }
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Emails/EmailOptionsValidator.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Emails/EmailOptionsValidator.cs
@@ -23,7 +23,9 @@ public sealed class EmailOptionsValidator : AbstractValidator<EmailOptions>
 
         RuleFor(x => x.Host)
             .NotEmpty()
-            .WithMessage($"{nameof(EmailOptions.Host)} is required");
+            .WithMessage(
+                $"{EmailOptions.ConfigurationSection}:{nameof(EmailOptions.Host)} (the SMTP host) is required. "
+                + $"Inject it via the {EmailOptions.ConfigurationSection}__{nameof(EmailOptions.Host)} environment variable.");
 
         RuleFor(x => x.Port)
             .InclusiveBetween(1, 65535)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/LotroKoniecDev.AuthSystem.Persistence.csproj
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/LotroKoniecDev.AuthSystem.Persistence.csproj
@@ -11,6 +11,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="LotroKoniecDev.AuthSystem.API.Tests.Integration" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="FluentValidation" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Settings/ConnectionStringSettingsValidator.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Settings/ConnectionStringSettingsValidator.cs
@@ -2,12 +2,22 @@ using FluentValidation;
 
 namespace LotroKoniecDev.AuthSystem.Persistence.Settings;
 
+/// <summary>
+/// Fail-fast startup validation of the auth database connection string (ADR-0008 §3, M6-05). It is
+/// required in every environment — the dev compose stack needs it too — so the rule is unconditional;
+/// the message names the full configuration key and its environment-variable form so a missing value
+/// aborts boot with an actionable error rather than a request-time 500.
+/// </summary>
 internal sealed class ConnectionStringSettingsValidator : AbstractValidator<ConnectionStringSettings>
 {
     public ConnectionStringSettingsValidator()
     {
         RuleFor(x => x.AuthDatabase)
             .NotEmpty()
-            .WithMessage("AuthDatabase connection string is required.");
+            .WithMessage(
+                $"{ConnectionStringSettings.ConfigurationSection}:{nameof(ConnectionStringSettings.AuthDatabase)} "
+                + "is required. Inject it via the "
+                + $"{ConnectionStringSettings.ConfigurationSection}__{nameof(ConnectionStringSettings.AuthDatabase)} "
+                + "environment variable.");
     }
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Settings/AuthSystemSettingsValidator.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Settings/AuthSystemSettingsValidator.cs
@@ -2,6 +2,12 @@ using FluentValidation;
 
 namespace LotroKoniecDev.Frontend.Settings;
 
+/// <summary>
+/// Fail-fast startup validation of the OIDC relying-party configuration the Frontend authenticates
+/// translators with (ADR-0008 §3, M6-05). Required in every environment; messages name the full
+/// configuration key so a missing/invalid value aborts boot rather than breaking the login flow at
+/// runtime.
+/// </summary>
 internal sealed class AuthSystemSettingsValidator : AbstractValidator<AuthSystemSettings>
 {
     public AuthSystemSettingsValidator()
@@ -9,29 +15,35 @@ internal sealed class AuthSystemSettingsValidator : AbstractValidator<AuthSystem
         RuleFor(x => x.BaseUrl)
             .NotEmpty()
             .Must(BeAbsoluteHttpUrl)
-            .WithMessage($"{nameof(AuthSystemSettings.BaseUrl)} must be an absolute http(s) URL.");
+            .WithMessage(KeyPath(nameof(AuthSystemSettings.BaseUrl)) + " must be a non-empty absolute http(s) URL.");
 
         RuleFor(x => x.Authority)
             .NotEmpty()
             .Must(BeAbsoluteHttpUrl)
-            .WithMessage($"{nameof(AuthSystemSettings.Authority)} must be an absolute http(s) URL.");
+            .WithMessage(KeyPath(nameof(AuthSystemSettings.Authority)) + " must be a non-empty absolute http(s) URL.");
 
         RuleFor(x => x.ClientId)
-            .NotEmpty();
+            .NotEmpty()
+            .WithMessage(KeyPath(nameof(AuthSystemSettings.ClientId)) + " is required.");
 
         RuleFor(x => x.CallbackPath)
             .NotEmpty()
             .Must(BeRootedPath)
-            .WithMessage($"{nameof(AuthSystemSettings.CallbackPath)} must be a rooted path (starting with '/').");
+            .WithMessage(KeyPath(nameof(AuthSystemSettings.CallbackPath)) + " must be a rooted path (starting with '/').");
 
         RuleFor(x => x.SignedOutCallbackPath)
             .NotEmpty()
             .Must(BeRootedPath)
-            .WithMessage($"{nameof(AuthSystemSettings.SignedOutCallbackPath)} must be a rooted path (starting with '/').");
+            .WithMessage(
+                KeyPath(nameof(AuthSystemSettings.SignedOutCallbackPath)) + " must be a rooted path (starting with '/').");
 
         RuleFor(x => x.Scopes)
-            .NotEmpty();
+            .NotEmpty()
+            .WithMessage(KeyPath(nameof(AuthSystemSettings.Scopes)) + " must contain at least one scope.");
     }
+
+    private static string KeyPath(string propertyName)
+        => $"{AuthSystemSettings.ConfigurationSection}:{propertyName}";
 
     private static bool BeAbsoluteHttpUrl(string value)
     {

--- a/src/Frontend/LotroKoniecDev.Frontend/Settings/TranslationSystemSettingsValidator.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Settings/TranslationSystemSettingsValidator.cs
@@ -2,6 +2,11 @@ using FluentValidation;
 
 namespace LotroKoniecDev.Frontend.Settings;
 
+/// <summary>
+/// Fail-fast startup validation of the TMS API base address the Frontend calls (ADR-0008 §3, M6-05).
+/// Required in every environment; the message names the full configuration key so a missing value
+/// aborts boot rather than failing the first API call at runtime.
+/// </summary>
 internal sealed class TranslationSystemSettingsValidator : AbstractValidator<TranslationSystemSettings>
 {
     public TranslationSystemSettingsValidator()
@@ -9,7 +14,9 @@ internal sealed class TranslationSystemSettingsValidator : AbstractValidator<Tra
         RuleFor(x => x.BaseUrl)
             .NotEmpty()
             .Must(BeAbsoluteHttpUrl)
-            .WithMessage($"{nameof(TranslationSystemSettings.BaseUrl)} must be an absolute http(s) URL.");
+            .WithMessage(
+                $"{TranslationSystemSettings.ConfigurationSection}:{nameof(TranslationSystemSettings.BaseUrl)} "
+                + "must be a non-empty absolute http(s) URL.");
     }
 
     private static bool BeAbsoluteHttpUrl(string value)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/AuthSettingsValidator.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/AuthSettingsValidator.cs
@@ -2,23 +2,35 @@ using FluentValidation;
 
 namespace LotroKoniecDev.TranslationSystem.API.Auth;
 
+/// <summary>
+/// Fail-fast startup validation of the JWT bearer settings the TMS uses to validate AuthSystem
+/// (OpenIddict) tokens (ADR-0008 §3, M6-05). Issuer + Audience are required in every environment —
+/// the dev compose and Testing harness both need a configured issuer — so the rules are
+/// unconditional; messages name the full configuration key so a missing value aborts boot rather
+/// than rejecting every request at runtime.
+/// </summary>
 internal sealed class AuthSettingsValidator : AbstractValidator<AuthSettings>
 {
     public AuthSettingsValidator()
     {
         RuleFor(x => x.Issuer)
             .NotEmpty()
+            .WithMessage(KeyPath(nameof(AuthSettings.Issuer)) + " is required.")
             .Must(BeAbsoluteHttpUrl)
-            .WithMessage("Issuer must be an absolute http(s) URL.");
+            .WithMessage(KeyPath(nameof(AuthSettings.Issuer)) + " must be an absolute http(s) URL.");
 
         RuleFor(x => x.Audience)
-            .NotEmpty();
+            .NotEmpty()
+            .WithMessage(KeyPath(nameof(AuthSettings.Audience)) + " is required.");
 
         RuleFor(x => x.Authority!)
             .Must(BeAbsoluteHttpUrl)
             .When(x => !string.IsNullOrWhiteSpace(x.Authority))
-            .WithMessage("Authority must be an absolute http(s) URL.");
+            .WithMessage(KeyPath(nameof(AuthSettings.Authority)) + " must be an absolute http(s) URL.");
     }
+
+    private static string KeyPath(string propertyName)
+        => $"{AuthSettings.ConfigurationSection}:{propertyName}";
 
     private static bool BeAbsoluteHttpUrl(string value)
     {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Settings/ConnectionStringSettingsValidator.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Settings/ConnectionStringSettingsValidator.cs
@@ -2,12 +2,22 @@ using FluentValidation;
 
 namespace LotroKoniecDev.TranslationSystem.Persistence.Settings;
 
+/// <summary>
+/// Fail-fast startup validation of the TMS database connection string (ADR-0008 §3, M6-05). It is
+/// required in every environment — the dev compose stack needs it too — so the rule is unconditional;
+/// the message names the full configuration key and its environment-variable form so a missing value
+/// aborts boot with an actionable error rather than a request-time 500.
+/// </summary>
 internal sealed class ConnectionStringSettingsValidator : AbstractValidator<ConnectionStringSettings>
 {
     public ConnectionStringSettingsValidator()
     {
         RuleFor(x => x.TranslationDatabase)
             .NotEmpty()
-            .WithMessage("TranslationDatabase connection string is required.");
+            .WithMessage(
+                $"{ConnectionStringSettings.ConfigurationSection}:{nameof(ConnectionStringSettings.TranslationDatabase)} "
+                + "is required. Inject it via the "
+                + $"{ConnectionStringSettings.ConfigurationSection}__{nameof(ConnectionStringSettings.TranslationDatabase)} "
+                + "environment variable.");
     }
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/ConnectionStringSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/ConnectionStringSettingsValidatorTests.cs
@@ -1,0 +1,45 @@
+using FluentValidation.Results;
+using LotroKoniecDev.AuthSystem.Persistence.Settings;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Settings;
+
+/// <summary>
+/// Pure unit coverage for the AuthSystem connection-string startup guard (M6-05). It lives in the
+/// integration project only because the AuthSystem has no API unit project; it instantiates no
+/// factory and starts no container. The connection string is required in every environment, so the
+/// rule is unconditional.
+/// </summary>
+public sealed class ConnectionStringSettingsValidatorTests
+{
+    private readonly ConnectionStringSettingsValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithPopulatedConnectionString_Passes()
+    {
+        ConnectionStringSettings settings = new()
+        {
+            AuthDatabase = "Host=localhost;Database=lotro_auth;Username=postgres;Password=changeme"
+        };
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WithMissingConnectionString_FailsNamingTheKey(string? connectionString)
+    {
+        ConnectionStringSettings settings = new() { AuthDatabase = connectionString! };
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(ConnectionStringSettings.AuthDatabase));
+        result.Errors.ShouldContain(error =>
+            error.ErrorMessage.Contains("ConnectionStrings:AuthDatabase", StringComparison.Ordinal));
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/EmailOptionsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/EmailOptionsValidatorTests.cs
@@ -1,0 +1,50 @@
+using FluentValidation.Results;
+using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Settings;
+
+/// <summary>
+/// Pure unit coverage for the AuthSystem email/SMTP startup guard (M6-05), focused on the SMTP host
+/// the ticket calls out. It lives in the integration project only because the AuthSystem has no API
+/// unit project; it instantiates no factory and starts no container.
+/// </summary>
+public sealed class EmailOptionsValidatorTests
+{
+    private readonly EmailOptionsValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithCompleteValidOptions_Passes()
+    {
+        EmailOptions options = Options();
+
+        ValidationResult result = _validator.Validate(options);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WithMissingSmtpHost_FailsNamingTheKey(string? host)
+    {
+        EmailOptions options = Options(host: host!);
+
+        ValidationResult result = _validator.Validate(options);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(EmailOptions.Host));
+        result.Errors.ShouldContain(error =>
+            error.ErrorMessage.Contains("Email:Host", StringComparison.Ordinal));
+    }
+
+    private static EmailOptions Options(string host = "mailpit") => new()
+    {
+        SenderEmail = "no-reply@lotro.koniec.dev",
+        Sender = "LotroKoniecDev",
+        Host = host,
+        Port = 587,
+        Mode = EmailSecurityMode.StartTls
+    };
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/OpenIddictSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/OpenIddictSettingsValidatorTests.cs
@@ -1,0 +1,253 @@
+using LotroKoniecDev.AuthSystem.API.Settings;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Settings;
+
+/// <summary>
+/// Pure unit coverage for the AuthSystem OpenIddict startup guard (M6-05). It lives in the
+/// integration project only because the AuthSystem has no API unit project; it instantiates no
+/// factory and starts no container.
+/// </summary>
+public sealed class OpenIddictSettingsValidatorTests
+{
+    private const string Production = "Production";
+    private const string Staging = "Staging";
+    private const string Development = "Development";
+    private const string Testing = "Testing";
+
+    // The validator only checks these two for presence (IsNullOrWhiteSpace), never for shape, so a
+    // plain non-empty placeholder is sufficient and keeps high-entropy strings out of the repo.
+    private const string ValidEncryptionKey = "dummy-non-empty-encryption-key";
+    private const string ValidSigningKeyXml = "dummy-non-empty-signing-key-xml";
+    private const string ValidApiClientSecret = "a-strong-and-sufficiently-long-secret-value";
+    private const string ValidIssuer = "https://auth.lotro.koniec.dev";
+
+    [Theory]
+    [InlineData(Development)]
+    [InlineData(Testing)]
+    public void Validate_NonDeployedEnvironmentWithEmptyKeyMaterial_Succeeds(string environmentName)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(environmentName);
+        OpenIddictSettings settings = SettingsWith(
+            encryptionKey: string.Empty,
+            signingKeyXml: string.Empty,
+            apiClientSecret: string.Empty,
+            issuer: "https://localhost:5003");
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(Production)]
+    [InlineData(Staging)]
+    public void Validate_DeployedEnvironmentWithCompleteValidSettings_Succeeds(string environmentName)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(environmentName);
+        OpenIddictSettings settings = SettingsWith();
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ProductionWithMissingEncryptionKey_FailsNamingTheKeyAndEnvironment(string? encryptionKey)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(encryptionKey: encryptionKey);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:EncryptionKey:Key", StringComparison.Ordinal)
+            && failure.Contains(Production, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ProductionWithMissingSigningKey_FailsNamingTheKeyAndEnvironment(string? signingKeyXml)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(signingKeyXml: signingKeyXml);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:SigningKey:RsaPrivateKeyXml", StringComparison.Ordinal)
+            && failure.Contains(Production, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ProductionWithMissingApiClientSecret_FailsNamingTheKeyAndEnvironment(string? apiClientSecret)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(apiClientSecret: apiClientSecret);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:ApiClientSecret", StringComparison.Ordinal)
+            && failure.Contains(Production, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ProductionWithTooShortApiClientSecret_FailsNamingTheKey()
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(apiClientSecret: "too-short");
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:ApiClientSecret", StringComparison.Ordinal)
+            && failure.Contains("at least 32", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ProductionWithApiClientSecretOneCharBelowMinimum_FailsNamingTheKey()
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(apiClientSecret: new string('a', 31));
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:ApiClientSecret", StringComparison.Ordinal)
+            && failure.Contains("at least 32", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ProductionWithApiClientSecretAtExactMinimum_Succeeds()
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(apiClientSecret: new string('a', 32));
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ProductionWithMissingIssuer_FailsNamingTheKeyAndEnvironment(string? issuer)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(issuer: issuer);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:Issuer", StringComparison.Ordinal)
+            && failure.Contains(Production, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://auth.lotro.koniec.dev")]
+    [InlineData("auth.lotro.koniec.dev")]
+    public void Validate_ProductionWithNonHttpIssuer_FailsNamingTheKey(string issuer)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(issuer: issuer);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:Issuer", StringComparison.Ordinal)
+            && failure.Contains("absolute", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ProductionWithLocalhostIssuer_FailsNamingTheKey()
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(issuer: "https://localhost:5003");
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:Issuer", StringComparison.Ordinal)
+            && failure.Contains("localhost", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ProductionWithEverythingMissing_ReportsEveryMissingKey()
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(
+            encryptionKey: string.Empty,
+            signingKeyXml: string.Empty,
+            apiClientSecret: string.Empty,
+            issuer: string.Empty);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure => failure.Contains("OpenIddict:EncryptionKey:Key", StringComparison.Ordinal));
+        result.Failures.ShouldContain(failure => failure.Contains("OpenIddict:SigningKey:RsaPrivateKeyXml", StringComparison.Ordinal));
+        result.Failures.ShouldContain(failure => failure.Contains("OpenIddict:ApiClientSecret", StringComparison.Ordinal));
+        result.Failures.ShouldContain(failure => failure.Contains("OpenIddict:Issuer", StringComparison.Ordinal));
+    }
+
+    private static OpenIddictSettings SettingsWith(
+        string? encryptionKey = ValidEncryptionKey,
+        string? signingKeyXml = ValidSigningKeyXml,
+        string? apiClientSecret = ValidApiClientSecret,
+        string? issuer = ValidIssuer) => new()
+    {
+        Issuer = issuer!,
+        ApiClientSecret = apiClientSecret!,
+        EncryptionKey = new EncryptionKeySettings { Key = encryptionKey! },
+        SigningKey = new SigningKeySettings { RsaPrivateKeyXml = signingKeyXml! }
+    };
+
+    private static OpenIddictSettingsValidator CreateValidator(string environmentName)
+        => new(new FakeWebHostEnvironment(environmentName));
+}
+
+file sealed class FakeWebHostEnvironment : IWebHostEnvironment
+{
+    public FakeWebHostEnvironment(string environmentName)
+    {
+        EnvironmentName = environmentName;
+    }
+
+    public string EnvironmentName { get; set; }
+    public string ApplicationName { get; set; } = "auth-tests";
+    public string ContentRootPath { get; set; } = string.Empty;
+    public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    public string WebRootPath { get; set; } = string.Empty;
+    public IFileProvider WebRootFileProvider { get; set; } = null!;
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/AuthSystemSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/AuthSystemSettingsValidatorTests.cs
@@ -55,14 +55,45 @@ public sealed class AuthSystemSettingsValidatorTests
         result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSystemSettings.Scopes));
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://localhost:5003")]
+    public void Validate_WithNonHttpBaseUrl_FailsNamingTheKey(string baseUrl)
+    {
+        AuthSystemSettings settings = Settings(baseUrl: baseUrl);
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSystemSettings.BaseUrl));
+        result.Errors.ShouldContain(error =>
+            error.ErrorMessage.Contains("AuthSystem:BaseUrl", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_WithMissingClientId_FailsNamingTheKey()
+    {
+        AuthSystemSettings settings = Settings(clientId: "");
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSystemSettings.ClientId));
+        result.Errors.ShouldContain(error =>
+            error.ErrorMessage.Contains("AuthSystem:ClientId", StringComparison.Ordinal));
+    }
+
     private static AuthSystemSettings Settings(
+        string baseUrl = "https://localhost:5003/",
         string authority = "https://localhost:5003",
+        string clientId = "lotrokoniecdev-web",
         string callbackPath = "/callback",
         IReadOnlyList<string>? scopes = null) => new()
     {
-        BaseUrl = "https://localhost:5003/",
+        BaseUrl = baseUrl,
         Authority = authority,
-        ClientId = "lotrokoniecdev-web",
+        ClientId = clientId,
         CallbackPath = callbackPath,
         SignedOutCallbackPath = "/signout-callback-oidc",
         Scopes = scopes ?? ["openid", "profile", "api"]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/TranslationSystemSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/TranslationSystemSettingsValidatorTests.cs
@@ -30,5 +30,7 @@ public sealed class TranslationSystemSettingsValidatorTests
 
         result.IsValid.ShouldBeFalse();
         result.Errors.ShouldContain(error => error.PropertyName == nameof(TranslationSystemSettings.BaseUrl));
+        result.Errors.ShouldContain(error =>
+            error.ErrorMessage.Contains("TranslationSystem:BaseUrl", StringComparison.Ordinal));
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Settings/ConnectionStringSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Settings/ConnectionStringSettingsValidatorTests.cs
@@ -1,0 +1,45 @@
+using FluentValidation.Results;
+using LotroKoniecDev.TranslationSystem.Persistence.Settings;
+using Shouldly;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Settings;
+
+/// <summary>
+/// Pure unit coverage for the TMS connection-string startup guard (M6-05). It lives in the
+/// integration project because the validator is internal to the Persistence assembly, whose
+/// internals are visible only to this project; it instantiates no factory and starts no container.
+/// The connection string is required in every environment, so the rule is unconditional.
+/// </summary>
+public sealed class ConnectionStringSettingsValidatorTests
+{
+    private readonly ConnectionStringSettingsValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithPopulatedConnectionString_Passes()
+    {
+        ConnectionStringSettings settings = new()
+        {
+            TranslationDatabase = "Host=localhost;Database=lotro_translation;Username=postgres;Password=changeme"
+        };
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WithMissingConnectionString_FailsNamingTheKey(string? connectionString)
+    {
+        ConnectionStringSettings settings = new() { TranslationDatabase = connectionString! };
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(ConnectionStringSettings.TranslationDatabase));
+        result.Errors.ShouldContain(error =>
+            error.ErrorMessage.Contains("ConnectionStrings:TranslationDatabase", StringComparison.Ordinal));
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/AuthSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/AuthSettingsValidatorTests.cs
@@ -1,0 +1,99 @@
+using FluentValidation.Results;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Auth;
+
+public sealed class AuthSettingsValidatorTests
+{
+    private readonly AuthSettingsValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithCompleteValidSettings_Passes()
+    {
+        AuthSettings settings = Settings();
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithNullAuthority_Passes()
+    {
+        // Authority is optional; it falls back to Issuer when absent (EffectiveAuthority).
+        AuthSettings settings = Settings(authority: null);
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WithMissingIssuer_FailsNamingTheKey(string? issuer)
+    {
+        AuthSettings settings = Settings(issuer: issuer!);
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSettings.Issuer));
+        result.Errors.ShouldContain(error => error.ErrorMessage.Contains("Auth:Issuer", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://auth.lotro.koniec.dev")]
+    [InlineData("auth.lotro.koniec.dev")]
+    public void Validate_WithNonHttpIssuer_FailsNamingTheKey(string issuer)
+    {
+        AuthSettings settings = Settings(issuer: issuer);
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSettings.Issuer));
+        result.Errors.ShouldContain(error => error.ErrorMessage.Contains("Auth:Issuer", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WithMissingAudience_FailsNamingTheKey(string? audience)
+    {
+        AuthSettings settings = Settings(audience: audience!);
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSettings.Audience));
+        result.Errors.ShouldContain(error => error.ErrorMessage.Contains("Auth:Audience", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://auth.lotro.koniec.dev")]
+    public void Validate_WithNonHttpAuthority_FailsNamingTheKey(string authority)
+    {
+        AuthSettings settings = Settings(authority: authority);
+
+        ValidationResult result = _validator.Validate(settings);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(AuthSettings.Authority));
+        result.Errors.ShouldContain(error => error.ErrorMessage.Contains("Auth:Authority", StringComparison.Ordinal));
+    }
+
+    private static AuthSettings Settings(
+        string issuer = "https://auth.lotro.koniec.dev",
+        string audience = "lotrokoniecdev-api",
+        string? authority = "https://auth.lotro.koniec.dev") => new()
+    {
+        Issuer = issuer,
+        Audience = audience,
+        Authority = authority
+    };
+}


### PR DESCRIPTION
Closes #170

## What & why
Extends the startup configuration-validation regime (ADR-0008 §3) so a missing or invalid **deployment-critical** setting **aborts boot** in Staging/Production with a message **naming the configuration key** (and the environment, where the validator is environment-aware) — instead of surfacing as a cryptic request-time 500. This is the primary defense against the "works locally, breaks on staging" failure mode and produces the env list that feeds M6-11.

The repo already had a strong floor (`AddOptionsWithFluentValidation` → `ValidateOnStart()`, the M6-03 CORS validators, the M6-04 Data Protection guard). This PR fills the remaining gaps and makes every critical validator's failure message **name the key + env-var form** consistently across auth-api, tms-api, and the Frontend.

## Changes
- **auth-api `OpenIddictSettingsValidator`** — converted to an explicit ctor; every message now names `OpenIddict:<key>` + the environment; **added the missing `Issuer` rules** (non-empty + absolute http(s) URL + no `localhost`), all env-named; still **skips Development/Testing** (ephemeral keys). Removed the no-op `ValidateDataAnnotations()` (the settings carry no DataAnnotations attributes — `required` is a binder constraint).
- **Connection strings (auth + tms), `AuthSettingsValidator` (tms), `EmailOptionsValidator` SMTP host (auth), Frontend `AuthSystem`/`TranslationSystem` validators** — messages now name the full section-prefixed configuration key + its env-var form. These keys are required in **every** environment (dev compose needs them too), so the rules stay unconditional.
- **DataProtection reconciliation (#169 / M6-04):** the `DataProtection:KeyRingPath` guard stays the single pre-DI guard (`DataProtectionExtensions.GuardKeyRingPath` for auth-api, the inline guard in `AddFrontendDataProtection` for the Frontend). **Not double-guarded** — it's pre-DI by necessity (Data Protection is configured before the host is built; an `IValidateOptions` would run too late / trip ASP0000). CORS stays guarded by M6-03.
- **Tests:** every changed validator gets valid + each-missing-key + boundary cases (incl. the 31/32-char `ApiClientSecret` off-by-one). Pure validator tests live in the integration projects where there is no API unit project (auth) or the validator is `internal` to Persistence (tms) — mirroring the M6-03/M6-04 precedent — plus the tms `AuthSettingsValidatorTests` in the tms API unit project and the extended Frontend settings tests. Added `InternalsVisibleTo` on auth Persistence to match the tms Persistence csproj.

## Acceptance criteria
- [x] Booting any app in Production/Staging with a missing critical var fails at startup, naming the key (+ env where env-aware).
- [x] Development boot still works with current dev defaults (ephemeral OpenIddict keys + empty keyring path stay valid; conn-string/issuer/SMTP keys are supplied by dev appsettings + the Testing harness).
- [x] Validators unit-tested (valid + each missing-key + boundary).
- [x] Zero warnings, green build.

## Verification
- `dotnet build LotroKoniecDev.slnx` → **0 warnings, 0 errors**.
- Pure suites green (no Docker): auth Integration `Tests.Settings` **54**, tms Integration `Tests.Settings` **4**, tms API Unit **129**, Frontend Unit **193**, tms Domain **128**, SharedKernel **69**, patcher Unit **232**.
- code-reviewer agent: **APPROVE** (no Critical/Major; the off-by-one boundary nit it raised is folded in).
- `/security-review`: **no vulnerabilities** (net hardening of auth/crypto/DB config; messages name keys, never values).

---

## Required env per environment (feeds M6-11)

What each app must have **set & valid** to boot, per environment. **Development** is permissive only where the value is genuinely ephemeral (OpenIddict keys, empty keyring); everything else is required in every environment but already supplied by the base/dev `appsettings.json` (and the Testing harness). The **env-var form** uses `__` for the `:` separator. "Inject in deployed envs" = a secret or environment-specific value a deployer must provide for Staging/Production.

### auth-api
| Config key | Env var | Dev | Staging/Prod | Notes |
|---|---|---|---|---|
| `ConnectionStrings:AuthDatabase` | `ConnectionStrings__AuthDatabase` | dev compose value | **inject** | always required; empty → boot fails |
| `OpenIddict:EncryptionKey:Key` | `OpenIddict__EncryptionKey__Key` | — (ephemeral) | **inject** | 256-bit, base64 |
| `OpenIddict:SigningKey:RsaPrivateKeyXml` | `OpenIddict__SigningKey__RsaPrivateKeyXml` | — (ephemeral) | **inject** | RSA private key XML, base64 |
| `OpenIddict:ApiClientSecret` | `OpenIddict__ApiClientSecret` | — | **inject** | ≥ 32 chars |
| `OpenIddict:Issuer` | `OpenIddict__Issuer` | base appsettings | **inject** | absolute http(s), no `localhost` (baked URL stripped in M6-06) |
| `Cors:AllowedOrigins` | `Cors__AllowedOrigins__0`, `__1`, … | — (permissive policy) | **inject** | ≥ 1 bare http(s) origin (M6-03) |
| `DataProtection:KeyRingPath` | `DataProtection__KeyRingPath` | — (host default) | **inject** | persistent/shared volume (M6-04) |
| `Email:Host` (SMTP) | `Email__Host` | `mailpit` | **inject** | + `Email__Port`/`Mode`; `Email__Username`/`Password` when the relay needs auth |

### tms-api
| Config key | Env var | Dev | Staging/Prod | Notes |
|---|---|---|---|---|
| `ConnectionStrings:TranslationDatabase` | `ConnectionStrings__TranslationDatabase` | dev compose value | **inject** | always required |
| `Auth:Issuer` | `Auth__Issuer` | base appsettings | **inject** | absolute http(s); must match auth-api's token `iss` |
| `Auth:Audience` | `Auth__Audience` | base appsettings | **inject** | required |
| `Auth:Authority` | `Auth__Authority` | falls back to `Issuer` | optional | OIDC metadata host; absolute http(s) when set |
| `Cors:AllowedOrigins` | `Cors__AllowedOrigins__0`, … | — (permissive policy) | **inject** | ≥ 1 bare http(s) origin (M6-03) |

### frontend
| Config key | Env var | Dev | Staging/Prod | Notes |
|---|---|---|---|---|
| `TranslationSystem:BaseUrl` | `TranslationSystem__BaseUrl` | base appsettings | **inject** | absolute http(s) |
| `AuthSystem:BaseUrl` | `AuthSystem__BaseUrl` | base appsettings | **inject** | absolute http(s) |
| `AuthSystem:Authority` | `AuthSystem__Authority` | base appsettings | **inject** | absolute http(s) |
| `AuthSystem:ClientId` | `AuthSystem__ClientId` | `lotrokoniecdev-web` | **inject** | required |
| `AuthSystem:CallbackPath` / `SignedOutCallbackPath` | `AuthSystem__CallbackPath` / `…__SignedOutCallbackPath` | base appsettings | supplied | rooted paths |
| `AuthSystem:Scopes` | `AuthSystem__Scopes__0`, … | base appsettings | supplied | ≥ 1 scope |
| `DataProtection:KeyRingPath` | `DataProtection__KeyRingPath` | — (host default) | **inject** | persistent/shared volume (ADR-0005 / M6-04) |

> Note on issuer/authority/audience defaults: the base `appsettings.json` for auth-api and tms-api currently **bake** `https://auth.lotro.koniec.dev`; M6-06 strips those baked URLs so they become purely env-injected. Until then they have a default but are still environment-specific — listed as "inject" for deployed environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
