### PR TITLE
M6-10: production migrations — self-contained EF bundle + pre-deploy strategy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,9 @@ name: CD
 #   * lotrokoniecdev-auth-api   — src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
 #   * lotrokoniecdev-tms-api    — src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
 #   * lotrokoniecdev-frontend   — src/Frontend/LotroKoniecDev.Frontend/Dockerfile
-#   * lotrokoniecdev-migrator   — Dockerfile.migrator
+#   * lotrokoniecdev-migrator   — Dockerfile.migrator.prod (the lean, self-contained EF migration-bundle
+#                                 image — the artifact a cloud pre-deploy job runs; M6-10, ADR-0008 §6.
+#                                 The dev Dockerfile.migrator is built locally by compose.yaml, never published.)
 #
 # Triggers:
 #   * push to main           → publishes :sha-<short> and :latest (the moving "tip of main")
@@ -55,7 +57,7 @@ jobs:
           - image: lotrokoniecdev-frontend
             dockerfile: src/Frontend/LotroKoniecDev.Frontend/Dockerfile
           - image: lotrokoniecdev-migrator
-            dockerfile: Dockerfile.migrator
+            dockerfile: Dockerfile.migrator.prod
 
     steps:
       - name: Checkout

--- a/Dockerfile.migrator.prod
+++ b/Dockerfile.migrator.prod
@@ -1,0 +1,89 @@
+# Production migration image (ADR-0008 §6, ticket M6-10).
+#
+# The dev Dockerfile.migrator (kept as-is) ships the full SDK + the dotnet-ef tool + the sources and
+# runs `dotnet ef database update` — convenient for dev, multi-GB, and not a production artifact.
+# This image instead bakes two SELF-CONTAINED `dotnet ef migrations bundle` executables (one per
+# write context) onto a lean runtime-deps base: no SDK, no dotnet-ef tool, no sources, no .NET
+# runtime install — each bundle carries its own. The result is a standalone "apply migrations against
+# a connection string" job, ~10x smaller than the dev SDK image.
+#
+# It runs as a PRE-DEPLOY job / init step: compose.prod's migrator service runs this to completion and
+# both APIs `depend_on` its success (service_completed_successfully), so a failed migration blocks API
+# startup and there is never half-migrated serving. The same image is the unit a cloud pre-deploy job
+# (ACA Job / ECS task) runs — see docs/deployment/runbook.md.
+#
+# Why self-contained (not framework-dependent): the ticket calls for a "standalone executable", and a
+# runtime-deps base + self-contained bundles removes any .NET-runtime-version coupling between this
+# image and the API images. The trade-off is larger bundle binaries (~260 MB for the two vs ~90 MB
+# framework-dependent); accepted for the standalone property and the leaner base.
+
+ARG BUILD_CONFIGURATION=Release
+ARG TARGET_RUNTIME=linux-x64
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION
+ARG TARGET_RUNTIME
+WORKDIR /src
+
+# dotnet-ef is the CLI only; the bundle is built against each project's pinned EF Core version
+# (Directory.Packages.props), so this is left unpinned exactly like the dev Dockerfile.migrator.
+RUN dotnet tool install --global dotnet-ef
+ENV PATH="$PATH:/root/.dotnet/tools"
+
+COPY ["Directory.Build.props", "./"]
+COPY ["Directory.Packages.props", "./"]
+COPY [".editorconfig", "./"]
+
+# Docker content-hashes these directory COPYs, so any migration/source change invalidates them and
+# the two `bundle` RUN layers below — the bundles can never go stale against the source.
+COPY ["src/TranslationSystem/", "src/TranslationSystem/"]
+COPY ["src/AuthSystem/", "src/AuthSystem/"]
+COPY ["src/SharedKernel/", "src/SharedKernel/"]
+COPY ["src/Utilities/", "src/Utilities/"]
+
+# Restore the two startup projects (`ef migrations bundle` does not restore on its own) — exactly the
+# two projects the dev migrator restores.
+RUN dotnet restore src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/LotroKoniecDev.TranslationSystem.Persistence.csproj && \
+    dotnet restore src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj
+
+# TMS migrations resolve through the Persistence project (it carries EF Core Design + the design-time
+# factory); Auth resolves through its API project (Auth Persistence intentionally has no Design
+# package). The throwaway --connection at the end satisfies the design-time factory while EF builds
+# the model to bundle it — the real connection string is supplied at RUN time by the bundle itself.
+RUN dotnet ef migrations bundle \
+      --self-contained --target-runtime "$TARGET_RUNTIME" --configuration "$BUILD_CONFIGURATION" \
+      --project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
+      --startup-project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
+      --context ApplicationWriteDbContext \
+      --output /bundles/tms-migrate \
+      -- --connection "Host=build-time-placeholder;Database=build;Username=build;Password=build"
+
+RUN dotnet ef migrations bundle \
+      --self-contained --target-runtime "$TARGET_RUNTIME" --configuration "$BUILD_CONFIGURATION" \
+      --project src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence \
+      --startup-project src/AuthSystem/LotroKoniecDev.AuthSystem.API \
+      --context AuthDbContext \
+      --output /bundles/auth-migrate \
+      -- --connection "Host=build-time-placeholder;Database=build;Username=build;Password=build"
+
+# runtime-deps = the leanest official base that runs a self-contained app (native deps + ICU, no
+# managed runtime). USER $APP_UID drops to the non-root app user the base image ships.
+# libgssapi-krb5-2 lets Npgsql negotiate GSSAPI cleanly (some Postgres hosts advertise it); without
+# it Npgsql logs a noisy `libgssapi_krb5.so.2: cannot open shared object file` before falling back to
+# password auth. Installing it keeps the migrator output clean and works against GSSAPI-capable hosts.
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0 AS final
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgssapi-krb5-2 \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+
+COPY --from=build /bundles/tms-migrate ./tms-migrate
+COPY --from=build /bundles/auth-migrate ./auth-migrate
+COPY ["scripts/apply-migrations.sh", "./apply-migrations.sh"]
+
+USER $APP_UID
+
+# Idempotent by construction: EF skips migrations already recorded in each context's
+# __EFMigrationsHistory table, so re-running this job is a no-op. Ordering and fail-fast (set -e) live
+# in the entrypoint script.
+ENTRYPOINT ["/bin/sh", "/app/apply-migrations.sh"]

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -55,10 +55,15 @@ services:
       retries: 30
       start_period: 10s
 
+  # Production migrator (ADR-0008 §6, M6-10): the lean, self-contained EF migration-bundle image
+  # (Dockerfile.migrator.prod) — NOT the dev SDK migrator (Dockerfile.migrator stays dev-only). Runs
+  # both bundles to completion against the connection strings, in order; both APIs depend on its
+  # success below (service_completed_successfully), so a failed migration (non-zero exit) blocks API
+  # startup and there is never half-migrated serving. Idempotent — re-running is a no-op.
   migrator:
     build:
       context: .
-      dockerfile: Dockerfile.migrator
+      dockerfile: Dockerfile.migrator.prod
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ConnectionStrings__TranslationDatabase: ${ConnectionStrings__TranslationDatabase}

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -1,0 +1,103 @@
+# Deployment runbook
+
+> Operator-facing procedures for running LotroKoniecDev on a container host. Provider-neutral by
+> design (ADR-0008): everything here is "a 12-factor OCI image behind a TLS ingress" and applies to
+> Azure Container Apps, AWS ECS/App Runner, or a plain Docker host alike.
+>
+> **Scope today:** database migrations (M6-10). The full bring-up walkthrough, secrets handling, and
+> the Azure⇄AWS service mapping land with M6-11 / M6-12 and extend this file.
+
+## Database migrations
+
+### Strategy (ADR-0008 §6)
+
+Schema changes apply as a **pre-deploy job** — a one-shot container that runs to completion *before*
+the APIs serve traffic — never from inside the application at startup. The rules:
+
+- **Two write contexts, one job.** The Translation Management System (`ApplicationWriteDbContext`,
+  schema `translation`, database `lotro_translation`) and the Auth server (`AuthDbContext`, schema
+  `auth`, database `lotro_auth`) each have their own migration history. The job applies Translation
+  first, then Auth.
+- **The artifact is the migrator image** `ghcr.io/koniecdev/lotrokoniecdev-migrator` — built by
+  `Dockerfile.migrator.prod` and published by CD (M6-09). It bakes two **self-contained**
+  `dotnet ef migrations bundle` executables (one per context) onto a lean `runtime-deps` base — no
+  SDK, no `dotnet-ef` tool, no source, no separate .NET runtime. It is ~10× smaller than the dev SDK
+  migrator and carries everything it needs to apply migrations against a connection string.
+- **Idempotent.** Each bundle applies only the migrations missing from that context's
+  `__EFMigrationsHistory` table, so re-running the job is a safe no-op.
+- **Fail-fast = no half-migrated serving.** Any failure (unreachable DB, bad migration, missing
+  connection string) exits the job non-zero. Wire the APIs to depend on the job's **success** so a
+  failed migration blocks API startup (compose: `depends_on: condition:
+  service_completed_successfully`; ACA: a Job the revision waits on; ECS: an `essential` init task /
+  a gated pipeline step).
+- **Forward-only.** There is no automated rollback step. EF down-migrations exist but are not run by
+  this job; a bad migration is rolled forward with a new migration (the repo has zero production
+  users — breaking changes are free; ADR-0002). Take a database snapshot before applying in a real
+  environment.
+
+### Inputs (environment variables)
+
+The migrator reads exactly two variables — Npgsql connection strings, one per context:
+
+| Variable | Context | Example |
+|---|---|---|
+| `ConnectionStrings__TranslationDatabase` | TMS write context | `Host=db;Port=5432;Database=lotro_translation;Username=app;Password=…;Ssl Mode=Require;Trust Server Certificate=true` |
+| `ConnectionStrings__AuthDatabase` | Auth context | `Host=db;Port=5432;Database=lotro_auth;Username=app;Password=…;Ssl Mode=Require;Trust Server Certificate=true` |
+
+Both databases must already exist (a managed Postgres typically provisions one DB; create the second
+with `CREATE DATABASE "lotro_auth";` — `scripts/init-postgres.sh` does this for the self-hosted
+parity Postgres).
+
+### Running migrations
+
+**Local production-parity stack (`compose.prod.yaml`).** Automatic — the `migrator` service runs the
+bundle image to completion and `auth-api` / `tms-api` wait on its success:
+
+```bash
+scripts/up-prod.sh --build          # PowerShell: scripts/up-prod.ps1 --build
+docker compose -f compose.prod.yaml --env-file .env.prod logs migrator   # watch it apply
+```
+
+**A real environment (cloud pre-deploy job, run by an operator).** Pull the published image and run
+it once against the target database, before rolling out the new API revision:
+
+```bash
+docker run --rm \
+  -e ConnectionStrings__TranslationDatabase="Host=…;Database=lotro_translation;Username=…;Password=…;Ssl Mode=Require;Trust Server Certificate=true" \
+  -e ConnectionStrings__AuthDatabase="Host=…;Database=lotro_auth;Username=…;Password=…;Ssl Mode=Require;Trust Server Certificate=true" \
+  ghcr.io/koniecdev/lotrokoniecdev-migrator:<tag>
+```
+
+Use the **same image tag** (commit SHA or `vX.Y.Z`) you are about to deploy for the APIs, so schema
+and code move together. Expected tail on success:
+
+```
+== TRANSLATION MIGRATOR DONE ==
+== AUTH MIGRATOR DONE ==
+== MIGRATOR COMPLETE ==
+```
+
+A non-zero exit means migrations did **not** fully apply — do not roll out the APIs; read the log,
+fix forward, re-run.
+
+- **Azure Container Apps:** run the image as a manual/scheduled **Container Apps Job** (or an
+  `az containerapp job start`) gating the revision rollout.
+- **AWS ECS:** run it as a one-off **RunTask** (or a CodePipeline/CodeBuild step) that the service
+  update waits on.
+
+### Authoring a new migration (developer, not operator)
+
+Migrations are generated with the SDK + `dotnet-ef` against the source — see the CLAUDE.md "TMS — EF
+Core migrations" command block for the exact `dotnet ef migrations add …` invocations (TMS resolves
+through its Persistence project; Auth through its API project — only those two carry EF Core Design).
+Once committed, the next CD build bakes them into the migrator image automatically; operators never
+generate migrations.
+
+### Verifying
+
+```bash
+# applied Translation migrations
+psql "$ConnectionStrings__TranslationDatabase" -c 'SELECT "MigrationId" FROM translation."__EFMigrationsHistory" ORDER BY "MigrationId";'
+# applied Auth migrations
+psql "$ConnectionStrings__AuthDatabase"        -c 'SELECT "MigrationId" FROM auth."__EFMigrationsHistory" ORDER BY "MigrationId";'
+```

--- a/scripts/apply-migrations.sh
+++ b/scripts/apply-migrations.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Production migration entrypoint (ADR-0008 §6, ticket M6-10).
+#
+# Runs the two self-contained EF migration bundles baked into Dockerfile.migrator.prod, in order
+# (Translation, then Auth — same order as the dev migrator), each against its own connection string
+# from the environment. set -e makes ANY failure abort the whole job with a non-zero exit, so the
+# pre-deploy job fails and the APIs (which depend on its success) never start against a half-migrated
+# schema. Re-running is safe: EF applies only migrations missing from each context's
+# __EFMigrationsHistory table.
+#
+# The connection is passed as `-- --connection <cs>` (forwarded to the design-time factory), NOT via
+# the bundle's own `--connection` option: each context's IDesignTimeDbContextFactory builds the
+# DbContext first and, without that arg, falls back to reading appsettings.json (absent here). The
+# factory's GetArgumentValue("--connection") picks the string up and wires it into the options.
+#
+# Required environment:
+#   ConnectionStrings__TranslationDatabase  - Npgsql connection string for the TMS write context
+#   ConnectionStrings__AuthDatabase         - Npgsql connection string for the Auth context
+set -e
+
+if [ -z "$ConnectionStrings__TranslationDatabase" ]; then
+    echo "FATAL: ConnectionStrings__TranslationDatabase is not set." >&2
+    exit 1
+fi
+
+if [ -z "$ConnectionStrings__AuthDatabase" ]; then
+    echo "FATAL: ConnectionStrings__AuthDatabase is not set." >&2
+    exit 1
+fi
+
+echo "== MIGRATOR START =="
+
+echo "== Applying Translation migrations =="
+/app/tms-migrate -- --connection "$ConnectionStrings__TranslationDatabase"
+echo "== TRANSLATION MIGRATOR DONE =="
+
+echo "== Applying Auth migrations =="
+/app/auth-migrate -- --connection "$ConnectionStrings__AuthDatabase"
+echo "== AUTH MIGRATOR DONE =="
+
+echo "== MIGRATOR COMPLETE =="


### PR DESCRIPTION
Closes #175

## What
Production migration strategy per ADR-0008 §6 (M6-10): a lean, **self-contained** `dotnet ef migrations bundle` artifact run as a **pre-deploy job**, replacing the dev SDK migrator for production only.

## Changes
- **`Dockerfile.migrator.prod`** (new) — multi-stage: SDK stage builds two self-contained bundles (TMS via Persistence, Auth via API — the only two projects carrying EF Core Design), final stage copies them onto a lean `runtime-deps:10.0` base (non-root `$APP_UID`, `libgssapi-krb5-2` for clean Npgsql GSSAPI negotiation). ~10× smaller than the dev SDK migrator.
- **`scripts/apply-migrations.sh`** (new) — entrypoint: applies both bundles in order (Translation then Auth) against `ConnectionStrings__{Translation,Auth}Database`; `set -e` + empty-env guards = fail-fast; passes `-- --connection` so each context's design-time factory receives the string (the bundle's own `--connection` does **not** reach the factory). Idempotent.
- **`compose.prod.yaml`** — migrator now builds the prod Dockerfile; APIs already `depend_on: condition: service_completed_successfully`.
- **`.github/workflows/cd.yml`** — published `lotrokoniecdev-migrator` image now builds from the prod Dockerfile (the deployable artifact); dev `Dockerfile.migrator` is built locally by dev compose, never published.
- **`docs/deployment/runbook.md`** (new) — migrations section: strategy, env inputs, local + cloud (ACA Job / ECS RunTask) invocation, forward-only stance, verification queries.

The dev `compose.yaml` and dev `Dockerfile.migrator` are **untouched** (ticket requirement).

## Acceptance criteria
- [x] **Migration bundle(s) built and runnable against a connection string (both contexts)** — both bundles build; end-to-end run applied all 8 TMS + 1 Auth migrations into the `translation`/`auth` schemas.
- [x] **compose.prod applies schema via the bundle before APIs serve traffic** — full `compose.prod` postgres+migrator path verified (migrator exit 0); both APIs gate on `service_completed_successfully`.
- [x] **Failed migration blocks API startup (no half-migrated serving)** — unreachable DB → exit 1, missing connection env var → exit 1, success → exit 0; `service_completed_successfully` only proceeds on exit 0.
- [x] **Documented in runbook** — `docs/deployment/runbook.md`.

## Verification
Built and ran the migrator end-to-end against a throwaway Postgres and via the full `compose.prod.yaml` stack (SSL): both contexts migrate; a second run is a clean idempotent no-op ("No migrations were applied"); all three fail-fast modes exit non-zero. gitleaks staged scan clean.

## Notes for a real prod run
- Set the two `ConnectionStrings__*` (managed Postgres = one env swap); both databases must exist (`lotro_auth` created by `scripts/init-postgres.sh` in the parity stack).
- CD builds the bundle as `linux-x64` (matches the amd64 runner + amd64 cloud hosts).
- Forward-only: no automated rollback; take a DB snapshot before applying (zero prod users today — breaking changes are free per ADR-0002).

Code-reviewer verdict: **APPROVE** (one Minor nit — a vestigial `CACHEBUST` ARG — actioned before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)