### PR TITLE
M6-09: CD — build & push container images to GHCR

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,103 @@
+name: CD
+
+# Build + push the four service images to GHCR (ADR-0008 §6, ticket M6-09). The deployment unit is
+# an OCI image (ADR-0008 §1); this is the only workflow that publishes one. It builds the existing
+# multi-stage Dockerfiles — no new build logic — and pushes to ghcr.io/koniecdev/<image>:
+#   * lotrokoniecdev-auth-api   — src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
+#   * lotrokoniecdev-tms-api    — src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
+#   * lotrokoniecdev-frontend   — src/Frontend/LotroKoniecDev.Frontend/Dockerfile
+#   * lotrokoniecdev-migrator   — Dockerfile.migrator
+#
+# Triggers:
+#   * push to main           → publishes :sha-<short> and :latest (the moving "tip of main")
+#   * push of a v* tag       → publishes :sha-<short>, :<major.minor.patch> and :<major.minor>
+#                              (immutable release coordinates; `latest` is NOT moved by a tag — it
+#                               tracks the default branch only, so its meaning stays unambiguous)
+#
+# Pull a published image (the runbook — M6-11 — documents this for operators):
+#   docker pull ghcr.io/koniecdev/lotrokoniecdev-tms-api:latest
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+
+# Don't pile up publishes for the same ref; a newer push supersedes an in-flight one. Keyed by ref
+# so a main push and a tag push (different refs) never cancel each other.
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: read the repo, write packages (GHCR). GITHUB_TOKEN is scoped to this repo's
+# packages only — no PAT, no cross-repo reach.
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+  build-and-push:
+    name: Build & push ${{ matrix.image }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    strategy:
+      # Publish every image even if one fails, so a single flaky build doesn't mask the rest.
+      fail-fast: false
+      matrix:
+        include:
+          - image: lotrokoniecdev-auth-api
+            dockerfile: src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
+          - image: lotrokoniecdev-tms-api
+            dockerfile: src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
+          - image: lotrokoniecdev-frontend
+            dockerfile: src/Frontend/LotroKoniecDev.Frontend/Dockerfile
+          - image: lotrokoniecdev-migrator
+            dockerfile: Dockerfile.migrator
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Log in to GHCR with the workflow's own scoped token — no stored secret.
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags & labels
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}
+          # `latest` is added explicitly below (default-branch only), never auto-applied to tags.
+          flavor: |
+            latest=false
+          tags: |
+            type=sha
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build & push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_CONFIGURATION=Release
+          # Per-image GHA layer cache so unchanged layers (restore/build) are reused across runs,
+          # keeping rebuilds fast. Scoped per image so the four builds don't clobber each other.
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          provenance: false


### PR DESCRIPTION
Closes #174

## What changed
Adds `.github/workflows/cd.yml` — the first workflow that publishes the deployment artifact (ADR-0008 §1/§6). It builds the four existing multi-stage Dockerfiles and pushes them to GHCR:

| Image | Dockerfile |
|---|---|
| `ghcr.io/koniecdev/lotrokoniecdev-auth-api` | `src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile` |
| `ghcr.io/koniecdev/lotrokoniecdev-tms-api` | `src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile` |
| `ghcr.io/koniecdev/lotrokoniecdev-frontend` | `src/Frontend/LotroKoniecDev.Frontend/Dockerfile` |
| `ghcr.io/koniecdev/lotrokoniecdev-migrator` | `Dockerfile.migrator` |

**Triggers & tags**
- push to `main` → `:sha-<short>` + `:latest` (the moving tip of the default branch)
- push of a `v*` tag → `:sha-<short>` + `:<major.minor.patch>` + `:<major.minor>` (immutable release coordinates; `latest` is **not** moved by a tag, so its meaning stays unambiguous)

**Design notes**
- Matrix over the four images (parallel, `fail-fast: false` so one flaky build can't mask the rest).
- `buildx` + per-image GHA layer cache (`scope=${{ matrix.image }}` on `cache-from`/`cache-to`) — no cross-image clobber, fast rebuilds.
- `BUILD_CONFIGURATION=Release`; images stay non-root (the Dockerfiles already are; the migrator is a one-shot batch container).
- Least privilege: `permissions: contents: read + packages: write`; GHCR login via the repo-scoped `GITHUB_TOKEN` (no PAT).
- Image namespace is `${{ github.repository_owner }}` → `koniecdev`, matching the ticket + ADR-0008 §6.
- Mirrors the repo's existing workflow conventions (`ubuntu-24.04`, `actions/checkout@v5`, `concurrency` keyed by `github.ref` with `cancel-in-progress`, `timeout-minutes`). Action majors: `setup-buildx@v3`, `login@v3`, `metadata@v6`, `build-push@v7`.

## How verified (locally / pre-merge)
- **`actionlint`** (via `rhysd/actionlint` Docker image) — clean (exit 0) on `cd.yml` and across all five workflows.
- **All four images build** with `docker buildx build --build-arg BUILD_CONFIGURATION=Release` → exit 0. (Passing `BUILD_CONFIGURATION` to the migrator, which declares no such ARG, is silently ignored — no warning.)
- **Runtime smoke:** `auth-api` and `tms-api` images, given a throwaway Postgres, start and return **HTTP 200 on `/health/live`**. (`/health/live` has no checks per ADR-0008 §3, but `Program.cs` runs DB seeding/migration at startup, so a DB must be reachable for the container to come up.)
- **code-reviewer agent: APPROVE** — zero Critical/Major/Minor findings against the diff; tag strategy, matrix mapping, cache scoping, permissions and injection surface all verified correct.
- **/security-review: clean** — no HIGH/MEDIUM findings (safe trigger model — `push` to main/tags only, no fork path; no `run:` steps so no script-injection surface; least privilege; no secrets baked into images or passed as build-args).

## What remains for the first real `main` run (cannot be exercised from a feature branch)
A CD workflow that pushes to GHCR can only be fully proven on `main` with `packages: write`. On the first merge to `main`, confirm:
1. The four packages appear under `ghcr.io/koniecdev/lotrokoniecdev-*` tagged `:sha-<short>` + `:latest`.
2. A pushed `v*` tag yields the `:<x.y.z>` + `:<x.y>` tags (and does **not** move `:latest`).
3. `docker pull ghcr.io/koniecdev/lotrokoniecdev-tms-api:latest` then a DB-backed run serves `/health/live` (the pull-then-run leg of AC #2).
4. (One-time) The packages may need to be linked to the repo / made visible per the org's GHCR package settings.

## Out of scope (noted, not addressed here)
- Documenting image coordinates + pull instructions in the **runbook** is explicitly deferred to **M6-11** (`docs/deployment/` doesn't exist yet); the coordinates are recorded in the workflow header + this PR for now.
- `Dockerfile.migrator` runs as root and emits a pre-existing buildx `JSONArgsRecommended` advisory (line 27) — both pre-existing, independent of this workflow; M6-10/#175 replaces this migrator with an `ef migrations bundle` under the same image name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)