### PR TITLE
refactor: replace StronglyTypedId package with custom record-struct IDs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,6 @@
   <ItemGroup>
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <!-- Strongly-typed IDs (source generator) -->
-    <PackageVersion Include="StronglyTypedId" Version="0.2.1" />
     <!-- ASP.NET Core & API -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />

--- a/docs/adr/0010-custom-strongly-typed-ids-instead-of-package.md
+++ b/docs/adr/0010-custom-strongly-typed-ids-instead-of-package.md
@@ -1,0 +1,197 @@
+# ADR-0010: Custom strongly-typed IDs instead of the StronglyTypedId package
+
+**Status:** Accepted
+**Date:** 2026-06-25
+**Decision-makers:** Solo maintainer
+**Related:** `SharedKernel/StronglyTypedIds`, `TranslationSystem.Primitives` (all `*Id` structs), `TranslationSystem.Persistence/Converters`, ADR-0002 (amendment 2026-06-12 — the `IStronglyTypedId` base lives in SharedKernel), ADR-0007 (read projections key on the same interface)
+
+## Context
+
+Every aggregate id in the TMS is a `partial struct` carrying a `Guid`, annotated with
+`[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]` and implementing
+the **repo-owned** marker `IStronglyTypedId<TSelf>`
+(`SharedKernel/StronglyTypedIds/Common/IStronglyTypedId.cs`). The package
+`StronglyTypedId 0.2.1` (Andrew Lock) source-generates the struct body. Five ids use it:
+`GameVersionId`, `TranslationId`, `TranslatorId`, `PrecomputedTranslationFileId`
+(`TranslationSystem.Primitives`) and `IdentityId` (`SharedKernel`).
+
+Code facts that constrain the choice:
+
+- **The package is the engine, not the foundation.** The marker interface is ours; the generic
+  scaffolding already keys on *it*, not on the package: `Ensure.NotEmpty<T>() where T : IStronglyTypedId<T>`
+  (`SharedKernel/Guards/Ensure.cs:39`), `GenericRepository<TAggregateRoot, TAggregateRootId> where
+  TAggregateRootId : struct, IStronglyTypedId<TAggregateRootId>`
+  (`TranslationSystem.Persistence/GenericRepository.cs:10`), `IReadOnlyEntity<out T> where
+  T : struct, IStronglyTypedId<T>` (`ReadModels/Core/BuildingBlocks/ReadOnlyEntity.cs:5`). Swapping
+  the engine leaves all of this untouched.
+- **The version is effectively abandoned.** `Directory.Packages.props:9` pins `0.2.1` while the
+  package's 1.x line has shipped for years. Depending on a stale, unmaintained generator for a
+  type-system primitive on .NET 10 is the risk this ADR removes.
+- **The reference leaks transitively.** Both `SharedKernel.csproj:8` and
+  `TranslationSystem.Primitives.csproj:9` declare `<PackageReference Include="StronglyTypedId" />`
+  **without `PrivateAssets="all"`**, so a build-time-only generator flows as a transitive dependency
+  to everything referencing those projects.
+- **The generated surface is partly dead and partly a foot-gun.** The emitted struct
+  (verified in `obj/.../GameVersionId.*.generated.cs`) exposes a **public** `ctor(Guid)` with no
+  validation, a `New()` factory, `static readonly Empty`, `IEquatable`/`IComparable`, `==` (routed
+  through `CompareTo`), `ToString()`→bare guid, a nested `TypeConverter`, and an STJ
+  `JsonConverter` that serializes as a string. Of these: `New()` is **dead** (no call site; the
+  code uses the hand-written `Create()` instead), the nested `TypeConverter` is **dead** (routes
+  bind `{id:guid}` and wrap manually — `GetGameVersion.cs:65`, `GetTranslation.cs:89`,
+  `ApproveTranslation.cs:114`, `ImportExportedTexts.cs:225`), and the public `ctor(Guid)`
+  **bypasses** the `Ensure.NotEmpty` that `Create(Guid)` performs — validation is silently
+  skippable, and the endpoints do skip it.
+- **EF conversion is already hand-rolled, five times over.**
+  `TranslationSystem.Persistence/Converters/StronglyTypedIdsConverters.cs` declares one
+  `ValueConverter<TId, Guid>` subclass per id (lines 52–70) — the package contributes nothing here.
+- **JSON travels with the type, not via global registration.** `ConfigureHttpJsonOptions` adds only
+  `JsonStringEnumConverter` (`TranslationSystem.API/ApiDependencyInjection.cs:54`); ids serialize
+  purely through the generated per-type `[JsonConverter]` attribute, so the same id round-trips
+  correctly in the API, the Frontend HttpClients, and the E2E clients without any host knowing about it.
+
+## Decision
+
+### 1. Drop the package; own the struct
+
+Remove `StronglyTypedId` from `Directory.Packages.props` and both `.csproj` files. Each id becomes
+a hand-written `public readonly record struct` implementing `IStronglyTypedId<TSelf>`. The compiler
+supplies `Equals`/`GetHashCode`/`==`/`!=`/`IEquatable<TSelf>` (the per-type equality that value
+types cannot inherit), so the struct body stays ~8 lines.
+
+### 2. Validation cannot be bypassed — private ctor, two static factories
+
+The constructor is **private**. The interface gains a second, **non-validating** factory so
+infrastructure can rehydrate from a trusted store without re-running domain guards:
+
+```csharp
+public interface IStronglyTypedId<out TSelf> where TSelf : IStronglyTypedId<TSelf>
+{
+    Guid Value { get; }
+    static abstract TSelf Create();          // domain: new id (Guid v7)
+    static abstract TSelf Create(Guid id);   // untrusted input: Ensure.NotEmpty
+    static abstract TSelf FromValue(Guid id);// trusted rehydration (EF/JSON): no validation
+}
+```
+
+`Create(Guid)` is the only path from untrusted input and always validates; `FromValue` is the only
+path used by the EF and JSON converters. There is no public `new XId(guid)` to skip the guard.
+(`default(TId)` still exists — unavoidable for any value type — and is handled exactly as today via
+the retained `Empty`.)
+
+### 3. One generic JSON converter, pointed to per type
+
+A single `StronglyTypedIdJsonConverter<TId> : JsonConverter<TId> where TId : struct,
+IStronglyTypedId<TId>` (in SharedKernel) reads a string→`TId.FromValue(Guid.Parse(...))` and writes
+`value.Value`. Each id keeps the attribute form, now closed over itself:
+`[JsonConverter(typeof(StronglyTypedIdJsonConverter<GameVersionId>))]`. The conversion keeps
+travelling with the type — API, Frontend, and E2E need **zero** new global registration.
+
+### 4. One generic EF converter, replacing five classes
+
+A single `StronglyTypedIdValueConverter<TId> : ValueConverter<TId, Guid>` (`id => id.Value`,
+`v => TId.FromValue(v)`) replaces the five hand-written subclasses. The explicit per-id
+registration list in `RegisterAllStronglyTypedIdConverters` stays (it doubles as an id inventory);
+only the converter *bodies* collapse to one generic type. The `UtcDateTimeOffsetConverter` in that
+file is unrelated and untouched.
+
+### 5. Keep the live surface, drop the dead surface
+
+Retain `Value`, `Empty`, value equality, and `ToString()`→bare guid (the JSON/log/link contract).
+Drop the generated `New()` (dead) and the nested `TypeConverter` (dead). `IComparable<TSelf>` is
+**not** emitted by `record struct`; add it per id **only if** the zero-warning build proves a real
+consumer — not speculatively.
+
+### 6. Migrate the call sites
+
+Replace every `new XId(guid)`. The EF sites vanish into the generic converter. **Route endpoints
+wrap the `{id:guid}` route value with `XId.FromValue(id)` — not `Create`** — so an empty id stays a
+`Result.Failure(Validation)` from the handler's existing `== Empty` guard rather than an
+`ArgumentException`, honoring the "errors are values" house rule; the handler guard (and its tests)
+therefore stays. Test fixtures and domain/FK construction use the validating `Create(guid)`.
+`CurrentUserAccessor` wraps the JWT subject with `FromValue` (unchanged non-validating behavior).
+
+## Consequences
+
+### Positive
+
+- One fewer third-party dependency for a core type-system primitive — and a *stale, unmaintained*
+  one at that; no transitive leak from a build-time generator.
+- Validation is structurally unbypassable: the only constructor is private, the only untrusted entry
+  is the guarding `Create`.
+- Less code than today, not more: five EF converter classes collapse to one generic; the dead
+  `New()` and `TypeConverter` are gone; one idiom for creating ids instead of two (`Create` vs `New`).
+- Fully ours and debuggable on .NET 10 — no generated `obj` artifacts to reason about, plain source.
+- No behavioural change for serialization: ids still round-trip as JSON strings via the attribute, so
+  API/Frontend/E2E are unaffected.
+
+### Negative / Accepted Trade-offs
+
+- Per-id equality is now in source (compiler-generated by `record struct`) rather than hidden in a
+  generator — trivially more lines per id, but visible and inert.
+- `static abstract` members put a small generic-math-style ceremony on the interface; the cost is one
+  extra factory method (`FromValue`) every id must declare.
+- A one-time mechanical sweep of ~25–30 `new XId(guid)` call sites (EF, endpoints, test fixtures).
+  Guarded by the existing build (`TreatWarningsAsErrors`) and the integration test suite.
+- If a future id must key on something other than `Guid` (e.g. `long`), the interface's `Guid Value`
+  shape would need revisiting — acceptable: every current id is a `Guid` (v7), and YAGNI applies.
+
+## Alternatives Considered
+
+### A. Keep `StronglyTypedId 0.2.1`
+
+Zero work, already wired. **Rejected.** It is the exact dependency the maintainer distrusts —
+abandoned version, transitive leak, dead generated surface, and a validation-skipping public ctor.
+
+### B. Write our own incremental source generator
+
+Reproduce `[StronglyTypedId]` as a first-party Roslyn generator. **Rejected.** A separate
+`netstandard2.0` analyzer project plus its own test suite and generator-debugging tax, to emit ~8
+lines for **five** ids — a factory built for five screws. Violates the repo's right-size/YAGNI rule.
+Revisit only if the id count grows by an order of magnitude.
+
+### C. Fully hand-written structs, no shared infrastructure
+
+Each id spells out equality, JSON, and EF conversion inline. **Rejected.** ~60 lines of duplicated
+boilerplate × 5, with real drift risk between types; the generic JSON/EF converters exist precisely
+to avoid this.
+
+### D. Keep the public `ctor(Guid)` (the "1:1" variant)
+
+Public ctor as "rehydration", `Create` validates — identical to today's behaviour, zero call-site
+churn, but per-type converters must stay (no static factory to drive a generic) and validation stays
+skippable. **Rejected.** The maintainer chose the hard-encapsulation variant; unbypassable validation
+plus the converter collapse is worth the mechanical sweep.
+
+### E. Global `JsonConverterFactory` instead of the per-type attribute
+
+Register one factory in every host's `JsonSerializerOptions`. **Rejected.** It moves a correctness
+guarantee from "travels with the type" to "every host must remember to register it" — API, Frontend
+RP, *and* the E2E clients — an easy omission. The attribute form keeps the conversion intrinsic to
+the id.
+
+## Implementation Notes
+
+- **Changed (SharedKernel):** `StronglyTypedIds/Common/IStronglyTypedId.cs` (add `FromValue`);
+  `StronglyTypedIds/IdentityId.cs` (rewrite as `record struct`, private ctor, attribute);
+  new `StronglyTypedIds/Json/StronglyTypedIdJsonConverter.cs`; `SharedKernel.csproj` (drop ref).
+- **Changed (Primitives):** `GameVersionId`, `TranslationId`, `TranslatorId`,
+  `Projections/PrecomputedTranslationFileId` (rewrite to the new shape);
+  `TranslationSystem.Primitives.csproj` (drop ref).
+- **Changed (Persistence):** `Converters/StronglyTypedIdsConverters.cs` — replace the five
+  `*IdConverter` subclasses with one generic `StronglyTypedIdValueConverter<TId>`; keep the explicit
+  registration list and `UtcDateTimeOffsetConverter`.
+- **Changed (call sites):** ~25–30 `new XId(guid)` → `XId.Create(guid)` across
+  `TranslationSystem.API/Features/*` endpoints, `Auth/CurrentUserAccessor.cs`, and test fixtures
+  (Frontend unit, API unit, integration, E2E).
+- **Removed:** `StronglyTypedId` from `Directory.Packages.props` and both `.csproj` files; the dead
+  `New()` and nested `TypeConverter`.
+- **Verify:** zero-warning build (`dotnet build LotroKoniecDev.slnx`) and the full test suite green;
+  add `IComparable<TSelf>` per id only if the build surfaces a consumer.
+
+## References
+
+- ADR-0001 — slim SRP handlers; same "own the small primitive, drop the third-party indirection" instinct
+- ADR-0002 (amendment 2026-06-12) — the `IStronglyTypedId` base belongs in SharedKernel
+- ADR-0007 — read projections key on `IStronglyTypedId<T>` (the constraint this ADR preserves)
+- StronglyTypedId package — https://github.com/andrewlock/StronglyTypedId (1.x supersedes the pinned 0.2.1)
+- .NET `static abstract` interface members / generic math — the mechanism behind the `Create`/`FromValue` factories

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
@@ -206,7 +206,7 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
-        ApiResult<TranslationDetailResponse> result = await Loader.LoadAsync(new TranslationId(Id), CancellationToken.None);
+        ApiResult<TranslationDetailResponse> result = await Loader.LoadAsync(TranslationId.FromValue(Id), CancellationToken.None);
         if (result.IsSuccess)
         {
             _detail = result.Value;
@@ -263,7 +263,7 @@ else
         {
             _approved = true;
 
-            ApiResult<TranslationDetailResponse> reload = await Loader.LoadAsync(new TranslationId(Id), CancellationToken.None);
+            ApiResult<TranslationDetailResponse> reload = await Loader.LoadAsync(TranslationId.FromValue(Id), CancellationToken.None);
             if (reload.IsSuccess)
             {
                 _detail = reload.Value;

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
@@ -232,7 +232,7 @@
         await using Stream fileStream = input.File.OpenReadStream();
 
         ApiResult<ImportSummary> result = await Loader.ImportAsync(
-            new GameVersionId(input.GameVersionId),
+            GameVersionId.FromValue(input.GameVersionId),
             fileStream,
             input.File.FileName,
             input.AllowMassRemoval,

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/LotroKoniecDev.SharedKernel.csproj
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/LotroKoniecDev.SharedKernel.csproj
@@ -4,7 +4,4 @@
         <PlatformTarget>AnyCPU</PlatformTarget>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="StronglyTypedId" />
-    </ItemGroup>
 </Project>

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/Common/IStronglyTypedId.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/Common/IStronglyTypedId.cs
@@ -15,4 +15,11 @@ public interface IStronglyTypedId<out TSelf> where TSelf : IStronglyTypedId<TSel
 
     public static abstract TSelf Create();
     public static abstract TSelf Create(Guid id);
+
+    /// <summary>
+    /// Rehydrates an ID from a trusted store (EF materialization, JSON deserialization) without
+    /// running domain validation — the store is the source of truth. Untrusted input must go
+    /// through <see cref="Create(Guid)"/> instead.
+    /// </summary>
+    public static abstract TSelf FromValue(Guid id);
 }

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/IdentityId.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/IdentityId.cs
@@ -1,10 +1,26 @@
+using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Json;
 
 namespace LotroKoniecDev.SharedKernel.StronglyTypedIds;
 
-[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]
-public partial struct IdentityId : IStronglyTypedId<IdentityId>
+[JsonConverter(typeof(StronglyTypedIdJsonConverter<IdentityId>))]
+public readonly record struct IdentityId : IStronglyTypedId<IdentityId>
 {
+    public static readonly IdentityId Empty;
+
+    public Guid Value { get; }
+
+    private IdentityId(Guid value)
+    {
+        Value = value;
+    }
+
     public static IdentityId Create() => new(Guid.CreateVersion7());
+
     public static IdentityId Create(Guid id) => new(id);
+
+    public static IdentityId FromValue(Guid id) => new(id);
+
+    public override string ToString() => Value.ToString();
 }

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/Json/StronglyTypedIdJsonConverter.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/StronglyTypedIds/Json/StronglyTypedIdJsonConverter.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+
+namespace LotroKoniecDev.SharedKernel.StronglyTypedIds.Json;
+
+/// <summary>
+/// Serializes any <see cref="IStronglyTypedId{TSelf}"/> as a plain JSON string holding its
+/// underlying Guid. Pointed to per type via <c>[JsonConverter(typeof(...))]</c> so the conversion
+/// travels with the ID — no host needs to register it globally.
+/// </summary>
+public sealed class StronglyTypedIdJsonConverter<TId> : JsonConverter<TId>
+    where TId : struct, IStronglyTypedId<TId>
+{
+    public override TId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        TId.FromValue(reader.GetGuid());
+
+    public override void Write(Utf8JsonWriter writer, TId value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.Value);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/CurrentUserAccessing/CurrentUserAccessor.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/CurrentUserAccessing/CurrentUserAccessor.cs
@@ -29,7 +29,7 @@ internal sealed class CurrentUserAccessor : ICurrentUserAccessor
         get
         {
             string? subject = User?.FindFirstValue(SubjectClaimType);
-            IdentityId? result = Guid.TryParse(subject, out Guid userId) ? new IdentityId(userId) : null;
+            IdentityId? result = Guid.TryParse(subject, out Guid userId) ? IdentityId.FromValue(userId) : null;
             return ValueMaybe<IdentityId>.From(result);
         }
     }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/GetGameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/GetGameVersion.cs
@@ -62,7 +62,7 @@ internal sealed class GetGameVersion : IEndpoint
                 IGameVersionAggregateLinkFactory gameVersionLinkFactory,
                 CancellationToken cancellationToken) =>
             {
-                Result<GameVersionResponse> result = await handler.Handle(new Query(new GameVersionId(id)), cancellationToken);
+                Result<GameVersionResponse> result = await handler.Handle(new Query(GameVersionId.FromValue(id)), cancellationToken);
 
                 if (result.IsFailure)
                 {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ApproveTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ApproveTranslation.cs
@@ -111,7 +111,7 @@ internal sealed class ApproveTranslation : IEndpoint
                 ICommandHandler<Command, Result> handler,
                 CancellationToken cancellationToken) =>
             {
-                Result result = await handler.Handle(new Command(new TranslationId(id)), cancellationToken);
+                Result result = await handler.Handle(new Command(TranslationId.FromValue(id)), cancellationToken);
 
                 return result.IsSuccess
                     ? Results.NoContent()

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslation.cs
@@ -86,7 +86,7 @@ internal sealed class GetTranslation : IEndpoint
                 ClaimsPrincipal user,
                 CancellationToken cancellationToken) =>
             {
-                Result<QueryResult> result = await handler.Handle(new Query(new TranslationId(id)), cancellationToken);
+                Result<QueryResult> result = await handler.Handle(new Query(TranslationId.FromValue(id)), cancellationToken);
 
                 if (result.IsFailure)
                 {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdValueConverter.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdValueConverter.cs
@@ -1,0 +1,23 @@
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Converters;
+
+/// <summary>
+/// Maps any <see cref="IStronglyTypedId{TSelf}"/> to its underlying Guid column. Rehydrates via the
+/// non-validating <see cref="IStronglyTypedId{TSelf}.FromValue"/> — the database is the source of
+/// truth. The conversions are routed through static helpers so the expression trees contain no
+/// access to a static-abstract interface member (which the compiler forbids in an expression tree).
+/// </summary>
+public sealed class StronglyTypedIdValueConverter<TId> : ValueConverter<TId, Guid>
+    where TId : struct, IStronglyTypedId<TId>
+{
+    public StronglyTypedIdValueConverter()
+        : base(id => ToGuid(id), value => FromGuid(value))
+    {
+    }
+
+    private static Guid ToGuid(TId id) => id.Value;
+
+    private static TId FromGuid(Guid value) => TId.FromValue(value);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdsConverters.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Converters/StronglyTypedIdsConverters.cs
@@ -21,26 +21,26 @@ public static class StronglyTypedIdsConverters
 
         configurationBuilder
             .Properties<GameVersionId>()
-            .HaveConversion<GameVersionIdConverter>();
+            .HaveConversion<StronglyTypedIdValueConverter<GameVersionId>>();
 
         configurationBuilder
             .Properties<TranslationId>()
-            .HaveConversion<TranslationIdConverter>();
+            .HaveConversion<StronglyTypedIdValueConverter<TranslationId>>();
 
         configurationBuilder
             .Properties<PrecomputedTranslationFileId>()
-            .HaveConversion<PrecomputedTranslationFileIdConverter>();
+            .HaveConversion<StronglyTypedIdValueConverter<PrecomputedTranslationFileId>>();
 
         configurationBuilder
             .Properties<TranslatorId>()
-            .HaveConversion<TranslatorIdConverter>();
+            .HaveConversion<StronglyTypedIdValueConverter<TranslatorId>>();
 
         // IdentityId is the AuthSystem user id (cross-context reference) carried by the Translator as
         // the lazy-provisioning key (ADR-0004); it lives in the SharedKernel, not the TMS Primitives,
         // but persists the same way.
         configurationBuilder
             .Properties<IdentityId>()
-            .HaveConversion<IdentityIdConverter>();
+            .HaveConversion<StronglyTypedIdValueConverter<IdentityId>>();
 
         return configurationBuilder;
     }
@@ -48,24 +48,4 @@ public static class StronglyTypedIdsConverters
     private sealed class UtcDateTimeOffsetConverter() : ValueConverter<DateTimeOffset, DateTimeOffset>(
         dto => dto.ToUniversalTime(),
         dto => dto.ToUniversalTime());
-
-    private sealed class GameVersionIdConverter() : ValueConverter<GameVersionId, Guid>(
-        id => id.Value,
-        value => new GameVersionId(value));
-
-    private sealed class TranslationIdConverter() : ValueConverter<TranslationId, Guid>(
-        id => id.Value,
-        value => new TranslationId(value));
-
-    private sealed class PrecomputedTranslationFileIdConverter() : ValueConverter<PrecomputedTranslationFileId, Guid>(
-        id => id.Value,
-        value => new PrecomputedTranslationFileId(value));
-
-    private sealed class TranslatorIdConverter() : ValueConverter<TranslatorId, Guid>(
-        id => id.Value,
-        value => new TranslatorId(value));
-
-    private sealed class IdentityIdConverter() : ValueConverter<IdentityId, Guid>(
-        id => id.Value,
-        value => new IdentityId(value));
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/GameVersionAggregate/GameVersionId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/GameVersionAggregate/GameVersionId.cs
@@ -1,15 +1,31 @@
+using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.Guards;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Json;
 
 namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 
-[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]
-public partial struct GameVersionId : IStronglyTypedId<GameVersionId>
+[JsonConverter(typeof(StronglyTypedIdJsonConverter<GameVersionId>))]
+public readonly record struct GameVersionId : IStronglyTypedId<GameVersionId>
 {
+    public static readonly GameVersionId Empty;
+
+    public Guid Value { get; }
+
+    private GameVersionId(Guid value)
+    {
+        Value = value;
+    }
+
     public static GameVersionId Create() => new(Guid.CreateVersion7());
+
     public static GameVersionId Create(Guid id)
     {
         Ensure.NotEmpty(id);
         return new GameVersionId(id);
     }
+
+    public static GameVersionId FromValue(Guid id) => new(id);
+
+    public override string ToString() => Value.ToString();
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationAggregate/TranslationId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationAggregate/TranslationId.cs
@@ -1,15 +1,31 @@
+using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.Guards;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Json;
 
 namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 
-[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]
-public partial struct TranslationId : IStronglyTypedId<TranslationId>
+[JsonConverter(typeof(StronglyTypedIdJsonConverter<TranslationId>))]
+public readonly record struct TranslationId : IStronglyTypedId<TranslationId>
 {
+    public static readonly TranslationId Empty;
+
+    public Guid Value { get; }
+
+    private TranslationId(Guid value)
+    {
+        Value = value;
+    }
+
     public static TranslationId Create() => new(Guid.CreateVersion7());
+
     public static TranslationId Create(Guid id)
     {
         Ensure.NotEmpty(id);
         return new TranslationId(id);
     }
+
+    public static TranslationId FromValue(Guid id) => new(id);
+
+    public override string ToString() => Value.ToString();
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslatorAggregate/TranslatorId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslatorAggregate/TranslatorId.cs
@@ -1,15 +1,31 @@
+using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.Guards;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Json;
 
 namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
 
-[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]
-public partial struct TranslatorId : IStronglyTypedId<TranslatorId>
+[JsonConverter(typeof(StronglyTypedIdJsonConverter<TranslatorId>))]
+public readonly record struct TranslatorId : IStronglyTypedId<TranslatorId>
 {
+    public static readonly TranslatorId Empty;
+
+    public Guid Value { get; }
+
+    private TranslatorId(Guid value)
+    {
+        Value = value;
+    }
+
     public static TranslatorId Create() => new(Guid.CreateVersion7());
+
     public static TranslatorId Create(Guid id)
     {
         Ensure.NotEmpty(id);
         return new TranslatorId(id);
     }
+
+    public static TranslatorId FromValue(Guid id) => new(id);
+
+    public override string ToString() => Value.ToString();
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/LotroKoniecDev.TranslationSystem.Primitives.csproj
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/LotroKoniecDev.TranslationSystem.Primitives.csproj
@@ -6,10 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="StronglyTypedId" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\..\SharedKernel\LotroKoniecDev.SharedKernel\LotroKoniecDev.SharedKernel.csproj" />
     </ItemGroup>
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Projections/PrecomputedTranslationFileId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Projections/PrecomputedTranslationFileId.cs
@@ -1,15 +1,31 @@
+using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.Guards;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds.Common;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds.Json;
 
 namespace LotroKoniecDev.TranslationSystem.Primitives.Projections;
 
-[StronglyTypedId(jsonConverter: StronglyTypedIdJsonConverter.SystemTextJson)]
-public partial struct PrecomputedTranslationFileId : IStronglyTypedId<PrecomputedTranslationFileId>
+[JsonConverter(typeof(StronglyTypedIdJsonConverter<PrecomputedTranslationFileId>))]
+public readonly record struct PrecomputedTranslationFileId : IStronglyTypedId<PrecomputedTranslationFileId>
 {
+    public static readonly PrecomputedTranslationFileId Empty;
+
+    public Guid Value { get; }
+
+    private PrecomputedTranslationFileId(Guid value)
+    {
+        Value = value;
+    }
+
     public static PrecomputedTranslationFileId Create() => new(Guid.CreateVersion7());
+
     public static PrecomputedTranslationFileId Create(Guid id)
     {
         Ensure.NotEmpty(id);
         return new PrecomputedTranslationFileId(id);
     }
+
+    public static PrecomputedTranslationFileId FromValue(Guid id) => new(id);
+
+    public override string ToString() => Value.ToString();
 }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
@@ -239,7 +239,7 @@ public sealed class EditorTests : BunitContext
         }
 
         return new TranslationDetailResponse(
-            new TranslationId(Guid.NewGuid()),
+            TranslationId.Create(Guid.NewGuid()),
             FileId: 620756992,
             GossipId: 1002,
             SourceText: sourceText,

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportLoaderTests.cs
@@ -106,7 +106,7 @@ public sealed class ImportExportLoaderTests
             out StubHttpMessageHandler handler);
         using MemoryStream file = new(Encoding.UTF8.GetBytes("620756992||1001||Witaj||NULL||NULL||1"));
 
-        await loader.ImportAsync(new GameVersionId(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
+        await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
 
         handler.LastRequest.ShouldNotBeNull();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Post);
@@ -123,7 +123,7 @@ public sealed class ImportExportLoaderTests
             out StubHttpMessageHandler handler);
         using MemoryStream file = new(Encoding.UTF8.GetBytes("620756992||1001||Witaj||NULL||NULL||1"));
 
-        await loader.ImportAsync(new GameVersionId(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
+        await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
 
         handler.LastRequestBody.ShouldNotBeNull();
         handler.LastRequestBody!.ShouldContain("name=file");
@@ -142,7 +142,7 @@ public sealed class ImportExportLoaderTests
             out StubHttpMessageHandler handler);
         using MemoryStream file = new(Encoding.UTF8.GetBytes("x"));
 
-        await loader.ImportAsync(new GameVersionId(GameVersionGuid), file, "exported.txt", allowMassRemoval: true);
+        await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: true);
 
         handler.LastRequest!.RequestUri!.Query.ShouldBe("?allowMassRemoval=true");
     }
@@ -157,7 +157,7 @@ public sealed class ImportExportLoaderTests
         using MemoryStream file = new(Encoding.UTF8.GetBytes("x"));
 
         ApiResult<ImportSummary> result =
-            await loader.ImportAsync(new GameVersionId(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
+            await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
 
         result.IsSuccess.ShouldBeTrue();
         result.Value.Added.ShouldBe(3);
@@ -178,7 +178,7 @@ public sealed class ImportExportLoaderTests
         using MemoryStream file = new(Encoding.UTF8.GetBytes("x"));
 
         ApiResult<ImportSummary> result =
-            await loader.ImportAsync(new GameVersionId(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
+            await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
 
         result.IsFailure.ShouldBeTrue();
         result.ProblemDetails!.Status.ShouldBe(422);
@@ -223,7 +223,7 @@ public sealed class ImportExportLoaderTests
     }
 
     private static GameVersionResponse VersionFixture() =>
-        new(new GameVersionId(GameVersionGuid), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed);
+        new(GameVersionId.Create(GameVersionGuid), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed);
 
     private static ImportSummary SummaryFixture() =>
         new(Added: 3, SourceChanged: 2, Invalidated: 1, Removed: 4, Unchanged: 10, Warnings: ["1 wiersz przywrócony."]);

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportTests.cs
@@ -56,7 +56,7 @@ public sealed class ImportExportTests : BunitContext
         // admin-only import panel stays hidden — driven by the server's affordance, not a local role check.
         AuthorizeAs("Frodo");
         StubVersions(
-            new GameVersionResponse(new GameVersionId(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed));
+            new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed));
 
         IRenderedComponent<ImportExportComponent> component = RenderPage();
 
@@ -69,8 +69,8 @@ public sealed class ImportExportTests : BunitContext
     {
         AuthorizeAs("Sam");
         StubVersionsWithRegisterRel(
-            new GameVersionResponse(new GameVersionId(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed),
-            new GameVersionResponse(new GameVersionId(Guid.NewGuid()), "47.2", DateTimeOffset.UnixEpoch, GameVersionStatus.Processed));
+            new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed),
+            new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "47.2", DateTimeOffset.UnixEpoch, GameVersionStatus.Processed));
 
         IRenderedComponent<ImportExportComponent> component = RenderPage();
 
@@ -84,7 +84,7 @@ public sealed class ImportExportTests : BunitContext
         // property of a [SupplyParameterFromForm] model, so the inputs MUST be named ImportInput.* —
         // a bare name (e.g. "UploadFile") binds null and the import can never run.
         AuthorizeAs("Sam");
-        StubVersionsWithRegisterRel(new GameVersionResponse(new GameVersionId(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed));
+        StubVersionsWithRegisterRel(new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed));
 
         IRenderedComponent<ImportExportComponent> component = RenderPage();
 
@@ -97,7 +97,7 @@ public sealed class ImportExportTests : BunitContext
     public async Task Submit_WhenNoFileChosen_ShowsTheChooseFileValidationAndDoesNotCallImport()
     {
         AuthorizeAs("Sam");
-        StubVersionsWithRegisterRel(new GameVersionResponse(new GameVersionId(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed));
+        StubVersionsWithRegisterRel(new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed));
         IRenderedComponent<ImportExportComponent> component = RenderPage();
 
         await component.Find("form").SubmitAsync();


### PR DESCRIPTION
## What & why

Removes the **abandoned `StronglyTypedId 0.2.1`** NuGet source generator and replaces it with a
first-party pattern. The package was pinned to a stale version (1.x has shipped for years), leaked
transitively (no `PrivateAssets="all"` on either reference), and its generated **public** `ctor(Guid)`
let callers bypass the `Ensure.NotEmpty` that `Create(Guid)` performs.

Decision recorded in **ADR-0010**.

## Changes

- **5 IDs** (`IdentityId`, `GameVersionId`, `TranslationId`, `TranslatorId`, `PrecomputedTranslationFileId`)
  are now hand-written `readonly record struct` with a **private** ctor — validation is structurally
  unbypassable.
- `IStronglyTypedId<TSelf>` gains a non-validating **`FromValue`** factory (trusted EF/JSON rehydration)
  beside the validating `Create`.
- **One** generic `StronglyTypedIdJsonConverter<TId>` (pointed to per type by attribute — no global
  registration, so Frontend/E2E are unaffected) and **one** generic `StronglyTypedIdValueConverter<TId>`
  replacing the five per-type EF converter classes.
- ~30 `new XId(guid)` call sites migrated: route endpoints / Razor RP / `CurrentUserAccessor` → `FromValue`
  (an empty id stays a `Result.Failure(Validation)` from the handler guard, not an `ArgumentException`);
  test fixtures / domain → `Create`. Dead `New()` and `TypeConverter` surface dropped.
- Package removed from `Directory.Packages.props` and both `.csproj` files.

## Verification

- `dotnet build LotroKoniecDev.slnx` → **0 warnings / 0 errors** (whole solution).
- **823 tests green, 0 failed**: 520 unit (SharedKernel 69 · Domain 128 · API 130 · Frontend 193) +
  303 integration on **real PostgreSQL** (TMS 130 · Auth 173 — exercises the generic EF converter round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
