### PR TITLE
Critical bug: lift exported.txt upload cap (30 MB → 256 MB) (#208)

### DIFF
--- a/docs/specs/0003-large-export-upload.md
+++ b/docs/specs/0003-large-export-upload.md
@@ -1,0 +1,87 @@
+# Spec 0003: Large exported.txt upload (lift the 30 MB cap)
+
+- **Status:** Implemented
+- **Date:** 2026-06-28
+- **Author:** ticket-worker
+- **Ticket:** #208 (Critical bug — exported.txt is too large to upload)
+- **Related:** spec 0001 (import lifecycle), KittySaver `CreateCatGalleryItem` (RequestSizeLimit mirror), branch `208-critical-bug-exportedtxt-is-too-large-to-upload`
+
+## Business context
+
+An admin updates the catalog by uploading a fresh `exported.txt` through the Blazor SSR import form,
+which forwards it to the TMS API's import endpoint (spec 0001). The export is ~80 MB today and grows
+as the game adds text, but both hops cap a request body at Kestrel's 30 MB default, so the upload is
+rejected before it can be imported — the core update loop is blocked. This is a critical bug.
+
+## Goal
+
+An admin can upload the entire `exported.txt` (~80 MB, with headroom to grow) in a single operation
+and have it imported, without the request being rejected for its size or aborted by a client timeout.
+
+## In scope
+
+- Lift the request-body and multipart form-length limits to a shared ceiling on **both** hops:
+  the Frontend host (browser → Blazor SSR form) and the TMS API import endpoint (Frontend → API).
+- A single shared ceiling constant (`ImportUploadLimits.MaxUploadBytes` = 256 MB), with the API side
+  configurable via `Import:MaxUploadBytes` so ops can lift it further without a code change.
+- Make the Frontend's resilience (Polly) timeout upload-aware: a multipart upload gets a wide budget
+  (the default 10 s would abort an ~80 MB upload + its synchronous server-side import).
+- A clean, actionable `413 Payload Too Large` when an upload does exceed the ceiling.
+
+## Out of scope
+
+- A **chunked / resumable upload protocol** (e.g. tus). The present need is "the cap blocks 80 MB",
+  not "uploads are interrupted"; a single admin uploads occasionally over a reliable connection, and
+  the house YAGNI rule says pick the simple path. Revisit only if real uploads prove unreliable.
+- Streaming the import row-by-row off the socket — the framework still buffers the upload to a temp
+  file (spills past 64 KB), which is fine for an admin-only, infrequent operation.
+- Changing the import's semantics — it is already atomic (one DB transaction, all-or-nothing,
+  idempotent re-upload; spec 0001). "Atomically" here means the whole file in one request, which the
+  single multipart POST already delivers.
+- Ingress/reverse-proxy body limits (Caddy streams with no default cap; ACA ingress limits are large
+  and configured in infra, not app code) — a deployment concern, noted in the runbook if it bites.
+
+## Business rules & edge cases
+
+- An upload at or under the ceiling is accepted and imported as before.
+- An upload over the ceiling is rejected with `413 Payload Too Large` (a ProblemDetails the Frontend
+  surfaces) — consistently, whether Kestrel's request-body cap (real 413) or the multipart
+  form-length cap (an `InvalidDataException` that minimal-API binding wraps as a 400) trips first.
+- The endpoint stays admin-only and rate-limited, which bounds the abuse surface of a high ceiling.
+- No server-side request timeout is added: a full-catalog import legitimately runs for minutes.
+
+## Contract
+
+- **Trigger:** `POST /api/v1/game-versions/{id}/import` (multipart `file`), unchanged route.
+- **Input:** `ImportExportedTexts.Command(GameVersionId, Stream, bool AllowMassRemoval)` — unchanged.
+- **Output:** `ImportSummary` (200) — unchanged.
+- **Errors:** existing 401/403/404/422; **new** `413 Payload Too Large` when the body exceeds the
+  configured ceiling.
+- **Config:** `ImportUploadLimits.MaxUploadBytes` (shared const, 256 MB) is the API default for
+  `Import:MaxUploadBytes` and the Frontend's Kestrel + form ceiling.
+- **Files touched:** none on disk beyond the framework's transient upload temp file.
+
+## Acceptance criteria
+
+- [x] An `exported.txt` well over the legacy 30 MB cap is accepted by the API import endpoint
+      (request-body + multipart limits raised to the configured ceiling).
+- [x] The Frontend host accepts and forwards a body over the legacy 30 MB cap (Kestrel + form limits
+      raised to the same ceiling).
+- [x] An upload exceeding the configured ceiling is rejected with `413` and persists no rows.
+- [x] A multipart upload is granted a far wider client timeout than an ordinary JSON call, so a large
+      upload + import is not aborted mid-flight.
+
+## Open questions
+
+- **How should "atomic large upload" work — single-request (raise limits) or chunked/resumable?**
+  Resolved by derivation, not invention: the house YAGNI rule ("pick the simple path; don't add infra
+  without a real present need") plus the context (zero users, a single admin, occasional uploads over
+  a reliable link, an already-atomic import) point to single-request + raised limits. A chunked
+  protocol is deferred (Out of scope). Flagged here so the user can veto before merge if they actually
+  want resumable uploads.
+
+## Assumptions
+
+- The export stays a single plain-text `||` file uploaded whole (spec 0001 contract); it does not
+  become a multi-part or compressed artifact.
+- 256 MB (≈3× today's ~80 MB) is enough headroom for years; if not, it is a one-line config bump.

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientsDependencyInjectionExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientsDependencyInjectionExtensions.cs
@@ -3,6 +3,7 @@ using LotroKoniecDev.Frontend.Settings;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 using Polly;
+using Polly.Timeout;
 
 namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 
@@ -19,6 +20,11 @@ public static class HttpClientsDependencyInjectionExtensions
                     TranslationSystemSettings settings = sp
                         .GetRequiredService<IOptions<TranslationSystemSettings>>().Value;
                     client.BaseAddress = new Uri(settings.BaseUrl);
+
+                    // Let the resilience pipeline own the time budget: HttpClient.Timeout is a single cap
+                    // across the whole pipeline (and would otherwise default to 100 s, cutting a large
+                    // upload short), whereas the per-attempt timeout below scales with the request kind.
+                    client.Timeout = Timeout.InfiniteTimeSpan;
                 })
                 .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
                 {
@@ -52,8 +58,34 @@ public static class HttpClientsDependencyInjectionExtensions
             ShouldHandle = args => ValueTask.FromResult(IsHandledTransientFailure(args.Outcome, args.Context))
         });
 
-        pipeline.AddTimeout(TimeSpan.FromSeconds(10));
+        // A normal JSON call keeps the tight default budget, but a multipart upload carries exported.txt
+        // (~80 MB and growing) and then waits on the API's synchronous import — minutes, not seconds. The
+        // body is forward-only so it is already excluded from retries (below); the single attempt simply
+        // needs a wider window than the default, or a healthy upload is aborted mid-flight (spec 0003).
+        pipeline.AddTimeout(new TimeoutStrategyOptions
+        {
+            TimeoutGenerator = args => ValueTask.FromResult(ResolveTimeout(args.Context.GetRequestMessage()))
+        });
     }
+
+    /// <summary>The per-attempt budget for ordinary (JSON) calls — kept tight so a stalled API fails fast.</summary>
+    internal static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// The per-attempt budget for a multipart upload: it must cover transferring exported.txt (~80 MB)
+    /// plus the API's synchronous import (parse + full diff + save + artifact rebuild), so it is far
+    /// longer than <see cref="DefaultRequestTimeout"/> (spec 0003, #208).
+    /// </summary>
+    internal static readonly TimeSpan UploadRequestTimeout = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Picks the resilience timeout for a request: the wide upload budget when the body is a multipart
+    /// form (the exported.txt upload), otherwise the tight default for ordinary JSON calls.
+    /// </summary>
+    internal static TimeSpan ResolveTimeout(HttpRequestMessage? request) =>
+        request?.Content is MultipartFormDataContent
+            ? UploadRequestTimeout
+            : DefaultRequestTimeout;
 
     /// <summary>
     /// Multipart uploads are excluded: their body stream is forward-only and cannot be replayed, so a

--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -7,6 +7,7 @@ using LotroKoniecDev.Frontend.Infrastructure.Auth;
 using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Settings;
 using LotroKoniecDev.Options;
+using LotroKoniecDev.TranslationSystem.Contracts.Import;
 using Microsoft.AspNetCore.Http.Features;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -83,6 +84,15 @@ try
         options.KnownIPNetworks.Clear();
         options.KnownProxies.Clear();
     });
+
+    // The Blazor SSR import form (admin-only) uploads exported.txt, which is ~80 MB and grows — far
+    // past Kestrel's 30 MB default body cap and the framework's multipart form-length limit. Lift both
+    // to the shared upload ceiling so the whole file posts to this host in one request, then streams on
+    // to the TMS API (spec 0003, #208).
+    builder.WebHost.ConfigureKestrel(kestrelOptions =>
+        kestrelOptions.Limits.MaxRequestBodySize = ImportUploadLimits.MaxUploadBytes);
+    builder.Services.Configure<FormOptions>(formOptions =>
+        formOptions.MultipartBodyLengthLimit = ImportUploadLimits.MaxUploadBytes);
 
     builder.Services.AddRazorComponents();
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using FluentValidation;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -78,6 +79,14 @@ internal static class ApiDependencyInjection
         {
             services.AddSingleton<ITranslationExportParser, TranslationExportParser>();
             services.AddOptions<ImportSettings>().BindConfiguration(ImportSettings.ConfigurationSection);
+
+            // The import is the only multipart endpoint, so lifting the global multipart form-length
+            // limit to the configured upload ceiling is safe and keeps it in step with the endpoint's
+            // request-body limit — otherwise the framework's 128 MB default would cap a larger ceiling
+            // (spec 0003, #208).
+            services.AddOptions<FormOptions>()
+                .Configure<IOptions<ImportSettings>>((formOptions, importSettings) =>
+                    formOptions.MultipartBodyLengthLimit = importSettings.Value.MaxUploadBytes);
 
             services.AddScoped<IValidator<ImportExportedTexts.Command>, ImportExportedTexts.Validator>();
             services.AddScoped<ICommandHandler<ImportExportedTexts.Command, Result<ImportSummary>>, ImportExportedTexts.Handler>();

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/BadHttpRequestExceptionHandler.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ExceptionHandlers/BadHttpRequestExceptionHandler.cs
@@ -30,13 +30,26 @@ internal sealed partial class BadHttpRequestExceptionHandler : IExceptionHandler
             return false;
         }
 
-        ProblemDetails problemDetails = new()
-        {
-            Status = badHttpRequestException.StatusCode,
-            Type = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
-            Title = "Bad Request",
-            Extensions = { ["errorCode"] = "Http.BadRequest" }
-        };
+        // An oversized upload surfaces inconsistently — Kestrel's request-body cap throws a 413, while
+        // the multipart form-length cap throws an InvalidDataException that minimal-API binding wraps as
+        // a generic 400. Normalize both to a clean 413 so an admin uploading too large an exported.txt
+        // gets an actionable "too large" response rather than a bare "Bad Request" (#208).
+        ProblemDetails problemDetails = IsPayloadTooLarge(badHttpRequestException)
+            ? new ProblemDetails
+            {
+                Status = StatusCodes.Status413PayloadTooLarge,
+                Type = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413",
+                Title = "Payload Too Large",
+                Detail = "The upload exceeds the maximum allowed size.",
+                Extensions = { ["errorCode"] = "Http.PayloadTooLarge" }
+            }
+            : new ProblemDetails
+            {
+                Status = badHttpRequestException.StatusCode,
+                Type = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+                Title = "Bad Request",
+                Extensions = { ["errorCode"] = "Http.BadRequest" }
+            };
 
         if (_environment.IsTesting() || _environment.IsDevelopment())
         {
@@ -57,6 +70,25 @@ internal sealed partial class BadHttpRequestExceptionHandler : IExceptionHandler
 
         return true;
     }
+
+    /// <summary>
+    /// True when the bad request is really an over-limit upload, to be normalized to 413: a direct 413
+    /// from Kestrel's request-body cap, or — because the multipart form reader's length cap throws an
+    /// <see cref="InvalidDataException"/> that minimal-API binding wraps as a 400 — a wrapped
+    /// <see cref="InvalidDataException"/> or wrapped 413.
+    /// <para>
+    /// The <see cref="InvalidDataException"/> arm maps <em>every</em> wrapped form-read data error to
+    /// 413, not only the size one. That is acceptable today because the version-bound import upload is
+    /// the API's only form-accepting endpoint and, with the framework's default form limits, its sole
+    /// realistic form-read failure is the body-length (size) cap. Revisit this predicate before adding
+    /// another form endpoint whose other form limits (key/value/count) could legitimately trip — those
+    /// are genuine 400s, not "too large".
+    /// </para>
+    /// </summary>
+    private static bool IsPayloadTooLarge(BadHttpRequestException exception)
+        => exception.StatusCode == StatusCodes.Status413PayloadTooLarge
+           || exception.InnerException is InvalidDataException
+           || exception.InnerException is BadHttpRequestException { StatusCode: StatusCodes.Status413PayloadTooLarge };
 
     [LoggerMessage(EventId = EventIds.BadHttpRequest, Level = LogLevel.Warning, Message = "Bad HTTP request: {ErrorCode} ({ErrorType}) — {ErrorMessage}")]
     private static partial void LogBadHttpRequest(ILogger logger, Exception exception, string errorCode, string errorType, string errorMessage);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
@@ -222,6 +222,13 @@ internal sealed class ImportExportedTexts : IEndpoint
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
     {
+        // The exported.txt is ~80 MB and grows, so this single endpoint overrides Kestrel's 30 MB
+        // default body cap with the configured ceiling (spec 0003, #208). No server-side request
+        // timeout is added: a full-catalog import legitimately runs for minutes, and the only client
+        // budget that needed lifting is the Frontend's (HttpClientsDependencyInjectionExtensions).
+        long maxUploadBytes = endpointRouteBuilder.ServiceProvider
+            .GetRequiredService<IOptions<ImportSettings>>().Value.MaxUploadBytes;
+
         endpointRouteBuilder.MapPost("/api/v1/game-versions/{id:guid}/import", async (
                 Guid id,
                 IFormFile file,
@@ -243,8 +250,10 @@ internal sealed class ImportExportedTexts : IEndpoint
             .WithTags("Import")
             .RequireAuthorization(AuthorizationPolicies.RequireAdminRole)
             .DisableAntiforgery()
+            .WithMetadata(new RequestSizeLimitAttribute(maxUploadBytes))
             .Produces<ImportSummary>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status413PayloadTooLarge)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
     }
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportSettings.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportSettings.cs
@@ -1,3 +1,5 @@
+using LotroKoniecDev.TranslationSystem.Contracts.Import;
+
 namespace LotroKoniecDev.TranslationSystem.API.Features.Import;
 
 /// <summary>
@@ -11,4 +13,12 @@ internal sealed class ImportSettings
     public const string ConfigurationSection = "Import";
 
     public double MaxRemovedFractionWithoutOverride { get; init; } = 0.20;
+
+    /// <summary>
+    /// Maximum accepted upload size in bytes, enforced on the import endpoint (request body + multipart
+    /// form length). Defaults to <see cref="ImportUploadLimits.MaxUploadBytes"/>; configurable so ops
+    /// can lift it as the export grows without a code change (it is read at startup, so a restart — not
+    /// a redeploy — applies a new value) (spec 0003, #208).
+    /// </summary>
+    public long MaxUploadBytes { get; init; } = ImportUploadLimits.MaxUploadBytes;
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Import/ImportUploadLimits.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Import/ImportUploadLimits.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.TranslationSystem.Contracts.Import;
+
+/// <summary>
+/// Upload-size ceiling for an <c>exported.txt</c> import, shared by both ends of the upload so they
+/// never disagree: the Frontend's Blazor SSR form (its Kestrel request-body + multipart form limits)
+/// and the TMS API's import endpoint (its per-endpoint request-body + multipart form limits). The
+/// export is ~80 MB today and grows as the game adds text, so the ceiling keeps a wide headroom while
+/// still bounding an oversized/abusive upload — the endpoint is admin-only and rate-limited.
+/// </summary>
+public static class ImportUploadLimits
+{
+    /// <summary>Maximum accepted <c>exported.txt</c> upload size, in bytes (256 MB).</summary>
+    public const long MaxUploadBytes = 256L * 1024 * 1024;
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientsResilienceTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientsResilienceTests.cs
@@ -1,0 +1,58 @@
+using System.Net.Http.Json;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+
+/// <summary>
+/// Guards the resilience pipeline's per-request timeout decision (#208): the exported.txt upload is a
+/// multipart POST that must be granted a far wider budget than an ordinary JSON call, or a healthy
+/// ~80 MB upload is aborted mid-flight by the tight default while the API is still importing.
+/// </summary>
+public sealed class HttpClientsResilienceTests
+{
+    [Fact]
+    public void ResolveTimeout_ForMultipartUpload_UsesTheWiderUploadBudget()
+    {
+        using MultipartFormDataContent content = new();
+        using HttpRequestMessage request = new(HttpMethod.Post, "api/v1/game-versions/x/import")
+        {
+            Content = content
+        };
+
+        TimeSpan timeout = HttpClientsDependencyInjectionExtensions.ResolveTimeout(request);
+
+        timeout.ShouldBe(HttpClientsDependencyInjectionExtensions.UploadRequestTimeout);
+        timeout.ShouldBeGreaterThan(HttpClientsDependencyInjectionExtensions.DefaultRequestTimeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_ForJsonRequest_UsesTheTightDefaultBudget()
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, "api/v1/translations")
+        {
+            Content = JsonContent.Create(new { id = 1 })
+        };
+
+        TimeSpan timeout = HttpClientsDependencyInjectionExtensions.ResolveTimeout(request);
+
+        timeout.ShouldBe(HttpClientsDependencyInjectionExtensions.DefaultRequestTimeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_ForRequestWithoutContent_UsesTheTightDefaultBudget()
+    {
+        using HttpRequestMessage request = new(HttpMethod.Get, "api/v1/game-versions");
+
+        TimeSpan timeout = HttpClientsDependencyInjectionExtensions.ResolveTimeout(request);
+
+        timeout.ShouldBe(HttpClientsDependencyInjectionExtensions.DefaultRequestTimeout);
+    }
+
+    [Fact]
+    public void ResolveTimeout_ForNullRequest_UsesTheTightDefaultBudget()
+    {
+        TimeSpan timeout = HttpClientsDependencyInjectionExtensions.ResolveTimeout(null);
+
+        timeout.ShouldBe(HttpClientsDependencyInjectionExtensions.DefaultRequestTimeout);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
@@ -13,7 +14,10 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Import;
@@ -262,6 +266,58 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         (await CountTranslationsAsync()).ShouldBe(1);
     }
 
+    [Fact]
+    public async Task Import_BodyExceedingConfiguredUploadLimit_ShouldReturn413()
+    {
+        // Arrange — a host whose upload ceiling is tiny, so a small payload deterministically trips the
+        // limit. Production lifts the ceiling to ImportUploadLimits.MaxUploadBytes (256 MB) so the
+        // ~80 MB exported.txt posts in one request (#208); here we only prove the ceiling is enforced.
+        // The single Import:MaxUploadBytes key drives both the request-body cap (RequestSizeLimitAttribute)
+        // and the multipart form-length cap (FormOptions), so this asserts the configured ceiling is
+        // enforced without isolating which cap fires; both map to the same 413 (see BadHttpRequestExceptionHandler).
+        const long uploadLimit = 64 * 1024;
+        using WebApplicationFactory<Program> factory = WithUploadLimit(uploadLimit);
+        GameVersionId versionId = await SeedVersionAsync("48.0");
+        using HttpClient client = AdminClient(factory);
+
+        string oversized = string.Join('\n', Enumerable.Repeat(Line(1, "Alpha"), 5_000));
+        Encoding.UTF8.GetByteCount(oversized).ShouldBeGreaterThan((int)uploadLimit);
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(ImportRoute(versionId), TextContent(oversized));
+
+        // Assert — rejected at the transport layer before any row is written.
+        response.StatusCode.ShouldBe(HttpStatusCode.RequestEntityTooLarge);
+        (await CountTranslationsAsync()).ShouldBe(0);
+        (await GetVersionStatusAsync(versionId)).ShouldBe(GameVersionStatus.Unprocessed);
+    }
+
+    [Fact]
+    public async Task Import_BodyWithinConfiguredUploadLimit_ShouldStillSucceed()
+    {
+        // Arrange — the same tiny ceiling, but a payload comfortably under it must still import: the
+        // limit is a ceiling, not a blanket rejection.
+        const long uploadLimit = 64 * 1024;
+        using WebApplicationFactory<Program> factory = WithUploadLimit(uploadLimit);
+        GameVersionId versionId = await SeedVersionAsync("48.0");
+        using HttpClient client = AdminClient(factory);
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(ImportRoute(versionId), ExportContent(Line(1, "Alpha")));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await CountTranslationsAsync()).ShouldBe(1);
+    }
+
+    private WebApplicationFactory<Program> WithUploadLimit(long maxUploadBytes) =>
+        _factory.WithWebHostBuilder(builder =>
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Import:MaxUploadBytes"] = maxUploadBytes.ToString(CultureInfo.InvariantCulture)
+                })));
+
     private static async Task<string?> ReadErrorCodeAsync(HttpResponseMessage response)
     {
         await using Stream stream = await response.Content.ReadAsStreamAsync();
@@ -284,9 +340,11 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         return new MultipartFormDataContent { { fileContent, "file", "exported.txt" } };
     }
 
-    private HttpClient AdminClient()
+    private HttpClient AdminClient() => AdminClient(_factory);
+
+    private static HttpClient AdminClient(WebApplicationFactory<Program> factory)
     {
-        HttpClient client = _factory.CreateClient();
+        HttpClient client = factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
             "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Admin));
         return client;

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/ExceptionHandlers/BadHttpRequestExceptionHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/ExceptionHandlers/BadHttpRequestExceptionHandlerTests.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using LotroKoniecDev.TranslationSystem.API.ExceptionHandlers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.ExceptionHandlers;
+
+/// <summary>
+/// Pins the bad-request handler's status normalization (#208): an over-limit upload — however the
+/// framework surfaces it — is reported as a clean 413, while every other bad request stays 400 and a
+/// non-bad-request exception is left for the next handler.
+/// </summary>
+public sealed class BadHttpRequestExceptionHandlerTests
+{
+    [Fact]
+    public async Task TryHandleAsync_ForKestrelRequestBodyTooLarge_ShouldReturn413()
+    {
+        BadHttpRequestException exception = new("Request body too large.", StatusCodes.Status413PayloadTooLarge);
+
+        (bool handled, DefaultHttpContext context, ProblemDetails? problemDetails) = await HandleAsync(exception);
+
+        handled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status413PayloadTooLarge);
+        problemDetails.ShouldNotBeNull();
+        problemDetails.Status.ShouldBe(StatusCodes.Status413PayloadTooLarge);
+        problemDetails.Extensions["errorCode"].ShouldBe("Http.PayloadTooLarge");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ForMultipartLengthLimitWrappedAsBadRequest_ShouldReturn413()
+    {
+        // The multipart form-length cap throws InvalidDataException, which minimal-API binding wraps as
+        // a generic 400 — normalized here to a clean 413.
+        BadHttpRequestException exception = new(
+            "Failed to read parameter \"file\" from the request body as form.",
+            StatusCodes.Status400BadRequest,
+            new InvalidDataException("Multipart body length limit 65536 exceeded."));
+
+        (bool handled, DefaultHttpContext context, ProblemDetails? problemDetails) = await HandleAsync(exception);
+
+        handled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status413PayloadTooLarge);
+        problemDetails.ShouldNotBeNull();
+        problemDetails.Extensions["errorCode"].ShouldBe("Http.PayloadTooLarge");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ForKestrel413WrappedDuringFormRead_ShouldReturn413()
+    {
+        // Kestrel's request-body cap (413) thrown while the form reader pulls the body, wrapped as a 400.
+        BadHttpRequestException exception = new(
+            "Failed to read parameter \"file\" from the request body as form.",
+            StatusCodes.Status400BadRequest,
+            new BadHttpRequestException("Request body too large.", StatusCodes.Status413PayloadTooLarge));
+
+        (bool handled, DefaultHttpContext context, ProblemDetails? problemDetails) = await HandleAsync(exception);
+
+        handled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status413PayloadTooLarge);
+        problemDetails.ShouldNotBeNull();
+        problemDetails.Extensions["errorCode"].ShouldBe("Http.PayloadTooLarge");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ForOrdinaryBadRequest_ShouldStay400()
+    {
+        // A malformed JSON body is a genuine 400 and must NOT be relabeled "too large" — the regression
+        // guard for the over-broad payload-too-large detection.
+        BadHttpRequestException exception = new(
+            "Failed to read parameter \"command\" from the request body as JSON.",
+            StatusCodes.Status400BadRequest,
+            new JsonException("Unexpected end of JSON input."));
+
+        (bool handled, DefaultHttpContext context, ProblemDetails? problemDetails) = await HandleAsync(exception);
+
+        handled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+        problemDetails.ShouldNotBeNull();
+        problemDetails.Extensions["errorCode"].ShouldBe("Http.BadRequest");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ForNonBadHttpRequestException_ShouldNotHandle()
+    {
+        (bool handled, DefaultHttpContext context, ProblemDetails? problemDetails) =
+            await HandleAsync(new InvalidOperationException("boom"));
+
+        handled.ShouldBeFalse();
+        problemDetails.ShouldBeNull();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status200OK);
+    }
+
+    private static async Task<(bool Handled, DefaultHttpContext Context, ProblemDetails? ProblemDetails)> HandleAsync(
+        Exception exception)
+    {
+        ProblemDetails? captured = null;
+        IProblemDetailsService problemDetailsService = Substitute.For<IProblemDetailsService>();
+        problemDetailsService
+            .When(service => service.WriteAsync(Arg.Any<ProblemDetailsContext>()))
+            .Do(call => captured = call.Arg<ProblemDetailsContext>().ProblemDetails);
+
+        // Production environment so the handler keeps its clean ProblemDetails rather than enriching it
+        // with the raw exception message / stack trace (which it does only in Development/Testing).
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns("Production");
+
+        BadHttpRequestExceptionHandler handler = new(
+            NullLogger<BadHttpRequestExceptionHandler>.Instance,
+            environment,
+            problemDetailsService);
+
+        DefaultHttpContext context = new();
+        bool handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        return (handled, context, captured);
+    }
+}


### PR DESCRIPTION
Closes #208

## What

The Blazor SSR import form and the TMS API import endpoint both capped the request body at Kestrel's 30 MB default, so the ~80 MB `exported.txt` that drives the catalog-update loop could not be uploaded at all (critical bug). This lifts both hops to a shared, configurable ceiling.

## Why

`exported.txt` is ~80 MB today and grows as the game adds text. A single admin uploads it occasionally over a reliable link, and the import is already atomic (one transaction, idempotent re-upload), so the simple fix — raise the limits — is the right one. Chunked/resumable upload is deferred (spec 0003, Out of scope).

## How

- **Shared ceiling** `ImportUploadLimits.MaxUploadBytes` = 256 MB in `Contracts`, referenced by both ends so they never disagree. API side configurable via `Import:MaxUploadBytes` (restart, not redeploy).
- **API** (`ImportExportedTexts`, `ApiDependencyInjection`): per-endpoint `RequestSizeLimit` + global `FormOptions.MultipartBodyLengthLimit` raised to the ceiling.
- **Frontend host** (`Program.cs`): Kestrel `MaxRequestBodySize` + `FormOptions` raised to the same ceiling; the form forwards as `MultipartFormDataContent`.
- **Frontend resilience** (`HttpClientsDependencyInjectionExtensions`): a multipart upload gets a 5 min per-attempt timeout (vs 10 s for JSON) and stays excluded from retries — a healthy large upload + synchronous import is not aborted mid-flight.
- **413 normalization** (`BadHttpRequestExceptionHandler`): an over-ceiling upload surfaces a clean `413 Payload Too Large` whether Kestrel's body cap or the multipart form-length cap trips first.

## Tests

- Integration (real PostgreSQL): over-ceiling → 413 + no rows + version stays Unprocessed; under-ceiling → still imports.
- Unit: exception handler — all three 413 exception shapes + a 400 regression guard; resilience — multipart/JSON/no-content/null timeout selection.
- Build green, zero warnings; full import suite (14) + new unit suites (5 + 4) pass. Verified locally end-to-end with a real ~80 MB file.

## Follow-up (not in this PR)

The import itself runs for minutes on the full catalog — it's vanilla per-row EF Core change tracking over hundreds of thousands of rows. A separate ticket (spec + ADR) will move the import write path to bulk/set-based DB operations (`COPY` + set-based diff). Orthogonal to this cap fix.

## Out of scope

Chunked/resumable upload, row-by-row streaming, ingress/proxy body limits. A >256 MB browser upload is rejected at the Frontend hop and lands on the generic error page (conscious accept — 256 MB is ~3× today's file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)