### PR TITLE
fix(tests): repair patcher E2E after src/Patcher grouping (#197)

### DIFF
--- a/tests/LotroKoniecDev.Tests.E2E/TestFixture.cs
+++ b/tests/LotroKoniecDev.Tests.E2E/TestFixture.cs
@@ -153,7 +153,7 @@ public sealed class E2ETestFixture : IAsyncLifetime
     private static async Task BuildCliProjectAsync()
     {
         string solutionRoot = FindSolutionRoot();
-        string cliProjectPath = Path.Combine(solutionRoot, "src", CliProjectName);
+        string cliProjectPath = Path.Combine(solutionRoot, "src", "Patcher", CliProjectName);
 
         using Process process = new();
         process.StartInfo = new ProcessStartInfo
@@ -206,12 +206,12 @@ public sealed class E2ETestFixture : IAsyncLifetime
     private static string FindCliExe()
     {
         string solutionRoot = FindSolutionRoot();
-        string cliBinDir = Path.Combine(solutionRoot, "src", CliProjectName, "bin");
+        string cliBinDir = Path.Combine(solutionRoot, "src", "Patcher", CliProjectName, "bin");
 
         if (!Directory.Exists(cliBinDir))
         {
             throw new InvalidOperationException(
-                $"CLI bin directory not found at {cliBinDir}. Build the CLI first: dotnet build src/{CliProjectName}");
+                $"CLI bin directory not found at {cliBinDir}. Build the CLI first: dotnet build src/Patcher/{CliProjectName}");
         }
 
         string exeName = $"{CliProjectName}.exe";
@@ -219,7 +219,7 @@ public sealed class E2ETestFixture : IAsyncLifetime
             .OrderByDescending(File.GetLastWriteTimeUtc)
             .FirstOrDefault() 
             ?? throw new InvalidOperationException(
-                $"CLI exe '{exeName}' not found under {cliBinDir}. Build the CLI first: dotnet build src/{CliProjectName}");
+                $"CLI exe '{exeName}' not found under {cliBinDir}. Build the CLI first: dotnet build src/Patcher/{CliProjectName}");
 
         return exePath;
     }

--- a/tests/LotroKoniecDev.Tests.E2E/Tests/ErrorPathE2ETests.cs
+++ b/tests/LotroKoniecDev.Tests.E2E/Tests/ErrorPathE2ETests.cs
@@ -103,8 +103,8 @@ public sealed class ErrorPathE2ETests
         CliResult result = await _fixture.RunCliAsync(
             $"patch \"{garbagePath}\" -d \"{tempDatPath}\"");
 
-        //Assert — parser returns empty list → Patcher returns NoTranslations → exit code 3
-        result.ExitCode.ShouldBe((int)CliExitCode.OperationFailed,
+        //Assert — parser skips all unparseable lines → empty list → NoTranslations (Validation) → exit code 1
+        result.ExitCode.ShouldBe((int)CliExitCode.InvalidArguments,
             $"Patch with garbage translations should fail. stdout: {result.Stdout}");
     }
 
@@ -127,8 +127,8 @@ public sealed class ErrorPathE2ETests
         CliResult result = await _fixture.RunCliAsync(
             $"patch \"{commentsPath}\" -d \"{tempDatPath}\"");
 
-        //Assert — all lines skipped → empty translations → exit code 3
-        result.ExitCode.ShouldBe((int)CliExitCode.OperationFailed,
+        //Assert — all lines skipped → empty translations → NoTranslations (Validation) → exit code 1
+        result.ExitCode.ShouldBe((int)CliExitCode.InvalidArguments,
             $"Patch with comment-only file should fail. stdout: {result.Stdout}");
     }
 


### PR DESCRIPTION
## What

Two Windows-only patcher E2E breakages — both invisible on the macOS/CI gate (the patcher E2E suite is `SkippableFact` off-Windows and off the PR gate by name).

- **`TestFixture.cs`** — CLI project + `bin` paths now resolve under `src/Patcher/`. The #197 grouping refactor moved the projects but left the fixture pointing at `src/<CliProjectName>`, so setup threw `MSB1003` and **all 23 E2E tests failed** on first Windows run.
- **`ErrorPathE2ETests.cs`** — garbage / comment-only patch input yields an empty translation list → `NoTranslations`, which is `Error.Validation` → exit code **1** (`InvalidArguments`), not **3** (`OperationFailed`). These two asserts were wrong since M1; only surfaced now that the suite runs green again.

## Verification

`dotnet test tests/LotroKoniecDev.Tests.E2E` → **23/23 passed** on Windows (real DAT in `TestData/`, no admin). Zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)