### PR TITLE
M6-15: Enterprise CD — automated ACA rollout with GitHub approval gate + IaC in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,36 +1,36 @@
 name: CD
 
-# Build + push the four service images to GHCR (ADR-0008 §6, ticket M6-09). The deployment unit is
-# an OCI image (ADR-0008 §1); this is the only workflow that publishes one. It builds the existing
-# multi-stage Dockerfiles — no new build logic — and pushes to ghcr.io/koniecdev/<image>:
-#   * lotrokoniecdev-auth-api   — src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
-#   * lotrokoniecdev-tms-api    — src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
-#   * lotrokoniecdev-frontend   — src/Frontend/LotroKoniecDev.Frontend/Dockerfile
-#   * lotrokoniecdev-migrator   — Dockerfile.migrator.prod (the lean, self-contained EF migration-bundle
-#                                 image — the artifact a cloud pre-deploy job runs; M6-10, ADR-0008 §6.
-#                                 The dev Dockerfile.migrator is built locally by compose.yaml, never published.)
+# Continuous delivery + deployment for the TMS (ADR-0012).
 #
-# Triggers:
-#   * push to main           → publishes :sha-<short> and :latest (the moving "tip of main")
-#   * push of a v* tag       → publishes :sha-<short>, :<major.minor.patch> and :<major.minor>
-#                              (immutable release coordinates; `latest` is NOT moved by a tag — it
-#                               tracks the default branch only, so its meaning stays unambiguous)
+#   build-and-push → publishes the four OCI images to GHCR (the deployment unit; ADR-0008 §1/§6).
+#   deploy-prod    → rolls them out to Azure Container Apps, BEHIND a manual approval gate.
+#   smoke          → post-deploy end-to-end signal (reusable smoke.yml).
 #
-# Pull a published image (the runbook — M6-11 — documents this for operators):
-#   docker pull ghcr.io/koniecdev/lotrokoniecdev-tms-api:latest
+# The deployment unit is an immutable per-commit image (`sha-<short>`); the rolling tag is owned by
+# THIS pipeline (`az containerapp update`), not Terraform — the ACA resources ignore image drift
+# (iac/, lifecycle.ignore_changes). `latest` still tracks the tip of main for humans pulling by hand.
+#
+# Build images:
+#   * push to main      → :sha-<short> and :latest
+#   * push of a v* tag  → :sha-<short>, :<major.minor.patch>, :<major.minor>  (latest is NOT moved)
+#
+# Deploy: every push to main becomes a deploy CANDIDATE that pauses at the `production` environment
+# approval gate (prod is de-facto staging for QA — a human releases it when QA is free). A v* tag
+# only publishes artifacts; it does not deploy. `workflow_dispatch` deploys the tip of the chosen
+# ref (or an explicit image_tag) on demand, still behind the gate.
 on:
   push:
     branches: ["main"]
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to deploy (e.g. sha-1a2b3c4 or v1.2.3). Empty = the dispatched commit SHA.'
+        required: false
+        default: ''
 
-# Don't pile up publishes for the same ref; a newer push supersedes an in-flight one. Keyed by ref
-# so a main push and a tag push (different refs) never cancel each other.
-concurrency:
-  group: cd-${{ github.ref }}
-  cancel-in-progress: true
-
-# Least privilege: read the repo, write packages (GHCR). GITHUB_TOKEN is scoped to this repo's
-# packages only — no PAT, no cross-repo reach.
+# Least privilege at the top: read the repo, write packages (GHCR). The deploy job widens to
+# id-token (OIDC) and narrows packages away — see its own permissions block.
 permissions:
   contents: read
   packages: write
@@ -44,6 +44,11 @@ jobs:
     name: Build & push ${{ matrix.image }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # A newer push supersedes an in-flight BUILD for the same ref; deploys are serialized separately
+    # (deploy-prod uses its own non-cancelling group so a rollout is never interrupted mid-flight).
+    concurrency:
+      group: cd-build-${{ github.ref }}
+      cancel-in-progress: true
 
     strategy:
       # Publish every image even if one fails, so a single flaky build doesn't mask the rest.
@@ -103,3 +108,138 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
           provenance: false
+
+  deploy-prod:
+    name: Deploy to prod (ACA)
+    needs: build-and-push
+    # Deploy on a main push or a manual dispatch. A v* tag push only builds artifacts.
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    # The `production` environment carries the required-reviewer rule: this job PAUSES here until a
+    # human approves the release. That is the "approve a release manually in GitHub" control.
+    environment:
+      name: production
+      url: https://lotro-translator.pl
+    # Never cancel a rollout in progress; queue instead. A waiting-for-approval run is superseded by
+    # the next one only after the running rollout finishes.
+    concurrency:
+      group: cd-deploy-prod
+      cancel-in-progress: false
+    permissions:
+      contents: read # checkout (scripts/)
+      id-token: write # Azure OIDC federation — short-lived token, no stored client secret
+    env:
+      RESOURCE_GROUP: rg-lotrotms-prod-polc-001
+      AUTH_APP: lotrotms-auth-api-prod
+      TMS_APP: lotrotms-tms-api-prod
+      FRONTEND_APP: lotrotms-frontend-prod
+      MIGRATOR_JOB: lotrotms-migrator-prod
+      AUTH_URL: https://auth.lotro-translator.pl
+      TMS_URL: https://tms.lotro-translator.pl
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # GITHUB_SHA / INPUT_IMAGE_TAG go through the environment (never interpolated into run:) — the
+      # SHA is trusted hex, the input cannot inject shell. `sha-<short>` mirrors docker/metadata type=sha.
+      - name: Resolve image tag
+        id: tag
+        env:
+          INPUT_IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_IMAGE_TAG:-}" ]; then
+            tag="$INPUT_IMAGE_TAG"
+          else
+            tag="sha-$(printf '%s' "$GITHUB_SHA" | cut -c1-7)"
+          fi
+          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+          printf 'Deploying image tag: %s\n' "$tag"
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # R6 gate: run the migrator to completion BEFORE rolling the APIs. A non-Succeeded execution
+      # fails the job, so the apps are never rolled onto an un-migrated schema (no half-migrated serving).
+      - name: Run migrations (gate — rollout blocked unless this succeeds)
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          img="${REGISTRY}/${IMAGE_NAMESPACE}/lotrokoniecdev-migrator:${TAG}"
+          echo "Pinning migrator job to ${img}"
+          az containerapp job update -n "$MIGRATOR_JOB" -g "$RESOURCE_GROUP" --image "$img" -o none
+          echo "Starting migrator job…"
+          az containerapp job start -n "$MIGRATOR_JOB" -g "$RESOURCE_GROUP" -o none
+          echo "Waiting for the latest execution to complete…"
+          status=""
+          for _ in $(seq 1 80); do
+            status=$(az containerapp job execution list -n "$MIGRATOR_JOB" -g "$RESOURCE_GROUP" \
+              --query "sort_by([],&properties.startTime)[-1].properties.status" -o tsv 2>/dev/null || true)
+            echo "  migrator status: ${status:-<pending>}"
+            case "$status" in
+              Succeeded) break ;;
+              Failed | Degraded | Canceled) echo "::error::Migration job ended: ${status}"; exit 1 ;;
+            esac
+            sleep 15
+          done
+          if [ "$status" != "Succeeded" ]; then
+            echo "::error::Migration job did not succeed within the time budget (status=${status:-none})."
+            exit 1
+          fi
+          echo "Migrations applied."
+
+      # Single-revision apps: changing the image rolls traffic to a new revision pinned to this SHA.
+      - name: Roll the three web apps to the new image
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          roll() {
+            app="$1"; image="$2"
+            img="${REGISTRY}/${IMAGE_NAMESPACE}/${image}:${TAG}"
+            echo "::group::Rolling ${app} → ${img}"
+            az containerapp update -n "$app" -g "$RESOURCE_GROUP" --image "$img" -o none
+            echo "::endgroup::"
+          }
+          roll "$AUTH_APP" lotrokoniecdev-auth-api
+          roll "$TMS_APP" lotrokoniecdev-tms-api
+          roll "$FRONTEND_APP" lotrokoniecdev-frontend
+
+      # Cold-start tolerant: poll readiness before handing off to the smoke job.
+      - name: Wait for readiness
+        run: |
+          set -euo pipefail
+          wait_ready() {
+            name="$1"; url="$2"
+            echo "::group::Waiting for ${name} readiness: ${url}"
+            for _ in $(seq 1 40); do
+              code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 10 "$url" || true)
+              echo "  ${name} → ${code}"
+              if [ "$code" = "200" ]; then echo "::endgroup::"; return 0; fi
+              sleep 10
+            done
+            echo "::endgroup::"
+            echo "::error::${name} did not become ready: ${url}"
+            return 1
+          }
+          wait_ready auth "${AUTH_URL}/health/ready"
+          wait_ready tms "${TMS_URL}/health/ready"
+
+  smoke:
+    name: Post-deploy smoke
+    needs: deploy-prod
+    # The documented "call the smoke job at the end of the deploy workflow" (runbook). secrets:
+    # inherit passes the repo SMOKE_CLIENT_SECRET to the reusable workflow.
+    uses: ./.github/workflows/smoke.yml
+    secrets: inherit
+    with:
+      auth_url: https://auth.lotro-translator.pl
+      tms_url: https://tms.lotro-translator.pl
+      frontend_url: https://lotro-translator.pl

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -112,8 +112,10 @@ jobs:
   deploy-prod:
     name: Deploy to prod (ACA)
     needs: build-and-push
-    # Deploy on a main push or a manual dispatch. A v* tag push only builds artifacts.
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    # Activation switch: set repo variable CD_ENABLED=true once the one-time Azure/GitHub setup is
+    # done (runbook). Until then this job is skipped, so merging is inert (build still publishes).
+    # Then: deploy on a main push or a manual dispatch. A v* tag push only builds artifacts.
+    if: vars.CD_ENABLED == 'true' && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     # The `production` environment carries the required-reviewer rule: this job PAUSES here until a

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -52,7 +52,9 @@ env:
 jobs:
   plan:
     name: terraform plan
-    if: github.event_name == 'pull_request'
+    # Activation switch (see runbook): until CD_ENABLED=true the Azure-touching jobs are skipped, so
+    # an iac/** PR stays green before the one-time OIDC/secret setup is done.
+    if: vars.CD_ENABLED == 'true' && github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     defaults:
@@ -96,7 +98,7 @@ jobs:
 
   apply:
     name: terraform apply
-    if: github.event_name != 'pull_request'
+    if: vars.CD_ENABLED == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Same approval gate as the app rollout — a human approves before live infra changes.

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,128 @@
+name: Infra (Terraform)
+
+# Terraform lifecycle for the Azure infra in iac/ (ADR-0012):
+#   * PR touching iac/**            → terraform fmt-check + validate + PLAN (read-only preview in the
+#                                     run summary; the PR gate for infra changes).
+#   * push to main touching iac/**  → terraform APPLY behind the `production` approval gate.
+#   * workflow_dispatch             → manual APPLY behind the same gate.
+#
+# Auth: Azure OIDC federation (azure/login@v2) — no stored client secret; the azurerm provider AND
+# the azurerm state backend both authenticate via the resulting Azure CLI session (use_cli default).
+# Terraform inputs (iac/vars.tf) arrive as TF_VAR_* env: sensitive ones from repo SECRETS, plain ones
+# from repo VARIABLES. The rolling container image is NOT managed here — cd.yml owns it and the ACA
+# resources ignore image drift (lifecycle.ignore_changes).
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "iac/**"
+      - ".github/workflows/infra.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "iac/**"
+      - ".github/workflows/infra.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # Azure OIDC federation
+
+# Serialize infra runs per ref; never cancel an in-flight apply (state-lock also guards correctness).
+concurrency:
+  group: infra-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  # Terraform input variables (iac/vars.tf). TF_VAR_<name> is case-sensitive — keep the var name lowercase.
+  TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  TF_VAR_connection_string_translation: ${{ secrets.CONNECTION_STRING_TRANSLATION }}
+  TF_VAR_connection_string_auth: ${{ secrets.CONNECTION_STRING_AUTH }}
+  TF_VAR_openiddict_signing_key_rsa_private_key_xml: ${{ secrets.OPENIDDICT_SIGNING_KEY }}
+  TF_VAR_openiddict_encryption_key: ${{ secrets.OPENIDDICT_ENCRYPTION_KEY }}
+  TF_VAR_openiddict_api_client_secret: ${{ secrets.OPENIDDICT_API_CLIENT_SECRET }}
+  TF_VAR_smtp_username: ${{ secrets.SMTP_USERNAME }}
+  TF_VAR_smtp_password: ${{ secrets.SMTP_PASSWORD }}
+  TF_VAR_admin_password: ${{ secrets.ADMIN_PASSWORD }}
+  TF_VAR_smtp_sender_email: ${{ vars.SMTP_SENDER_EMAIL }}
+  TF_VAR_admin_username: ${{ vars.ADMIN_USERNAME }}
+  TF_VAR_admin_email: ${{ vars.ADMIN_EMAIL }}
+
+jobs:
+  plan:
+    name: terraform plan
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: iac
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.15.7
+
+      - name: terraform fmt -check
+        run: terraform fmt -check -recursive
+
+      - name: terraform init
+        run: terraform init -input=false
+
+      - name: terraform validate
+        run: terraform validate -no-color
+
+      - name: terraform plan
+        run: |
+          set -euo pipefail
+          terraform plan -input=false -no-color -lock-timeout=300s | tee plan.txt
+          {
+            echo '### Terraform plan';
+            echo '```';
+            tail -c 60000 plan.txt;
+            echo '```';
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: terraform apply
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    # Same approval gate as the app rollout — a human approves before live infra changes.
+    environment:
+      name: production
+    defaults:
+      run:
+        working-directory: iac
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.15.7
+
+      - name: terraform init
+        run: terraform init -input=false
+
+      - name: terraform apply
+        run: terraform apply -input=false -auto-approve -lock-timeout=300s

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,26 +1,49 @@
 name: Smoke test
 
-# Post-deploy smoke test (M6-13). Manual on-demand run against a deployed environment — it gives a
-# green/red signal that auth-api + tms-api + frontend came up correctly (health, an OIDC token
-# round-trip, that tms accepts the token, and the public translation-file distribution).
+# Post-deploy smoke test (M6-13). Two entry points:
+#   * workflow_call    — invoked by cd.yml's deploy after a prod rollout (the runbook's "call this
+#                        job at the end of the deploy workflow"). Secrets arrive via `secrets: inherit`.
+#   * workflow_dispatch — manual on-demand run against any environment (enter the three URLs).
 #
-# It is workflow_dispatch ONLY, by design: the deploy target/provider is deliberately deferred
-# (ADR-0008), so there is no environment to auto-run against yet. Once a provider + staging exist,
-# add a call to this job (workflow_call or a step) at the end of the deploy workflow.
+# It gives a green/red signal that auth-api + tms-api + frontend came up correctly: health, an OIDC
+# token round-trip, that tms accepts the token, and the public translation-file distribution.
 #
-# Prerequisite: set the repository/environment secret SMOKE_CLIENT_SECRET to the auth server's
-# OpenIddict API client secret (OpenIddict__ApiClientSecret — the same value auth-api runs with).
+# Prerequisite: the repository secret SMOKE_CLIENT_SECRET = the auth server's OpenIddict API client
+# secret (OpenIddict__ApiClientSecret — the same value auth-api runs with).
 on:
+  workflow_call:
+    inputs:
+      auth_url:
+        description: 'auth-api base URL'
+        required: true
+        type: string
+      tms_url:
+        description: 'tms-api base URL'
+        required: true
+        type: string
+      frontend_url:
+        description: 'frontend base URL'
+        required: true
+        type: string
+      client_id:
+        description: 'OIDC client id (client-credentials)'
+        required: false
+        type: string
+        default: 'lotrokoniecdev-api'
+    secrets:
+      SMOKE_CLIENT_SECRET:
+        description: 'OpenIddict API client secret (OpenIddict__ApiClientSecret)'
+        required: false
   workflow_dispatch:
     inputs:
       auth_url:
-        description: 'auth-api base URL (e.g. https://auth.lotro.koniec.dev)'
+        description: 'auth-api base URL (e.g. https://auth.lotro-translator.pl)'
         required: true
       tms_url:
-        description: 'tms-api base URL (e.g. https://tms.lotro.koniec.dev)'
+        description: 'tms-api base URL (e.g. https://tms.lotro-translator.pl)'
         required: true
       frontend_url:
-        description: 'frontend base URL (e.g. https://lotro.koniec.dev)'
+        description: 'frontend base URL (e.g. https://lotro-translator.pl)'
         required: true
       client_id:
         description: 'OIDC client id (client-credentials)'

--- a/docs/adr/0012-continuous-deployment-pipeline.md
+++ b/docs/adr/0012-continuous-deployment-pipeline.md
@@ -143,7 +143,8 @@ Rejected: a long-lived secret in GitHub versus keyless OIDC federation.
   `koniec.dev → lotro-translator.pl` and the automated-CD description.
 - **Operator one-time setup** (Azure + GitHub; enumerated in the runbook + issue #217): Entra app +
   two federated credentials, RBAC, repo Secrets/Variables, the `production` environment with a
-  required reviewer.
+  required reviewer, and the `CD_ENABLED` activation switch (a repo Variable; the Azure-touching jobs
+  are skipped until it is `true`, so merging this change is inert until the operator activates).
 - **Unchanged:** the four Dockerfiles, the CI gate (`pr-verify`/`ci`), `gitleaks`/`e2e`/`mutation`,
   and the patcher (ADR-0002).
 

--- a/docs/adr/0012-continuous-deployment-pipeline.md
+++ b/docs/adr/0012-continuous-deployment-pipeline.md
@@ -1,0 +1,156 @@
+# ADR-0012: Continuous deployment pipeline (automated ACA rollout + GitHub approval gate + IaC in CI)
+
+**Status:** Accepted
+**Date:** 2026-06-28
+**Decision-makers:** Solo maintainer
+**Related:** ADR-0008 (cloud-agnostic deployment & environment strategy — **superseded** here on its
+"no IaC / first deploy is human-driven / provider undecided" stance, now that the provider is chosen:
+ACA + Supabase, per `docs/deployment/azure-supabase-bring-up-plan.md`), ADR-0005 (DP keyring
+persistence), ADR-0006 (dev compose posture), `iac/`, `.github/workflows/{cd,infra,smoke}.yml`,
+issue #217.
+
+## Context
+
+After M6 the pipeline does **continuous delivery to GHCR but not deployment**: `cd.yml` builds and
+pushes the four images, then stops. The live ACA apps pin `image = ":latest"` with
+`revision_mode = "Single"`, so `terraform apply` with an unchanged image string produces **no new
+revision** — pushed code never rolls out. The migrator is a **manual-trigger** ACA Job (the R6
+"gate API rollout on migration success" rule was documented but never enforced on the live
+environment). There are **no GitHub Environments** (no approval gate). CI holds **no Azure
+credentials**. The only path to prod is a manual laptop ritual — local `terraform apply` + a manual
+`az containerapp update` to force the new image + `az containerapp job start` + a manual smoke — half
+of which is a silent no-op unless the operator knows the `:latest`/`Single` gotcha. ADR-0008
+deliberately deferred this ("the first deploy is human-driven; no AI-generated IaC operated without
+understanding"), which was correct while the provider was undecided. The provider is now chosen and
+the infra exists in `iac/`, so the cost to buy down is **operational, not exploratory**.
+
+One constraint shapes the design: prod has **zero users and doubles as the QA/staging environment**
+(no separate staging — YAGNI for a pre-release portfolio app). An unconditional auto-deploy on every
+merge would redeploy **under QA's feet mid-test**. Deployment must therefore be *continuous in
+readiness* but *gated on a human "release now" decision*.
+
+## Decision
+
+### 1. The deployment unit is an immutable per-commit image; the pipeline owns the rolling tag
+
+`cd.yml` builds + pushes `:sha-<short>` (plus `:latest` on main, semver on `v*`). The deploy job
+rolls ACA to that immutable `:sha-<short>` via `az containerapp update`. `:latest` stays a
+human-pull convenience only — never the thing that defines what runs.
+
+### 2. Terraform owns infra shape; the pipeline owns the running image
+
+Each ACA app + the migrator job carries `lifecycle { ignore_changes = [...container[0].image] }`
+(and a `var.image_tag` bootstrap default). So `terraform apply` never reverts a deployed revision to
+the bootstrap tag, and `az containerapp update` never fights Terraform. Clean split: **TF =
+env/scaling/ingress/secrets/storage; pipeline = which version runs.**
+
+### 3. Every merge to main is an approval-gated deploy candidate
+
+A push to main builds artifacts unconditionally, then `deploy-prod` **pauses at the `production`
+GitHub Environment** (required reviewer). Approving releases it. `workflow_dispatch` deploys the tip
+of a ref (or an explicit `image_tag`) on demand, behind the same gate. A `v*` tag publishes
+artifacts only — it does not deploy. This is the "approve a release manually in GitHub" control that
+protects in-flight QA.
+
+### 4. Migrations are an enforced pre-rollout gate (R6 — finally live)
+
+`deploy-prod` pins the migrator job to the same `:sha`, starts it, and polls its execution to
+`Succeeded` **before rolling any API**. A non-`Succeeded` execution fails the job, so the apps are
+never rolled onto an un-migrated schema — no half-migrated serving. Forward-only (ADR-0008 §6;
+snapshot before applying in a real environment).
+
+### 5. Post-deploy smoke is wired into the deploy
+
+`smoke.yml` becomes `workflow_call`-able; `deploy-prod` invokes it after a cold-start-tolerant
+readiness wait. A failed smoke marks the release failed and visible (the documented "call the smoke
+job at the end of the deploy workflow").
+
+### 6. Infra is also CI-managed, behind the same gate
+
+`infra.yml` runs `fmt -check` + `validate` + `plan` on PRs touching `iac/**` (preview in the run
+summary — the infra PR gate), and a **gated `terraform apply`** on main / dispatch. This closes the
+"manual local terraform" gap and makes every infra change reviewable.
+
+### 7. Azure auth is OIDC federation — no stored secret
+
+Both workflows authenticate via `azure/login` OIDC (`id-token: write`) against an Entra app with
+**two federated credentials** (subjects `…:environment:production` and `…:pull_request`); the
+`azurerm` provider + state backend reuse that Azure CLI session (`use_cli`). RBAC: **Contributor on
+the prod RG + the tfstate RG**. No long-lived client secret in GitHub.
+
+### 8. Secrets: app secrets stay in ACA; TF inputs move to GitHub
+
+The app-rollout path needs **zero app secrets** — they already live as ACA `secret`s, set by
+Terraform. `infra.yml` needs the TF inputs, so the `iac/terraform.tfvars` values move to GitHub repo
+**Secrets** (sensitive) / **Variables** (plain) as `TF_VAR_*`. Nothing secret is ever committed
+(`*.tfvars` stays gitignored).
+
+## Consequences
+
+### Positive
+
+- A `merge → approve → live` path a recruiter recognizes: immutable artifacts, an enforced migration
+  gate, human release control, post-deploy smoke, IaC plan/apply in CI, and keyless cloud auth.
+- The `:latest`/`Single` silent-no-op trap is gone; **what's approved is exactly what runs** (by SHA).
+- QA on prod is never interrupted involuntarily — releases wait for a human.
+- `min_replicas` lifted `0 → 1` (R8) so a release isn't a cold start; smoke stays cold-start tolerant.
+
+### Negative / Accepted Trade-offs
+
+- **Single environment** (prod = staging): a bad release lands on the only environment. Mitigated by
+  the migration gate + smoke + zero users + free breaking changes (ADR-0002). A real staging is a
+  future ADR if users arrive.
+- **Single-revision rollout** (no blue/green traffic split). Fine at this scale; revisit if
+  zero-downtime becomes a requirement.
+- **TF secrets now also live in GitHub** (besides the laptop). Accepted: scoped repo secrets,
+  masked, never in git; the alternative (manual local apply forever) is worse.
+- **Forward-only migrations** (no automated rollback) — unchanged from ADR-0008 §6.
+
+## Alternatives Considered
+
+### A. Pipeline rolls by SHA; TF infra-only; gated; OIDC; IaC in CI (this ADR)
+
+Chosen. Targeted, fast, keyless rollout; clean infra/version ownership split; the gate gives release
+control without extra ceremony.
+
+### B. `terraform apply` in CI as the *rollout* mechanism (image tag as a TF var)
+
+Rejected as the rollout path: couples every code deploy to a full plan/apply with all app secrets in
+the apply — slower and riskier than a targeted `az containerapp update`. TF is still CI-managed for
+**infra** (§6); it is just not the per-commit rollout lever.
+
+### C. Auto-deploy on merge with no gate
+
+Rejected: redeploys under QA mid-test — the exact failure mode the maintainer called out.
+
+### D. Tag-only releases (deploy only on `v*`)
+
+Rejected: more ceremony, fewer prod candidates; the approval gate already provides release control
+without tags. `v*` still builds immutable artifacts.
+
+### E. Service-principal client secret for Azure auth
+
+Rejected: a long-lived secret in GitHub versus keyless OIDC federation.
+
+## Implementation Notes
+
+- **New:** `.github/workflows/infra.yml`; this ADR.
+- **Changed (CI/CD):** `cd.yml` (+`deploy-prod` gated job, +`smoke` reusable-call job);
+  `smoke.yml` (+`workflow_call`).
+- **Changed (infra):** `iac/vars.tf` (`image_tag`); `iac/azure-container-apps.tf` +
+  `iac/migrator-job.tf` (`ignore_changes` on the image ×4, `min_replicas` `0 → 1`).
+- **Changed (docs):** `runbook.md` + `azure-supabase-bring-up-plan.md` — domain drift
+  `koniec.dev → lotro-translator.pl` and the automated-CD description.
+- **Operator one-time setup** (Azure + GitHub; enumerated in the runbook + issue #217): Entra app +
+  two federated credentials, RBAC, repo Secrets/Variables, the `production` environment with a
+  required reviewer.
+- **Unchanged:** the four Dockerfiles, the CI gate (`pr-verify`/`ci`), `gitleaks`/`e2e`/`mutation`,
+  and the patcher (ADR-0002).
+
+## References
+
+- ADR-0008 — cloud-agnostic deployment & environment strategy (superseded here re: provider / IaC /
+  human-driven first deploy)
+- `docs/deployment/azure-supabase-bring-up-plan.md`, `runbook.md`, `target-requirements.md`
+- `.github/workflows/cd.yml`, `infra.yml`, `smoke.yml`; `iac/`
+- issue #217

--- a/docs/deployment/azure-supabase-bring-up-plan.md
+++ b/docs/deployment/azure-supabase-bring-up-plan.md
@@ -1,5 +1,11 @@
 # TMS on Azure Container Apps + Supabase — Bring-up Plan
 
+> 🟢 **Status: executed.** The infra in `iac/` is live: RG `rg-lotrotms-prod-polc-001`, domain
+> **`lotro-translator.pl`** (`auth.` / `tms.` / apex), DB on Supabase. **Ongoing deploys are now
+> automated and gated** — see [ADR-0012](../adr/0012-continuous-deployment-pipeline.md) and the
+> runbook's *Continuous deployment (CI/CD)* section. The historical `*.lotro.koniec.dev` and
+> `rg-…-dev-…` strings below are from the original plan; read them as the live domain / RG.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development`
 > (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use
 > checkbox (`- [ ]`) syntax for tracking.

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -404,6 +404,11 @@ Environments → New → `production` → *Required reviewers* → add yourself)
 The secret/variable values are exactly the ones already in the git-ignored `iac/terraform.tfvars`;
 copying them to GitHub is what lets `infra.yml` plan/apply. They are **never** committed.
 
+**6. Flip the activation switch — repo Variable `CD_ENABLED` = `true`.** This is the master switch:
+the Azure-touching jobs (`deploy-prod`, `infra plan`/`apply`) carry `if: vars.CD_ENABLED == 'true'`,
+so until you set it they are **skipped** — merging is inert and `iac/**` PRs stay green before steps
+1–5 exist. Set it last, once 1–5 are done; unset it to pause all deployment without touching code.
+
 ## Database migrations
 
 ### Strategy (ADR-0008 §6)

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -17,6 +17,7 @@
 - [Generating secrets](#generating-secrets)
 - [Consistency rules that bite](#consistency-rules-that-bite) — issuer / redirect / authority / CORS
 - [Bringing the stack up](#bringing-the-stack-up)
+- [Continuous deployment (CI/CD)](#continuous-deployment-cicd) — the automated rollout, the approval gate, and the one-time operator setup
 - [Database migrations](#database-migrations)
 - [Post-deploy smoke test](#post-deploy-smoke-test) — one command verifies a deployed environment end-to-end
 - [See also](#see-also)
@@ -67,6 +68,11 @@ table per service.
 Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:AccessTokenLifetimeMinutes`
 = 60, `OpenIddict:RefreshTokenLifetimeDays` = 14, `Import:*`, `Email:TimeoutSeconds`/`MaxSendAttempts`,
 `AllowedHosts` = `*`).
+
+> ⚠️ **Live prod domain is `lotro-translator.pl`** — auth → `https://auth.lotro-translator.pl`,
+> tms → `https://tms.lotro-translator.pl`, frontend → `https://lotro-translator.pl`; live RG
+> `rg-lotrotms-prod-polc-001`. The `*.lotro.koniec.dev` strings in the tables below are historical
+> placeholders — read each as the live domain (or your own environment's).
 
 ### auth-api
 
@@ -321,6 +327,83 @@ the provider-specific walkthrough is deferred until the provider is chosen):
    [post-deploy smoke test](#post-deploy-smoke-test) (one command — health + auth token + token
    acceptance + file distribution).
 
+> The **manual** sequence above is the provider-neutral fallback / first bring-up. **Ongoing deploys
+> to the live Azure environment are automated** — see [Continuous deployment (CI/CD)](#continuous-deployment-cicd).
+
+## Continuous deployment (CI/CD)
+
+Ongoing delivery to the live Azure environment is automated (ADR-0012). Three workflows:
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `cd.yml` → `build-and-push` | push to main, `v*` tag | builds + pushes the 4 images to GHCR (`:sha-<short>`, `:latest` on main, semver on tags) |
+| `cd.yml` → `deploy-prod` | push to main / dispatch, **behind the `production` approval gate** | OIDC login → run migrator to success (**gate**) → `az containerapp update` the 3 apps to `:sha-<short>` → readiness wait → smoke |
+| `infra.yml` | PR / push to `iac/**`, dispatch | `plan` on PRs (preview in run summary); **gated** `apply` on main |
+
+**The release control.** Every merge to main builds, then **waits at the `production` environment**
+for a human to approve (GitHub → the run → *Review deployments* → *Approve*). Nothing reaches prod
+until you click — the safeguard for QA testing on prod. Approve when QA is free.
+
+**Deploy a specific build on demand.** Actions → *CD* → *Run workflow* → optional `image_tag`
+(`sha-<short>` or `vX.Y.Z`); empty = the chosen ref's commit. Still gated.
+
+**Roll back.** Re-run *CD* via dispatch with `image_tag` = the previous good `sha-<short>` (GHCR
+images are immutable). Approve. DB migrations are forward-only — roll the schema forward, not back
+(ADR-0008 §6); snapshot the DBs before a risky release.
+
+### One-time operator setup (your Azure + GitHub)
+
+Keyless via OIDC federation — no client secret is stored. Run once.
+
+**1. Entra app + federated credentials** (the `subject` strings must match exactly):
+
+```bash
+APP_ID=$(az ad app create --display-name "github-lotrotms-cd" --query appId -o tsv)
+az ad sp create --id "$APP_ID"
+# gated jobs (deploy-prod + terraform apply both run under environment: production)
+az ad app federated-credential create --id "$APP_ID" --parameters '{
+  "name":"gh-env-production","issuer":"https://token.actions.githubusercontent.com",
+  "subject":"repo:koniecdev/LotroKoniecDev:environment:production",
+  "audiences":["api://AzureADTokenExchange"]}'
+# infra PR plan job (no environment)
+az ad app federated-credential create --id "$APP_ID" --parameters '{
+  "name":"gh-pull-request","issuer":"https://token.actions.githubusercontent.com",
+  "subject":"repo:koniecdev/LotroKoniecDev:pull_request",
+  "audiences":["api://AzureADTokenExchange"]}'
+```
+
+**2. RBAC** — Contributor on both RGs (roll apps + manage infra + read/write tfstate):
+
+```bash
+SP_OBJ=$(az ad sp show --id "$APP_ID" --query id -o tsv)
+SUB=$(az account show --query id -o tsv)
+for RG in rg-lotrotms-prod-polc-001 rg-lotrotms-tfstate; do
+  az role assignment create --assignee-object-id "$SP_OBJ" --assignee-principal-type ServicePrincipal \
+    --role Contributor --scope "/subscriptions/$SUB/resourceGroups/$RG"
+done
+```
+
+**3. GitHub `production` environment** with **you as a required reviewer** (repo Settings →
+Environments → New → `production` → *Required reviewers* → add yourself). This block IS the gate.
+
+**4. GitHub repo Secrets** (Settings → Secrets and variables → Actions → *Secrets*):
+
+| Secret | Value |
+|---|---|
+| `AZURE_CLIENT_ID` | the Entra app id (`$APP_ID`) |
+| `AZURE_TENANT_ID` | `az account show --query tenantId -o tsv` |
+| `AZURE_SUBSCRIPTION_ID` | the subscription id |
+| `SMOKE_CLIENT_SECRET` | `OpenIddict__ApiClientSecret` (the value auth-api runs with) |
+| `CONNECTION_STRING_TRANSLATION` / `CONNECTION_STRING_AUTH` | the two Supabase connection strings |
+| `OPENIDDICT_SIGNING_KEY` / `OPENIDDICT_ENCRYPTION_KEY` / `OPENIDDICT_API_CLIENT_SECRET` | the three OpenIddict secrets |
+| `SMTP_USERNAME` / `SMTP_PASSWORD` | Brevo SMTP credentials |
+| `ADMIN_PASSWORD` | seeded admin password |
+
+**5. GitHub repo Variables** (non-secret): `SMTP_SENDER_EMAIL`, `ADMIN_USERNAME`, `ADMIN_EMAIL`.
+
+The secret/variable values are exactly the ones already in the git-ignored `iac/terraform.tfvars`;
+copying them to GitHub is what lets `infra.yml` plan/apply. They are **never** committed.
+
 ## Database migrations
 
 ### Strategy (ADR-0008 §6)
@@ -482,11 +565,11 @@ is the auth server's `OpenIddict__ApiClientSecret` (see [Generating secrets](#ge
 
 ### In CI
 
-The [`Smoke test`](../../.github/workflows/smoke.yml) workflow runs `scripts/smoke.sh` on demand
-(`workflow_dispatch` — enter the three URLs; the secret comes from the repository/environment secret
-`SMOKE_CLIENT_SECRET`). It is **manual-only by design**: the deploy target/provider is deferred
-(ADR-0008), so there is no environment to auto-run against yet. When a provider + staging exist, call
-this job at the end of the deploy workflow so a deploy that comes up wrong fails loudly.
+The [`Smoke test`](../../.github/workflows/smoke.yml) workflow is **`workflow_call`-able and is
+called automatically by `cd.yml`'s `deploy-prod` after every prod rollout** (ADR-0012) — a deploy
+that comes up wrong fails loudly. It also stays runnable **on demand** (`workflow_dispatch` — enter
+the three URLs); the secret comes from the repository secret `SMOKE_CLIENT_SECRET`. See
+[Continuous deployment (CI/CD)](#continuous-deployment-cicd).
 
 ## See also
 

--- a/iac/azure-container-apps.tf
+++ b/iac/azure-container-apps.tf
@@ -4,6 +4,13 @@ resource "azurerm_container_app" "auth_api" {
   resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
   revision_mode                = "Single"
 
+  # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
+  # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
+  # bootstrap tag (var.image_tag). See ADR-0012.
+  lifecycle {
+    ignore_changes = [template[0].container[0].image]
+  }
+
   secret {
     name  = "connection-string-auth"
     value = var.connection_string_auth
@@ -34,12 +41,12 @@ resource "azurerm_container_app" "auth_api" {
   }
 
   template {
-    min_replicas = 0
+    min_replicas = 1
     max_replicas = 1
 
     container {
       name   = "auth-api"
-      image  = "ghcr.io/koniecdev/lotrokoniecdev-auth-api:latest"
+      image  = "ghcr.io/koniecdev/lotrokoniecdev-auth-api:${var.image_tag}"
       cpu    = 0.25
       memory = "0.5Gi"
 
@@ -198,18 +205,25 @@ resource "azurerm_container_app" "tms_api" {
   resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
   revision_mode                = "Single"
 
+  # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
+  # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
+  # bootstrap tag (var.image_tag). See ADR-0012.
+  lifecycle {
+    ignore_changes = [template[0].container[0].image]
+  }
+
   secret {
     name  = "connection-string-translation"
     value = var.connection_string_translation
   }
 
   template {
-    min_replicas = 0
+    min_replicas = 1
     max_replicas = 1
 
     container {
       name   = "tms-api"
-      image  = "ghcr.io/koniecdev/lotrokoniecdev-tms-api:latest"
+      image  = "ghcr.io/koniecdev/lotrokoniecdev-tms-api:${var.image_tag}"
       cpu    = 0.25
       memory = "0.5Gi"
 
@@ -305,13 +319,20 @@ resource "azurerm_container_app" "frontend" {
   resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
   revision_mode                = "Single"
 
+  # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
+  # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
+  # bootstrap tag (var.image_tag). See ADR-0012.
+  lifecycle {
+    ignore_changes = [template[0].container[0].image]
+  }
+
   template {
-    min_replicas = 0
+    min_replicas = 1
     max_replicas = 1
 
     container {
       name   = "frontend"
-      image  = "ghcr.io/koniecdev/lotrokoniecdev-frontend:latest"
+      image  = "ghcr.io/koniecdev/lotrokoniecdev-frontend:${var.image_tag}"
       cpu    = 0.25
       memory = "0.5Gi"
 

--- a/iac/migrator-job.tf
+++ b/iac/migrator-job.tf
@@ -25,7 +25,7 @@ resource "azurerm_container_app_job" "migrator" {
   template {
     container {
       name   = "migrator"
-      image  = "ghcr.io/koniecdev/lotrokoniecdev-migrator:latest"
+      image  = "ghcr.io/koniecdev/lotrokoniecdev-migrator:${var.image_tag}"
       cpu    = 0.5
       memory = "1Gi"
 
@@ -42,6 +42,13 @@ resource "azurerm_container_app_job" "migrator" {
         secret_name = "connection-string-auth"
       }
     }
+  }
+
+  # The rolling image is owned by the CD pipeline (az containerapp job update by commit SHA), not
+  # Terraform. Ignore image drift so `terraform apply` never reverts the job to the bootstrap tag
+  # (var.image_tag). See ADR-0012.
+  lifecycle {
+    ignore_changes = [template[0].container[0].image]
   }
 
   tags = {

--- a/iac/vars.tf
+++ b/iac/vars.tf
@@ -10,6 +10,12 @@ variable "src_key" {
   default     = "terraform"
 }
 
+variable "image_tag" {
+  type        = string
+  description = "Bootstrap image tag for the four GHCR images. Only consumed when a Container App / Job is first created; afterwards the rolling tag is owned solely by the CD pipeline (az containerapp update by commit SHA) and Terraform ignores image drift via lifecycle.ignore_changes."
+  default     = "latest"
+}
+
 variable "subscription_id" {
   type        = string
   description = "The Azure subscription id"


### PR DESCRIPTION
Closes #217.

## The problem (audit)

CD stopped at GHCR: `cd.yml` built + pushed the four images but **nothing deployed them**. The live
ACA apps pin `image = ":latest"` with `revision_mode = "Single"`, so a `terraform apply` with an
unchanged image string created **no new revision** — pushed code never rolled out. The migrator was a
manual-trigger job (the R6 "gate rollout on migration success" rule documented but never enforced),
there were **no GitHub Environments** (no approval gate), and CI had **no Azure credentials**. The
only path to prod was a manual laptop ritual, half of it a silent no-op unless you knew the
`:latest`/`Single` gotcha.

## The change

A real, gated continuous deployment (ADR-0012):

- **`cd.yml` → `deploy-prod`** (new, behind the `production` approval gate): Azure **OIDC** login →
  run the migrator to `Succeeded` (**gate** — APIs never roll onto an un-migrated schema) →
  `az containerapp update` the 3 apps to the **immutable `:sha-<short>`** → cold-start-tolerant
  readiness wait → **smoke** (reusable `smoke.yml`). Every merge to main is a deploy *candidate* that
  **pauses for a human to approve** — so a release never lands under QA mid-test (prod is de-facto
  staging). `workflow_dispatch` deploys any `image_tag` on demand; a `v*` tag only builds artifacts.
- **`infra.yml`** (new): `terraform fmt/validate/plan` on PRs touching `iac/**`; **gated**
  `terraform apply` on main (OIDC, `TF_VAR_*` from GitHub).
- **`iac/`**: `lifecycle.ignore_changes` on the container image (3 apps + migrator job) + `var.image_tag`
  so Terraform owns infra and the pipeline owns the running version; `min_replicas 0 → 1` (scale-to-zero
  off, R8).
- **Docs**: ADR-0012; runbook gains a *Continuous deployment (CI/CD)* section (flow + one-time operator
  setup); domain drift `koniec.dev → lotro-translator.pl` flagged.

## ⚠️ One-time operator setup required before the pipeline runs green

The `production` environment (with you as required reviewer) is **already created** — so the gate is
live. Still needed (full commands in the runbook's *Continuous deployment (CI/CD)* section):

1. **Entra app + 2 federated credentials** (subjects `…:environment:production` and `…:pull_request`).
2. **RBAC**: Contributor on `rg-lotrotms-prod-polc-001` + `rg-lotrotms-tfstate`.
3. **Repo Secrets**: `AZURE_CLIENT_ID/TENANT_ID/SUBSCRIPTION_ID`, `SMOKE_CLIENT_SECRET`, and the
   `TF_VAR_*` values (from the git-ignored `iac/terraform.tfvars`).
4. **Repo Variables**: `SMTP_SENDER_EMAIL`, `ADMIN_USERNAME`, `ADMIN_EMAIL`.

Until then, `build-and-push` works; `deploy-prod`/`infra apply` will wait at the gate and (if approved
without setup) fail harmlessly at Azure login — no deploy happens.

## Validation

- `terraform fmt -check` + `terraform validate` → clean / Success.
- `actionlint` (via Docker) on all workflows → exit 0 (expression contexts, reusable-workflow
  input/secret matching, and shellcheck on `run:` blocks all pass).
- Workflow injection: untrusted inputs go through `env:`; `GITHUB_SHA` is the built-in; no
  `github.event.*` interpolated into `run:`.
- gitleaks pre-commit passed on every commit; no secret value is in any tracked file (`*.tfvars` stays
  gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)