### PR TITLE
fix(patcher): widen GossipId from int to ulong

### DIFF
--- a/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
+++ b/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
@@ -270,11 +270,17 @@ For every row of the uploaded export, compared against the stored source state b
 - *Why is exclusion enough for English fallback?* Launcher chunk-patching already delivers fresh
   English; only re-applying stale Polish could mask it (`dat-protection.md`,
   `update-detection-strategy.md`).
-- *Do real GossipIds exceed `int.MaxValue`?* `[needs verification]` — scan a real `exported.txt`
-  on the Windows box (`awk -F'\|\|' 'max<$2+0{max=$2+0}END{print max}'`). Export writes raw
-  8-byte `FragmentId`; the **patcher's** parser does `int.Parse` (`TranslationFileParser.cs:86`)
-  and would warn-skip larger IDs — dormant today, candidate patcher **bugfix** ticket (allowed
-  under freeze) if the scan finds large IDs. TMS uses `long` regardless (#93).
+- *Do real GossipIds exceed `int.MaxValue`?* **Resolved — #109 (M1-15), 2026-06-21.** Hardened
+  defensively instead of measured on the Windows box: the **patcher's** `Translation.GossipId` and
+  `TranslationFileParser` were widened from `int` to `ulong` — matching the producer exactly, since
+  `export` writes the raw 8-byte `Fragment.FragmentId` (a `ulong` read via `ReadUInt64`). The parser
+  now round-trips the **full** unsigned 8-byte range, so the scan is moot: every id the exporter can
+  emit is covered regardless of its actual maximum (`int.MaxValue` was the old silent-loss ceiling;
+  proven ids like `620756992` always fit). Out-of-range/garbage ids (negative, `> ulong.MaxValue`)
+  warn-skip cleanly instead of throwing (`OverflowException` joined the per-line `catch`). The TMS
+  stores GossipId as signed 64-bit `long` (#93), so a hypothetical high-bit id (`> long.MaxValue`)
+  would be rejected at TMS import rather than silently lost — a deliberate, surfaced boundary, not a
+  drop; widening the TMS contract is a separate ADR-level decision if such an id ever appears.
 
 ### Business decisions — resolved by the user, 2026-06-11
 
@@ -329,6 +335,6 @@ For every row of the uploaded export, compared against the stored source state b
   #104 (update-cycle integration scenario).
 - **New tickets:** **#107** (M2-19) GameVersion endpoints (list + manual register fallback),
   **#108** (M2-20) CLI auto-download (launch sync; freeze amendment), **#109** (M1-15) GossipId
-  int-overflow verification/hardening `[needs verification]`.
+  int-overflow hardening — `int`→`ulong` in the patcher parser + domain `[resolved 2026-06-21]`.
 - **Post-MVP unchanged:** #84/#31 (crowdsource reports), #50 (TranslationHistory), #30 (XML
   contexts), #38/#39 (glossary/UX).

--- a/src/LotroKoniecDev.Application/Parsers/TranslationFileParser.cs
+++ b/src/LotroKoniecDev.Application/Parsers/TranslationFileParser.cs
@@ -83,7 +83,7 @@ public sealed class TranslationFileParser : ITranslationParser
             Translation translation = new()
             {
                 FileId = int.Parse(parts[0]),
-                GossipId = int.Parse(parts[1]),
+                GossipId = ulong.Parse(parts[1]),
                 Content = UnescapeContent(content),
                 ArgsOrder = ParseArgsArray(parts[^3]),
                 ArgsId = ParseArgsArray(parts[^2]),
@@ -92,7 +92,7 @@ public sealed class TranslationFileParser : ITranslationParser
 
             return Result.Success(translation);
         }
-        catch (FormatException ex)
+        catch (Exception ex) when (ex is FormatException or OverflowException)
         {
             return Result.Failure<Translation>(
                 DomainErrors.Translation.ParseError(line, ex.Message));

--- a/src/LotroKoniecDev.Domain/Models/Translation.cs
+++ b/src/LotroKoniecDev.Domain/Models/Translation.cs
@@ -8,7 +8,7 @@ namespace LotroKoniecDev.Domain.Models;
 public sealed class Translation
 {
     public int FileId { get; init; }
-    public int GossipId { get; init; }
+    public ulong GossipId { get; init; }
     public string Content { get; init; } = string.Empty;
     public int[]? ArgsOrder { get; init; }
     public int[]? ArgsId { get; init; }
@@ -20,9 +20,10 @@ public sealed class Translation
     public bool HasArguments => ArgsOrder is { Length: > 0 };
 
     /// <summary>
-    /// Gets the fragment ID as an unsigned long.
+    /// Gets the fragment ID — the 8-byte unsigned <see cref="Fragment.FragmentId"/> this row
+    /// targets. Equal to <see cref="GossipId"/>, surfaced under the DAT-domain name.
     /// </summary>
-    public ulong FragmentId => (ulong)GossipId;
+    public ulong FragmentId => GossipId;
 
     /// <summary>
     /// Splits the content into text pieces using the separator.

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Features/PatchingServiceTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Features/PatchingServiceTests.cs
@@ -50,7 +50,7 @@ public sealed class PatchingServiceTests
 
     private static Translation CreateTranslation(
         int fileId = TextFileId,
-        int gossipId = (int)FragmentId1,
+        ulong gossipId = FragmentId1,
         string content = "Przetlumaczony tekst",
         int[]? argsOrder = null,
         bool isApproved = true) =>
@@ -290,8 +290,8 @@ public sealed class PatchingServiceTests
         _datFileHandler.GetSubfileData(DatHandle, TextFileId, 100)
             .Returns(Result.Success(subFileData));
 
-        Translation t1 = CreateTranslation(gossipId: (int)FragmentId1);
-        Translation t2 = CreateTranslation(gossipId: (int)FragmentId2);
+        Translation t1 = CreateTranslation(gossipId: FragmentId1);
+        Translation t2 = CreateTranslation(gossipId: FragmentId2);
         SetupTranslations(t1, t2);
 
         // Act
@@ -364,8 +364,8 @@ public sealed class PatchingServiceTests
         _datFileHandler.GetSubfileData(DatHandle, TextFileId, 100)
             .Returns(Result.Success(subFileData));
 
-        Translation approved = CreateTranslation(gossipId: (int)FragmentId1, isApproved: true);
-        Translation unapproved = CreateTranslation(gossipId: (int)FragmentId2, isApproved: false);
+        Translation approved = CreateTranslation(gossipId: FragmentId1, isApproved: true);
+        Translation unapproved = CreateTranslation(gossipId: FragmentId2, isApproved: false);
         SetupTranslations(approved, unapproved);
 
         // Act

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Models/TranslationTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Models/TranslationTests.cs
@@ -71,6 +71,21 @@ public sealed class TranslationTests
     }
 
     [Fact]
+    public void FragmentId_WithMaxUnsignedGossipId_ShouldReturnSameValueWithoutNarrowing()
+    {
+        // Arrange
+        Translation translation = new()
+        {
+            FileId = 1,
+            GossipId = ulong.MaxValue,
+            Content = "Test"
+        };
+
+        // Assert — the old int-backed GossipId would have truncated anything above int.MaxValue.
+        translation.FragmentId.ShouldBe(ulong.MaxValue);
+    }
+
+    [Fact]
     public void GetPieces_WithoutSeparator_ShouldReturnSinglePiece()
     {
         // Arrange

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserTests.cs
@@ -109,7 +109,7 @@ public sealed class TranslationFileParserTests : IDisposable
         result.IsSuccess.ShouldBeTrue();
         result.Value.Count.ShouldBe(1);
         result.Value[0].FileId.ShouldBe(12345);
-        result.Value[0].GossipId.ShouldBe(67890);
+        result.Value[0].GossipId.ShouldBe(67890UL);
         result.Value[0].Content.ShouldBe("Hello World");
         result.Value[0].ArgsOrder.ShouldBeNull();
         result.Value[0].ArgsId.ShouldBeNull();
@@ -167,11 +167,11 @@ public sealed class TranslationFileParserTests : IDisposable
         result.IsSuccess.ShouldBeTrue();
         result.Value.Count.ShouldBe(3);
         result.Value[0].FileId.ShouldBe(100);
-        result.Value[0].GossipId.ShouldBe(200);
+        result.Value[0].GossipId.ShouldBe(200UL);
         result.Value[1].FileId.ShouldBe(100);
-        result.Value[1].GossipId.ShouldBe(300);
+        result.Value[1].GossipId.ShouldBe(300UL);
         result.Value[2].FileId.ShouldBe(200);
-        result.Value[2].GossipId.ShouldBe(300);
+        result.Value[2].GossipId.ShouldBe(300UL);
     }
 
     [Fact]
@@ -218,6 +218,35 @@ public sealed class TranslationFileParserTests : IDisposable
         result.Error.Code.ShouldBe("Translation.ParseError");
     }
 
+    [Theory]
+    [InlineData("100||2147483647||Content||NULL||NULL||1", 2147483647UL)]                       // int.MaxValue — the old ceiling
+    [InlineData("100||2147483648||Content||NULL||NULL||1", 2147483648UL)]                       // int.MaxValue + 1 — previously warn-skipped (silent loss)
+    [InlineData("100||9223372036854775808||Content||NULL||NULL||1", 9223372036854775808UL)]     // long.MaxValue + 1 — the high-bit band long cannot hold
+    [InlineData("100||18446744073709551615||Content||NULL||NULL||1", 18446744073709551615UL)]   // ulong.MaxValue — full 8-byte range the exporter can write
+    public void ParseLine_GossipIdAtOrAboveIntMaxValue_ShouldParseFullUnsignedRange(string line, ulong expectedGossipId)
+    {
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.GossipId.ShouldBe(expectedGossipId);
+    }
+
+    [Theory]
+    [InlineData("100||-5||Content||NULL||NULL||1")]                          // negative — meaningless for an unsigned 8-byte id
+    [InlineData("100||18446744073709551616||Content||NULL||NULL||1")]        // ulong.MaxValue + 1 — beyond the 8-byte range
+    public void ParseLine_GossipIdOutsideUnsignedRange_ShouldReturnFailure(string line)
+    {
+        // Act — the tolerant parser must report a per-line failure (warn-skip), not let the
+        // OverflowException abort the whole file.
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translation.ParseError");
+    }
+
     [Fact]
     public void ParseLine_ValidLine_ShouldReturnSuccess()
     {
@@ -227,7 +256,7 @@ public sealed class TranslationFileParserTests : IDisposable
         // Assert
         result.IsSuccess.ShouldBeTrue();
         result.Value.FileId.ShouldBe(100);
-        result.Value.GossipId.ShouldBe(200);
+        result.Value.GossipId.ShouldBe(200UL);
         result.Value.Content.ShouldBe("Test content");
     }
 
@@ -273,7 +302,7 @@ public sealed class TranslationFileParserTests : IDisposable
         // Assert
         result.IsSuccess.ShouldBeTrue();
         result.Value.FileId.ShouldBe(100);
-        result.Value.GossipId.ShouldBe(200);
+        result.Value.GossipId.ShouldBe(200UL);
         result.Value.Content.ShouldBe("Left||Right");
         result.Value.ArgsOrder.ShouldBeNull();
         result.Value.ArgsId.ShouldBeNull();


### PR DESCRIPTION
## Summary

Widen `Translation.GossipId` from `int` to `ulong` so the patcher parser accepts the full 8-byte unsigned range that `export` writes (`Fragment.FragmentId` via `ReadUInt64`).

## Changes

- **Domain:** `Translation.GossipId` → `ulong`; `FragmentId` getter is now identity (no cast)
- **Parser:** `int.Parse` → `ulong.Parse`; `OverflowException` added to the per-line catch for clean warn-skip
- **Tests:** boundary cases at `int.MaxValue+1`, `long.MaxValue+1`, `ulong.MaxValue`, plus negative/overflow failure paths
- **Spec 0001:** open question marked resolved

## Risk

Allowed bugfix under the patcher freeze — no behavioral change for IDs that already fit in `int`; extends coverage to previously-truncated IDs.

Closes #109