### PR TITLE
fix: repair patcher .bat wrappers (win-x86 exe path + modernize lotro.bat)

### DIFF
--- a/export.bat
+++ b/export.bat
@@ -7,5 +7,5 @@ if errorlevel 1 (
 )
 dotnet build src\Patcher\LotroKoniecDev.Cli -v:minimal -nologo
 if errorlevel 1 exit /b 1
-src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\LotroKoniecDev.Cli.exe export %*
+src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe export %*
 pause

--- a/lotro.bat
+++ b/lotro.bat
@@ -1,53 +1,11 @@
 @echo off
-setlocal enabledelayedexpansion
-
-set "DAT_FILE=client_local_English.dat"
-
-if "%~1" neq "" (
-    set "LOTRO_PATH=%~1"
-    goto :check_dat
+net session >nul 2>&1
+if errorlevel 1 (
+    echo Requesting administrator privileges...
+    powershell -Command "Start-Process cmd -Verb RunAs -ArgumentList '/c cd /d \"%CD%\" && \"%~f0\" %*'"
+    exit /b
 )
-
-set "LOTRO_PATH=%ProgramFiles(x86)%\StandingStoneGames\The Lord of the Rings Online"
-if exist "!LOTRO_PATH!\!DAT_FILE!" goto :check_dat
-
-set "LOTRO_PATH=%ProgramFiles(x86)%\Steam\steamapps\common\The Lord of the Rings Online"
-
-:check_dat
-if not exist "!LOTRO_PATH!\!DAT_FILE!" (
-    echo ERROR: LOTRO installation not found at: !LOTRO_PATH!
-    echo Usage: lotro.bat [path_to_lotro_folder]
-    exit /b 1
-)
-
-echo === LOTRO Polish Patcher - Launch Helper ===
-echo Path: !LOTRO_PATH!
-echo.
-
-echo Setting !DAT_FILE! to read-only (protects translations from launcher^)...
-attrib +R "!LOTRO_PATH!\!DAT_FILE!"
-
-set "LAUNCHER="
-if exist "!LOTRO_PATH!\LotroLauncher.exe" set "LAUNCHER=!LOTRO_PATH!\LotroLauncher.exe"
-if not defined LAUNCHER if exist "!LOTRO_PATH!\LotroLauncher.exe" set "LAUNCHER=!LOTRO_PATH!\LotroLauncher.exe"
-
-if not defined LAUNCHER (
-    echo ERROR: No launcher found in !LOTRO_PATH!
-    attrib -R "!LOTRO_PATH!\!DAT_FILE!"
-    exit /b 1
-)
-
-echo Launching: !LAUNCHER!
-echo.
-echo DAT file is READ-ONLY. Launcher cannot overwrite translations.
-echo Write access will be restored when the launcher closes.
-echo.
-
-start /wait "" "!LAUNCHER!"
-
-echo.
-echo Restoring write access to !DAT_FILE!...
-attrib -R "!LOTRO_PATH!\!DAT_FILE!"
-echo Done.
-
-endlocal
+dotnet build src\Patcher\LotroKoniecDev.Cli -v:minimal -nologo
+if errorlevel 1 exit /b 1
+src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe launch %*
+pause

--- a/patch.bat
+++ b/patch.bat
@@ -7,5 +7,5 @@ if errorlevel 1 (
 )
 dotnet build src\Patcher\LotroKoniecDev.Cli -v:minimal -nologo
 if errorlevel 1 exit /b 1
-src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\LotroKoniecDev.Cli.exe patch %*
+src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe patch %*
 pause


### PR DESCRIPTION
## What

The patcher `.bat` wrappers stopped working after the CLI gained a `win-x86`
runtime identifier — `export.bat` errored with *"is not recognized as an internal
or external command"*. This repairs all three.

## Why it broke

`LotroKoniecDev.Cli.csproj` sets `<RuntimeIdentifier>win-x86</RuntimeIdentifier>`,
so `dotnet build` emits the exe under
`bin\Debug\net10.0-windows\win-x86\`. `export.bat` and `patch.bat` still pointed
at the pre-RID path (no `win-x86` segment), so the exe wasn't found.

## Changes

- **`export.bat`, `patch.bat`** — add the missing `win-x86\` path segment.
- **`lotro.bat`** — was the abandoned **legacy** flow: it set the DAT read-only
  (`attrib +R`) and launched `LotroLauncher.exe` directly, **never invoking the
  CLI or patching translations**. Per `docs/knowledge-base`, `attrib +R` is
  unnecessary and the validated flow is the CLI `launch` command (hash-check →
  patch only if the translation file changed → fire-and-forget launch). Rewired
  it to build + run `launch %*`, mirroring `export.bat`/`patch.bat`.

## Usage note

`lotro.bat` now takes the translation name like `patch.bat` does:
`lotro.bat polish` (was: an optional LOTRO folder path).

## Testing

No automated coverage — these are dev/launch shell wrappers. Verified manually:
the `win-x86` exe path exists post-build; `lotro.bat` now drives the same
`launch` handler already proven in `docs/knowledge-base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
