### PR TITLE
209 fe lack of crud operation ui for managing gameversion

### DIFF
--- a/docs/specs/0005-game-versions-management-ui.md
+++ b/docs/specs/0005-game-versions-management-ui.md
@@ -1,0 +1,125 @@
+# Spec 0005: Game versions management UI (Frontend) + guarded delete
+
+- **Status:** Agreed
+- **Date:** 2026-06-28
+- **Author:** koniecdev
+- **Ticket:** #209 (FE — CRUD UI for managing GameVersion)
+- **Related:** Spec 0001 (game-update lifecycle), ADR-0003 (LotroNotationVersion canonical form),
+  #107/M2-19 (GameVersion endpoints), #158/M3-12 (HATEOAS-driven affordances), `Components/Pages/ImportExport/` (sibling slice)
+
+## Business context
+
+After a LOTRO update the admin reacts to detected game versions (spec 0001): a forum watcher
+(deferred, #85) creates **unprocessed** `GameVersion` rows, and the admin imports a fresh
+`exported.txt` against the relevant version. Today the only place versions surface in the Frontend
+is the import/export page's target `<select>` — there is **no dedicated screen** to review every
+known version (detected vs processed vs superseded) and **no UI to manually register** a version
+when the forum scrape is down (spec 0001's "degenerate fallback", exposed by `POST
+/api/v1/game-versions` in #107 but never wired into the UI). A manual register is also error-prone
+(a typo'd version string), so the admin needs a way to **remove a mistaken, not-yet-used entry**.
+#209 closes that gap.
+
+## Goal
+
+An authenticated translator can review every known game version (newest-first, with detection time
+and lifecycle status). An admin can manually register a new version when the forum is unavailable,
+and delete a still-unprocessed version they registered by mistake.
+
+## In scope
+
+- New Blazor **Static SSR** page `/game-versions` (`Components/Pages/GameVersions/`): lists
+  `GET /api/v1/game-versions` newest-first — version string, detected-at, status badge.
+- Admin-only **register-version** form (plain `<form method="post">` SSR idiom), shown only when the
+  collection advertises the admin-only `register` rel (#158 affordance pattern), POSTing to
+  `POST /api/v1/game-versions` through the typed client.
+- Admin-only **delete** affordance per row, shown only when the item advertises a `delete` rel
+  (emitted for admins on **Unprocessed** versions), POSTing to a new `DELETE /api/v1/game-versions/{id}`.
+- **New backend delete slice** `Features/GameVersions/DeleteGameVersion.cs` with a domain guard:
+  delete only when the version is `Unprocessed` **and** referenced by no translation; otherwise a
+  `Result` conflict failure. `IGameVersionRepository.Delete` + an
+  `ITranslationRepository`/read-side "is any translation bound to this version?" check.
+- A `GameVersionsLoader` (thin injectable client seam, mirrors `ImportExportLoader`):
+  `ListGameVersionsAsync` + `RegisterGameVersionAsync` + `DeleteGameVersionAsync`.
+- `Rels.Delete` + the link factory emitting `delete` (item-level, admin + Unprocessed).
+- Sidebar nav entry, DI registration, handler/endpoint integration tests + bUnit render tests + loader tests.
+
+## Out of scope
+
+- **Manual status edit** (mark Processed/Superseded) — status is lifecycle-driven by import/approve
+  (spec 0001), not manually editable; the version string is the aggregate's identity. Exposing
+  manual status edits would contradict the lifecycle model.
+- **Deleting a Processed/Superseded or referenced version** — domain-unsafe: a `GameVersion` is
+  referenced by translations (`IntroducedInVersion`, `LastSourceChangeInVersion`, `RemovedInVersion`).
+  The guard refuses it.
+- **Triggering a forum scrape** — no public trigger endpoint in MVP (spec 0001 §contract); the
+  watcher runs server-side. The FE only displays its output plus the manual fallback.
+
+## Business rules & edge cases
+
+- The list is open to any translator; the register form / delete buttons show **only** when the
+  resource advertises the admin-only `register` / `delete` rel — never a locally recomputed role (#158).
+- Duplicate version (normalized per ADR-0003: `48` ≡ `48.0` ≡ `48.0.0`) → the API returns a
+  conflict; surface the `ProblemDetails` and keep the list intact.
+- **Delete guard (server-side, authoritative):** load the version → not found ⇒ 404; status is not
+  `Unprocessed` ⇒ conflict (`CannotDeleteProcessedVersion`); any translation references it ⇒ conflict
+  (`CannotDeleteReferencedVersion`); else remove + save ⇒ 204. Under the lifecycle an Unprocessed
+  version has never been imported against, so the referenced check is defense-in-depth (it should
+  not normally trigger).
+- The `delete` rel is emitted per item for admins **only when `Status == Unprocessed`** (cheap,
+  status is on the response); the referenced check stays server-side.
+- Empty list → friendly empty state; the register form (when admin) still shows so the first version
+  can be added.
+- Failed list fetch → surface the error; the register form / delete buttons cannot show (rels can't
+  be read), mirroring import/export.
+- After a successful register or delete, **refresh the list** so it reflects the new state.
+- Version input is trimmed; the field carries the same `maxlength` as
+  `LotroNotationVersion.VersionMaxLength` (12). Real format validation is server-side (ADR-0003 grammar).
+
+## Contract
+
+- **Page route:** `GET /game-versions` (`[Authorize]`), Static SSR.
+- **List:** `GameVersionsLoader.ListGameVersionsAsync` → `GET /api/v1/game-versions` →
+  `CollectionResponse<GameVersionResponse>` (keep `Links`).
+- **Register:** `GameVersionsLoader.RegisterGameVersionAsync(string version)` →
+  `POST /api/v1/game-versions` body `RegisterGameVersionRequest(string Version)` →
+  `GameVersionResponse` (201) or `ProblemDetails` (400 / 409-conflict / 422).
+- **Delete:** `GameVersionsLoader.DeleteGameVersionAsync(GameVersionId id)` →
+  `DELETE /api/v1/game-versions/{id}` (admin) → 204, or `ProblemDetails`
+  (404 not found / 409 conflict when Processed/Superseded/referenced).
+- **Errors:** new `DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted` (covers Processed
+  **and** Superseded) and `CannotDeleteReferencedVersion` (both `TypeOfError.DataConflict` → 422).
+- **Files touched:** new `Features/GameVersions/DeleteGameVersion.cs`, repository `Delete` +
+  referenced-check, `Rels.Delete`, the GameVersion link factory; new
+  `Components/Pages/GameVersions/{GameVersions.razor, GameVersionsLoader.cs}`; nav link in
+  `Components/Layout/NavMenu.razor`; DI in API + `DependencyInjection.cs`; tests on both sides.
+
+## Acceptance criteria
+
+- [ ] `/game-versions` lists versions **newest-first** with version, detected-at, and a status badge.
+- [ ] A non-admin translator sees the list but **no register form and no delete buttons**.
+- [ ] An admin sees the register form; submitting a valid version POSTs and the new row appears.
+- [ ] An admin sees a delete button only on **Unprocessed** rows; deleting removes the row.
+- [ ] `DELETE` on a Processed/Superseded version ⇒ conflict; on an unknown id ⇒ 404; on a referenced
+      version ⇒ conflict — each surfaced as `ProblemDetails`, list preserved.
+- [ ] A duplicate/invalid register surfaces the API `ProblemDetails` without losing the list.
+- [ ] An empty list shows the empty state; a failed fetch surfaces the error.
+- [ ] The sidebar shows a "Wersje gry" link.
+- [ ] Tests: `DeleteGameVersion` handler unit tests (guard matrix) + endpoint integration test (real
+      PostgreSQL); `GameVersionsLoader` tests; bUnit render tests (list, admin gating, register, delete, errors).
+
+## Open questions
+
+Resolved with the user (2026-06-28):
+
+1. **Scope** → List + manual Register **+ guarded Delete** of a still-`Unprocessed`, unreferenced
+   version (option B). Manual status edit (full CRUD) is rejected — contradicts the lifecycle.
+2. **Visibility** → dedicated `/game-versions` page visible to **all translators** (read-only list);
+   register **and** delete are admin-only, gated by the `register` / `delete` HATEOAS rels.
+3. **Delete guard** → "delete only when `Unprocessed` **and** unreferenced by any translation",
+   enforced server-side; the `delete` rel is emitted item-level for admins on Unprocessed versions.
+
+## Assumptions
+
+- Forum-watch auto-detection (#85) stays deferred; versions appear via that future watcher plus the
+  manual register. This work does not depend on the watcher existing.
+- Polish UI copy, consistent with the existing pages.

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
@@ -19,6 +19,9 @@
         <NavLink class="nav-link" href="/import-export">
             <span class="nav-text">Import / Eksport</span>
         </NavLink>
+        <NavLink class="nav-link" href="/game-versions">
+            <span class="nav-text">Wersje gry</span>
+        </NavLink>
         <NavLink class="nav-link" href="/dashboard">
             <span class="nav-text">Panel</span>
         </NavLink>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersionStatusDisplay.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersionStatusDisplay.cs
@@ -1,0 +1,28 @@
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+
+namespace LotroKoniecDev.Frontend.Components.Pages.GameVersions;
+
+/// <summary>
+/// Maps a <see cref="GameVersionStatus"/> to its Polish label and badge CSS class for the list view.
+/// The Frontend is Polish-only (aligned with the rest of the UI), so labels are inlined rather than
+/// localized. <see cref="GameVersionStatus.Unset"/> is a never-persisted sentinel and renders
+/// defensively as the neutral "unknown" badge. Mirrors <c>TranslationStatusDisplay</c>.
+/// </summary>
+internal static class GameVersionStatusDisplay
+{
+    public static string Label(GameVersionStatus status) => status switch
+    {
+        GameVersionStatus.Unprocessed => "Nieprzetworzona",
+        GameVersionStatus.Processed => "Przetworzona",
+        GameVersionStatus.Superseded => "Zastąpiona",
+        _ => "Nieznany"
+    };
+
+    public static string BadgeClass(GameVersionStatus status) => status switch
+    {
+        GameVersionStatus.Processed => "badge-success",
+        GameVersionStatus.Unprocessed => "badge-warning",
+        GameVersionStatus.Superseded => "badge-neutral",
+        _ => "badge-neutral"
+    };
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
@@ -1,0 +1,243 @@
+@page "/game-versions"
+@attribute [Authorize]
+@using System.Globalization
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Mvc
+@using LotroKoniecDev.Frontend.Infrastructure.Hateoas
+@using LotroKoniecDev.Frontend.Infrastructure.HttpClients
+@using LotroKoniecDev.TranslationSystem.Contracts.Common
+@using LotroKoniecDev.TranslationSystem.Contracts.GameVersions
+@using LotroKoniecDev.TranslationSystem.Contracts.Hateoas
+@using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate
+@inject GameVersionsLoader Loader
+
+<PageTitle>Wersje gry — LotroKoniecDev</PageTitle>
+
+<section class="page-head">
+    <h1>Wersje gry</h1>
+    <p class="lede">
+        Przeglądaj wykryte wersje gry LOTRO i ich stan w cyklu aktualizacji. Administrator może ręcznie
+        zarejestrować wersję, gdy odczyt z forum jest niedostępny, oraz usunąć błędnie dodaną, jeszcze
+        nieprzetworzoną wersję.
+    </p>
+</section>
+
+@if (_versionsProblem is not null)
+{
+    <section class="panel">
+        <p class="status-line status-down" role="alert">
+            <span class="dot"></span>@(_versionsProblem.Title ?? "Nie udało się wczytać listy wersji gry.")
+        </p>
+    </section>
+}
+
+@if (_actionProblem is not null)
+{
+    <section class="panel">
+        <p class="status-line status-down" role="alert">
+            <span class="dot"></span>@(_actionProblem.Detail ?? _actionProblem.Title ?? "Operacja nie powiodła się.")
+        </p>
+    </section>
+}
+else if (_actionMessage is not null)
+{
+    <section class="panel">
+        <p class="status-line status-ok" role="status">
+            <span class="dot"></span>@_actionMessage
+        </p>
+    </section>
+}
+
+@* The register affordance is the collection's admin-only `register` rel (#158) — not a local role check. *@
+@if (_canRegister)
+{
+    <section class="panel">
+        <h2>Zarejestruj wersję ręcznie</h2>
+        <p class="lede">
+            Podaj wersję w notacji LOTRO (np. <code class="mono">48.0</code>). Nowa wersja pojawi się jako
+            nieprzetworzona (operacja administratora).
+        </p>
+        <form method="post" @formname="register-version" @onsubmit="RegisterAsync" class="filter-form">
+            <AntiforgeryToken/>
+            <div class="filter-field filter-search">
+                <label for="new-version">Wersja</label>
+                <input id="new-version" name="RegisterInput.Version" type="text"
+                       maxlength="@MaxVersionLength" placeholder="np. 48.0"
+                       value="@(RegisterInput?.Version)" autocomplete="off"/>
+            </div>
+            <div class="filter-actions">
+                <button type="submit" class="btn btn-primary">Zarejestruj</button>
+            </div>
+        </form>
+    </section>
+}
+
+@if (_versions is null && _versionsProblem is null)
+{
+    <section class="results-meta">
+        <div class="loading-indicator">
+            <span class="li-spin"></span> Wczytywanie wersji gry…
+        </div>
+    </section>
+}
+else if (_versions is { Count: 0 })
+{
+    <section class="panel">
+        <div class="empty">
+            <h2>Brak wersji gry</h2>
+            <p>Nie wykryto jeszcze żadnej wersji gry.</p>
+        </div>
+    </section>
+}
+else if (_versions is not null)
+{
+    <section class="table-wrap">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th scope="col">Wersja</th>
+                    <th scope="col">Wykryto</th>
+                    <th scope="col" class="col-status">Status</th>
+                    <th scope="col" class="col-actions"><span class="visually-hidden">Akcje</span></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (GameVersionResponse version in _versions)
+                {
+                    <tr>
+                        <td class="mono">@version.Version</td>
+                        <td>@version.DetectedAt.ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture)</td>
+                        <td class="col-status">
+                            <span class="badge @GameVersionStatusDisplay.BadgeClass(version.Status)">
+                                <span class="dot"></span>@GameVersionStatusDisplay.Label(version.Status)
+                            </span>
+                        </td>
+                        <td class="col-actions">
+                            @* The `delete` rel is emitted only for an admin on an Unprocessed version (#158). *@
+                            @if (version.Links.HasLink(Rels.Delete))
+                            {
+                                <form method="post" @formname="@DeleteFormName(version.Id)"
+                                      @onsubmit="() => DeleteAsync(version.Id)">
+                                    <AntiforgeryToken/>
+                                    <button type="submit" class="btn btn-ghost btn-sm">Usuń</button>
+                                </form>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </section>
+}
+
+@code
+{
+    /// <summary>
+    /// Mirrors the server's <c>LotroNotationVersion.VersionMaxLength</c> (12) as a client-side input cap.
+    /// The Frontend cannot reference the Domain constant, and the server validation (ADR-0003 grammar)
+    /// stays authoritative — this is only a UX nicety.
+    /// </summary>
+    private const int MaxVersionLength = 12;
+
+    [SupplyParameterFromForm(FormName = "register-version")]
+    private RegisterFormModel? RegisterInput { get; set; }
+
+    private IReadOnlyList<GameVersionResponse>? _versions;
+    private ProblemDetails? _versionsProblem;
+    private ProblemDetails? _actionProblem;
+    private string? _actionMessage;
+    private bool _canRegister;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // A property initializer is rejected for a [SupplyParameterFromForm] model (BL0008), so seed it
+        // here: on a non-matching render the model stays empty, on a matching post the bound model wins.
+        RegisterInput ??= new RegisterFormModel();
+
+        // The list is open to any translator; whether the register form and per-item delete buttons show
+        // is decided by the server's admin-only rels (#158) — not a locally recomputed role.
+        await LoadVersionsAsync();
+    }
+
+    private async Task LoadVersionsAsync()
+    {
+        ApiResult<CollectionResponse<GameVersionResponse>> result = await Loader.ListGameVersionsAsync(CancellationToken.None);
+        if (result.IsSuccess)
+        {
+            _versions = [.. result.Value.Items];
+            _canRegister = result.Value.Links.HasLink(Rels.Register);
+            _versionsProblem = null;
+        }
+        else
+        {
+            _versions = null;
+            _canRegister = false;
+            _versionsProblem = result.ProblemDetails;
+        }
+    }
+
+    private async Task RegisterAsync()
+    {
+        _actionProblem = null;
+        _actionMessage = null;
+
+        if (!_canRegister)
+        {
+            return;
+        }
+
+        string version = RegisterInput?.Version?.Trim() ?? string.Empty;
+        if (version.Length == 0)
+        {
+            _actionProblem = new ProblemDetails { Title = "Podaj wersję gry." };
+            await LoadVersionsAsync();
+            return;
+        }
+
+        ApiResult<GameVersionResponse> result = await Loader.RegisterGameVersionAsync(version, CancellationToken.None);
+        if (result.IsSuccess)
+        {
+            _actionMessage = $"Zarejestrowano wersję {result.Value.Version}.";
+            RegisterInput = new RegisterFormModel();
+        }
+        else
+        {
+            _actionProblem = result.ProblemDetails;
+        }
+
+        // The registration changed the catalog; refresh so the new Unprocessed row appears.
+        await LoadVersionsAsync();
+    }
+
+    private async Task DeleteAsync(GameVersionId id)
+    {
+        _actionProblem = null;
+        _actionMessage = null;
+
+        ApiResult result = await Loader.DeleteGameVersionAsync(id, CancellationToken.None);
+        if (result.IsSuccess)
+        {
+            _actionMessage = "Usunięto wersję gry.";
+        }
+        else
+        {
+            _actionProblem = result.ProblemDetails;
+        }
+
+        // The row is gone (or the delete was refused); refresh to reflect the authoritative state.
+        await LoadVersionsAsync();
+    }
+
+    /// <summary>
+    /// A per-row form name so each delete posts to its own row. Blazor static SSR dispatches the post to
+    /// the matching <c>@@formname</c> and re-creates this row's <c>@@onsubmit</c> closure over the freshly
+    /// loaded version id — the same per-item action idiom the editor uses for a single row.
+    /// </summary>
+    private static string DeleteFormName(GameVersionId id) =>
+        string.Create(CultureInfo.InvariantCulture, $"delete-{id.Value}");
+
+    private sealed class RegisterFormModel
+    {
+        public string? Version { get; set; }
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersionsLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersionsLoader.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+
+namespace LotroKoniecDev.Frontend.Components.Pages.GameVersions;
+
+/// <summary>
+/// Drives the game-versions page's TMS calls through the typed client (#209): list every known
+/// version as the HATEOAS collection envelope — <b>keeping its <c>Links</c></b> so the page can gate
+/// the admin <c>register</c> / per-item <c>delete</c> affordances on the server-advertised rels (#158)
+/// rather than recomputing the role locally — register one manually (<c>POST /api/v1/game-versions</c>,
+/// #107) and delete a still-unprocessed mistaken entry (<c>DELETE /api/v1/game-versions/{id}</c>).
+/// Kept as a thin injectable seam so the page's data flow is unit-testable end-to-end over a stubbed
+/// HTTP handler and so a bUnit render test can drive the page through a substituted loader.
+/// </summary>
+internal sealed class GameVersionsLoader
+{
+    private const string GameVersionsApiPath = "/api/v1/game-versions";
+
+    private readonly ITranslationSystemClient _client;
+
+    public GameVersionsLoader(ITranslationSystemClient client)
+    {
+        _client = client;
+    }
+
+    public Task<ApiResult<CollectionResponse<GameVersionResponse>>> ListGameVersionsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return _client.GetApiResultAsync<CollectionResponse<GameVersionResponse>>(
+            GameVersionsApiPath,
+            cancellationToken);
+    }
+
+    public Task<ApiResult<GameVersionResponse>> RegisterGameVersionAsync(
+        string version,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.PostApiResultAsync<GameVersionResponse>(
+            GameVersionsApiPath,
+            new RegisterGameVersionRequest(version),
+            cancellationToken);
+    }
+
+    public Task<ApiResult> DeleteGameVersionAsync(
+        GameVersionId id,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.DeleteApiResultAsync(
+            string.Create(CultureInfo.InvariantCulture, $"{GameVersionsApiPath}/{id.Value}"),
+            cancellationToken);
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/DependencyInjection.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using FluentValidation;
 using LotroKoniecDev.Frontend.Components.Pages.Dashboard;
 using LotroKoniecDev.Frontend.Components.Pages.Editor;
+using LotroKoniecDev.Frontend.Components.Pages.GameVersions;
 using LotroKoniecDev.Frontend.Components.Pages.ImportExport;
 using LotroKoniecDev.Frontend.Components.Pages.Translations;
 using LotroKoniecDev.Frontend.Infrastructure.Auth;
@@ -30,6 +31,7 @@ public static class DependencyInjection
             services.AddScoped<TranslationEditorLoader>();
             services.AddScoped<DashboardStatsLoader>();
             services.AddScoped<ImportExportLoader>();
+            services.AddScoped<GameVersionsLoader>();
 
             return services;
         }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -139,6 +139,9 @@ internal static class ApiDependencyInjection
             services.AddScoped<
                 ICommandHandler<RegisterGameVersion.Command, Result<GameVersionResponse>>,
                 RegisterGameVersion.Handler>();
+
+            services.AddScoped<IValidator<DeleteGameVersion.Command>, DeleteGameVersion.Validator>();
+            services.AddScoped<ICommandHandler<DeleteGameVersion.Command, Result>, DeleteGameVersion.Handler>();
         }
 
         private void AddBootstrapFeature()

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/DeleteGameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/DeleteGameVersion.cs
@@ -1,0 +1,118 @@
+using FluentValidation;
+using FluentValidation.Results;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
+
+/// <summary>
+/// Deletes a manually-registered game version that was added by mistake (#209). The guard is strict:
+/// only an <see cref="Primitives.Aggregates.GameVersionAggregate.Enums.GameVersionStatus.Unprocessed"/>
+/// version with no translation referencing it can be removed — a processed or superseded version is
+/// woven into the update lifecycle (spec 0001) and removing it would orphan the rows that point at it
+/// (422). Requires the admin policy; an unknown id is a 404.
+/// </summary>
+internal sealed class DeleteGameVersion : IEndpoint
+{
+    internal sealed record Command(GameVersionId Id) : ICommand<Result>;
+
+    internal sealed class Validator : AbstractValidator<Command>
+    {
+        public Validator()
+        {
+            RuleFor(command => command.Id)
+                .NotEqual(GameVersionId.Empty)
+                .WithMessage("The game version id is required.");
+        }
+    }
+
+    internal sealed class Handler : ICommandHandler<Command, Result>
+    {
+        private readonly IValidator<Command> _validator;
+        private readonly IGameVersionRepository _gameVersionRepository;
+        private readonly ITranslationRepository _translationRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public Handler(
+            IValidator<Command> validator,
+            IGameVersionRepository gameVersionRepository,
+            ITranslationRepository translationRepository,
+            IUnitOfWork unitOfWork)
+        {
+            _validator = validator;
+            _gameVersionRepository = gameVersionRepository;
+            _translationRepository = translationRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async ValueTask<Result> Handle(Command command, CancellationToken cancellationToken)
+        {
+            ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                string message = string.Join("; ", validationResult.Errors.Select(failure => failure.ErrorMessage));
+                return Result.Failure(new Error("GameVersions.Validation", message, TypeOfError.Validation));
+            }
+
+            Maybe<GameVersion> gameVersionMaybe = await _gameVersionRepository.GetByIdAsync(command.Id, cancellationToken);
+            if (gameVersionMaybe.HasNoValue)
+            {
+                return Result.Failure(DomainErrors.GameVersionEntity.NotFound(command.Id));
+            }
+
+            GameVersion gameVersion = gameVersionMaybe.Value;
+
+            Result deletableResult = gameVersion.EnsureCanBeDeleted();
+            if (deletableResult.IsFailure)
+            {
+                return deletableResult;
+            }
+
+            // Cross-aggregate safety net: under the lifecycle an Unprocessed version has never been
+            // imported against, so nothing should reference it — but a referenced version must never be
+            // removed, or its translations would point at a missing version.
+            if (await _translationRepository.AnyReferencesGameVersionAsync(command.Id, cancellationToken))
+            {
+                return Result.Failure(DomainErrors.GameVersionEntity.CannotDeleteReferencedVersion(command.Id));
+            }
+
+            _gameVersionRepository.Remove(gameVersion);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success();
+        }
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapDelete("/api/v1/game-versions/{id:guid}", async (
+                Guid id,
+                ICommandHandler<Command, Result> handler,
+                CancellationToken cancellationToken) =>
+            {
+                Result result = await handler.Handle(new Command(GameVersionId.FromValue(id)), cancellationToken);
+
+                return result.IsSuccess
+                    ? Results.NoContent()
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(DeleteGameVersion))
+            .WithTags("GameVersions")
+            .RequireAuthorization(AuthorizationPolicies.RequireAdminRole)
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/GetGameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/GetGameVersion.cs
@@ -1,4 +1,6 @@
+using System.Security.Claims;
 using LotroKoniecDev.Hateoas.ContentNegotiation;
+using LotroKoniecDev.SharedKernel.Authorization;
 using LotroKoniecDev.SharedKernel.Messaging;
 using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.API.Auth;
@@ -60,6 +62,7 @@ internal sealed class GetGameVersion : IEndpoint
                 Guid id,
                 IQueryHandler<Query, Result<GameVersionResponse>> handler,
                 IGameVersionAggregateLinkFactory gameVersionLinkFactory,
+                ClaimsPrincipal user,
                 CancellationToken cancellationToken) =>
             {
                 Result<GameVersionResponse> result = await handler.Handle(new Query(GameVersionId.FromValue(id)), cancellationToken);
@@ -69,8 +72,10 @@ internal sealed class GetGameVersion : IEndpoint
                     return Results.Problem(result.Error.ToProblemDetails());
                 }
 
+                bool callerIsAdmin = user.IsInRole(AuthConstants.Roles.Admin);
+
                 return HateoasResults.Ok(result.Value, r =>
-                    r.Links = gameVersionLinkFactory.CreateGameVersionLinks(r.Id));
+                    r.Links = gameVersionLinkFactory.CreateGameVersionLinks(r.Id, r.Status, callerIsAdmin));
             })
             .WithName(nameof(GetGameVersion))
             .WithTags("GameVersions")

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/ListGameVersions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/ListGameVersions.cs
@@ -94,7 +94,7 @@ internal sealed class ListGameVersions : IEndpoint
                 {
                     foreach (GameVersionResponse item in collection.Items)
                     {
-                        item.Links = gameVersionLinkFactory.CreateGameVersionLinks(item.Id);
+                        item.Links = gameVersionLinkFactory.CreateGameVersionLinks(item.Id, item.Status, callerIsAdmin);
                     }
 
                     collection.Links = gameVersionLinkFactory.CreateCollectionLinks(callerIsAdmin);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/GameVersionAggregateLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/GameVersionAggregateLinkFactory.cs
@@ -3,6 +3,7 @@ using LotroKoniecDev.Hateoas.LinkFactories;
 using LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
 using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
 
 namespace LotroKoniecDev.TranslationSystem.API.Hateoas.GameVersionAggregateFactories;
 
@@ -15,7 +16,7 @@ internal sealed class GameVersionAggregateLinkFactory : IGameVersionAggregateLin
         _linkFactory = linkFactory;
     }
 
-    public List<LinkDto> CreateGameVersionLinks(GameVersionId id)
+    public List<LinkDto> CreateGameVersionLinks(GameVersionId id, GameVersionStatus status, bool callerIsAdmin)
     {
         List<LinkDto> links = [];
 
@@ -24,6 +25,17 @@ internal sealed class GameVersionAggregateLinkFactory : IGameVersionAggregateLin
             rel: Rels.Self,
             method: HttpMethods.Get,
             values: new { id = id.Value }));
+
+        // Deleting a mistaken manual registration is an admin action, and only an unprocessed version
+        // may be removed (a processed/superseded one is referenced by translations — spec 0001).
+        if (callerIsAdmin && status is GameVersionStatus.Unprocessed)
+        {
+            links.AddIfPresent(_linkFactory.Create(
+                endpoint: nameof(DeleteGameVersion),
+                rel: Rels.Delete,
+                method: HttpMethods.Delete,
+                values: new { id = id.Value }));
+        }
 
         return links;
     }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/IGameVersionAggregateLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/IGameVersionAggregateLinkFactory.cs
@@ -1,16 +1,21 @@
 using LotroKoniecDev.Hateoas.Abstractions;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
 
 namespace LotroKoniecDev.TranslationSystem.API.Hateoas.GameVersionAggregateFactories;
 
 /// <summary>
-/// Builds HATEOAS links for the game-version aggregate: a per-item <c>self</c> and the collection's
-/// <c>self</c> plus the role-gated <c>register</c> action.
+/// Builds HATEOAS links for the game-version aggregate: a per-item <c>self</c> plus the role-gated
+/// <c>delete</c> action, and the collection's <c>self</c> plus the role-gated <c>register</c> action.
 /// </summary>
 internal interface IGameVersionAggregateLinkFactory
 {
-    /// <summary>Per-item links for one game version (currently <c>self</c>).</summary>
-    List<LinkDto> CreateGameVersionLinks(GameVersionId id);
+    /// <summary>
+    /// Per-item links for one game version: <c>self</c>, plus <c>delete</c> when the caller holds the
+    /// Admin role and the version is still <see cref="GameVersionStatus.Unprocessed"/> — a processed or
+    /// superseded version is woven into the update lifecycle and cannot be removed.
+    /// </summary>
+    List<LinkDto> CreateGameVersionLinks(GameVersionId id, GameVersionStatus status, bool callerIsAdmin);
 
     /// <summary>
     /// Collection-level links for the game-version list: <c>self</c>, plus <c>register</c> when the

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
@@ -10,6 +10,7 @@ public static class Rels
 
     // GameVersion aggregate actions
     public const string Register = "register";
+    public const string Delete = "delete";
 
     // Collection / pagination navigation
     public const string FirstPage = "first-page";

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
@@ -49,6 +49,22 @@ public sealed class GameVersion : AggregateRoot<GameVersionId>
         return Result.Success();
     }
 
+    /// <summary>
+    /// Guards deletion: only an <see cref="GameVersionStatus.Unprocessed"/> version may be removed. A
+    /// processed or superseded version has been woven into the update lifecycle (spec 0001) and removing
+    /// it would orphan the translations that reference it. The cross-aggregate "no translation references
+    /// this version" check stays in the delete handler — the aggregate only owns the status invariant.
+    /// </summary>
+    public Result EnsureCanBeDeleted()
+    {
+        if (Status is not GameVersionStatus.Unprocessed)
+        {
+            return Result.Failure(DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted(Id));
+        }
+
+        return Result.Success();
+    }
+
     public static Result<GameVersion> Create(
         LotroNotationVersion version,
         DateTimeOffset detectedAt)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Repositories/ITranslationRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Repositories/ITranslationRepository.cs
@@ -2,6 +2,7 @@ using LotroKoniecDev.SharedKernel.BuildingBlocks;
 using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 
 namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
@@ -23,4 +24,11 @@ public interface ITranslationRepository : IRepository<Translation, TranslationId
     Task<Maybe<Translation>> GetByFragmentKeyAsync(FragmentKey fragmentKey, CancellationToken cancellationToken);
 
     void InsertRange(IEnumerable<Translation> translations);
+
+    /// <summary>
+    /// Whether any stored translation is bound to the given game version — by introduction, source
+    /// change or removal (spec 0001). Guards game-version deletion: a referenced version must never be
+    /// removed, or those rows would point at a missing version.
+    /// </summary>
+    Task<bool> AnyReferencesGameVersionAsync(GameVersionId gameVersionId, CancellationToken cancellationToken);
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
@@ -27,6 +27,18 @@ public static partial class DomainErrors
                 $"Game version with ID '{id.Value}' is already processed and cannot be superseded.",
                 "ProcessedCannotBeSuperseded");
 
+        public static Error OnlyUnprocessedCanBeDeleted(GameVersionId id)
+            => InvalidOperation(
+                nameof(GameVersionEntity),
+                $"Game version with ID '{id.Value}' is not unprocessed and cannot be deleted; only unprocessed versions can be deleted.",
+                "OnlyUnprocessedCanBeDeleted");
+
+        public static Error CannotDeleteReferencedVersion(GameVersionId id)
+            => InvalidOperation(
+                nameof(GameVersionEntity),
+                $"Game version with ID '{id.Value}' is referenced by one or more translations and cannot be deleted.",
+                "CannotDeleteReferencedVersion");
+
         public static class VersionProperty
         {
             public static Error NullOrEmpty

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
@@ -3,6 +3,7 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.En
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using Microsoft.EntityFrameworkCore;
 
@@ -39,5 +40,17 @@ internal sealed class TranslationRepository : GenericRepository<Translation, Tra
         ArgumentNullException.ThrowIfNull(translations);
 
         DbContext.Set<Translation>().AddRange(translations);
+    }
+
+    public async Task<bool> AnyReferencesGameVersionAsync(GameVersionId gameVersionId, CancellationToken cancellationToken)
+    {
+        bool referenced = await DbContext.Set<Translation>()
+            .AnyAsync(
+                translation => translation.IntroducedInVersion == gameVersionId
+                    || translation.LastSourceChangeInVersion == gameVersionId
+                    || translation.RemovedInVersion == gameVersionId,
+                cancellationToken);
+
+        return referenced;
     }
 }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/NavMenuTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/NavMenuTests.cs
@@ -60,7 +60,7 @@ public sealed class NavMenuTests : BunitContext
             .Select(anchor => anchor.GetAttribute("href")!)
             .ToArray();
 
-        navTargets.ShouldBe(["/", "/translations", "/import-export", "/dashboard"]);
+        navTargets.ShouldBe(["/", "/translations", "/import-export", "/game-versions", "/dashboard"]);
     }
 
     /// <summary>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionStatusDisplayTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionStatusDisplayTests.cs
@@ -1,0 +1,27 @@
+using LotroKoniecDev.Frontend.Components.Pages.GameVersions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.GameVersions;
+
+public sealed class GameVersionStatusDisplayTests
+{
+    [Theory]
+    [InlineData(GameVersionStatus.Unprocessed, "Nieprzetworzona")]
+    [InlineData(GameVersionStatus.Processed, "Przetworzona")]
+    [InlineData(GameVersionStatus.Superseded, "Zastąpiona")]
+    [InlineData(GameVersionStatus.Unset, "Nieznany")]
+    public void Label_ReturnsThePolishLabelForEveryStatus(GameVersionStatus status, string expected)
+    {
+        GameVersionStatusDisplay.Label(status).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(GameVersionStatus.Processed, "badge-success")]
+    [InlineData(GameVersionStatus.Unprocessed, "badge-warning")]
+    [InlineData(GameVersionStatus.Superseded, "badge-neutral")]
+    [InlineData(GameVersionStatus.Unset, "badge-neutral")]
+    public void BadgeClass_MapsEveryStatusToAKnownBadgeClass(GameVersionStatus status, string expected)
+    {
+        GameVersionStatusDisplay.BadgeClass(status).ShouldBe(expected);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsLoaderTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.Frontend.Components.Pages.GameVersions;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.GameVersions;
+
+public sealed class GameVersionsLoaderTests
+{
+    private const string BaseUrl = "https://localhost:5002/";
+    private static readonly Guid GameVersionGuid = Guid.Parse("0192a000-0000-7000-8000-0000000000aa");
+
+    // Mirrors the JSON options the Frontend's HTTP seam uses (HttpClientApiExtensions) so the stub
+    // body deserializes through the exact same contract the loader relies on.
+    private static readonly JsonSerializerOptions ApiJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    [Fact]
+    public async Task ListGameVersionsAsync_RequestsTheGameVersionsCollectionEndpoint()
+    {
+        GameVersionsLoader loader = CreateLoader(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(new CollectionResponse<GameVersionResponse> { Items = [VersionFixture()] }, ApiJsonOptions),
+            out StubHttpMessageHandler handler);
+
+        await loader.ListGameVersionsAsync();
+
+        handler.LastRequest.ShouldNotBeNull();
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
+        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/game-versions");
+    }
+
+    [Fact]
+    public async Task ListGameVersionsAsync_PreservesTheCollectionRegisterRelSoTheFormCanBeGated()
+    {
+        // The collection's admin-only `register` rel must survive deserialization — the page gates the
+        // register form on its presence (#158) rather than recomputing the role locally.
+        CollectionResponse<GameVersionResponse> collection = new()
+        {
+            Items = [VersionFixture()],
+            Links = [new LinkDto("https://tms.example/api/v1/game-versions", Rels.Register, "POST")]
+        };
+        GameVersionsLoader loader = CreateLoader(HttpStatusCode.OK, JsonSerializer.Serialize(collection, ApiJsonOptions), out _);
+
+        ApiResult<CollectionResponse<GameVersionResponse>> result = await loader.ListGameVersionsAsync();
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Links.ShouldContain(link => link.Rel == Rels.Register);
+        result.Value.Items.ShouldHaveSingleItem().Version.ShouldBe("48");
+    }
+
+    [Fact]
+    public async Task ListGameVersionsAsync_WhenApiFails_ReturnsFailureWithProblemDetails()
+    {
+        GameVersionsLoader loader = CreateLoader(
+            HttpStatusCode.InternalServerError,
+            """{ "title": "Nie udało się wczytać wersji.", "status": 500 }""",
+            out _);
+
+        ApiResult<CollectionResponse<GameVersionResponse>> result = await loader.ListGameVersionsAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(500);
+    }
+
+    [Fact]
+    public async Task RegisterGameVersionAsync_PostsTheVersionToTheCollectionEndpoint()
+    {
+        GameVersionsLoader loader = CreateLoader(
+            HttpStatusCode.Created,
+            JsonSerializer.Serialize(VersionFixture(), ApiJsonOptions),
+            out StubHttpMessageHandler handler);
+
+        ApiResult<GameVersionResponse> result = await loader.RegisterGameVersionAsync("48.0");
+
+        result.IsSuccess.ShouldBeTrue();
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/game-versions");
+        handler.LastRequestBody.ShouldNotBeNull();
+        handler.LastRequestBody!.ShouldContain("48.0");
+    }
+
+    [Fact]
+    public async Task RegisterGameVersionAsync_WhenDuplicate_ReturnsFailureWithProblemDetails()
+    {
+        GameVersionsLoader loader = CreateLoader(
+            HttpStatusCode.UnprocessableEntity,
+            """{ "title": "Data Conflict", "status": 422 }""",
+            out _);
+
+        ApiResult<GameVersionResponse> result = await loader.RegisterGameVersionAsync("48.0");
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(422);
+    }
+
+    [Fact]
+    public async Task DeleteGameVersionAsync_SendsDeleteToTheVersionScopedEndpoint()
+    {
+        GameVersionsLoader loader = CreateLoader(HttpStatusCode.NoContent, string.Empty, out StubHttpMessageHandler handler);
+
+        ApiResult result = await loader.DeleteGameVersionAsync(GameVersionId.Create(GameVersionGuid));
+
+        result.IsSuccess.ShouldBeTrue();
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Delete);
+        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/game-versions/{GameVersionGuid}");
+    }
+
+    [Fact]
+    public async Task DeleteGameVersionAsync_WhenRefused_ReturnsFailureWithProblemDetails()
+    {
+        GameVersionsLoader loader = CreateLoader(
+            HttpStatusCode.UnprocessableEntity,
+            """{ "title": "Data Conflict", "status": 422 }""",
+            out _);
+
+        ApiResult result = await loader.DeleteGameVersionAsync(GameVersionId.Create(GameVersionGuid));
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(422);
+    }
+
+    private static GameVersionResponse VersionFixture() =>
+        new(GameVersionId.Create(GameVersionGuid), "48", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed);
+
+    private static GameVersionsLoader CreateLoader(HttpStatusCode statusCode, string body, out StubHttpMessageHandler handler)
+    {
+        handler = StubHttpMessageHandler.RespondWith(statusCode, body);
+        return new GameVersionsLoader(CreateClient(handler));
+    }
+
+    private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)
+    {
+        HttpClient httpClient = new(handler)
+        {
+            BaseAddress = new Uri(BaseUrl)
+        };
+        return new TranslationSystemClient(httpClient);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
@@ -1,0 +1,218 @@
+using AngleSharp.Dom;
+using Bunit.TestDoubles;
+using LotroKoniecDev.Frontend.Components.Pages.GameVersions;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using GameVersionsComponent = LotroKoniecDev.Frontend.Components.Pages.GameVersions.GameVersions;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.GameVersions;
+
+/// <summary>
+/// Renders the <see cref="GameVersionsComponent"/> through bUnit over a stubbed TMS client, locking
+/// down the render wiring the loader tests cannot reach: the list shows every version with its Polish
+/// status label; the manual-register form is gated on the collection's admin-only <c>register</c> rel
+/// and the per-row delete button on the item's admin-only <c>delete</c> rel (#158) — not a locally
+/// recomputed role; submitting the register form with no version surfaces the validation notice without
+/// posting; and submitting a delete form follows through to the loader and confirms or surfaces a problem.
+/// <para>
+/// The shared post-action render blocks — the <c>_actionMessage</c> success line and the
+/// <c>_actionProblem</c> error line, both reused verbatim by register and delete — are pinned at the
+/// page level by the two delete-submit tests (success + API refusal), and the empty-register test pins
+/// the page-level validation-failure render plus list survival. The register submit that carries a typed
+/// version cannot be driven here: bUnit's static-SSR form submission does not serialize a programmatically
+/// set text field (mirrors why <c>ImportExportTests</c>/<c>EditorTests</c> never populate SSR text inputs),
+/// so the register POST request shape and its success/422 result mapping are covered by
+/// <c>GameVersionsLoaderTests</c>, and the full typed-form flow by the Playwright E2E (ADR-0009).
+/// </para>
+/// </summary>
+public sealed class GameVersionsTests : BunitContext
+{
+    private readonly ITranslationSystemClient _client = Substitute.For<ITranslationSystemClient>();
+
+    public GameVersionsTests()
+    {
+        Services.AddAntiforgery();
+        Services.AddSingleton(_client);
+        Services.AddScoped<GameVersionsLoader>();
+    }
+
+    [Fact]
+    public void Render_WhenVersionsExist_ListsEachVersionWithItsStatusLabel()
+    {
+        AuthorizeAs("Frodo");
+        StubVersions(
+            Version("48.0", GameVersionStatus.Unprocessed),
+            Version("47.2", GameVersionStatus.Processed));
+
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        component.FindAll("table.data-table tbody tr").Count.ShouldBe(2);
+        string table = component.Find("table.data-table").TextContent;
+        table.ShouldContain("48.0");
+        table.ShouldContain("Nieprzetworzona");
+        table.ShouldContain("47.2");
+        table.ShouldContain("Przetworzona");
+    }
+
+    [Fact]
+    public void Render_WhenCollectionLacksTheRegisterRel_DoesNotShowTheRegisterForm()
+    {
+        AuthorizeAs("Frodo");
+        StubVersions(Version("48.0", GameVersionStatus.Unprocessed));
+
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        component.FindAll("#new-version").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenCollectionHasTheRegisterRel_ShowsTheRegisterFormBoundToTheFormModel()
+    {
+        AuthorizeAs("Sam");
+        StubVersionsWithRegisterRel(Version("48.0", GameVersionStatus.Unprocessed));
+
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        component.Find("#new-version").GetAttribute("name").ShouldBe("RegisterInput.Version");
+    }
+
+    [Fact]
+    public void Render_WhenItemLacksTheDeleteRel_DoesNotShowADeleteButton()
+    {
+        AuthorizeAs("Frodo");
+        StubVersions(Version("48.0", GameVersionStatus.Unprocessed));
+
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        component.FindAll(".col-actions button").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenItemHasTheDeleteRel_ShowsADeleteButton()
+    {
+        AuthorizeAs("Sam");
+        StubVersions(Version("48.0", GameVersionStatus.Unprocessed, canDelete: true));
+
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        component.Find(".col-actions button").TextContent.ShouldContain("Usuń");
+    }
+
+    [Fact]
+    public async Task Register_WhenVersionEmpty_ShowsTheValidationNoticeAndDoesNotCallRegister()
+    {
+        AuthorizeAs("Sam");
+        // A single non-deletable item keeps the register form as the only form on the page.
+        StubVersionsWithRegisterRel(Version("48.0", GameVersionStatus.Unprocessed));
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        await component.Find("form").SubmitAsync();
+
+        component.Find(".status-down").TextContent.ShouldContain("Podaj wersję");
+        await _client.DidNotReceive().PostApiResultAsync<GameVersionResponse>(
+            Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
+        // A rejected register must not wipe the list (the reload still renders the table).
+        component.FindAll("table.data-table").ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Delete_WhenSubmitted_CallsTheLoaderAndConfirms()
+    {
+        AuthorizeAs("Sam");
+        // No register rel + one deletable item → the delete form is the only form to submit.
+        StubVersions(Version("48.0", GameVersionStatus.Unprocessed, canDelete: true));
+        _client.DeleteApiResultAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success());
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        await component.Find(".col-actions form").SubmitAsync();
+
+        // Behaviour-visible proof the delete ran: the confirmation only renders when the loader succeeded.
+        component.Find(".status-ok").TextContent.ShouldContain("Usunięto");
+    }
+
+    [Fact]
+    public async Task Delete_WhenApiRefuses_SurfacesTheProblemAndKeepsTheList()
+    {
+        AuthorizeAs("Sam");
+        StubVersions(Version("48.0", GameVersionStatus.Unprocessed, canDelete: true));
+        _client.DeleteApiResultAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure(new() { Title = "Nie można usunąć przetworzonej wersji.", Status = 422 }));
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        await component.Find(".col-actions form").SubmitAsync();
+
+        component.Find(".status-down").TextContent.ShouldContain("Nie można usunąć");
+        // The refused delete must not wipe the list (the reload still renders the table).
+        component.FindAll("table.data-table").ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenNoVersionsExist_ShowsTheEmptyStateInsteadOfTheTable()
+    {
+        AuthorizeAs("Frodo");
+        StubVersions();
+
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        component.Find(".empty").TextContent.ShouldContain("Brak wersji gry");
+        component.FindAll("table.data-table").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenTheCollectionFailsToLoad_SurfacesTheErrorAndHidesTheRegisterFormAndTable()
+    {
+        AuthorizeAs("Sam");
+        _client
+            .GetApiResultAsync<CollectionResponse<GameVersionResponse>>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<CollectionResponse<GameVersionResponse>>(new() { Title = "Nie udało się wczytać wersji." }));
+
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        component.Find(".status-down").TextContent.ShouldContain("Nie udało się wczytać wersji.");
+        component.FindAll("#new-version").ShouldBeEmpty();
+        component.FindAll("table.data-table").ShouldBeEmpty();
+    }
+
+    private IRenderedComponent<GameVersionsComponent> RenderPage() =>
+        Render<GameVersionsComponent>();
+
+    private void AuthorizeAs(string userName) =>
+        AddAuthorization().SetAuthorized(userName);
+
+    /// <summary>Stubs the versions list as a plain translator sees it — no admin <c>register</c> rel.</summary>
+    private void StubVersions(params GameVersionResponse[] versions) =>
+        _client
+            .GetApiResultAsync<CollectionResponse<GameVersionResponse>>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(new CollectionResponse<GameVersionResponse> { Items = versions }));
+
+    /// <summary>Stubs the versions list as an admin sees it — the collection carries the <c>register</c> rel.</summary>
+    private void StubVersionsWithRegisterRel(params GameVersionResponse[] versions) =>
+        _client
+            .GetApiResultAsync<CollectionResponse<GameVersionResponse>>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(new CollectionResponse<GameVersionResponse>
+            {
+                Items = versions,
+                Links = [new LinkDto("https://tms.example/api/v1/game-versions", Rels.Register, "POST")]
+            }));
+
+    private static GameVersionResponse Version(string version, GameVersionStatus status, bool canDelete = false)
+    {
+        GameVersionId id = GameVersionId.Create(Guid.NewGuid());
+        List<LinkDto> links = [];
+        if (canDelete)
+        {
+            links.Add(new LinkDto($"https://tms.example/api/v1/game-versions/{id.Value}", Rels.Delete, "DELETE"));
+        }
+
+        return new GameVersionResponse(id, version, DateTimeOffset.UnixEpoch, status) { Links = links };
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/DeleteGameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/DeleteGameVersionTests.cs
@@ -1,0 +1,203 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.GameVersions;
+
+[Collection("TranslationApi")]
+public sealed class DeleteGameVersionTests : IAsyncLifetime
+{
+    private const string Route = "/api/v1/game-versions";
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+
+    public DeleteGameVersionTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Delete_UnprocessedUnreferencedVersion_ShouldReturn204AndRemoveItFromTheList()
+    {
+        // Arrange
+        using HttpClient client = AdminClient();
+        GameVersionId id = await SeedVersionAsync("48.0", GameVersionStatus.Unprocessed);
+
+        // Act
+        HttpResponseMessage response = await client.DeleteAsync($"{Route}/{id.Value}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        (await ListVersionStringsAsync(client)).ShouldNotContain("48");
+    }
+
+    [Fact]
+    public async Task Delete_UnknownId_ShouldReturn404()
+    {
+        // Arrange
+        using HttpClient client = AdminClient();
+
+        // Act
+        HttpResponseMessage response = await client.DeleteAsync($"{Route}/{Guid.NewGuid()}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_ProcessedVersion_ShouldReturn422AndKeepIt()
+    {
+        // Arrange — a processed version is woven into the lifecycle and cannot be removed.
+        using HttpClient client = AdminClient();
+        GameVersionId id = await SeedVersionAsync("48.0", GameVersionStatus.Processed);
+
+        // Act
+        HttpResponseMessage response = await client.DeleteAsync($"{Route}/{id.Value}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        (await ListVersionStringsAsync(client)).ShouldContain("48");
+    }
+
+    [Fact]
+    public async Task Delete_SupersededVersion_ShouldReturn422AndKeepIt()
+    {
+        // Arrange — a superseded version is also outside the deletable (unprocessed) state.
+        using HttpClient client = AdminClient();
+        GameVersionId id = await SeedVersionAsync("48.0", GameVersionStatus.Superseded);
+
+        // Act
+        HttpResponseMessage response = await client.DeleteAsync($"{Route}/{id.Value}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        (await ListVersionStringsAsync(client)).ShouldContain("48");
+    }
+
+    [Fact]
+    public async Task Delete_VersionReferencedByATranslation_ShouldReturn422AndKeepIt()
+    {
+        // Arrange — an unprocessed version that a translation references (the defense-in-depth guard,
+        // exercised against real PostgreSQL so AnyReferencesGameVersionAsync is proven to translate).
+        using HttpClient client = AdminClient();
+        GameVersionId id = await SeedVersionAsync("48.0", GameVersionStatus.Unprocessed);
+        await SeedTranslationReferencingAsync(id);
+
+        // Act
+        HttpResponseMessage response = await client.DeleteAsync($"{Route}/{id.Value}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        (await ListVersionStringsAsync(client)).ShouldContain("48");
+    }
+
+    [Fact]
+    public async Task Delete_AsTranslator_ShouldReturn403()
+    {
+        // Arrange — deletion is an admin-only action.
+        using HttpClient adminClient = AdminClient();
+        GameVersionId id = await SeedVersionAsync("48.0", GameVersionStatus.Unprocessed);
+
+        // Act
+        HttpResponseMessage response = await TranslatorClient().DeleteAsync($"{Route}/{id.Value}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Delete_WithoutToken_ShouldReturn401()
+    {
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().DeleteAsync($"{Route}/{Guid.NewGuid()}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<string[]> ListVersionStringsAsync(HttpClient client)
+    {
+        CollectionResponse<GameVersionResponse>? list = await (await client.GetAsync(Route))
+            .Content.ReadFromJsonAsync<CollectionResponse<GameVersionResponse>>(JsonOptions);
+        list.ShouldNotBeNull();
+        return list.Items.Select(version => version.Version).ToArray();
+    }
+
+    private async Task<GameVersionId> SeedVersionAsync(string version, GameVersionStatus status)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, Now).Value;
+        switch (status)
+        {
+            case GameVersionStatus.Processed:
+                gameVersion.MarkAsProcessed();
+                break;
+            case GameVersionStatus.Superseded:
+                gameVersion.MarkSuperseded();
+                break;
+        }
+
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+
+        return gameVersion.Id;
+    }
+
+    private async Task SeedTranslationReferencingAsync(GameVersionId versionId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(620756992, 1001).Value,
+            TranslationSource.Create("Witaj", null, null).Value,
+            versionId,
+            Now).Value;
+
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private HttpClient AdminClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Admin));
+        return client;
+    }
+
+    private HttpClient TranslatorClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+        return client;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/GameVersionAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/GameVersionAggregateHateoasTests.cs
@@ -17,8 +17,9 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Hateoas;
 
 /// <summary>
 /// Verifies the game-version aggregate's HATEOAS links: per-item <c>self</c> (resolving to the new
-/// item endpoint), the collection <c>self</c>, and the role-gated <c>register</c> action (admins
-/// only). Plain <c>application/json</c> requests must carry no links and still deserialize.
+/// item endpoint) plus the role-gated <c>delete</c> action (admins only, on unprocessed versions), the
+/// collection <c>self</c>, and the role-gated <c>register</c> action (admins only). Plain
+/// <c>application/json</c> requests must carry no links and still deserialize.
 /// </summary>
 [Collection("TranslationApi")]
 public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
@@ -75,9 +76,9 @@ public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ListGameVersions_AsAdmin_ReturnsCollectionSelfRegisterAndPerItemSelf()
+    public async Task ListGameVersions_AsAdmin_ReturnsCollectionSelfRegisterAndPerItemSelfAndDelete()
     {
-        // Arrange
+        // Arrange — the seeded version is unprocessed, so an admin may delete it.
         GameVersionId id = await SeedAsync("48.0");
 
         // Act
@@ -88,11 +89,10 @@ public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
         response.Links.ShouldContain(l => l.Rel == Rels.Self && l.Method == "GET");
         response.Links.ShouldContain(l => l.Rel == Rels.Register && l.Method == "POST");
 
-        // Assert — each item carries its own self
+        // Assert — each item carries its own self plus the admin delete affordance
         GameVersionResponse item = response.Items.First(i => i.Id == id);
-        LinkDto itemSelf = item.Links.ShouldHaveSingleItem();
-        itemSelf.Rel.ShouldBe(Rels.Self);
-        itemSelf.Href.ShouldContain($"{Route}/{id.Value}");
+        item.Links.ShouldContain(l => l.Rel == Rels.Self && l.Href.Contains($"{Route}/{id.Value}"));
+        item.Links.ShouldContain(l => l.Rel == Rels.Delete && l.Method == "DELETE" && l.Href.Contains($"{Route}/{id.Value}"));
     }
 
     [Fact]
@@ -123,6 +123,53 @@ public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
         // Assert
         response.Links.ShouldContain(l => l.Rel == Rels.Self);
         response.Links.ShouldNotContain(l => l.Rel == Rels.Register);
+    }
+
+    [Fact]
+    public async Task ListGameVersions_AsAdmin_WhenVersionIsProcessed_DoesNotAdvertiseDeleteOnTheItem()
+    {
+        // Arrange — only an unprocessed version may be deleted; a processed one offers self only.
+        GameVersionId id = await SeedProcessedAsync("48.0");
+
+        // Act
+        CollectionResponse<GameVersionResponse> response =
+            await GetHateoasAsync<CollectionResponse<GameVersionResponse>>(AdminClient(), Route);
+
+        // Assert
+        GameVersionResponse item = response.Items.First(i => i.Id == id);
+        item.Links.ShouldContain(l => l.Rel == Rels.Self);
+        item.Links.ShouldNotContain(l => l.Rel == Rels.Delete);
+    }
+
+    [Fact]
+    public async Task ListGameVersions_AsTranslator_DoesNotAdvertiseDeleteOnTheItem()
+    {
+        // Arrange — delete is the admin action; a translator sees self only on an unprocessed version.
+        GameVersionId id = await SeedAsync("48.0");
+
+        // Act
+        CollectionResponse<GameVersionResponse> response =
+            await GetHateoasAsync<CollectionResponse<GameVersionResponse>>(TranslatorClient(), Route);
+
+        // Assert
+        GameVersionResponse item = response.Items.First(i => i.Id == id);
+        item.Links.ShouldContain(l => l.Rel == Rels.Self);
+        item.Links.ShouldNotContain(l => l.Rel == Rels.Delete);
+    }
+
+    [Fact]
+    public async Task GetGameVersion_AsAdmin_WhenUnprocessed_ReturnsSelfAndDelete()
+    {
+        // Arrange
+        GameVersionId id = await SeedAsync("48.0");
+
+        // Act
+        GameVersionResponse response = await GetHateoasAsync<GameVersionResponse>(
+            AdminClient(), $"{Route}/{id.Value}");
+
+        // Assert
+        response.Links.ShouldContain(l => l.Rel == Rels.Self);
+        response.Links.ShouldContain(l => l.Rel == Rels.Delete && l.Method == "DELETE");
     }
 
     [Fact]
@@ -175,6 +222,19 @@ public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+
+        return gameVersion.Id;
+    }
+
+    private async Task<GameVersionId> SeedProcessedAsync(string version)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, Now).Value;
+        gameVersion.MarkAsProcessed();
         dbContext.GameVersions.Add(gameVersion);
         await dbContext.SaveChangesAsync();
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/GameVersions/DeleteGameVersionHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/GameVersions/DeleteGameVersionHandlerTests.cs
@@ -1,0 +1,115 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Core.Errors;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.GameVersions;
+
+public sealed class DeleteGameVersionHandlerTests
+{
+    private static readonly DateTimeOffset DetectedAt = new(2026, 6, 12, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IGameVersionRepository _gameVersionRepository = Substitute.For<IGameVersionRepository>();
+    private readonly ITranslationRepository _translationRepository = Substitute.For<ITranslationRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private DeleteGameVersion.Handler CreateHandler()
+        => new(new DeleteGameVersion.Validator(), _gameVersionRepository, _translationRepository, _unitOfWork);
+
+    private static GameVersion UnprocessedVersion()
+        => GameVersion.Create(LotroNotationVersion.Create("48.0").Value, DetectedAt).Value;
+
+    [Fact]
+    public async Task Handle_WhenIdEmpty_ShouldReturnValidationErrorAndNotDelete()
+    {
+        // Act
+        Result result = await CreateHandler().Handle(new DeleteGameVersion.Command(GameVersionId.Empty), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("GameVersions.Validation");
+        _gameVersionRepository.DidNotReceive().Remove(Arg.Any<GameVersion>());
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenVersionNotFound_ShouldReturnNotFoundAndNotDelete()
+    {
+        // Arrange
+        GameVersionId id = GameVersionId.Create();
+        _gameVersionRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(Maybe<GameVersion>.None);
+
+        // Act
+        Result result = await CreateHandler().Handle(new DeleteGameVersion.Command(id), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.NotFound(id));
+        _gameVersionRepository.DidNotReceive().Remove(Arg.Any<GameVersion>());
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenVersionIsProcessed_ShouldReturnConflictAndNotDelete()
+    {
+        // Arrange — a processed version is woven into the lifecycle and may not be removed.
+        GameVersion gameVersion = UnprocessedVersion();
+        gameVersion.MarkAsProcessed();
+        _gameVersionRepository.GetByIdAsync(gameVersion.Id, Arg.Any<CancellationToken>())
+            .Returns(Maybe<GameVersion>.From(gameVersion));
+
+        // Act
+        Result result = await CreateHandler().Handle(new DeleteGameVersion.Command(gameVersion.Id), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted(gameVersion.Id));
+        // The status guard short-circuits before the cross-aggregate reference check.
+        await _translationRepository.DidNotReceive().AnyReferencesGameVersionAsync(Arg.Any<GameVersionId>(), Arg.Any<CancellationToken>());
+        _gameVersionRepository.DidNotReceive().Remove(Arg.Any<GameVersion>());
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenVersionIsReferencedByATranslation_ShouldReturnConflictAndNotDelete()
+    {
+        // Arrange — an unprocessed version that (defensively) a translation still references.
+        GameVersion gameVersion = UnprocessedVersion();
+        _gameVersionRepository.GetByIdAsync(gameVersion.Id, Arg.Any<CancellationToken>())
+            .Returns(Maybe<GameVersion>.From(gameVersion));
+        _translationRepository.AnyReferencesGameVersionAsync(gameVersion.Id, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        Result result = await CreateHandler().Handle(new DeleteGameVersion.Command(gameVersion.Id), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.CannotDeleteReferencedVersion(gameVersion.Id));
+        _gameVersionRepository.DidNotReceive().Remove(Arg.Any<GameVersion>());
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenUnprocessedAndUnreferenced_ShouldRemoveAndPersist()
+    {
+        // Arrange — repository reports no referencing translation (default substitute returns false).
+        GameVersion gameVersion = UnprocessedVersion();
+        _gameVersionRepository.GetByIdAsync(gameVersion.Id, Arg.Any<CancellationToken>())
+            .Returns(Maybe<GameVersion>.From(gameVersion));
+
+        // Act
+        Result result = await CreateHandler().Handle(new DeleteGameVersion.Command(gameVersion.Id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        _gameVersionRepository.Received(1).Remove(gameVersion);
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/GameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/GameVersionTests.cs
@@ -136,4 +136,47 @@ public sealed class GameVersionTests
         result.Error.ShouldBe(DomainErrors.GameVersionEntity.ProcessedCannotBeSuperseded(gameVersion.Id));
         gameVersion.Status.ShouldBe(GameVersionStatus.Processed);
     }
+
+    [Fact]
+    public void EnsureCanBeDeleted_WhenUnprocessed_ShouldSucceed()
+    {
+        // Arrange
+        GameVersion gameVersion = CreateGameVersion();
+
+        // Act
+        Result result = gameVersion.EnsureCanBeDeleted();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void EnsureCanBeDeleted_WhenProcessed_ShouldReturnFailure()
+    {
+        // Arrange
+        GameVersion gameVersion = CreateGameVersion();
+        gameVersion.MarkAsProcessed();
+
+        // Act
+        Result result = gameVersion.EnsureCanBeDeleted();
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted(gameVersion.Id));
+    }
+
+    [Fact]
+    public void EnsureCanBeDeleted_WhenSuperseded_ShouldReturnFailure()
+    {
+        // Arrange
+        GameVersion gameVersion = CreateGameVersion();
+        gameVersion.MarkSuperseded();
+
+        // Act
+        Result result = gameVersion.EnsureCanBeDeleted();
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted(gameVersion.Id));
+    }
 }


### PR DESCRIPTION
- **docs: spec 0005 — game versions management UI + guarded delete (#209)**
- **feat(api): guarded DELETE /game-versions/{id} + admin delete rel (#209)**
- **feat(frontend): /game-versions management page (list, register, delete) (#209)**
