### PR TITLE
M6-06: appsettings.Production.json for TMS + production settings cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,11 +19,19 @@ AUTH_ADMIN_USERNAME=
 AUTH_ADMIN_EMAIL=
 AUTH_ADMIN_PASSWORD=
 
-# --- Production-only OpenIddict keys (NOT needed for local dev) ---
-# In Development the auth-api generates EPHEMERAL signing/encryption keys, so this
-# dev stack boots without them. A production deployment runs auth-api under
-# ASPNETCORE_ENVIRONMENT=Production and injects these via its own orchestrator
-# (this dev compose pins auth-api to Development and does not wire them):
-#   OpenIddict__EncryptionKey__Key            base64 of a >=32-byte key
-#   OpenIddict__SigningKey__RsaPrivateKeyXml  base64 of RSA.ToXmlString(true), >=2048-bit
-#   OpenIddict__ApiClientSecret               >=32 characters
+# --- Production-only auth/email settings (NOT needed for local dev) ---
+# In Development the auth-api generates EPHEMERAL signing/encryption keys and reads its
+# URLs + email identity from appsettings.Development.json, so this dev stack boots without
+# any of the values below. The base appsettings.json no longer bakes environment-specific
+# URLs or the email identity (M6-06): a production deployment runs auth-api (and tms-api)
+# under ASPNETCORE_ENVIRONMENT=Production and injects these via its own orchestrator (this
+# dev compose pins both APIs to Development and does not wire them). Missing values fail the
+# boot fast, naming the key (M6-05):
+#   OpenIddict__EncryptionKey__Key                    base64 of a >=32-byte key
+#   OpenIddict__SigningKey__RsaPrivateKeyXml          base64 of RSA.ToXmlString(true), >=2048-bit
+#   OpenIddict__ApiClientSecret                       >=32 characters
+#   OpenIddict__Issuer                                public token issuer URL (e.g. https://auth.lotro.koniec.dev)
+#   OpenIddict__WebClient__RedirectUris__0            web client OAuth callback (e.g. https://lotro.koniec.dev/callback)
+#   OpenIddict__WebClient__PostLogoutRedirectUris__0  post-logout URL (e.g. https://lotro.koniec.dev)
+#   Email__Host / Email__SenderEmail / Email__Sender  real SMTP host + sender identity
+#   Auth__Issuer (tms-api)                            the same public issuer URL the tokens carry

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/OpenIddictSettingsValidator.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/OpenIddictSettingsValidator.cs
@@ -5,10 +5,13 @@ namespace LotroKoniecDev.AuthSystem.API.Settings;
 
 /// <summary>
 /// Fails fast at startup when the OpenIddict server is misconfigured in a deployed environment
-/// (Staging/Production), naming the offending key and the environment (ADR-0008 §3, M6-05).
-/// Development and Testing mint ephemeral signing/encryption keys (see <c>OpenIddictExtensions</c>),
-/// so the production key material is intentionally absent there and validation is skipped — mirroring
-/// <see cref="CorsSettingsValidator"/> and the Data Protection keyring guard.
+/// (Staging/Production), naming the offending key and the environment (ADR-0008 §3, M6-05). Guards
+/// the production key material, the issuer, and — since the base <c>appsettings.json</c> no longer
+/// bakes them (M6-06) — the web client redirect URIs the seeder registers.
+/// Development and Testing mint ephemeral signing/encryption keys (see <c>OpenIddictExtensions</c>)
+/// and supply localhost redirect URIs from their own configuration, so the production values are
+/// intentionally absent there and validation is skipped — mirroring <see cref="CorsSettingsValidator"/>
+/// and the Data Protection keyring guard.
 /// </summary>
 internal sealed class OpenIddictSettingsValidator : IValidateOptions<OpenIddictSettings>
 {
@@ -83,6 +86,50 @@ internal sealed class OpenIddictSettingsValidator : IValidateOptions<OpenIddictS
             errors.Add(
                 $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.Issuer)} cannot contain "
                 + $"'localhost' in {_environment.EnvironmentName}.");
+        }
+
+        if (options.WebClient.RedirectUris.Length == 0)
+        {
+            errors.Add(
+                $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.WebClient)}:"
+                + $"{nameof(WebClientSettings.RedirectUris)} must contain at least one absolute http(s) URL in "
+                + $"{_environment.EnvironmentName}. Inject the web client OAuth callback URL(s) via the "
+                + $"{OpenIddictSettings.ConfigurationSection}__{nameof(OpenIddictSettings.WebClient)}__"
+                + $"{nameof(WebClientSettings.RedirectUris)}__0 environment variable "
+                + "(e.g. https://lotro.koniec.dev/callback).");
+        }
+
+        foreach (string redirectUri in options.WebClient.RedirectUris)
+        {
+            if (!BeAbsoluteHttpUrl(redirectUri))
+            {
+                errors.Add(
+                    $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.WebClient)}:"
+                    + $"{nameof(WebClientSettings.RedirectUris)} entry '{redirectUri}' must be an absolute http(s) URL "
+                    + $"in {_environment.EnvironmentName}.");
+            }
+        }
+
+        if (options.WebClient.PostLogoutRedirectUris.Length == 0)
+        {
+            errors.Add(
+                $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.WebClient)}:"
+                + $"{nameof(WebClientSettings.PostLogoutRedirectUris)} must contain at least one absolute http(s) URL in "
+                + $"{_environment.EnvironmentName}. Inject the web client post-logout URL(s) via the "
+                + $"{OpenIddictSettings.ConfigurationSection}__{nameof(OpenIddictSettings.WebClient)}__"
+                + $"{nameof(WebClientSettings.PostLogoutRedirectUris)}__0 environment variable "
+                + "(e.g. https://lotro.koniec.dev).");
+        }
+
+        foreach (string postLogoutRedirectUri in options.WebClient.PostLogoutRedirectUris)
+        {
+            if (!BeAbsoluteHttpUrl(postLogoutRedirectUri))
+            {
+                errors.Add(
+                    $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.WebClient)}:"
+                    + $"{nameof(WebClientSettings.PostLogoutRedirectUris)} entry '{postLogoutRedirectUri}' must be an "
+                    + $"absolute http(s) URL in {_environment.EnvironmentName}.");
+            }
         }
 
         return errors.Count > 0

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.json
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.json
@@ -10,7 +10,7 @@
     "AuthDatabase": ""
   },
   "OpenIddict": {
-    "Issuer": "https://auth.lotro.koniec.dev",
+    "Issuer": "",
     "AccessTokenLifetimeMinutes": 60,
     "RefreshTokenLifetimeDays": 14,
     "EncryptionKey": {
@@ -21,12 +21,8 @@
     },
     "ApiClientSecret": "",
     "WebClient": {
-      "RedirectUris": [
-        "https://lotro.koniec.dev/callback"
-      ],
-      "PostLogoutRedirectUris": [
-        "https://lotro.koniec.dev"
-      ]
+      "RedirectUris": [],
+      "PostLogoutRedirectUris": []
     }
   },
   "DataProtection": {
@@ -59,9 +55,9 @@
     "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId", "WithCorrelationId", "WithCorrelationIdHeader"]
   },
   "Email": {
-    "SenderEmail": "noreply@lotro.koniec.dev",
-    "Sender": "lotro.koniec.dev",
-    "Host": "mailpit",
+    "SenderEmail": "",
+    "Sender": "",
+    "Host": "",
     "Port": 1025,
     "Mode": "StartTls",
     "TimeoutSeconds": 10,

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/appsettings.Production.json
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/appsettings.Production.json
@@ -1,0 +1,24 @@
+{
+  "Serilog": {
+    "Using": ["Serilog.Sinks.Console", "Serilog.Sinks.File", "Serilog.Enrichers.CorrelationId"],
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "./Logs/log-.txt",
+          "rollingInterval": "Day",
+          "rollOnFileSizeLimit": true,
+          "fileSizeLimitBytes": 104857600,
+          "retainedFileCountLimit": 30,
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ]
+  }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/appsettings.json
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/appsettings.json
@@ -10,7 +10,7 @@
     "TranslationDatabase": ""
   },
   "Auth": {
-    "Issuer": "https://auth.lotro.koniec.dev",
+    "Issuer": "",
     "Audience": "lotrokoniecdev-api"
   },
   "Bootstrap": {

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -48,6 +48,12 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
                 { "AdminUser:Username", "seeded-admin" },
                 { "AdminUser:Email", "admin@lotro.koniec.dev" },
                 { "AdminUser:Password", "AdminTest123!" },
+                // Email identity is no longer baked into base appsettings.json (M6-06); supply it here
+                // so the unconditional EmailOptionsValidator passes at startup (the senders themselves
+                // are replaced with spies below, so these values are never used to send mail).
+                { "Email:SenderEmail", "noreply@lotro.koniec.dev" },
+                { "Email:Sender", "lotro.koniec.dev" },
+                { "Email:Host", "localhost" },
             });
         });
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/OpenIddictSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/OpenIddictSettingsValidatorTests.cs
@@ -25,6 +25,11 @@ public sealed class OpenIddictSettingsValidatorTests
     private const string ValidApiClientSecret = "a-strong-and-sufficiently-long-secret-value";
     private const string ValidIssuer = "https://auth.lotro.koniec.dev";
 
+    // Redirect URIs are full callback URLs (path included), so they are validated as absolute http(s)
+    // URLs — not as bare CORS origins.
+    private static readonly string[] ValidRedirectUris = ["https://lotro.koniec.dev/callback"];
+    private static readonly string[] ValidPostLogoutRedirectUris = ["https://lotro.koniec.dev"];
+
     [Theory]
     [InlineData(Development)]
     [InlineData(Testing)]
@@ -209,7 +214,9 @@ public sealed class OpenIddictSettingsValidatorTests
             encryptionKey: string.Empty,
             signingKeyXml: string.Empty,
             apiClientSecret: string.Empty,
-            issuer: string.Empty);
+            issuer: string.Empty,
+            redirectUris: [],
+            postLogoutRedirectUris: []);
 
         ValidateOptionsResult result = validator.Validate(name: null, settings);
 
@@ -219,18 +226,106 @@ public sealed class OpenIddictSettingsValidatorTests
         result.Failures.ShouldContain(failure => failure.Contains("OpenIddict:SigningKey:RsaPrivateKeyXml", StringComparison.Ordinal));
         result.Failures.ShouldContain(failure => failure.Contains("OpenIddict:ApiClientSecret", StringComparison.Ordinal));
         result.Failures.ShouldContain(failure => failure.Contains("OpenIddict:Issuer", StringComparison.Ordinal));
+        result.Failures.ShouldContain(failure => failure.Contains("OpenIddict:WebClient:RedirectUris", StringComparison.Ordinal));
+        result.Failures.ShouldContain(failure => failure.Contains("OpenIddict:WebClient:PostLogoutRedirectUris", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(Development)]
+    [InlineData(Testing)]
+    public void Validate_NonDeployedEnvironmentWithEmptyRedirectUris_Succeeds(string environmentName)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(environmentName);
+        OpenIddictSettings settings = SettingsWith(redirectUris: [], postLogoutRedirectUris: []);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ProductionWithEmptyRedirectUris_FailsNamingTheKeyAndEnvironment()
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(redirectUris: []);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:WebClient:RedirectUris", StringComparison.Ordinal)
+            && failure.Contains(Production, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://lotro.koniec.dev/callback")]
+    [InlineData("lotro.koniec.dev/callback")]
+    public void Validate_ProductionWithNonHttpRedirectUri_FailsNamingTheKey(string redirectUri)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(redirectUris: [redirectUri]);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:WebClient:RedirectUris", StringComparison.Ordinal)
+            && failure.Contains("absolute", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ProductionWithEmptyPostLogoutRedirectUris_FailsNamingTheKeyAndEnvironment()
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(postLogoutRedirectUris: []);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:WebClient:PostLogoutRedirectUris", StringComparison.Ordinal)
+            && failure.Contains(Production, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://lotro.koniec.dev")]
+    [InlineData("lotro.koniec.dev")]
+    public void Validate_ProductionWithNonHttpPostLogoutRedirectUri_FailsNamingTheKey(string postLogoutRedirectUri)
+    {
+        OpenIddictSettingsValidator validator = CreateValidator(Production);
+        OpenIddictSettings settings = SettingsWith(postLogoutRedirectUris: [postLogoutRedirectUri]);
+
+        ValidateOptionsResult result = validator.Validate(name: null, settings);
+
+        result.Failed.ShouldBeTrue();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.ShouldContain(failure =>
+            failure.Contains("OpenIddict:WebClient:PostLogoutRedirectUris", StringComparison.Ordinal)
+            && failure.Contains("absolute", StringComparison.Ordinal));
     }
 
     private static OpenIddictSettings SettingsWith(
         string? encryptionKey = ValidEncryptionKey,
         string? signingKeyXml = ValidSigningKeyXml,
         string? apiClientSecret = ValidApiClientSecret,
-        string? issuer = ValidIssuer) => new()
+        string? issuer = ValidIssuer,
+        string[]? redirectUris = null,
+        string[]? postLogoutRedirectUris = null) => new()
     {
         Issuer = issuer!,
         ApiClientSecret = apiClientSecret!,
         EncryptionKey = new EncryptionKeySettings { Key = encryptionKey! },
-        SigningKey = new SigningKeySettings { RsaPrivateKeyXml = signingKeyXml! }
+        SigningKey = new SigningKeySettings { RsaPrivateKeyXml = signingKeyXml! },
+        WebClient = new WebClientSettings
+        {
+            RedirectUris = redirectUris ?? ValidRedirectUris,
+            PostLogoutRedirectUris = postLogoutRedirectUris ?? ValidPostLogoutRedirectUris
+        }
     };
 
     private static OpenIddictSettingsValidator CreateValidator(string environmentName)

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
@@ -161,7 +161,11 @@ public sealed class E2ETestFixture : IAsyncLifetime
             .WithEnvironment("AdminUser__Email", AdminEmail)
             .WithEnvironment("AdminUser__Password", AdminPassword)
             // No mailpit in this network: the confirmation-email send fails fast and registration auto-confirms,
-            // so a freshly-registered translator can log in without the email round-trip.
+            // so a freshly-registered translator can log in without the email round-trip. The sender identity is
+            // no longer baked into base appsettings.json (M6-06), so it is injected here too — otherwise the
+            // unconditional EmailOptionsValidator would abort auth-api startup.
+            .WithEnvironment("Email__SenderEmail", "noreply@lotro.koniec.dev")
+            .WithEnvironment("Email__Sender", "lotro.koniec.dev")
             .WithEnvironment("Email__Host", "localhost")
             .WithEnvironment("Email__Port", "2525")
             .WithWaitStrategy(Wait.ForUnixContainer()


### PR DESCRIPTION
Strip environment-specific values out of the base appsettings.json for both
auth-api and tms-api so the committed defaults carry no deployment identity:
empty OpenIddict Issuer + WebClient redirect/post-logout URIs, empty Email
sender identity (SenderEmail/Sender/Host), and the tms-api Auth Issuer. A
Production deployment injects these via environment variables (documented in
.env.example); base appsettings now holds only non-secret, env-agnostic config.

Add appsettings.Production.json for tms-api carrying the secret-free production
Serilog shape (compact JSON to console + rolling file) — tracked deliberately,
since it holds no secrets (those go via env vars; local secret overrides use the
already-ignored appsettings.*.local.json).

Extend OpenIddictSettingsValidator to fail fast in deployed environments when the
web client RedirectUris / PostLogoutRedirectUris are missing or not absolute
http(s) URLs, naming the offending key and environment (mirrors the M6-05 guards).
Development/Testing supply localhost values from their own config and skip the check.

Update the auth integration factory and the E2E fixture to inject the Email sender
identity (no longer baked into base appsettings) so the unconditional
EmailOptionsValidator passes at startup, and cover the new redirect-URI validation
branches in OpenIddictSettingsValidatorTests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
