### PR TITLE
fix: FE E2E test fixes + explicit default for strongly-typed IDs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Playwright" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
   </ItemGroup>
 </Project>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
@@ -586,7 +586,7 @@
 
                             <div class="auth-field">
                                 <div class="auth-field-row">
-                                    <label asp-for="Password">Hasło</label>
+                                    <label asp-for="Password" for="password-input">Hasło</label>
                                     <a href="/Account/ForgotPassword" class="hint-link">Nie pamiętam hasła →</a>
                                 </div>
                                 <div class="auth-input-wrap">

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/GameVersionAggregate/GameVersionId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/GameVersionAggregate/GameVersionId.cs
@@ -8,7 +8,7 @@ namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggr
 [JsonConverter(typeof(StronglyTypedIdJsonConverter<GameVersionId>))]
 public readonly record struct GameVersionId : IStronglyTypedId<GameVersionId>
 {
-    public static readonly GameVersionId Empty;
+    public static readonly GameVersionId Empty = default;
 
     public Guid Value { get; }
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationAggregate/TranslationId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslationAggregate/TranslationId.cs
@@ -8,7 +8,7 @@ namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggr
 [JsonConverter(typeof(StronglyTypedIdJsonConverter<TranslationId>))]
 public readonly record struct TranslationId : IStronglyTypedId<TranslationId>
 {
-    public static readonly TranslationId Empty;
+    public static readonly TranslationId Empty = default;
 
     public Guid Value { get; }
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslatorAggregate/TranslatorId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Aggregates/TranslatorAggregate/TranslatorId.cs
@@ -8,7 +8,7 @@ namespace LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggre
 [JsonConverter(typeof(StronglyTypedIdJsonConverter<TranslatorId>))]
 public readonly record struct TranslatorId : IStronglyTypedId<TranslatorId>
 {
-    public static readonly TranslatorId Empty;
+    public static readonly TranslatorId Empty = default;
 
     public Guid Value { get; }
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Projections/PrecomputedTranslationFileId.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Projections/PrecomputedTranslationFileId.cs
@@ -8,7 +8,7 @@ namespace LotroKoniecDev.TranslationSystem.Primitives.Projections;
 [JsonConverter(typeof(StronglyTypedIdJsonConverter<PrecomputedTranslationFileId>))]
 public readonly record struct PrecomputedTranslationFileId : IStronglyTypedId<PrecomputedTranslationFileId>
 {
-    public static readonly PrecomputedTranslationFileId Empty;
+    public static readonly PrecomputedTranslationFileId Empty = default;
 
     public Guid Value { get; }
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -120,8 +120,10 @@ A **Playwright** browser suite over the same Testcontainers idiom (ADR-0009 — 
 FluentDocker). `PlaywrightStackFixture` builds the `auth`/`tms`/`frontend`/`migrator` images, boots the whole
 browser-facing stack on one network — postgres + migrator + auth-api + tms-api + **frontend** + **mailpit** —
 all over **HTTPS** (a cert generated in C#; SAN = the service DNS names; trusted in-container via an inline root
-entrypoint), plus the **official `Testcontainers.Playwright`** browser container. The host connects to the
-in-network browser over WS (`Chromium.ConnectAsync(GetConnectionString())`), so `https://auth-api:8443` resolves
+entrypoint), plus a Playwright `run-server` browser container built by hand (the `Testcontainers.Playwright`
+module is unusable on Playwright v1.55+ images — it omits run-server's `--host` and hard-codes a `localhost`
+readiness probe; see `PlaywrightStackFixture.StartBrowserAsync`). The host connects to the
+in-network browser over WS (`Chromium.ConnectAsync(ws://host:mappedPort/)`), so `https://auth-api:8443` resolves
 identically for the browser front-channel and the FE OIDC back-channel — the single-`Authority` constraint
 (ADR-0006) held in-network via DNS. Mailpit receives the real confirmation e-mail (no auto-confirm), read back
 over its HTTP API. Because the browser is in a container, the host needs **no** `playwright install` (no browser

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
@@ -7,7 +7,6 @@ using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
 using Microsoft.Playwright;
-using Testcontainers.Playwright;
 using Testcontainers.PostgreSql;
 
 namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
@@ -15,8 +14,10 @@ namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
 /// <summary>
 /// Boots the whole browser-facing stack — Postgres + the one-shot migrator + auth-api + tms-api +
 /// the Blazor SSR Frontend + Mailpit + a headless Chromium — as real containers on one private
-/// network, then connects Playwright to the in-network browser over WebSocket (the official
-/// <c>Testcontainers.Playwright</c> module). Every service has a DNS alias, so
+/// network, then connects Playwright to the in-network browser over WebSocket. (The browser
+/// container is built by hand rather than via the <c>Testcontainers.Playwright</c> module — see
+/// <see cref="StartBrowserAsync"/> for why that module is unusable with current Playwright images.)
+/// Every service has a DNS alias, so
 /// <c>https://auth-api:8443</c> resolves identically for the in-container browser front-channel AND
 /// the Frontend's server-side OIDC back-channel — the single-<c>Authority</c> property ADR-0006
 /// secured on the host via <c>localhost</c>, here secured in-network via DNS (ADR-0009). HTTPS is
@@ -34,6 +35,17 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
 
     // Pinned to match the Microsoft.Playwright client version, so ConnectAsync speaks the same protocol.
     private const string PlaywrightImage = "mcr.microsoft.com/playwright:v1.60.0-noble";
+    private const int PlaywrightPort = 8080;
+
+    /// <summary>
+    /// run-server command — identical to the one the <c>Testcontainers.Playwright</c> module emits
+    /// (the driver version is read from the image at startup so it matches the client protocol), but
+    /// with <c>--host 0.0.0.0</c> appended. Without it, Playwright v1.55+ binds the WebSocket server
+    /// to the container loopback, which the host can never reach through the published port.
+    /// </summary>
+    private const string PlaywrightServerCommand =
+        "npx -y playwright@$(sed --quiet 's/.*\\\"driverVersion\\\": *\"\\([^\"]*\\)\".*/\\1/p' ms-playwright/.docker-info) "
+        + "run-server --port 8080 --host 0.0.0.0";
 
     /// <summary>Image name → Dockerfile path (relative to the solution root), built in order if not present.</summary>
     private static readonly (string Image, string Dockerfile)[] DockerImages =
@@ -77,7 +89,7 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
     private IContainer _authApi = null!;
     private IContainer _tmsApi = null!;
     private IContainer _frontend = null!;
-    private PlaywrightContainer _playwrightContainer = null!;
+    private IContainer _playwrightContainer = null!;
     private IPlaywright _playwright = null!;
 
     public IBrowser Browser { get; private set; } = null!;
@@ -260,13 +272,29 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
 
     private async Task StartBrowserAsync()
     {
-        _playwrightContainer = new PlaywrightBuilder(PlaywrightImage)
+        // Built by hand instead of via PlaywrightBuilder: that module omits run-server's --host flag
+        // and hard-codes a "Listening on ws://localhost:8080/" readiness probe. Since Playwright v1.55+
+        // run-server binds to the container loopback (logging "ws://[::1]:8080/") unless --host is given,
+        // the module's probe never matches (so StartAsync hangs in the wait strategy) AND the loopback-
+        // bound server is unreachable through the published port (so ConnectAsync would hang too). Its
+        // wait strategies are append-only, so the broken probe can't be replaced. Binding 0.0.0.0 fixes
+        // both: the WebSocket server is reachable via the mapped port and logs the address we wait on.
+        _playwrightContainer = new ContainerBuilder(PlaywrightImage)
             .WithNetwork(_network)
+            .WithEntrypoint("/bin/sh", "-c")
+            .WithCommand(PlaywrightServerCommand)
+            .WithPortBinding(PlaywrightPort, true)
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilMessageIsLogged($"Listening on ws://0.0.0.0:{PlaywrightPort}"))
             .Build();
-        await _playwrightContainer.StartAsync();
+
+        await StartWithDiagnosticsAsync(_playwrightContainer, "playwright");
 
         _playwright = await Playwright.CreateAsync();
-        Browser = await _playwright.Chromium.ConnectAsync(_playwrightContainer.GetConnectionString());
+        string browserWsEndpoint = new UriBuilder(
+            "ws", _playwrightContainer.Hostname, _playwrightContainer.GetMappedPublicPort(PlaywrightPort)).ToString();
+        Browser = await _playwright.Chromium.ConnectAsync(
+            browserWsEndpoint, new BrowserTypeConnectOptions { Timeout = 60_000 });
     }
 
     /// <summary>

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/LotroKoniecDev.Frontend.E2E.Tests.csproj
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/LotroKoniecDev.Frontend.E2E.Tests.csproj
@@ -16,7 +16,6 @@
         <PackageReference Include="Microsoft.Playwright" />
         <PackageReference Include="Shouldly" />
         <PackageReference Include="Testcontainers" />
-        <PackageReference Include="Testcontainers.Playwright" />
         <PackageReference Include="Testcontainers.PostgreSql" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/README.md
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/README.md
@@ -13,8 +13,10 @@ postgres ─ migrator ─ auth-api ─ tms-api ─ frontend ─ mailpit ─ play
 ```
 
 - All app services get a DNS alias and serve **HTTPS** (`https://auth-api:8443`, `https://frontend:8443`).
-- The **browser is a container too** (the official `Testcontainers.Playwright` module); the host test
-  connects to it over WebSocket (`Chromium.ConnectAsync(container.GetConnectionString())`). Because the
+- The **browser is a container too** — a Playwright `run-server` container we build by hand (the
+  `Testcontainers.Playwright` module hard-codes a `localhost` readiness probe and omits run-server's
+  `--host`, both broken on Playwright v1.55+ images; see `PlaywrightStackFixture.StartBrowserAsync`).
+  The host test connects to it over WebSocket (`Chromium.ConnectAsync(ws://host:mappedPort/)`). Because the
   browser and the Frontend's OIDC back-channel are on the **same** network, `https://auth-api:8443`
   resolves identically for both — so the single-`Authority` OIDC constraint (ADR-0006) holds in-network.
 - HTTPS is mandatory (the OIDC correlation cookie is `SameSite=None`). The cert is **generated in C#**


### PR DESCRIPTION
Follow-up changes on top of the StronglyTypedId refactor (#200, already merged).

## Changes
- **explicit `default` keywords** for the static empty instantiations of the custom record-struct IDs (`GameVersionId`, `TranslationId`, `TranslatorId`, `PrecomputedTranslationFileId`).
- **FE E2E test bugfixes** — `PlaywrightStackFixture` hardening, `Login.cshtml` tweak, removal of an unused package reference, and doc/README touch-ups in the Frontend E2E test project.

## Notes
- Branched off the squash-merged `main` (`#200`), so this PR contains only these two commits.