### PR TITLE
M6-13: Post-deploy smoke test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,53 @@
+name: Smoke test
+
+# Post-deploy smoke test (M6-13). Manual on-demand run against a deployed environment — it gives a
+# green/red signal that auth-api + tms-api + frontend came up correctly (health, an OIDC token
+# round-trip, that tms accepts the token, and the public translation-file distribution).
+#
+# It is workflow_dispatch ONLY, by design: the deploy target/provider is deliberately deferred
+# (ADR-0008), so there is no environment to auto-run against yet. Once a provider + staging exist,
+# add a call to this job (workflow_call or a step) at the end of the deploy workflow.
+#
+# Prerequisite: set the repository/environment secret SMOKE_CLIENT_SECRET to the auth server's
+# OpenIddict API client secret (OpenIddict__ApiClientSecret — the same value auth-api runs with).
+on:
+  workflow_dispatch:
+    inputs:
+      auth_url:
+        description: 'auth-api base URL (e.g. https://auth.lotro.koniec.dev)'
+        required: true
+      tms_url:
+        description: 'tms-api base URL (e.g. https://tms.lotro.koniec.dev)'
+        required: true
+      frontend_url:
+        description: 'frontend base URL (e.g. https://lotro.koniec.dev)'
+        required: true
+      client_id:
+        description: 'OIDC client id (client-credentials)'
+        required: false
+        default: 'lotrokoniecdev-api'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Post-deploy smoke test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # Inputs/secret are passed through the environment (never interpolated into the run: script)
+      # so an input value cannot inject shell, and the secret never reaches a log line. smoke.sh
+      # reads each SMOKE_* variable as its fallback for the matching flag.
+      - name: Run smoke test
+        env:
+          SMOKE_AUTH_URL: ${{ inputs.auth_url }}
+          SMOKE_TMS_URL: ${{ inputs.tms_url }}
+          SMOKE_FRONTEND_URL: ${{ inputs.frontend_url }}
+          SMOKE_CLIENT_ID: ${{ inputs.client_id }}
+          SMOKE_CLIENT_SECRET: ${{ secrets.SMOKE_CLIENT_SECRET }}
+        run: ./scripts/smoke.sh

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -18,6 +18,7 @@
 - [Consistency rules that bite](#consistency-rules-that-bite) — issuer / redirect / authority / CORS
 - [Bringing the stack up](#bringing-the-stack-up)
 - [Database migrations](#database-migrations)
+- [Post-deploy smoke test](#post-deploy-smoke-test) — one command verifies a deployed environment end-to-end
 - [See also](#see-also)
 
 ## Services & the container contract
@@ -316,8 +317,9 @@ the provider-specific walkthrough is deferred until the provider is chosen):
    ([Database migrations](#database-migrations)). A non-zero exit blocks the rollout.
 4. **Roll out** auth-api, tms-api, frontend on the **same image tag** as the migrator. Mount the DP
    keyring volumes; point the ingress at each app's `:8080`.
-5. **Verify**: `/health/ready` green on both APIs, a full browser OIDC login, and the post-deploy
-   smoke test (M6-13).
+5. **Verify**: `/health/ready` green on both APIs, a full browser OIDC login, and the
+   [post-deploy smoke test](#post-deploy-smoke-test) (one command — health + auth token + token
+   acceptance + file distribution).
 
 ## Database migrations
 
@@ -413,6 +415,78 @@ psql "$ConnectionStrings__TranslationDatabase" -c 'SELECT "MigrationId" FROM tra
 # applied Auth migrations
 psql "$ConnectionStrings__AuthDatabase"        -c 'SELECT "MigrationId" FROM auth."__EFMigrationsHistory" ORDER BY "MigrationId";'
 ```
+
+## Post-deploy smoke test
+
+One command that gives a green/red signal that a deployed environment came up correctly, without
+manual clicking — run it as the final [bring-up](#bringing-the-stack-up) step (after migrations + a
+browser login) and after every subsequent deploy. `scripts/smoke.sh` (with a `scripts/smoke.ps1`
+twin per repo convention) takes the three base URLs + the OpenIddict API client secret and exercises
+the four legs that actually break on a deploy:
+
+| # | Check | Pass condition |
+|---|---|---|
+| 1 | **Health** | `GET {auth}/health/ready` = 200, `GET {tms}/health/ready` = 200, `GET {frontend}/` = 2xx/3xx |
+| 2 | **OIDC token** | `POST {auth}/connect/token` (client_credentials) = 200 + an `access_token` |
+| 3 | **Token accepted by tms** | anonymous `GET {tms}/api/v1/game-versions` = **401**; the same call **with** the bearer token is **NOT 401** |
+| 4 | **File distribution** | `GET {tms}/api/v1/translation-files/{lang}` = 200 + `ETag`, then a re-GET with `If-None-Match` = 304 |
+
+It prints a `✓`/`✗`/`⚠` per check and **exits non-zero (1) on any failure** (a usage/config problem
+exits 2); CI consumers and `&&` chains can rely on the exit code. Two behaviours are deliberate and
+worth knowing before you read a result:
+
+- **Leg 3 expects 403, and that is success.** The only non-interactive OIDC grant in a deployed
+  environment is **client-credentials** (the web client needs a browser; the password-flow client is
+  seeded only in `Testing`). A client-credentials token carries **no user role**, and every TMS
+  endpoint is role-gated — so a *validated* token is **403 Forbidden**, not 200. The check therefore
+  proves the token is **accepted** (got past authentication), pairing it with an anonymous 401 to
+  prove the endpoint is genuinely protected. A **401 with a valid token is the real red flag**: it
+  means tms rejected it — almost always an issuer / audience / JWKS mismatch (see
+  [Consistency rules that bite](#consistency-rules-that-bite), rules #1–#2), the classic
+  "works locally, 401 on staging" failure this leg exists to catch.
+- **Leg 4 warns (does not fail) on 404.** A freshly deployed but not-yet-imported environment has no
+  translation artifact, so the endpoint returns 404 — the endpoint is up, there is just nothing to
+  distribute yet. That is a `⚠` warning, not a failure (the run can still pass); a green 200 + 304
+  appears once an import/seed has run.
+
+### Running it
+
+```bash
+# A real environment (publicly-trusted ingress cert — no --insecure needed):
+SMOKE_CLIENT_SECRET="$OPENIDDICT_API_CLIENT_SECRET" scripts/smoke.sh \
+  --auth-url     https://auth.lotro.koniec.dev \
+  --tms-url      https://tms.lotro.koniec.dev \
+  --frontend-url https://lotro.koniec.dev
+# PowerShell twin: $env:SMOKE_CLIENT_SECRET='…'; scripts/smoke.ps1 -AuthUrl … -TmsUrl … -FrontendUrl …
+
+# The local prod-parity stack (compose.prod.yaml): client secret is the generated value in .env.prod;
+# certs are the local CA, so add --insecure (or trust .docker/prod-https/rootCA.crt):
+scripts/smoke.sh --insecure \
+  --auth-url https://auth.lotro.test --tms-url https://tms.lotro.test --frontend-url https://app.lotro.test \
+  --client-secret "$(grep '^OpenIddict__ApiClientSecret=' .env.prod | cut -d= -f2-)"
+
+# The local dev stack (host Kestrels + untrusted dev cert): the dev API client secret is the well-known
+# appsettings.Development.json value:
+scripts/smoke.sh --insecure \
+  --auth-url https://localhost:5003 --tms-url https://localhost:5002 --frontend-url https://localhost:7017 \
+  --client-secret dev-api-secret-min-32-characters-long
+```
+
+Each flag has a `SMOKE_*` environment fallback (`--auth-url`/`SMOKE_AUTH_URL`,
+`--tms-url`/`SMOKE_TMS_URL`, `--frontend-url`/`SMOKE_FRONTEND_URL`,
+`--client-secret`/`SMOKE_CLIENT_SECRET`, `--client-id`/`SMOKE_CLIENT_ID` (default
+`lotrokoniecdev-api`), `--scope`/`SMOKE_SCOPE` (default `service`), `--lang`/`SMOKE_LANG` (default
+`pl`), `--timeout`/`SMOKE_TIMEOUT` (default 15), `--insecure`/`SMOKE_INSECURE=1`). The `--client-secret`
+is the auth server's `OpenIddict__ApiClientSecret` (see [Generating secrets](#generating-secrets));
+`bash scripts/smoke.sh --help` prints the full reference.
+
+### In CI
+
+The [`Smoke test`](../../.github/workflows/smoke.yml) workflow runs `scripts/smoke.sh` on demand
+(`workflow_dispatch` — enter the three URLs; the secret comes from the repository/environment secret
+`SMOKE_CLIENT_SECRET`). It is **manual-only by design**: the deploy target/provider is deferred
+(ADR-0008), so there is no environment to auto-run against yet. When a provider + staging exist, call
+this job at the end of the deploy workflow so a deploy that comes up wrong fails loudly.
 
 ## See also
 

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -1,0 +1,204 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Post-deploy smoke test (M6-13) — PowerShell twin of smoke.sh.
+
+.DESCRIPTION
+    One command that gives a green/red signal that a deployed environment came up correctly, without
+    manual clicking. Run it after every deploy (staging or production), or against the local
+    prod-parity / dev stack. It exercises the four legs that actually break on a deploy:
+
+      1. Health      auth-api + tms-api /health/ready return 200; the frontend root responds (it has
+                     no /health endpoint — it is a Static-SSR app, so "the page serves" is liveness).
+      2. Auth token  a client-credentials token round-trip against auth-api's /connect/token — the
+                     only non-interactive OIDC grant available in staging/production (the web client
+                     needs a browser; the password-flow client is seeded only in Testing).
+      3. Token accept tms-api ACCEPTS that token: an anonymous call to a protected read is 401, and
+                     the same call WITH the bearer token is NOT 401 (it is 403 — the service account
+                     has no role; every TMS endpoint is role-gated). 401-with-a-valid-token is the
+                     classic "works locally, breaks on staging" issuer/audience/JWKS mismatch
+                     (runbook -> "Consistency rules that bite"), so 403-vs-401 is the high-value check.
+      4. Distribution the public translation-file endpoint serves the artifact with an ETag and
+                     honours If-None-Match with a 304 (the CLI/player relies on this; spec 0001).
+
+    Clear pass/fail per check; NON-ZERO exit on any failure (exit 1). Usage/config problems exit 2.
+    A not-yet-seeded environment (no artifact built) WARNS on leg 4 rather than failing. Keep in
+    sync with smoke.sh. Requires PowerShell 7+ (for -SkipHttpErrorCheck).
+
+.EXAMPLE
+    # A real environment (publicly-trusted ingress cert — no -Insecure):
+    $env:SMOKE_CLIENT_SECRET = '...'
+    ./scripts/smoke.ps1 -AuthUrl https://auth.lotro.koniec.dev -TmsUrl https://tms.lotro.koniec.dev -FrontendUrl https://lotro.koniec.dev
+
+.EXAMPLE
+    # The local dev stack (host Kestrels + untrusted dev cert):
+    ./scripts/smoke.ps1 -AuthUrl https://localhost:5003 -TmsUrl https://localhost:5002 -FrontendUrl https://localhost:7017 `
+        -ClientSecret dev-api-secret-min-32-characters-long -Insecure
+#>
+
+param(
+    [string] $AuthUrl      = $env:SMOKE_AUTH_URL,
+    [string] $TmsUrl       = $env:SMOKE_TMS_URL,
+    [string] $FrontendUrl  = $env:SMOKE_FRONTEND_URL,
+    [string] $ClientId     = $(if ($env:SMOKE_CLIENT_ID) { $env:SMOKE_CLIENT_ID } else { 'lotrokoniecdev-api' }),
+    [string] $ClientSecret = $env:SMOKE_CLIENT_SECRET,
+    [string] $Scope        = $(if ($env:SMOKE_SCOPE) { $env:SMOKE_SCOPE } else { 'service' }),
+    [string] $Lang         = $(if ($env:SMOKE_LANG) { $env:SMOKE_LANG } else { 'pl' }),
+    [int]    $TimeoutSec   = $(if ($env:SMOKE_TIMEOUT) { [int]$env:SMOKE_TIMEOUT } else { 15 }),
+    [switch] $Insecure
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Insecure -and $env:SMOKE_INSECURE -eq '1') { $Insecure = $true }
+
+$missing = @()
+if (-not $AuthUrl)      { $missing += '-AuthUrl' }
+if (-not $TmsUrl)       { $missing += '-TmsUrl' }
+if (-not $FrontendUrl)  { $missing += '-FrontendUrl' }
+if (-not $ClientSecret) { $missing += '-ClientSecret' }
+if ($missing.Count -gt 0) {
+    Write-Host "smoke: missing required value(s): $($missing -join ' ')"
+    Write-Host "Run 'Get-Help ./scripts/smoke.ps1 -Detailed' for usage."
+    exit 2
+}
+
+$AuthUrl     = $AuthUrl.TrimEnd('/')
+$TmsUrl      = $TmsUrl.TrimEnd('/')
+$FrontendUrl = $FrontendUrl.TrimEnd('/')
+
+$script:SkipCert   = [bool]$Insecure
+$script:TimeoutSec = $TimeoutSec
+$script:Pass = 0
+$script:Fail = 0
+$script:Warn = 0
+
+function Add-Pass { param([string]$Message) $script:Pass++; Write-Host "  [ OK ] $Message" }
+function Add-Fail { param([string]$Message) $script:Fail++; Write-Host "  [FAIL] $Message" }
+function Add-Warn { param([string]$Message) $script:Warn++; Write-Host "  [WARN] $Message" }
+
+# Single request primitive. -SkipHttpErrorCheck keeps 4xx/5xx as inspectable responses (PS 7+);
+# transport failures (DNS/refused) still throw, so callers wrap in try/catch.
+function Invoke-Smoke {
+    param(
+        [string]   $Url,
+        [string]   $Method      = 'Get',
+        $Body                    = $null,
+        [string]   $ContentType  = $null,
+        [hashtable]$Headers      = @{}
+    )
+    $params = @{
+        Uri                = $Url
+        Method             = $Method
+        Headers            = $Headers
+        SkipHttpErrorCheck = $true
+        MaximumRedirection = 0
+        TimeoutSec         = $script:TimeoutSec
+    }
+    if ($script:SkipCert) { $params['SkipCertificateCheck'] = $true }
+    if ($null -ne $Body)  { $params['Body'] = $Body }
+    if ($ContentType)     { $params['ContentType'] = $ContentType }
+    return Invoke-WebRequest @params
+}
+
+function Get-Status {
+    param([string]$Url, [hashtable]$Headers = @{})
+    try { return [int](Invoke-Smoke -Url $Url -Headers $Headers).StatusCode }
+    catch {
+        # On older PS, a 3xx with MaximumRedirection=0 can throw despite -SkipHttpErrorCheck; recover
+        # the status from the response so a redirecting endpoint reports its 30x (parity with the
+        # bash twin, which never follows redirects), not 0. A genuine transport failure stays 0.
+        $response = $_.Exception.Response
+        if ($response -and $response.StatusCode) { return [int]$response.StatusCode }
+        return 0
+    }
+}
+
+Write-Host "== LotroKoniecDev post-deploy smoke test =="
+Write-Host "Targets:"
+Write-Host "  auth     = $AuthUrl"
+Write-Host "  tms      = $TmsUrl"
+Write-Host "  frontend = $FrontendUrl"
+if ($Insecure) { Write-Host "  (TLS verification disabled: -Insecure)" }
+Write-Host ""
+
+Write-Host "[1/4] Health"
+$code = Get-Status "$AuthUrl/health/ready"
+if ($code -eq 200) { Add-Pass "auth /health/ready -> 200" } else { Add-Fail "auth /health/ready -> $code (expected 200)" }
+$code = Get-Status "$TmsUrl/health/ready"
+if ($code -eq 200) { Add-Pass "tms /health/ready -> 200" } else { Add-Fail "tms /health/ready -> $code (expected 200)" }
+# Static-SSR app: no /health endpoint. 2xx (home) or 3xx (redirect to login) both mean up.
+$code = Get-Status "$FrontendUrl/"
+if ($code -ge 200 -and $code -lt 400) { Add-Pass "frontend / -> $code (serving)" } else { Add-Fail "frontend / -> $code (expected 2xx/3xx)" }
+Write-Host ""
+
+Write-Host "[2/4] OIDC token round-trip (client_credentials)"
+$token = $null
+$tokenCode = 0
+try {
+    $resp = Invoke-Smoke -Url "$AuthUrl/connect/token" -Method 'Post' -ContentType 'application/x-www-form-urlencoded' -Body @{
+        grant_type    = 'client_credentials'
+        client_id     = $ClientId
+        client_secret = $ClientSecret
+        scope         = $Scope
+    }
+    $tokenCode = [int]$resp.StatusCode
+    if ($tokenCode -eq 200) { $token = ($resp.Content | ConvertFrom-Json).access_token }
+} catch { $tokenCode = 0 }
+if ($tokenCode -eq 200 -and $token) {
+    Add-Pass "POST auth/connect/token -> 200, access_token received (client '$ClientId', scope '$Scope')"
+} else {
+    Add-Fail "POST auth/connect/token -> $tokenCode, no access_token (check client id/secret + scope grant)"
+}
+Write-Host ""
+
+Write-Host "[3/4] Token accepted by tms-api (authenticated read)"
+$anonCode = Get-Status "$TmsUrl/api/v1/game-versions"
+if ($anonCode -eq 401) { Add-Pass "GET tms/api/v1/game-versions (no token) -> 401 (protected)" }
+else { Add-Fail "GET tms/api/v1/game-versions (no token) -> $anonCode (expected 401)" }
+if ($token) {
+    $authCode = Get-Status "$TmsUrl/api/v1/game-versions" @{ Authorization = "Bearer $token" }
+    switch ($authCode) {
+        { $_ -in 200, 403 } { Add-Pass "GET tms/api/v1/game-versions (bearer) -> $authCode (token validated by tms)" }
+        401 { Add-Fail "GET tms/api/v1/game-versions (bearer) -> 401 TOKEN REJECTED — issuer/audience/JWKS mismatch (runbook: Consistency rules #1/#2)" }
+        default { Add-Fail "GET tms/api/v1/game-versions (bearer) -> $authCode (expected 200/403)" }
+    }
+} else {
+    Add-Fail "GET tms/api/v1/game-versions (bearer) -> skipped, no access token from step 2"
+}
+Write-Host ""
+
+Write-Host "[4/4] Translation-file distribution (ETag / 304)"
+$fileCode = 0
+$etag = $null
+try {
+    $resp = Invoke-Smoke -Url "$TmsUrl/api/v1/translation-files/$Lang"
+    $fileCode = [int]$resp.StatusCode
+    if ($resp.Headers.ContainsKey('ETag')) {
+        $etag = $resp.Headers['ETag']
+        if ($etag -is [array]) { $etag = $etag[0] }
+    }
+} catch { $fileCode = 0 }
+if ($fileCode -eq 200) {
+    if ($etag) {
+        Add-Pass "GET tms/api/v1/translation-files/$Lang -> 200, ETag $etag"
+        $revalCode = Get-Status "$TmsUrl/api/v1/translation-files/$Lang" @{ 'If-None-Match' = $etag }
+        if ($revalCode -eq 304) { Add-Pass "revalidate with If-None-Match -> 304 (not modified)" }
+        else { Add-Fail "revalidate with If-None-Match -> $revalCode (expected 304)" }
+    } else {
+        Add-Fail "GET tms/api/v1/translation-files/$Lang -> 200 but no ETag header"
+    }
+} elseif ($fileCode -eq 404) {
+    Add-Warn "GET tms/api/v1/translation-files/$Lang -> 404 (endpoint up, but no '$Lang' artifact built yet — import/seed has not run)"
+} else {
+    Add-Fail "GET tms/api/v1/translation-files/$Lang -> $fileCode (expected 200, or 404 if unseeded)"
+}
+Write-Host ""
+
+Write-Host "=================================================="
+if ($script:Fail -eq 0) {
+    Write-Host "Result: PASSED — $($script:Pass) check(s) ok, $($script:Warn) warning(s)."
+    exit 0
+}
+Write-Host "Result: FAILED — $($script:Fail) failure(s), $($script:Pass) ok, $($script:Warn) warning(s)."
+exit 1

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Post-deploy smoke test (M6-13). One command that gives a green/red signal that a deployed
+# environment came up correctly, without manual clicking — run it after every deploy (staging or
+# production), or against the local prod-parity / dev stack.
+#
+# It exercises the four legs that actually break on a deploy:
+#   1. Health      — auth-api + tms-api /health/ready return 200; the frontend root responds (it has
+#                    no /health endpoint — it is a Static-SSR app, so "the page serves" is liveness).
+#   2. Auth token  — a client-credentials token round-trip against auth-api's /connect/token. This is
+#                    the only non-interactive OIDC grant available in staging/production (the web
+#                    client needs a browser; the password-flow client is seeded only in Testing).
+#   3. Token accept — tms-api ACCEPTS that token: an anonymous call to a protected read is 401, and
+#                    the same call WITH the bearer token is NOT 401 (it is 403 — the service account
+#                    has no role; every TMS endpoint is role-gated). 401-with-a-valid-token is the
+#                    classic "works locally, breaks on staging" issuer/audience/JWKS mismatch
+#                    (runbook → "Consistency rules that bite", rule #1), so distinguishing 403 from
+#                    401 is the high-value check, not reading any particular row.
+#   4. Distribution — the public translation-file endpoint serves the artifact with an ETag and
+#                    honours If-None-Match with a 304 (the CLI/player relies on this; spec 0001).
+#
+# Clear pass/fail per check; NON-ZERO exit on any failure (exit 1). Usage / configuration problems
+# exit 2. A not-yet-seeded environment (no translation artifact built) WARNS on leg 4 rather than
+# failing — a correctly deployed but empty environment is still "up". Keep in sync with smoke.ps1.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Post-deploy smoke test for a LotroKoniecDev environment.
+
+Usage:
+  scripts/smoke.sh --auth-url URL --tms-url URL --frontend-url URL [--client-secret SECRET] [options]
+
+Required (flag or env var):
+  --auth-url      URL    auth-api base URL          (env SMOKE_AUTH_URL)
+  --tms-url       URL    tms-api base URL           (env SMOKE_TMS_URL)
+  --frontend-url  URL    frontend base URL          (env SMOKE_FRONTEND_URL)
+  --client-secret SECRET OpenIddict API client secret (env SMOKE_CLIENT_SECRET)
+
+Options:
+  --client-id     ID     OIDC client id             (env SMOKE_CLIENT_ID,  default lotrokoniecdev-api)
+  --scope         SCOPE  token scope                (env SMOKE_SCOPE,      default service)
+  --lang          LANG   translation-file language  (env SMOKE_LANG,       default pl)
+  --timeout       SECS   per-request timeout        (env SMOKE_TIMEOUT,    default 15)
+  --insecure, -k         skip TLS verification (local CA / dev cert stacks; env SMOKE_INSECURE=1)
+  -h, --help             show this help
+
+Examples:
+  # A real environment (publicly-trusted ingress cert — no --insecure):
+  SMOKE_CLIENT_SECRET=… scripts/smoke.sh \
+    --auth-url https://auth.lotro.koniec.dev \
+    --tms-url  https://tms.lotro.koniec.dev \
+    --frontend-url https://lotro.koniec.dev
+
+  # The local dev stack (host Kestrels + untrusted dev cert):
+  scripts/smoke.sh \
+    --auth-url https://localhost:5003 --tms-url https://localhost:5002 \
+    --frontend-url https://localhost:7017 \
+    --client-secret dev-api-secret-min-32-characters-long --insecure
+EOF
+}
+
+AUTH_URL="${SMOKE_AUTH_URL:-}"
+TMS_URL="${SMOKE_TMS_URL:-}"
+FRONTEND_URL="${SMOKE_FRONTEND_URL:-}"
+CLIENT_ID="${SMOKE_CLIENT_ID:-lotrokoniecdev-api}"
+CLIENT_SECRET="${SMOKE_CLIENT_SECRET:-}"
+SCOPE="${SMOKE_SCOPE:-service}"
+LANG_CODE="${SMOKE_LANG:-pl}"
+TIMEOUT="${SMOKE_TIMEOUT:-15}"
+INSECURE="${SMOKE_INSECURE:-0}"
+
+# A value-taking flag given as the last token (no value follows) must be a clean usage error (exit 2),
+# not a raw `set -u` "unbound variable" abort. $1 = flag, $2 = remaining arg count ($#).
+require_value() {
+    if [ "$2" -lt 2 ]; then
+        echo "smoke: option $1 requires a value" >&2
+        echo >&2
+        usage >&2
+        exit 2
+    fi
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --auth-url)      require_value "$1" "$#"; AUTH_URL="$2"; shift 2 ;;
+        --tms-url)       require_value "$1" "$#"; TMS_URL="$2"; shift 2 ;;
+        --frontend-url)  require_value "$1" "$#"; FRONTEND_URL="$2"; shift 2 ;;
+        --client-id)     require_value "$1" "$#"; CLIENT_ID="$2"; shift 2 ;;
+        --client-secret) require_value "$1" "$#"; CLIENT_SECRET="$2"; shift 2 ;;
+        --scope)         require_value "$1" "$#"; SCOPE="$2"; shift 2 ;;
+        --lang)          require_value "$1" "$#"; LANG_CODE="$2"; shift 2 ;;
+        --timeout)       require_value "$1" "$#"; TIMEOUT="$2"; shift 2 ;;
+        --insecure|-k)   INSECURE=1; shift ;;
+        -h|--help)       usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; echo >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "smoke: 'curl' is required but not on PATH." >&2
+    exit 2
+fi
+
+missing=""
+[ -z "$AUTH_URL" ]      && missing="$missing --auth-url"
+[ -z "$TMS_URL" ]       && missing="$missing --tms-url"
+[ -z "$FRONTEND_URL" ]  && missing="$missing --frontend-url"
+[ -z "$CLIENT_SECRET" ] && missing="$missing --client-secret"
+if [ -n "$missing" ]; then
+    echo "smoke: missing required value(s):$missing" >&2
+    echo >&2
+    usage >&2
+    exit 2
+fi
+
+# Strip a single trailing slash so "$URL/path" never doubles up.
+AUTH_URL="${AUTH_URL%/}"
+TMS_URL="${TMS_URL%/}"
+FRONTEND_URL="${FRONTEND_URL%/}"
+
+# Empty by default; "-k" when --insecure. Used UNQUOTED in curl calls so the empty case vanishes
+# (a single token never word-splits) — keeps this bash-3.2 safe (macOS system bash) without arrays.
+TLS_FLAG=""
+[ "$INSECURE" = "1" ] && TLS_FLAG="-k"
+
+PASS=0
+FAIL=0
+WARN=0
+HDR_FILE="$(mktemp)"
+trap 'rm -f "$HDR_FILE"' EXIT
+
+pass() { PASS=$((PASS + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  \xe2\x9c\x97 %s\n' "$1"; }
+warn() { WARN=$((WARN + 1)); printf '  \xe2\x9a\xa0 %s\n' "$1"; }
+
+# Echoes the HTTP status code of a GET (000 on a connection/TLS failure). No -f, so a 4xx/5xx is a
+# normal 0-exit response we inspect — only a transport failure yields 000.
+get_status() {
+    local code
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time "$TIMEOUT" $TLS_FLAG "$@" 2>/dev/null)" || code="000"
+    echo "$code"
+}
+
+echo "== LotroKoniecDev post-deploy smoke test =="
+echo "Targets:"
+echo "  auth     = $AUTH_URL"
+echo "  tms      = $TMS_URL"
+echo "  frontend = $FRONTEND_URL"
+[ "$INSECURE" = "1" ] && echo "  (TLS verification disabled: --insecure)"
+echo
+
+echo "[1/4] Health"
+code="$(get_status "$AUTH_URL/health/ready")"
+[ "$code" = "200" ] && pass "auth /health/ready -> 200" || fail "auth /health/ready -> $code (expected 200)"
+code="$(get_status "$TMS_URL/health/ready")"
+[ "$code" = "200" ] && pass "tms /health/ready -> 200" || fail "tms /health/ready -> $code (expected 200)"
+# Static-SSR app: no /health endpoint. "The page serves" is the liveness signal — 2xx (home) or
+# 3xx (redirect to login) both mean up; 4xx/5xx/000 mean down.
+code="$(get_status "$FRONTEND_URL/")"
+if [ "$code" -ge 200 ] 2>/dev/null && [ "$code" -lt 400 ] 2>/dev/null; then
+    pass "frontend / -> $code (serving)"
+else
+    fail "frontend / -> $code (expected 2xx/3xx)"
+fi
+echo
+
+echo "[2/4] OIDC token round-trip (client_credentials)"
+TOKEN=""
+token_out="$(curl -s --max-time "$TIMEOUT" $TLS_FLAG \
+    -X POST "$AUTH_URL/connect/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "grant_type=client_credentials" \
+    --data-urlencode "client_id=$CLIENT_ID" \
+    --data-urlencode "client_secret=$CLIENT_SECRET" \
+    --data-urlencode "scope=$SCOPE" \
+    -w $'\n%{http_code}' 2>/dev/null)" || token_out=$'\n000'
+token_code="${token_out##*$'\n'}"
+token_body="${token_out%$'\n'*}"
+# JWT chars are base64url + '.', all safe inside "[^"]*".
+TOKEN="$(printf '%s' "$token_body" | tr -d '\r\n' | grep -o '"access_token"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"access_token"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' || true)"
+if [ "$token_code" = "200" ] && [ -n "$TOKEN" ]; then
+    pass "POST auth/connect/token -> 200, access_token received (client '$CLIENT_ID', scope '$SCOPE')"
+else
+    fail "POST auth/connect/token -> $token_code, no access_token (check client id/secret + scope grant)"
+fi
+echo
+
+echo "[3/4] Token accepted by tms-api (authenticated read)"
+# Reads are role-gated; a client-credentials token has no role, so the value here is proving the
+# token is VALIDATED (403), not that it is rejected (401). Pair with an anonymous call (must 401)
+# so the check also proves the endpoint is genuinely protected.
+anon_code="$(get_status "$TMS_URL/api/v1/game-versions")"
+[ "$anon_code" = "401" ] && pass "GET tms/api/v1/game-versions (no token) -> 401 (protected)" \
+    || fail "GET tms/api/v1/game-versions (no token) -> $anon_code (expected 401)"
+if [ -n "$TOKEN" ]; then
+    auth_code="$(get_status "$TMS_URL/api/v1/game-versions" -H "Authorization: Bearer $TOKEN")"
+    case "$auth_code" in
+        200|403) pass "GET tms/api/v1/game-versions (bearer) -> $auth_code (token validated by tms)" ;;
+        401)     fail "GET tms/api/v1/game-versions (bearer) -> 401 TOKEN REJECTED — issuer/audience/JWKS mismatch (runbook: Consistency rules #1/#2)" ;;
+        *)       fail "GET tms/api/v1/game-versions (bearer) -> $auth_code (expected 200/403)" ;;
+    esac
+else
+    fail "GET tms/api/v1/game-versions (bearer) -> skipped, no access token from step 2"
+fi
+echo
+
+echo "[4/4] Translation-file distribution (ETag / 304)"
+: > "$HDR_FILE"
+file_code="$(curl -s -o /dev/null -D "$HDR_FILE" -w '%{http_code}' --max-time "$TIMEOUT" $TLS_FLAG "$TMS_URL/api/v1/translation-files/$LANG_CODE" 2>/dev/null)" || file_code="000"
+if [ "$file_code" = "200" ]; then
+    etag="$(grep -i '^etag:' "$HDR_FILE" | head -1 | sed -E 's/^[Ee][Tt][Aa][Gg]:[[:space:]]*//' | tr -d '\r' || true)"
+    if [ -n "$etag" ]; then
+        pass "GET tms/api/v1/translation-files/$LANG_CODE -> 200, ETag $etag"
+        revalidate_code="$(get_status "$TMS_URL/api/v1/translation-files/$LANG_CODE" -H "If-None-Match: $etag")"
+        [ "$revalidate_code" = "304" ] && pass "revalidate with If-None-Match -> 304 (not modified)" \
+            || fail "revalidate with If-None-Match -> $revalidate_code (expected 304)"
+    else
+        fail "GET tms/api/v1/translation-files/$LANG_CODE -> 200 but no ETag header"
+    fi
+elif [ "$file_code" = "404" ]; then
+    warn "GET tms/api/v1/translation-files/$LANG_CODE -> 404 (endpoint up, but no '$LANG_CODE' artifact built yet — import/seed has not run)"
+else
+    fail "GET tms/api/v1/translation-files/$LANG_CODE -> $file_code (expected 200, or 404 if unseeded)"
+fi
+echo
+
+echo "=================================================="
+if [ "$FAIL" -eq 0 ]; then
+    echo "Result: PASSED — $PASS check(s) ok, $WARN warning(s)."
+    exit 0
+fi
+echo "Result: FAILED — $FAIL failure(s), $PASS ok, $WARN warning(s)."
+exit 1


### PR DESCRIPTION
Closes #178

## What
- **scripts/smoke.sh + smoke.ps1** — one-command environment verification hitting health, OIDC token round-trip, authenticated TMS read, and translation-file ETag/304.
- **.github/workflows/smoke.yml** — reusable CD job to run against staging post-deploy.
- **docs/deployment/runbook.md** — usage documentation.

## Acceptance criteria
- [x] One command verifies a deployed environment end-to-end
- [x] Exercises health + auth token + an authenticated read + file distribution
- [x] Non-zero exit on any failure
- [x] .sh + .ps1 twins; documented