### PR TITLE
fix(ci): unique CD build concurrency group per matrix image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,10 +44,12 @@ jobs:
     name: Build & push ${{ matrix.image }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    # A newer push supersedes an in-flight BUILD for the same ref; deploys are serialized separately
-    # (deploy-prod uses its own non-cancelling group so a rollout is never interrupted mid-flight).
+    # A newer push supersedes an in-flight BUILD of the SAME image for the same ref; deploys are
+    # serialized separately (deploy-prod uses its own non-cancelling group so a rollout is never
+    # interrupted mid-flight). The group MUST include matrix.image — otherwise all four matrix legs
+    # share one group and, with cancel-in-progress, cancel each other (only the last-started survives).
     concurrency:
-      group: cd-build-${{ github.ref }}
+      group: cd-build-${{ github.ref }}-${{ matrix.image }}
       cancel-in-progress: true
 
     strategy:


### PR DESCRIPTION
Regression from #218: the `build-and-push` matrix job carried a job-level
`concurrency.group` of `cd-build-${{ github.ref }}` — shared across all four
matrix legs. With `cancel-in-progress: true`, the legs cancelled each other
(only the last-started, `migrator`, survived), so the post-merge CD run came up
`cancelled` and `deploy-prod` was skipped.

Fix: include `${{ matrix.image }}` in the group so each image build is its own
concurrency scope (a newer push still supersedes the same image's in-flight build).

Validated with actionlint (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)