### PR TITLE
frontend e2e playwright

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,13 @@
 name: E2E
 
-# Heaviest possible job: the E2ETestFixture builds the auth/tms/migrator Docker images and spins up the
-# full stack (Postgres + migrator + both APIs) via Testcontainers, then drives the core loop over real HTTP
-# with real auth-api tokens. Manual only — never on push/PR — so it costs nothing routinely. The project is
-# named `...E2E.Tests` (not `*.Tests.Unit`/`*.Tests.Integration`), so pr-verify/ci skip it by convention.
+# Heaviest possible jobs, both via Testcontainers (the ubuntu runner has Docker preinstalled):
+#   - e2e:          builds the auth/tms/migrator images, boots Postgres + migrator + both APIs, and drives
+#                   the core loop over real HTTP with real auth-api tokens.
+#   - e2e-frontend: additionally builds the Frontend image, boots the whole browser-facing stack (+ Mailpit +
+#                   the official Testcontainers Playwright browser), and drives the register→confirm→login→
+#                   logout loop in a real headless Chromium (ADR-0009).
+# Manual only — never on push/PR — so they cost nothing routinely. Both projects are named `...E2E.Tests`
+# (not `*.Tests.Unit`/`*.Tests.Integration`), so pr-verify/ci skip them by convention.
 # Run from the Actions tab or `gh workflow run e2e.yml`.
 on:
   workflow_dispatch:
@@ -48,3 +52,37 @@ jobs:
       # then boots the stack via Testcontainers — no SKIP_DOCKER_BUILD, no pre-built images.
       - name: Run E2E Tests
         run: dotnet test tests/LotroKoniecDev.TranslationSystem.E2E.Tests/LotroKoniecDev.TranslationSystem.E2E.Tests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"
+
+  e2e-frontend:
+    name: E2E Frontend (browser via Testcontainers + Playwright)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.100'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore tests/LotroKoniecDev.Frontend.E2E.Tests/LotroKoniecDev.Frontend.E2E.Tests.csproj
+
+      - name: Build
+        run: dotnet build tests/LotroKoniecDev.Frontend.E2E.Tests/LotroKoniecDev.Frontend.E2E.Tests.csproj --configuration Release --no-restore
+
+      # The fixture builds the auth/tms/frontend/migrator images, then boots the whole browser-facing stack
+      # (+ Mailpit + the official Testcontainers Playwright browser) and drives it over a real headless Chromium.
+      # ConnectAsync uses the in-container browser, so no `playwright install` (no host browser download) is needed.
+      - name: Run Frontend E2E Tests
+        run: dotnet test tests/LotroKoniecDev.Frontend.E2E.Tests/LotroKoniecDev.Frontend.E2E.Tests.csproj --configuration Release --no-build --logger "console;verbosity=minimal"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ A KittySaver slice is one file: `internal sealed class <Action> : IEndpoint` con
 | Work a GitHub ticket end-to-end | run **`/ticket <number>`** (mind the pivot-supersedes rule in Project status) |
 | Touch DAT binary parsing / writing / native interop | delegate to the **`dat-format-expert`** agent |
 | Re-investigate update behavior, vnum, translation survival, launch flow | **don't** — empirically settled in `docs/knowledge-base/` (start at its README) |
-| Make a non-trivial architectural/modeling decision | skim `docs/adr/`, then **write a new ADR** (`/adr`); anchors: 0001 (no mediator), 0002 (TMS pivot + freeze amendment), 0008 (cloud-agnostic deployment + env strategy — M6) |
+| Make a non-trivial architectural/modeling decision | skim `docs/adr/`, then **write a new ADR** (`/adr`); anchors: 0001 (no mediator), 0002 (TMS pivot + freeze amendment), 0008 (cloud-agnostic deployment + env strategy — M6), 0009 (browser E2E via Testcontainers + Playwright) |
 | Deploy/operate the stack, or set env vars per environment | `docs/deployment/runbook.md` — env-var matrix (service × environment), secret generation, the issuer/redirect/authority/CORS gotchas, bring-up sequence + DB migrations |
 | Touch the update lifecycle (GameVersion, import diff, invalidation, distribution, CLI sync) | `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md` — the agreed domain spec |
 | Implement a feature whose business rules are fuzzy | **`/spec`** first (seed → questions → agreed spec in `docs/specs/`) |
@@ -407,7 +407,9 @@ structure.
 - **TMS test projects mirror KittySaver naming:**
   `tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit` (pure),
   `tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration` (real PostgreSQL — never in a
-  Unit project), Frontend unit tests in M3. Patcher test projects stay exactly as they are.
+  Unit project), Frontend unit tests in M3, and `tests/LotroKoniecDev.Frontend.E2E.Tests` (Playwright
+  browser stack via Testcontainers — ADR-0009; Docker-required, off the PR gate by name). Patcher test
+  projects stay exactly as they are.
 
 ## Workflow (the loop that compounds)
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,5 +69,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.Playwright" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
   </ItemGroup>
 </Project>

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -46,6 +46,7 @@
     <Project Path="tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj" />
     <Project Path="tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.TranslationSystem.E2E.Tests/LotroKoniecDev.TranslationSystem.E2E.Tests.csproj" />
+    <Project Path="tests/LotroKoniecDev.Frontend.E2E.Tests/LotroKoniecDev.Frontend.E2E.Tests.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.E2E/LotroKoniecDev.Tests.E2E.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Infrastructure/LotroKoniecDev.Tests.Infrastructure.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj" />

--- a/docs/adr/0009-browser-e2e-playwright-via-testcontainers.md
+++ b/docs/adr/0009-browser-e2e-playwright-via-testcontainers.md
@@ -1,0 +1,198 @@
+# ADR-0009: Browser E2E (Playwright) runs against an in-network Testcontainers stack, not a dedicated compose file
+
+**Status:** Accepted
+**Date:** 2026-06-24
+**Decision-makers:** Solo maintainer
+**Related:** M3 Frontend (Blazor SSR, OIDC RP), AuthSystem (OpenIddict + Identity Razor Pages),
+`tests/LotroKoniecDev.TranslationSystem.E2E.Tests` (existing Testcontainers API-E2E),
+`.docker/trust-ca-entrypoint.sh`, ADR-0002 (TheKittySaver 1:1 lift), ADR-0006 (single-`Authority`
+OIDC; Frontend on host in dev), ADR-0008 (cloud-agnostic deployment / HTTPS parity), TheKittySaver
+`tests/TheKittySaver.E2E.Frontend.Tests` + `compose.playwright.yaml` + ADR-0011 (the reference's
+all-in-container variant)
+
+## Context
+
+M3 ships the Blazor SSR Frontend and the golden account loop (register → confirm e-mail → log in
+via OIDC → log out) spanning **two origins** — the Frontend and the AuthSystem's own Identity Razor
+Pages. We want a browser end-to-end test for that loop that needs **no seeded database and no
+`exported.txt`**, runnable from a fresh clone.
+
+Code facts that constrain the design:
+
+- **Single-`Authority` OIDC (ADR-0006).** The RP collapses front-channel and back-channel onto one
+  `options.Authority = settings.Authority`
+  (`Frontend/Infrastructure/Auth/AuthenticationDependencyInjectionExtensions.cs:100`), with
+  `GetClaimsFromUserInfoEndpoint = true` (so the FE *also* calls userinfo server-to-server). The
+  browser redirect AND the FE back-channel (discovery, token, userinfo) must resolve that one URL to
+  the **same** origin, and it must equal the token `iss` OpenIddict stamps absolutely
+  (`OpenIddictExtensions.cs`). ADR-0006 secured this in dev by running everything on the host
+  (`localhost:5003` resolves identically for browser and host RP). A browser E2E needs the same
+  property in an automatable, headless-CI-friendly substrate.
+- **HTTPS is mandatory.** The OIDC code flow uses `response_mode=form_post`; the correlation/nonce
+  cookies are `SameSite=None`, which a browser only sends when `Secure`. Plain HTTP breaks the
+  callback. So the stack must serve HTTPS, which means a cert the FE/tms back-channels **trust** —
+  and .NET validates against the **OS trust store** (it ignores `SSL_CERT_FILE`; see
+  `.docker/trust-ca-entrypoint.sh`).
+- **We already orchestrate the full stack from C# with Testcontainers.**
+  `TranslationSystem.E2E.Tests/E2ETestFixture` builds the auth/tms/migrator images and boots
+  postgres + migrator + auth-api + tms-api on a private network via `ContainerBuilder` /
+  `NetworkBuilder`. "Orchestrate the stack from C#" is already this repo's idiom — there is **no**
+  compose file behind our E2E.
+- **Testcontainers has an official Playwright module.** `Testcontainers.Playwright` runs a
+  `mcr.microsoft.com/playwright` browser **in a container**, exposes a WebSocket endpoint
+  (`GetConnectionString()`), and shares a network (`GetNetwork()`) so the in-container browser
+  reaches other containers by DNS name. The documented split is "Docker Compose = CI-simplicity;
+  **Testcontainers = programmatic control + better local dev**" (Playwright .NET / Testcontainers
+  docs).
+- **Locator guidance.** Playwright officially recommends user-facing locators —
+  `GetByRole` → `GetByLabel` → `GetByText` — with `data-testid` as the explicit-contract fallback
+  when an element has no stable accessible name. TheKittySaver put a `data-testid` on everything;
+  `~/RiderProjects/unite-next` uses `getByRole`/`getByLabel`.
+- **The reference (TheKittySaver) uses a separate `compose.playwright.yaml` + shell scripts**
+  (all-in-container; the test runner itself is a container — ADR-0011). That is one valid topology,
+  but it is a *second* orchestration idiom alongside our existing Testcontainers API-E2E.
+
+## Decision
+
+### 1. Unify all E2E on Testcontainers; drive the browser with the official Playwright module
+
+The new `tests/LotroKoniecDev.Frontend.E2E.Tests` boots the whole stack — postgres + migrator +
+auth-api + tms-api + **frontend** + mailpit + the `Testcontainers.Playwright` **browser** — from a
+single `IAsyncLifetime` fixture, the same idiom as our API-E2E. The host test connects to the
+in-container browser over WS (`Chromium.ConnectAsync(playwrightContainer.GetConnectionString())`) and
+drives pages from there. The suite runs with **`dotnet test`** — no script to launch it.
+
+### 2. The in-network DNS topology satisfies single-`Authority` OIDC
+
+Every service joins one Testcontainers network with a DNS alias (`auth-api`, `tms-api`, `frontend`,
+`mailpit`). The **browser is a container on that same network**, so `https://auth-api:8443` resolves
+identically for the browser front-channel AND the FE back-channel — the exact property ADR-0006
+secured on the host via `localhost`, here secured **in-network via DNS**. The seeded web-client
+redirect URI is `https://frontend:8443/callback`, the issuer is `https://auth-api:8443`
+(`OpenIddict__Issuer`), and `AuthSystem__Authority` is the same — so `iss` matches by construction.
+No reverse proxy, no `MetadataAddress` split, no `host.docker.internal`.
+
+### 3. HTTPS via a C#-generated cert; trust via an inline root entrypoint (no committed script)
+
+The fixture generates a self-signed cert in C# (`CertificateRequest` + `SubjectAlternativeNameBuilder`,
+SAN: `auth-api`, `tms-api`, `frontend`, `mailpit`, `localhost`; `CA:TRUE`) — no `openssl`, fully
+cross-platform. auth/tms/frontend serve it on Kestrel (`https://+:8443`, plus `http://+:8080` for
+container health probes only). tms-api and the Frontend trust it for their outbound back-channels via
+an **inline** entrypoint — `WithEntrypoint("/bin/sh", "-c", …)` copies the mapped cert into
+`/usr/local/share/ca-certificates`, runs `update-ca-certificates`, then `exec`s the app — so there is
+**no committed shell script** (it mirrors the idea of the repo's `.docker/trust-ca-entrypoint.sh`
+without mounting it). Because `update-ca-certificates` must write the OS trust store, the container runs
+as **root** (`User = "0"`) and does **not** drop privileges — a deliberate simplification for this
+ephemeral test stack, and the one way it diverges from the prod-parity entrypoint (which drops back to
+the non-root app user). Mailpit receives the confirmation e-mail (`Email__Host=mailpit`), so
+registration sends a real confirmation link instead of auto-confirming.
+
+### 4. Locators: role/label first, `data-testid` only as a state-panel contract
+
+Inputs and buttons are reached by `GetByLabel` / `GetByRole` (the lifted Auth Razor Pages already
+associate `<label asp-for>` with their inputs). `data-testid` is added **only** where there is no
+stable accessible name: the success panels (`register-success`, `confirm-email-success`) and the two
+consent checkboxes on Register. This is the Playwright-recommended hybrid and keeps the edit to the
+lifted markup minimal. AuthSystem is **not** frozen (only the patcher is), so these hooks are fine.
+
+### 5. Scope: one no-seed flow, PL-only, off the PR gate
+
+The first flow is **register → confirm (Mailpit link) → login (FE OIDC) → logout** — no DB seed, no
+`exported.txt`. It is **PL-only**: our Auth pages and FE nav are Polish-only with no culture routing
+(unlike TheKittySaver's PL/EN matrix), so there is no culture parameter. The project is named
+`*.E2E.Tests`, so `pr-verify`/`ci` skip it by the existing convention; it runs via `e2e.yml`
+(`workflow_dispatch`) and local `dotnet test`, exactly like our API-E2E. Wiring it onto a routine
+gate is deferred (cost; mirrors TheKittySaver's deferral).
+
+### 6. Reject FluentDocker and reject a dedicated `compose.playwright.yaml`
+
+**FluentDocker** is not added: its only edge over Testcontainers is reading a *compose file* from
+C#, but the Playwright module removes the need for a compose file at all, so it would be a third
+orchestration tool doing what Testcontainers already does (YAGNI / single-idiom). A dedicated
+**`compose.playwright.yaml`** is likewise not created — it would reintroduce a second orchestration
+surface that the module makes redundant.
+
+## Consequences
+
+### Positive
+
+- **One orchestration idiom across all E2E** (API + browser) — Testcontainers, no compose, no bash,
+  no FluentDocker. Defensible: "the browser is just another container on the same network, via the
+  official Testcontainers Playwright module."
+- **`dotnet test` from a fresh clone** (needs only Docker, which our API-E2E already requires) — the
+  best "works from boot" ergonomics; runnable + debuggable from the IDE.
+- **Prod-parity HTTPS + single-`Authority` OIDC** validated end-to-end through a real browser, with
+  the cert trust inlined into the container entrypoint (no committed script).
+- **Locators follow official Playwright guidance**, touching the lifted Auth markup minimally.
+
+### Negative / Accepted Trade-offs
+
+- Testcontainers pulls the `mcr.microsoft.com/playwright` image (~2 GB) on first run; cached after.
+- **Diverges from TheKittySaver's all-in-container compose substrate** (ADR-0011). Accepted: the goal
+  here is the best, interview-defensible production pattern for *this* repo, which already
+  standardized on Testcontainers — consistency with our own API-E2E beats 1:1 mirroring of the
+  reference's *test substrate* (the slice/domain patterns are still mirrored 1:1 elsewhere).
+- An in-container CA-trust step is still required (HTTPS is mandatory) — it is inlined into the
+  container entrypoint (`WithEntrypoint`), so it adds no committed script, at the cost of running the
+  container as root (no privilege drop), unlike the prod-parity `.docker/trust-ca-entrypoint.sh`.
+- The browser runs headless only (no trace viewer UI mid-run); failures rely on Playwright tracing.
+
+## Alternatives Considered
+
+### A. Mirror TheKittySaver: `compose.playwright.yaml` + shell scripts, all-in-container
+
+Rejected. Proven and CI-shaped, but it is a *second* orchestration idiom next to our Testcontainers
+API-E2E, runs the test runner inside a container (no IDE debugging), and keeps the bash orchestration
+the goal was to shed. FluentDocker would only replace one of its three scripts (cert + in-container
+trust remain) while adding a redundant dependency.
+
+### B. Testcontainers + official Playwright module, in-network browser (this ADR)
+
+Chosen. Single idiom, `dotnet test`, official module, in-network DNS dissolves the OIDC constraint.
+
+### C. `compose.playwright.yaml` driven from C# via FluentDocker
+
+Rejected. Honours "a compose file driven from C#," but adds `Ductus.FluentDocker` overlapping
+Testcontainers and still needs the cert + in-container-trust scripts — more surface for no gain.
+
+### D. Host Frontend + host browser (ADR-0006 dev topology)
+
+Rejected for automated E2E. It works for manual dev, but requires `dotnet run` of the FE on the host
+(not a self-contained `dotnet test`), and headless CI would have to start and health-gate host
+processes — exactly the orchestration Testcontainers does cleanly in-process.
+
+## Implementation Notes
+
+- New project `tests/LotroKoniecDev.Frontend.E2E.Tests` (NuGet-only, no `ProjectReference` — it
+  drives everything over HTTP/the browser). Packages: `Microsoft.Playwright`,
+  `Testcontainers.Playwright` (+ `Testcontainers`, xUnit, Shouldly, `Xunit.SkippableFact`, Bogus).
+  Add `Microsoft.Playwright` + `Testcontainers.Playwright` to `Directory.Packages.props`; add the
+  project to `LotroKoniecDev.slnx`.
+- `PlaywrightStackFixture` (`IAsyncLifetime`): builds the auth/tms/frontend/migrator images
+  (`SKIP_DOCKER_BUILD=true` to reuse pre-built), generates the cert, creates the network, boots
+  postgres → migrator → auth-api → tms-api → frontend (+ mailpit + the Playwright module), health-
+  gates each, exposes the browser WS + mapped Mailpit port. auth runs the `Testing` profile (seeded
+  admin/clients) with `OpenIddict__Issuer`/`WebClient__RedirectUris__0` pointed at the in-network
+  HTTPS origins and `Email__Host=mailpit`; tms/frontend run `Development` with their `AuthSystem` /
+  `TranslationSystem` URLs overridden to the in-network HTTPS aliases.
+- Markup: `data-testid` on `register-success`, `confirm-email-success`, and the two Register consent
+  checkboxes (`Pages/Account/Register.cshtml`, `ConfirmEmail.cshtml`); FE nav reached by role.
+- Flow: `RegisterConfirmLoginLogoutTests` + infra helpers (`PlaywrightStackFixture`, `E2EConfig`,
+  `Routes`, `TestUser`, `MailpitClient`, `AuthActions`, `PlaywrightExtensions`, `Locators`,
+  `E2ETestBase`, `E2ECollection`). `MailpitClient` polls subject `Potwierdzenie konta` for a link to
+  `/Account/ConfirmEmail` (both already match the AuthSystem sender).
+- CI: add the project to `.github/workflows/e2e.yml` (manual `workflow_dispatch`); it stays off
+  `pr-verify`/`ci` by the `*.E2E.Tests` naming convention.
+
+## References
+
+- ADR-0006 — single-`Authority` OIDC; Frontend on host in dev (the constraint this ADR re-satisfies
+  in-network)
+- ADR-0002 — TheKittySaver 1:1 lift (slice/domain patterns; the test *substrate* deliberately
+  diverges here)
+- ADR-0008 — HTTPS parity + `.docker/trust-ca-entrypoint.sh` (the prod-parity trust pattern this stack
+  mirrors inline, without mounting the script)
+- Testcontainers for .NET — Playwright module (`https://dotnet.testcontainers.org/modules/playwright/`)
+- Playwright — Locators / Best Practices (role/label first, test-id as explicit contract)
+- TheKittySaver `tests/TheKittySaver.E2E.Frontend.Tests` + ADR-0011 (the all-in-container reference;
+  Alternative A)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmail.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmail.cshtml
@@ -312,7 +312,7 @@
                             <span class="panel-aside">Krok 2/2</span>
                         </header>
                         <div class="auth-panel-body">
-                            <div class="auth-alert success" role="status">
+                            <div class="auth-alert success" role="status" data-testid="confirm-email-success">
                                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
                                 <div>
                                     <span class="t">Twój adres e-mail został potwierdzony — możesz się zalogować</span>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
@@ -459,7 +459,7 @@
                             <span class="panel-aside">Gotowe</span>
                         </header>
                         <div class="auth-panel-body">
-                            <div class="auth-alert success" role="status">
+                            <div class="auth-alert success" role="status" data-testid="register-success">
                                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
                                 <div>
                                     <span class="t">Konto zostało utworzone — potwierdź adres e-mail</span>
@@ -540,12 +540,12 @@
 
                             <div class="auth-consents">
                                 <label class="checkbox">
-                                    <input asp-for="AcceptedPrivacyPolicy" type="checkbox" />
+                                    <input asp-for="AcceptedPrivacyPolicy" type="checkbox" data-testid="register-accept-privacy" />
                                     <span class="box" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
                                     <span>Akceptuję <a href="/Account/PrivacyPolicy" target="_blank" rel="noopener">politykę prywatności</a>.</span>
                                 </label>
                                 <label class="checkbox">
-                                    <input asp-for="AcceptedDataProcessingConsent" type="checkbox" />
+                                    <input asp-for="AcceptedDataProcessingConsent" type="checkbox" data-testid="register-accept-data-processing" />
                                     <span class="box" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
                                     <span>Wyrażam zgodę na przetwarzanie moich danych osobowych w celu prowadzenia konta.</span>
                                 </label>

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -8,6 +8,7 @@ dotnet test tests/LotroKoniecDev.Tests.Unit            # unit only — always gr
 dotnet test tests/LotroKoniecDev.Tests.Infrastructure  # real-infrastructure tests
 dotnet test tests/LotroKoniecDev.Tests.E2E             # full CLI pipeline — auto-skips off-Windows
 dotnet test tests/LotroKoniecDev.TranslationSystem.E2E.Tests  # real-process TMS stack — REQUIRES Docker (builds 3 images)
+dotnet test tests/LotroKoniecDev.Frontend.E2E.Tests          # browser stack via Testcontainers — REQUIRES Docker (4 images + Playwright)
 dotnet test --filter "FullyQualifiedName~Fragment"     # filter by name
 ```
 
@@ -112,6 +113,27 @@ layer the in-process `*.Tests.Integration` suite fakes by forging HS256 tokens.
 `*.Tests.Integration`), so the `pr-verify.yml`/`ci.yml` test-discovery globs skip it. It runs only via
 `.github/workflows/e2e.yml` (`workflow_dispatch`) or a local `dotnet test` of the project. It IS compiled by the
 solution build, so the zero-warning gate still covers it.
+
+## Frontend Browser E2E Tests (LotroKoniecDev.Frontend.E2E.Tests)
+
+A **Playwright** browser suite over the same Testcontainers idiom (ADR-0009 — **not** a compose file, **not**
+FluentDocker). `PlaywrightStackFixture` builds the `auth`/`tms`/`frontend`/`migrator` images, boots the whole
+browser-facing stack on one network — postgres + migrator + auth-api + tms-api + **frontend** + **mailpit** —
+all over **HTTPS** (a cert generated in C#; SAN = the service DNS names; trusted in-container via an inline root
+entrypoint), plus the **official `Testcontainers.Playwright`** browser container. The host connects to the
+in-network browser over WS (`Chromium.ConnectAsync(GetConnectionString())`), so `https://auth-api:8443` resolves
+identically for the browser front-channel and the FE OIDC back-channel — the single-`Authority` constraint
+(ADR-0006) held in-network via DNS. Mailpit receives the real confirmation e-mail (no auto-confirm), read back
+over its HTTP API. Because the browser is in a container, the host needs **no** `playwright install` (no browser
+download). NuGet-only (no `ProjectReference`) — it drives everything over HTTP/the browser.
+
+- `RegisterConfirmLoginLogoutTests` — register (Auth Razor Page) → confirm via the Mailpit link → login through
+  the FE OIDC challenge → logout. **No DB seed, no `exported.txt`.** PL-only (the pages have no culture routing).
+
+Locators follow Playwright's guidance: `GetByRole`/`GetByLabel` first, `data-testid` only for the consent
+checkboxes + state panels (`register-success`, `confirm-email-success`). **Requires Docker; off the PR gate by
+name** (`...E2E.Tests`) — runs via `e2e.yml` (the `e2e-frontend` job) or a local `dotnet test`. Compiled by the
+solution build, so the zero-warning gate covers it.
 
 ## Conventions
 

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/RegisterConfirmLoginLogoutTests.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/RegisterConfirmLoginLogoutTests.cs
@@ -1,0 +1,43 @@
+using LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+using Microsoft.Playwright;
+using Shouldly;
+
+namespace LotroKoniecDev.Frontend.E2E.Tests.Flows;
+
+/// <summary>
+/// Golden path: a brand-new visitor registers on the Auth server, confirms their e-mail through the
+/// link Mailpit captured, logs in via the Frontend's OIDC challenge, and logs out — proving the whole
+/// account-onboarding loop across both origins (Frontend + Auth). Needs no seeded database and no
+/// <c>exported.txt</c>: the user, the e-mail and the session are all created by the flow itself.
+/// </summary>
+public sealed class RegisterConfirmLoginLogoutTests : E2ETestBase
+{
+    public RegisterConfirmLoginLogoutTests(PlaywrightStackFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task Register_then_confirm_email_then_login_then_logout()
+    {
+        // Arrange
+        TestUser user = TestUser.CreateRandom();
+
+        // Act + Assert — registration shows the "check your email" confirmation panel.
+        await AuthActions.RegisterAsync(Page, Fixture, user);
+        (await ByTestId(TestIds.RegisterSuccess).IsVisibleAsync()).ShouldBeTrue();
+
+        // Confirm via the Mailpit link — the Auth page reports success.
+        await AuthActions.ConfirmEmailAsync(Page, Fixture, user);
+        (await ByTestId(TestIds.ConfirmEmailSuccess).IsVisibleAsync()).ShouldBeTrue();
+
+        // Log in through the FE OIDC challenge — the authenticated nav (the logout button) appears.
+        await AuthActions.LoginAsync(Page, Fixture, user);
+        (await Page.GetByRole(AriaRole.Button, new() { Name = Buttons.Logout, Exact = true }).IsVisibleAsync())
+            .ShouldBeTrue();
+
+        // Log out — the anonymous nav (the login link) returns.
+        await AuthActions.LogoutAsync(Page);
+        (await Page.GetByRole(AriaRole.Link, new() { Name = Links.Login, Exact = true }).IsVisibleAsync())
+            .ShouldBeTrue();
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
@@ -1,0 +1,63 @@
+using Microsoft.Playwright;
+
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// Reusable building blocks for the account loop: register on the Auth server's Razor Pages, confirm
+/// via the Mailpit link, and log in through the Frontend's OIDC challenge (so the FE — not only the
+/// Auth server — ends up authenticated). Registration is on the Auth origin (<c>/Account/Register</c>),
+/// not the Frontend, and is single-culture (the pages are Polish-only). Elements are reached by
+/// role/label, with <c>data-testid</c> only for the consent checkboxes and the state panels.
+/// </summary>
+internal static class AuthActions
+{
+    private const string ConfirmationSubject = "Potwierdzenie konta";
+    private const string ConfirmationLinkPath = "/Account/ConfirmEmail";
+    private static readonly TimeSpan MailTimeout = TimeSpan.FromSeconds(45);
+    private static readonly LocatorWaitForOptions LongWait = new() { Timeout = 30_000 };
+
+    public static async Task RegisterAsync(IPage page, PlaywrightStackFixture fixture, TestUser user)
+    {
+        await page.GotoAsync($"{fixture.AuthBaseUrl}/Account/Register");
+
+        await page.GetByLabel(FieldLabels.Username).FillAsync(user.Username);
+        await page.GetByLabel(FieldLabels.Email).FillAsync(user.Email);
+        await page.GetByLabel(FieldLabels.Password, new() { Exact = true }).FillAsync(user.Password);
+        await page.GetByLabel(FieldLabels.ConfirmPassword).FillAsync(user.Password);
+        await page.GetByTestId(TestIds.RegisterAcceptPrivacy).CheckViaLabelAsync();
+        await page.GetByTestId(TestIds.RegisterAcceptDataProcessing).CheckViaLabelAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = Buttons.Register, Exact = true }).ClickAsync();
+
+        await page.GetByTestId(TestIds.RegisterSuccess).WaitForAsync(LongWait);
+    }
+
+    public static async Task ConfirmEmailAsync(IPage page, PlaywrightStackFixture fixture, TestUser user)
+    {
+        string link = await MailpitClient.WaitForLinkAsync(
+            fixture.MailpitBaseUrl, user.Email, ConfirmationSubject, ConfirmationLinkPath, MailTimeout);
+
+        await page.GotoAsync(link);
+        await page.GetByTestId(TestIds.ConfirmEmailSuccess).WaitForAsync(LongWait);
+    }
+
+    public static async Task LoginAsync(IPage page, PlaywrightStackFixture fixture, TestUser user)
+    {
+        // Enter through the Frontend so the FE (not only the Auth server) ends up authenticated:
+        // the home nav's "Zaloguj" link hits /auth/login → OIDC challenge → Auth login page →
+        // callback → FE authenticated (the "Wyloguj" button appears).
+        await page.GotoAsync($"{fixture.FrontendBaseUrl}/");
+        await page.GetByRole(AriaRole.Link, new() { Name = Links.Login, Exact = true }).ClickAsync();
+
+        await page.GetByLabel(FieldLabels.Username).FillAsync(user.Username);
+        await page.GetByLabel(FieldLabels.Password, new() { Exact = true }).FillAsync(user.Password);
+        await page.GetByRole(AriaRole.Button, new() { Name = Buttons.Login, Exact = true }).ClickAsync();
+
+        await page.GetByRole(AriaRole.Button, new() { Name = Buttons.Logout, Exact = true }).WaitForAsync(LongWait);
+    }
+
+    public static async Task LogoutAsync(IPage page)
+    {
+        await page.GetByRole(AriaRole.Button, new() { Name = Buttons.Logout, Exact = true }).ClickAsync();
+        await page.GetByRole(AriaRole.Link, new() { Name = Links.Login, Exact = true }).WaitForAsync(LongWait);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/E2ECollection.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/E2ECollection.cs
@@ -1,0 +1,7 @@
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+[CollectionDefinition(Name)]
+public sealed class E2ECollection : ICollectionFixture<PlaywrightStackFixture>
+{
+    public const string Name = "Frontend-E2E";
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/E2ETestBase.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/E2ETestBase.cs
@@ -1,0 +1,43 @@
+using Microsoft.Playwright;
+
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// Base for every browser flow. Owns a per-test <see cref="IBrowserContext"/> (isolated cookies, so
+/// auth never leaks between cases) and a page off the shared in-network browser the
+/// <see cref="PlaywrightStackFixture"/> connected. The context ignores HTTPS errors — the stack
+/// serves a self-signed e2e cert. All element lookups go through role/label or <c>data-testid</c>.
+/// </summary>
+[Collection(E2ECollection.Name)]
+[Trait("Category", "E2E-Frontend")]
+public abstract class E2ETestBase : IAsyncLifetime
+{
+    protected E2ETestBase(PlaywrightStackFixture fixture)
+    {
+        Fixture = fixture;
+    }
+
+    protected PlaywrightStackFixture Fixture { get; }
+
+    protected IBrowserContext Context { get; private set; } = null!;
+
+    protected IPage Page { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        Context = await Fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true,
+            ViewportSize = new ViewportSize { Width = 1366, Height = 900 }
+        });
+        Context.SetDefaultTimeout(20_000);
+        Page = await Context.NewPageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await Context.DisposeAsync();
+    }
+
+    protected ILocator ByTestId(string testId) => Page.GetByTestId(testId);
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/Locators.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/Locators.cs
@@ -1,0 +1,38 @@
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// The few <c>data-testid</c> hooks added to the Auth Razor Pages where an element has no stable
+/// accessible name to target — the two consent checkboxes and the post-action state panels. Inputs,
+/// buttons and nav links carry no test-id: they are reached by role/label per Playwright's locator
+/// guidance (<see cref="FieldLabels"/> / <see cref="Buttons"/> / <see cref="Links"/>).
+/// </summary>
+internal static class TestIds
+{
+    public const string RegisterAcceptPrivacy = "register-accept-privacy";
+    public const string RegisterAcceptDataProcessing = "register-accept-data-processing";
+    public const string RegisterSuccess = "register-success";
+    public const string ConfirmEmailSuccess = "confirm-email-success";
+}
+
+/// <summary>Accessible names of the form fields (the <c>&lt;label&gt;</c> text), for <c>GetByLabel</c>.</summary>
+internal static class FieldLabels
+{
+    public const string Username = "Nazwa użytkownika";
+    public const string Email = "Adres e-mail";
+    public const string Password = "Hasło";
+    public const string ConfirmPassword = "Powtórz hasło";
+}
+
+/// <summary>Accessible names of the action buttons, for <c>GetByRole(AriaRole.Button)</c>.</summary>
+internal static class Buttons
+{
+    public const string Register = "Załóż konto";
+    public const string Login = "Zaloguj się";
+    public const string Logout = "Wyloguj";
+}
+
+/// <summary>Accessible names of the nav links, for <c>GetByRole(AriaRole.Link)</c>.</summary>
+internal static class Links
+{
+    public const string Login = "Zaloguj";
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/MailpitClient.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/MailpitClient.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// Thin client over the Mailpit HTTP API. The Auth server sends the confirmation link to Mailpit;
+/// the flow polls for the message by recipient + subject, then extracts the link (HTML-encoded in the
+/// body) so the browser can follow it. The base URL is the host-mapped Mailpit port from the fixture.
+/// </summary>
+internal static partial class MailpitClient
+{
+    public static async Task<string> WaitForLinkAsync(
+        string mailpitBaseUrl,
+        string recipientEmail,
+        string subjectContains,
+        string linkContains,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        using HttpClient client = new() { BaseAddress = new Uri(mailpitBaseUrl, UriKind.Absolute) };
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + timeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            string? messageId = await FindLatestMessageIdAsync(client, recipientEmail, subjectContains, cancellationToken);
+            if (messageId is not null)
+            {
+                string body = await GetMessageBodyAsync(client, messageId, cancellationToken);
+                string? link = ExtractLink(body, linkContains);
+                if (link is not null)
+                {
+                    return link;
+                }
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
+        }
+
+        throw new TimeoutException(
+            $"No email to '{recipientEmail}' (subject ~ '{subjectContains}') carrying a link containing " +
+            $"'{linkContains}' arrived within {timeout.TotalSeconds:0}s. Is Mailpit ({mailpitBaseUrl}) up?");
+    }
+
+    private static async Task<string?> FindLatestMessageIdAsync(
+        HttpClient client,
+        string recipientEmail,
+        string subjectContains,
+        CancellationToken cancellationToken)
+    {
+        string query = Uri.EscapeDataString($"to:{recipientEmail}");
+        using HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/v1/search?query={query}&limit=30", UriKind.Relative), cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using JsonDocument document = await JsonDocument.ParseAsync(stream, default, cancellationToken);
+
+        if (!document.RootElement.TryGetProperty("messages", out JsonElement messages)
+            || messages.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (JsonElement message in messages.EnumerateArray())
+        {
+            string subject = message.TryGetProperty("Subject", out JsonElement subjectElement)
+                ? subjectElement.GetString() ?? string.Empty
+                : string.Empty;
+
+            if (subject.Contains(subjectContains, StringComparison.OrdinalIgnoreCase)
+                && message.TryGetProperty("ID", out JsonElement idElement))
+            {
+                return idElement.GetString();
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<string> GetMessageBodyAsync(
+        HttpClient client,
+        string messageId,
+        CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/v1/message/{messageId}", UriKind.Relative), cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using JsonDocument document = await JsonDocument.ParseAsync(stream, default, cancellationToken);
+        JsonElement root = document.RootElement;
+
+        string html = root.TryGetProperty("HTML", out JsonElement htmlElement)
+            ? htmlElement.GetString() ?? string.Empty
+            : string.Empty;
+
+        if (!string.IsNullOrEmpty(html))
+        {
+            return html;
+        }
+
+        return root.TryGetProperty("Text", out JsonElement textElement)
+            ? textElement.GetString() ?? string.Empty
+            : string.Empty;
+    }
+
+    private static string? ExtractLink(string body, string linkContains)
+    {
+        foreach (Match match in HrefRegex().Matches(body))
+        {
+            string href = WebUtility.HtmlDecode(match.Groups[1].Value);
+            if (href.Contains(linkContains, StringComparison.OrdinalIgnoreCase))
+            {
+                return href;
+            }
+        }
+
+        foreach (Match match in BareUrlRegex().Matches(body))
+        {
+            string url = WebUtility.HtmlDecode(match.Value);
+            if (url.Contains(linkContains, StringComparison.OrdinalIgnoreCase))
+            {
+                return url;
+            }
+        }
+
+        return null;
+    }
+
+    [GeneratedRegex("href=[\"']([^\"']+)[\"']", RegexOptions.IgnoreCase)]
+    private static partial Regex HrefRegex();
+
+    [GeneratedRegex(@"https?://[^\s""'<>]+", RegexOptions.IgnoreCase)]
+    private static partial Regex BareUrlRegex();
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightExtensions.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.Playwright;
+
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// Playwright helpers for the Auth pages' custom-styled checkboxes. The real
+/// <c>&lt;input type="checkbox"&gt;</c> is hidden with <c>opacity:0; pointer-events:none</c> and a styled
+/// <c>.box</c> span is painted on top, so Playwright cannot click the input itself (its actionability
+/// check never sees the input receive a pointer event). A real user toggles it by clicking that painted
+/// box; this helper does the same, and the click propagates to the hidden input through the wrapping
+/// <c>&lt;label&gt;</c>.
+/// </summary>
+internal static class PlaywrightExtensions
+{
+    /// <summary>
+    /// Ensures a custom-styled checkbox ends up checked by clicking the decorative <c>.box</c> span
+    /// inside its wrapping <c>&lt;label&gt;</c>, which natively toggles the hidden input. Idempotent.
+    /// </summary>
+    public static async Task CheckViaLabelAsync(this ILocator checkbox)
+    {
+        if (await checkbox.IsCheckedAsync())
+        {
+            return;
+        }
+
+        // Click the box, not the label's geometric center: the privacy-consent label's text wraps an
+        // <a> (the privacy-policy link), and on a wide single-line viewport the label center lands on
+        // that link — per the HTML spec a click on interactive content inside a <label> activates the
+        // link instead of toggling the control. The .box span is inert, so clicking it always toggles.
+        await checkbox.Locator("xpath=ancestor::label[1]").Locator("span.box").ClickAsync();
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
@@ -1,0 +1,446 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Microsoft.Playwright;
+using Testcontainers.Playwright;
+using Testcontainers.PostgreSql;
+
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// Boots the whole browser-facing stack — Postgres + the one-shot migrator + auth-api + tms-api +
+/// the Blazor SSR Frontend + Mailpit + a headless Chromium — as real containers on one private
+/// network, then connects Playwright to the in-network browser over WebSocket (the official
+/// <c>Testcontainers.Playwright</c> module). Every service has a DNS alias, so
+/// <c>https://auth-api:8443</c> resolves identically for the in-container browser front-channel AND
+/// the Frontend's server-side OIDC back-channel — the single-<c>Authority</c> property ADR-0006
+/// secured on the host via <c>localhost</c>, here secured in-network via DNS (ADR-0009). HTTPS is
+/// mandatory (the OIDC correlation cookie is <c>SameSite=None</c>); the cert is generated in C# and
+/// the back-channel services trust it via an inline root entrypoint. Mailpit receives the real
+/// confirmation e-mail, so registration is NOT auto-confirmed and the confirm-link step is genuine.
+/// </summary>
+public sealed class PlaywrightStackFixture : IAsyncLifetime
+{
+    private const string AuthImage = "lotrokoniecdev-auth:fe-e2e";
+    private const string TmsImage = "lotrokoniecdev-tms:fe-e2e";
+    private const string FrontendImage = "lotrokoniecdev-frontend:fe-e2e";
+    private const string MigratorImage = "lotrokoniecdev-migrator:fe-e2e";
+    private const string MailpitImage = "axllent/mailpit:latest";
+
+    // Pinned to match the Microsoft.Playwright client version, so ConnectAsync speaks the same protocol.
+    private const string PlaywrightImage = "mcr.microsoft.com/playwright:v1.60.0-noble";
+
+    /// <summary>Image name → Dockerfile path (relative to the solution root), built in order if not present.</summary>
+    private static readonly (string Image, string Dockerfile)[] DockerImages =
+    [
+        (AuthImage, "src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile"),
+        (TmsImage, "src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile"),
+        (FrontendImage, "src/Frontend/LotroKoniecDev.Frontend/Dockerfile"),
+        (MigratorImage, "Dockerfile.migrator")
+    ];
+
+    private const int HttpsPort = 8443;
+    private const int HttpPort = 8080;
+    private const int MailpitHttpPort = 8025;
+    private const int MailpitSmtpPort = 1025;
+    private const string KestrelUrls = "https://+:8443;http://+:8080";
+
+    private const string AuthHttpsOrigin = "https://auth-api:8443";
+    private const string TmsHttpsOrigin = "https://tms-api:8443";
+    private const string FrontendHttpsOrigin = "https://frontend:8443";
+
+    private const string TranslationDatabaseName = "lotro_translation";
+    private const string AuthDatabaseName = "lotro_auth";
+    private const string PostgresUser = "postgres";
+    private const string PostgresPassword = "fe-e2e-postgres-password";
+
+    private const string Audience = "lotrokoniecdev-api";
+    private const string ApiClientSecret = "fe-e2e-api-client-secret-min-32-characters";
+    private const string WebClientId = "lotrokoniecdev-web";
+
+    private const string AdminUsername = "fe-e2e-admin";
+    private const string AdminEmail = "fe-e2e-admin@lotro.koniec.dev";
+    private const string AdminPassword = "FeE2eAdminPass123!";
+
+    private string _certPem = null!;
+    private string _keyPem = null!;
+
+    private INetwork _network = null!;
+    private PostgreSqlContainer _postgres = null!;
+    private IContainer _migrator = null!;
+    private IContainer _mailpit = null!;
+    private IContainer _authApi = null!;
+    private IContainer _tmsApi = null!;
+    private IContainer _frontend = null!;
+    private PlaywrightContainer _playwrightContainer = null!;
+    private IPlaywright _playwright = null!;
+
+    public IBrowser Browser { get; private set; } = null!;
+
+    /// <summary>Frontend origin, resolved by the in-network browser via the compose DNS alias.</summary>
+    public string FrontendBaseUrl => FrontendHttpsOrigin;
+
+    /// <summary>Auth (OpenIddict + Identity Razor Pages) origin, resolved by the in-network browser.</summary>
+    public string AuthBaseUrl => AuthHttpsOrigin;
+
+    /// <summary>Mailpit HTTP API, reached from the host test process over the mapped port.</summary>
+    public string MailpitBaseUrl => $"http://localhost:{_mailpit.GetMappedPublicPort(MailpitHttpPort)}";
+
+    private static string TranslationConnectionString => BuildConnectionString(TranslationDatabaseName);
+    private static string AuthConnectionString => BuildConnectionString(AuthDatabaseName);
+
+    public async Task InitializeAsync()
+    {
+        GenerateCertificate();
+        await BuildDockerImagesAsync();
+
+        _network = new NetworkBuilder()
+            .WithName($"fe-e2e-{Guid.NewGuid():N}")
+            .Build();
+        await _network.CreateAsync();
+
+        await StartPostgresAsync();
+        await StartMailpitAsync();
+        await RunMigratorAsync();
+        await StartAuthApiAsync();
+        await StartTmsApiAsync();
+        await StartFrontendAsync();
+        await StartBrowserAsync();
+    }
+
+    private async Task StartPostgresAsync()
+    {
+        // POSTGRES_DB creates lotro_translation on first boot; the bind-mounted init script adds the
+        // second database (lotro_auth) the AuthSystem needs — identical to the compose stack.
+        string initScriptPath = Path.Combine(FindSolutionDirectory(), "scripts", "init-postgres.sh");
+        _postgres = new PostgreSqlBuilder("postgres:17-alpine")
+            .WithNetwork(_network)
+            .WithNetworkAliases("postgres")
+            .WithUsername(PostgresUser)
+            .WithPassword(PostgresPassword)
+            .WithDatabase(TranslationDatabaseName)
+            .WithBindMount(initScriptPath, "/docker-entrypoint-initdb.d/10-init-databases.sh")
+            .Build();
+        await _postgres.StartAsync();
+    }
+
+    private async Task StartMailpitAsync()
+    {
+        _mailpit = new ContainerBuilder(MailpitImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases("mailpit")
+            .WithPortBinding(MailpitHttpPort, true)
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(request => request.ForPath("/").ForPort(MailpitHttpPort)))
+            .Build();
+        await _mailpit.StartAsync();
+    }
+
+    private async Task RunMigratorAsync()
+    {
+        _migrator = new ContainerBuilder(MigratorImage)
+            .WithNetwork(_network)
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
+            .WithEnvironment("ConnectionStrings__TranslationDatabase", TranslationConnectionString)
+            .WithEnvironment("ConnectionStrings__AuthDatabase", AuthConnectionString)
+            .Build();
+
+        await _migrator.StartAsync();
+
+        long exitCode = await _migrator.GetExitCodeAsync();
+        if (exitCode != 0)
+        {
+            (string? stdout, string? stderr) = await _migrator.GetLogsAsync();
+            throw new InvalidOperationException(
+                $"Migrator failed with exit code {exitCode}.\nStdout:\n{stdout}\nStderr:\n{stderr}");
+        }
+    }
+
+    private async Task StartAuthApiAsync()
+    {
+        // Testing profile: seeds a deterministic admin + the OpenIddict clients. The web client's
+        // redirect/post-logout URIs and the issuer are pointed at the in-network HTTPS origins, and
+        // Email targets Mailpit so a registration actually sends a confirmation link (no auto-confirm).
+        _authApi = new ContainerBuilder(AuthImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases("auth-api")
+            .WithPortBinding(HttpPort, true)
+            .WithCreateParameterModifier(parameters => parameters.User = "0")
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Testing")
+            .WithEnvironment("ASPNETCORE_URLS", KestrelUrls)
+            .WithEnvironment("ConnectionStrings__AuthDatabase", AuthConnectionString)
+            .WithEnvironment("OpenIddict__Issuer", AuthHttpsOrigin)
+            .WithEnvironment("OpenIddict__ApiClientSecret", ApiClientSecret)
+            .WithEnvironment("OpenIddict__WebClient__RedirectUris__0", $"{FrontendHttpsOrigin}/callback")
+            .WithEnvironment("OpenIddict__WebClient__PostLogoutRedirectUris__0", FrontendHttpsOrigin)
+            .WithEnvironment("OpenIddict__WebClient__PostLogoutRedirectUris__1", $"{FrontendHttpsOrigin}/")
+            .WithEnvironment("OpenIddict__WebClient__PostLogoutRedirectUris__2", $"{FrontendHttpsOrigin}/signout-callback-oidc")
+            .WithEnvironment("AdminUser__Username", AdminUsername)
+            .WithEnvironment("AdminUser__Email", AdminEmail)
+            .WithEnvironment("AdminUser__Password", AdminPassword)
+            .WithEnvironment("Email__SenderEmail", "noreply@lotro.koniec.dev")
+            .WithEnvironment("Email__Sender", "lotro.koniec.dev")
+            .WithEnvironment("Email__Host", "mailpit")
+            .WithEnvironment("Email__Port", MailpitSmtpPort.ToString(CultureInfo.InvariantCulture))
+            .WithEnvironment("Email__Mode", "None")
+            .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Path", "/certs/e2e.crt")
+            .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__KeyPath", "/certs/e2e.key")
+            .WithResourceMapping(Encoding.ASCII.GetBytes(_certPem), "/certs/e2e.crt")
+            .WithResourceMapping(Encoding.ASCII.GetBytes(_keyPem), "/certs/e2e.key")
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(request => request.ForPath("/health/live").ForPort(HttpPort)))
+            .Build();
+
+        await StartWithDiagnosticsAsync(_authApi, "auth-api");
+    }
+
+    private async Task StartTmsApiAsync()
+    {
+        // tms validates JWTs against the issuer over HTTPS (JWKS from https://auth-api:8443), so it
+        // trusts the e2e cert via the inline entrypoint. Not strictly exercised by the auth loop, but
+        // kept wired so the stack is complete and the later editor/list flows have a target.
+        _tmsApi = new ContainerBuilder(TmsImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases("tms-api")
+            .WithPortBinding(HttpPort, true)
+            .WithCreateParameterModifier(parameters => parameters.User = "0")
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
+            .WithEnvironment("ASPNETCORE_URLS", KestrelUrls)
+            .WithEnvironment("ConnectionStrings__TranslationDatabase", TranslationConnectionString)
+            .WithEnvironment("Auth__Issuer", AuthHttpsOrigin)
+            .WithEnvironment("Auth__Authority", AuthHttpsOrigin)
+            .WithEnvironment("Auth__Audience", Audience)
+            .WithEnvironment("Bootstrap__Enabled", "false")
+            .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Path", "/certs/e2e.crt")
+            .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__KeyPath", "/certs/e2e.key")
+            .WithResourceMapping(Encoding.ASCII.GetBytes(_certPem), "/certs/e2e.crt")
+            .WithResourceMapping(Encoding.ASCII.GetBytes(_keyPem), "/certs/e2e.key")
+            .WithEntrypoint("/bin/sh", "-c", TrustThenRun("LotroKoniecDev.TranslationSystem.API.dll"))
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(request => request.ForPath("/health/live").ForPort(HttpPort)))
+            .Build();
+
+        await StartWithDiagnosticsAsync(_tmsApi, "tms-api");
+    }
+
+    private async Task StartFrontendAsync()
+    {
+        // The RP's single Authority + the typed tms client both back-channel over HTTPS, so the FE
+        // trusts the e2e cert via the inline entrypoint. The browser hits the FE at the same origin.
+        _frontend = new ContainerBuilder(FrontendImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases("frontend")
+            .WithPortBinding(HttpPort, true)
+            .WithCreateParameterModifier(parameters => parameters.User = "0")
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
+            .WithEnvironment("ASPNETCORE_URLS", KestrelUrls)
+            .WithEnvironment("AuthSystem__Authority", AuthHttpsOrigin)
+            .WithEnvironment("AuthSystem__BaseUrl", $"{AuthHttpsOrigin}/")
+            .WithEnvironment("AuthSystem__ClientId", WebClientId)
+            .WithEnvironment("TranslationSystem__BaseUrl", $"{TmsHttpsOrigin}/")
+            .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Path", "/certs/e2e.crt")
+            .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__KeyPath", "/certs/e2e.key")
+            .WithResourceMapping(Encoding.ASCII.GetBytes(_certPem), "/certs/e2e.crt")
+            .WithResourceMapping(Encoding.ASCII.GetBytes(_keyPem), "/certs/e2e.key")
+            .WithEntrypoint("/bin/sh", "-c", TrustThenRun("LotroKoniecDev.Frontend.dll"))
+            // The FE has no health endpoint, and UseHttpsRedirection turns every HTTP request into a 307
+            // to the HTTPS origin — which the wait's HttpClient follows to an unpublished port and fails.
+            // So gate on the host startup log line instead: redirect-proof and deterministic. The browser
+            // still reaches the FE over in-network HTTPS (:8443) regardless.
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Application started"))
+            .Build();
+
+        await StartWithDiagnosticsAsync(_frontend, "frontend");
+    }
+
+    private async Task StartBrowserAsync()
+    {
+        _playwrightContainer = new PlaywrightBuilder(PlaywrightImage)
+            .WithNetwork(_network)
+            .Build();
+        await _playwrightContainer.StartAsync();
+
+        _playwright = await Playwright.CreateAsync();
+        Browser = await _playwright.Chromium.ConnectAsync(_playwrightContainer.GetConnectionString());
+    }
+
+    /// <summary>
+    /// Installs the e2e CA into the OS trust store (root) then execs the app — .NET validates the
+    /// back-channel leaf against the OS store (it ignores SSL_CERT_FILE), so the cert must land there
+    /// before Kestrel/HttpClient start. Inline, so it needs no committed entrypoint script.
+    /// </summary>
+    private static string TrustThenRun(string dll) =>
+        "cp /certs/e2e.crt /usr/local/share/ca-certificates/lotro-e2e.crt && " +
+        "update-ca-certificates >/dev/null 2>&1; " +
+        $"exec dotnet {dll}";
+
+    private void GenerateCertificate()
+    {
+        using RSA rsa = RSA.Create(2048);
+        CertificateRequest request = new(
+            "CN=lotro-e2e", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        SubjectAlternativeNameBuilder san = new();
+        san.AddDnsName("localhost");
+        san.AddDnsName("auth-api");
+        san.AddDnsName("tms-api");
+        san.AddDnsName("frontend");
+        san.AddDnsName("mailpit");
+        request.CertificateExtensions.Add(san.Build());
+        request.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: true, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.KeyCertSign,
+                critical: true));
+
+        using X509Certificate2 certificate = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(825));
+
+        _certPem = certificate.ExportCertificatePem();
+        _keyPem = rsa.ExportPkcs8PrivateKeyPem();
+    }
+
+    private static async Task StartWithDiagnosticsAsync(IContainer container, string name)
+    {
+        // Bound the readiness wait so a genuinely unhealthy container fails in minutes — the default
+        // strategy otherwise retries for ~1 hour.
+        using CancellationTokenSource cts = new(TimeSpan.FromMinutes(5));
+        try
+        {
+            await container.StartAsync(cts.Token);
+        }
+        catch (Exception ex)
+        {
+            (string? stdout, string? stderr) = await container.GetLogsAsync();
+            throw new InvalidOperationException(
+                $"Container '{name}' failed to reach its ready state within the timeout.\n" +
+                $"Stdout:\n{stdout}\nStderr:\n{stderr}", ex);
+        }
+    }
+
+    private static string BuildConnectionString(string database) =>
+        $"Host=postgres;Port=5432;Database={database};Username={PostgresUser};Password={PostgresPassword}";
+
+    private static async Task BuildDockerImagesAsync()
+    {
+        // CI pre-builds the images and sets SKIP_DOCKER_BUILD=true; locally the suite builds them on demand.
+        if (Environment.GetEnvironmentVariable("SKIP_DOCKER_BUILD") == "true")
+        {
+            Console.WriteLine("Skipping Docker image build (SKIP_DOCKER_BUILD=true).");
+            return;
+        }
+
+        string solutionDir = FindSolutionDirectory();
+        string cacheBust = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+
+        foreach ((string imageName, string dockerfile) in DockerImages)
+        {
+            Console.WriteLine($"Building Docker image: {imageName}...");
+
+            using Process process = new();
+            process.StartInfo = new ProcessStartInfo
+            {
+                FileName = "docker",
+                Arguments = $"build --build-arg CACHEBUST={cacheBust} -f {dockerfile} -t {imageName} .",
+                WorkingDirectory = solutionDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            process.Start();
+
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode != 0)
+            {
+                string stdout = await stdoutTask;
+                string stderr = await stderrTask;
+                throw new InvalidOperationException(
+                    $"Failed to build Docker image '{imageName}' (exit code {process.ExitCode}).\n" +
+                    $"Dockerfile: {dockerfile}\nWorking directory: {solutionDir}\n" +
+                    $"Stdout:\n{stdout}\nStderr:\n{stderr}");
+            }
+
+            Console.WriteLine($"Successfully built: {imageName}");
+        }
+    }
+
+    private static string FindSolutionDirectory()
+    {
+        DirectoryInfo? directory = new(Directory.GetCurrentDirectory());
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "LotroKoniecDev.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find the solution directory (LotroKoniecDev.slnx). Started from: {Directory.GetCurrentDirectory()}");
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (Browser is not null)
+        {
+            await Browser.DisposeAsync();
+        }
+
+        _playwright?.Dispose();
+
+        if (_playwrightContainer is not null)
+        {
+            await _playwrightContainer.DisposeAsync();
+        }
+
+        if (_frontend is not null)
+        {
+            await _frontend.DisposeAsync();
+        }
+
+        if (_tmsApi is not null)
+        {
+            await _tmsApi.DisposeAsync();
+        }
+
+        if (_authApi is not null)
+        {
+            await _authApi.DisposeAsync();
+        }
+
+        if (_mailpit is not null)
+        {
+            await _mailpit.DisposeAsync();
+        }
+
+        if (_migrator is not null)
+        {
+            await _migrator.DisposeAsync();
+        }
+
+        if (_postgres is not null)
+        {
+            await _postgres.DisposeAsync();
+        }
+
+        if (_network is not null)
+        {
+            await _network.DeleteAsync();
+        }
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/TestUser.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/TestUser.cs
@@ -1,0 +1,32 @@
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// A freshly-minted, globally-unique account for one registration flow. The username/email carry a
+/// GUID suffix so reruns never collide on the Auth side's uniqueness rules, and the email is routed
+/// to Mailpit (any domain works — nothing leaves the box). There is no phone number: unlike
+/// TheKittySaver, our registration form has no phone field.
+/// </summary>
+internal sealed class TestUser
+{
+    private TestUser(string username, string email, string password)
+    {
+        Username = username;
+        Email = email;
+        Password = password;
+    }
+
+    public string Username { get; }
+
+    public string Email { get; }
+
+    public string Password { get; }
+
+    public static TestUser CreateRandom()
+    {
+        string suffix = Guid.NewGuid().ToString("N")[..10];
+        return new TestUser(
+            username: $"e2e_{suffix}",
+            email: $"e2e_{suffix}@example.com",
+            password: "E2ePassw0rd!");
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/LotroKoniecDev.Frontend.E2E.Tests.csproj
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/LotroKoniecDev.Frontend.E2E.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.Playwright" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="Testcontainers" />
+        <PackageReference Include="Testcontainers.Playwright" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/README.md
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/README.md
@@ -1,0 +1,52 @@
+# LotroKoniecDev.Frontend.E2E.Tests
+
+Browser end-to-end tests for the Blazor SSR Frontend, driven with **Playwright + xUnit + Shouldly**
+over a full stack that the test **owns and boots itself via Testcontainers** — no `docker compose`,
+no shell scripts, no FluentDocker. Rationale + topology: **[ADR-0009](../../docs/adr/0009-browser-e2e-playwright-via-testcontainers.md)**.
+
+## How it works
+
+`PlaywrightStackFixture` (one xUnit collection fixture) boots, on a single private Docker network:
+
+```
+postgres ─ migrator ─ auth-api ─ tms-api ─ frontend ─ mailpit ─ playwright(browser)
+```
+
+- All app services get a DNS alias and serve **HTTPS** (`https://auth-api:8443`, `https://frontend:8443`).
+- The **browser is a container too** (the official `Testcontainers.Playwright` module); the host test
+  connects to it over WebSocket (`Chromium.ConnectAsync(container.GetConnectionString())`). Because the
+  browser and the Frontend's OIDC back-channel are on the **same** network, `https://auth-api:8443`
+  resolves identically for both — so the single-`Authority` OIDC constraint (ADR-0006) holds in-network.
+- HTTPS is mandatory (the OIDC correlation cookie is `SameSite=None`). The cert is **generated in C#**
+  (SAN: the service names); the back-channel services trust it via an inline root entrypoint.
+- **Mailpit** receives the confirmation e-mail, so registration is genuine (not auto-confirmed) and the
+  confirm-link step is real. The host test reads the link via Mailpit's HTTP API.
+
+Because `ConnectAsync` drives an **in-container** browser, the host needs **no** `playwright install`
+(no browser download) — only the NuGet driver, restored on build.
+
+## Running locally
+
+```bash
+# Requires a running Docker daemon. First run builds 4 images + pulls the Playwright image (~2 GB).
+dotnet test tests/LotroKoniecDev.Frontend.E2E.Tests
+
+# Reuse already-built app images (skip the in-fixture docker build):
+SKIP_DOCKER_BUILD=true dotnet test tests/LotroKoniecDev.Frontend.E2E.Tests
+```
+
+No Docker → the suite fails fast (it cannot boot the stack); it is **off the PR/CI gate by name**
+(`*.E2E.Tests`), running only via `.github/workflows/e2e.yml` (`workflow_dispatch`) or a local run.
+
+## Locator strategy
+
+Per Playwright's guidance: `GetByRole` / `GetByLabel` first (the form labels and the nav buttons/links),
+with `data-testid` **only** where there is no stable accessible name — the two consent checkboxes and the
+post-action state panels (`register-success`, `confirm-email-success`). See `Infrastructure/Locators.cs`.
+
+## Flows covered
+
+1. Register → confirm e-mail (Mailpit link) → login (FE OIDC) → logout.
+
+> PL-only: the Auth pages and the FE nav are Polish-only (no culture routing), so — unlike
+> TheKittySaver's PL/EN matrix — there is no culture parameter.


### PR DESCRIPTION
- **test(frontend-e2e): add data-testid hooks to Auth Register/ConfirmEmail**
- **test(frontend-e2e): browser E2E suite via Testcontainers + Playwright (ADR-0009)**
- **ci(e2e): add e2e-frontend job for the browser E2E suite**
- **docs(adr-0009): record browser E2E topology + index the new suite**
