### PR TITLE
M6-16: Azure Key Vault as the single source of truth for prod secrets (no plaintext on disk / in TF state)

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -8,7 +8,8 @@ name: Infra (Terraform)
 #
 # Auth: Azure OIDC federation (azure/login@v2) — no stored client secret; the azurerm provider AND
 # the azurerm state backend both authenticate via the resulting Azure CLI session (use_cli default).
-# Terraform inputs (iac/vars.tf) arrive as TF_VAR_* env: sensitive ones from repo SECRETS, plain ones
+# App secrets are NOT Terraform inputs anymore: they live in Azure Key Vault and the ACA apps read them
+# via a managed identity (ADR-0013), so only the non-secret inputs (iac/vars.tf) arrive as TF_VAR_*
 # from repo VARIABLES. The rolling container image is NOT managed here — cd.yml owns it and the ACA
 # resources ignore image drift (lifecycle.ignore_changes).
 on:
@@ -35,16 +36,10 @@ concurrency:
 
 env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  # Terraform input variables (iac/vars.tf). TF_VAR_<name> is case-sensitive — keep the var name lowercase.
+  # Terraform input variables (iac/vars.tf) — non-secret only. App secrets live in Key Vault (ADR-0013),
+  # read at runtime by the ACA managed identity, so no TF_VAR_* carries a secret. TF_VAR_<name> is
+  # case-sensitive — keep the var name lowercase.
   TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  TF_VAR_connection_string_translation: ${{ secrets.CONNECTION_STRING_TRANSLATION }}
-  TF_VAR_connection_string_auth: ${{ secrets.CONNECTION_STRING_AUTH }}
-  TF_VAR_openiddict_signing_key_rsa_private_key_xml: ${{ secrets.OPENIDDICT_SIGNING_KEY }}
-  TF_VAR_openiddict_encryption_key: ${{ secrets.OPENIDDICT_ENCRYPTION_KEY }}
-  TF_VAR_openiddict_api_client_secret: ${{ secrets.OPENIDDICT_API_CLIENT_SECRET }}
-  TF_VAR_smtp_username: ${{ secrets.SMTP_USERNAME }}
-  TF_VAR_smtp_password: ${{ secrets.SMTP_PASSWORD }}
-  TF_VAR_admin_password: ${{ secrets.ADMIN_PASSWORD }}
   TF_VAR_smtp_sender_email: ${{ vars.SMTP_SENDER_EMAIL }}
   TF_VAR_admin_username: ${{ vars.ADMIN_USERNAME }}
   TF_VAR_admin_email: ${{ vars.ADMIN_EMAIL }}

--- a/docs/adr/0013-key-vault-single-source-of-truth-for-prod-secrets.md
+++ b/docs/adr/0013-key-vault-single-source-of-truth-for-prod-secrets.md
@@ -1,0 +1,149 @@
+# ADR-0013: Azure Key Vault is the single source of truth for prod secrets (managed-identity references, no plaintext on disk / in state / in CI)
+
+**Status:** Accepted
+**Date:** 2026-06-29
+**Decision-makers:** Solo maintainer
+**Related:** ADR-0012 (continuous deployment — **supersedes its §8** "app secrets stay in ACA; TF
+inputs move to GitHub Secrets"), ADR-0008 (cloud-agnostic deployment — **refines §R3** of
+`docs/deployment/target-requirements.md`, which already named "Key Vault references / managed
+identity" as the Azure-native secret-injection option), ADR-0005 (DP keyring persistence),
+`iac/`, `scripts/seed-keyvault.{sh,ps1}`, `.github/workflows/infra.yml`, issue #222.
+
+## Context
+
+After ADR-0012 the 8 production app secrets (`connection-string-{translation,auth}`, the three
+`openiddict-*`, `smtp-username/password`, `admin-password`) rested as **plaintext in three places**:
+
+1. **Local disk** — `iac/terraform.tfvars` (gitignored, but plaintext on the operator's machine).
+2. **Terraform state** — the values flowed through `var.*` into inline ACA `secret { value = … }`
+   blocks, so every `terraform apply` wrote them into the remote `azurerm` state.
+3. **GitHub repo Secrets** — the `TF_VAR_*` inputs `infra.yml` fed to the gated `terraform apply`.
+
+Three copies of every secret means three blast radii, three rotation surfaces, and a standing
+invitation for a stray secret to land in a log or a state diff. ADR-0012 §8 accepted this as a
+pragmatic step; `target-requirements.md` §R3 had already flagged the better Azure-native target:
+**Key Vault references + a managed identity**. The app layer never needed the change — it reads its
+secrets from environment variables (12-factor; ADR-0008 §3) and does not care where they come from.
+Only the **IaC wiring** decides their resting place.
+
+## Decision
+
+### 1. Key Vault is the single source of truth; nothing else stores a plaintext value
+
+The 8 secrets live **only** in an Azure Key Vault (`lotrotms-kv-prod`, RBAC-authorization mode). They
+do not rest on local disk, in the Terraform state, or in GitHub Secrets.
+
+### 2. ACA reads secrets at runtime through a user-assigned managed identity
+
+A single user-assigned identity (`lotrotms-aca-prod`) is assigned to the three apps + the migrator
+job and granted **`Key Vault Secrets User`** on the Vault. Each ACA `secret` block references the
+Vault instead of carrying a value:
+
+```hcl
+secret {
+  name                = "connection-string-auth"
+  key_vault_secret_id = local.kv_secret_id["connection-string-auth"]  # versionless URI
+  identity            = data.azurerm_user_assigned_identity.aca.id
+}
+```
+
+Versionless URIs mean a rotation (a new secret version) is picked up on the **next** revision with no
+Terraform change.
+
+### 3. Terraform wires references; it never receives a plaintext value
+
+Terraform builds the secret URI from `data.azurerm_key_vault.secrets.vault_uri` + the secret name —
+it never reads the secret **value** (no `azurerm_key_vault_secret` data source, whose `.value` would
+land in state). So the state stays free of plaintext, and the 8 sensitive `variable`s + their
+`TF_VAR_*` inputs are **deleted** from `iac/vars.tf` and `infra.yml`.
+
+### 4. The Vault, secrets, identity and role assignment are foundational (seeded out-of-band)
+
+Like the tfstate backend storage account, these are bootstrapped **outside** Terraform by an
+idempotent script — `scripts/seed-keyvault.{sh,ps1}` — that reads the values from `SEED_*` env vars
+and ensures the Vault, the identity, the `Key Vault Secrets User` grant, and the 8 secrets. Two
+payoffs: (a) no chicken-and-egg (the Vault + secrets exist before any ACA references them, so a
+single `apply` converges), and (b) Terraform — and therefore the CI deploy principal — never needs
+to **create a role assignment**, so CI keeps needing only **Contributor** (ADR-0012 §7), not
+RBAC-admin. The script is also the rotation tool: re-run it with new `SEED_*` values.
+
+### 5. App code is unchanged; the neutrality contract holds
+
+The apps still read the same env vars; ACA resolves `secret_name` → Key Vault transparently. The
+Key Vault dependency lives entirely in the Azure IaC, never in a slice — consistent with ADR-0008's
+neutrality contract (porting to another provider swaps the IaC secret-injection wiring, not a line
+of application code).
+
+## Consequences
+
+### Positive
+
+- **One copy of each secret, in a purpose-built store.** No plaintext on disk, in the Terraform
+  state, or in GitHub Secrets. The 6 secret repo Secrets (`CONNECTION_STRING_*`, `OPENIDDICT_*`,
+  `SMTP_USERNAME/PASSWORD`, `ADMIN_PASSWORD`) are now unused and can be deleted.
+- **Rotation without a deploy or a code change** — `seed-keyvault` sets a new version; the next
+  revision picks it up via the versionless URI.
+- **Least-privilege CI is preserved** — the role assignment is foundational, so CI stays Contributor.
+- **Audited, access-controlled, soft-delete-protected** secret access (Key Vault data-plane logs).
+
+### Negative / Accepted Trade-offs
+
+- **An out-of-band bring-up/rotation step** (`seed-keyvault`) instead of a single `terraform apply`.
+  Accepted: it is what keeps plaintext out of the state, and it mirrors the existing
+  bootstrapped-tfstate precedent.
+- **Azure-specific wiring** (Key Vault references). Accepted: the IaC is already 100% `azurerm`; the
+  *app* stays provider-neutral (§5), so this does not deepen lock-in where it would hurt.
+- **The seed script holds the values transiently** in process env while setting them. Accepted: it
+  is a local operator action against the operator's own session; nothing is written to disk.
+- **Purge protection is left off** for now (soft-delete only), trading a hard-delete safety net for
+  pre-release teardown flexibility. Flip `--enable-purge-protection` when users arrive.
+
+## Alternatives Considered
+
+### A. Key Vault as source of truth; ACA reads via managed-identity references; TF wires only (this ADR)
+
+Chosen. Removes plaintext from all three resting places at once; rotation is decoupled from deploys;
+CI stays least-privilege.
+
+### B. Terraform seeds the Vault (`azurerm_key_vault_secret { value = var.x }`)
+
+Rejected. One `apply` does everything, but the values still flow through `var.*` → still need a
+plaintext source (tfvars / CI) **and still land in the Terraform state**. It removes the inline-ACA
+copy but not the two that matter most — a half-measure against the actual goal.
+
+### C. Keep inline ACA secrets; just drop `terraform.tfvars` and inject every value via `TF_VAR_*` env
+
+Rejected. No Key Vault at all (the explicit ask), secrets still written into state on every apply,
+and "no secrets on disk" reduced to operator discipline that regresses the first time someone writes
+a local tfvars to debug.
+
+### D. Access policies instead of RBAC on the Vault
+
+Rejected. Azure's current guidance is RBAC authorization (unified, auditable, least-privilege via
+`Key Vault Secrets User`/`Officer`); access policies are legacy.
+
+## Implementation Notes
+
+- **New:** `iac/keyvault.tf` (Vault + identity data sources, versionless secret-URI locals);
+  `scripts/seed-keyvault.sh` + `.ps1` twin; this ADR.
+- **Changed (infra):** `iac/azure-container-apps.tf` + `iac/migrator-job.tf` (`identity {}` block +
+  `secret { key_vault_secret_id, identity }` — auth-api ×7, tms-api ×1, migrator ×2; frontend has no
+  secrets); `iac/vars.tf` (drop the 8 sensitive variables; add non-secret `key_vault_name` +
+  `aca_identity_name`).
+- **Changed (CI):** `.github/workflows/infra.yml` (drop the 6 secret `TF_VAR_*` envs).
+- **Deleted:** `iac/terraform.tfvars` (was untracked; the values now live only in the Vault).
+- **Changed (docs):** `docs/deployment/runbook.md` (Key Vault seed step + rotation + the secret
+  matrix).
+- **Operator one-time setup** (enumerated in the runbook): `az login` as an Owner / User Access
+  Administrator, export the 8 `SEED_*`, run `scripts/seed-keyvault.sh`. The role assignment needs a
+  privileged principal **once** (the script, not CI). Thereafter rotation is the same script.
+- **Unchanged:** the four Dockerfiles, the app code, the patcher (ADR-0002), `cd.yml`'s rollout, and
+  the migration gate.
+
+## References
+
+- ADR-0012 — continuous deployment pipeline (its §8 GitHub-Secrets posture is superseded here)
+- ADR-0008 + `docs/deployment/target-requirements.md` §R3 — the Key-Vault-references target
+- `iac/keyvault.tf`, `iac/azure-container-apps.tf`, `iac/migrator-job.tf`, `iac/vars.tf`
+- `scripts/seed-keyvault.sh`, `scripts/seed-keyvault.ps1`
+- `.github/workflows/infra.yml`; issue #222

--- a/docs/deployment/azure-supabase-bring-up-plan.md
+++ b/docs/deployment/azure-supabase-bring-up-plan.md
@@ -3,8 +3,13 @@
 > 🟢 **Status: executed.** The infra in `iac/` is live: RG `rg-lotrotms-prod-polc-001`, domain
 > **`lotro-translator.pl`** (`auth.` / `tms.` / apex), DB on Supabase. **Ongoing deploys are now
 > automated and gated** — see [ADR-0012](../adr/0012-continuous-deployment-pipeline.md) and the
-> runbook's *Continuous deployment (CI/CD)* section. The historical `*.lotro.koniec.dev` and
-> `rg-…-dev-…` strings below are from the original plan; read them as the live domain / RG.
+> runbook's *Continuous deployment (CI/CD)* section. **Secret management below is superseded by
+> [ADR-0013](../adr/0013-key-vault-single-source-of-truth-for-prod-secrets.md):** the app secrets now
+> live only in Azure Key Vault (seeded by `scripts/seed-keyvault.{sh,ps1}`), read at runtime via a
+> managed identity — **not** in `iac/terraform.tfvars`, the TF state, or GitHub Secrets. Read every
+> `terraform.tfvars`/`TF_VAR_*`-secret reference below as "set via the Key Vault seed step instead".
+> The historical `*.lotro.koniec.dev` and `rg-…-dev-…` strings below are from the original plan; read
+> them as the live domain / RG.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development`
 > (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -386,28 +386,44 @@ done
 **3. GitHub `production` environment** with **you as a required reviewer** (repo Settings →
 Environments → New → `production` → *Required reviewers* → add yourself). This block IS the gate.
 
-**4. GitHub repo Secrets** (Settings → Secrets and variables → Actions → *Secrets*):
+**4. Seed the app secrets into Azure Key Vault (ADR-0013).** The 8 app secrets are the single source
+of truth in Key Vault (`lotrotms-kv-prod`), read at runtime by the `lotrotms-aca-prod` managed
+identity — they are **not** GitHub Secrets and **not** Terraform inputs (no plaintext on disk, in the
+TF state, or in CI). The idempotent seed script (also the rotation tool) ensures the Vault, the
+identity, its `Key Vault Secrets User` grant, and the 8 secrets. It needs **Owner / User Access
+Administrator** once — it creates a role assignment, which is why CI never does and stays Contributor:
+
+```bash
+az login   # an Owner / User Access Administrator on the subscription
+export SEED_CONNECTION_STRING_TRANSLATION='…'   # Supabase TMS connection string
+export SEED_CONNECTION_STRING_AUTH='…'          # Supabase Auth connection string
+export SEED_OPENIDDICT_SIGNING_KEY='…'          # base64 RSA xml  (scripts/gen-openiddict-keys.sh)
+export SEED_OPENIDDICT_ENCRYPTION_KEY='…'       # base64 32-byte key      (same generator)
+export SEED_OPENIDDICT_API_CLIENT_SECRET='…'    # >= 32 chars  (== SMOKE_CLIENT_SECRET below)
+export SEED_SMTP_USERNAME='…' SEED_SMTP_PASSWORD='…'   # Brevo SMTP credentials
+export SEED_ADMIN_PASSWORD='…'                  # seeded admin password
+scripts/seed-keyvault.sh                        # PowerShell twin: scripts/seed-keyvault.ps1
+```
+
+Rotation later = re-run the script with new `SEED_*` values; the versionless Key Vault URIs make the
+next deployment pick them up with no Terraform change.
+
+**5. GitHub repo Secrets** (Settings → Secrets and variables → Actions → *Secrets*) — **infra/OIDC
+only**, no app secrets (those live in Key Vault, step 4):
 
 | Secret | Value |
 |---|---|
 | `AZURE_CLIENT_ID` | the Entra app id (`$APP_ID`) |
 | `AZURE_TENANT_ID` | `az account show --query tenantId -o tsv` |
 | `AZURE_SUBSCRIPTION_ID` | the subscription id |
-| `SMOKE_CLIENT_SECRET` | `OpenIddict__ApiClientSecret` (the value auth-api runs with) |
-| `CONNECTION_STRING_TRANSLATION` / `CONNECTION_STRING_AUTH` | the two Supabase connection strings |
-| `OPENIDDICT_SIGNING_KEY` / `OPENIDDICT_ENCRYPTION_KEY` / `OPENIDDICT_API_CLIENT_SECRET` | the three OpenIddict secrets |
-| `SMTP_USERNAME` / `SMTP_PASSWORD` | Brevo SMTP credentials |
-| `ADMIN_PASSWORD` | seeded admin password |
+| `SMOKE_CLIENT_SECRET` | `OpenIddict__ApiClientSecret` (== the seeded `openiddict-api-client-secret`) |
 
-**5. GitHub repo Variables** (non-secret): `SMTP_SENDER_EMAIL`, `ADMIN_USERNAME`, `ADMIN_EMAIL`.
+**6. GitHub repo Variables** (non-secret): `SMTP_SENDER_EMAIL`, `ADMIN_USERNAME`, `ADMIN_EMAIL`.
 
-The secret/variable values are exactly the ones already in the git-ignored `iac/terraform.tfvars`;
-copying them to GitHub is what lets `infra.yml` plan/apply. They are **never** committed.
-
-**6. Flip the activation switch — repo Variable `CD_ENABLED` = `true`.** This is the master switch:
+**7. Flip the activation switch — repo Variable `CD_ENABLED` = `true`.** This is the master switch:
 the Azure-touching jobs (`deploy-prod`, `infra plan`/`apply`) carry `if: vars.CD_ENABLED == 'true'`,
 so until you set it they are **skipped** — merging is inert and `iac/**` PRs stay green before steps
-1–5 exist. Set it last, once 1–5 are done; unset it to pause all deployment without touching code.
+1–6 exist. Set it last, once 1–6 are done; unset it to pause all deployment without touching code.
 
 ## Database migrations
 

--- a/iac/azure-container-apps.tf
+++ b/iac/azure-container-apps.tf
@@ -4,6 +4,11 @@ resource "azurerm_container_app" "auth_api" {
   resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
   revision_mode                = "Single"
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [data.azurerm_user_assigned_identity.aca.id]
+  }
+
   # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
   # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
   # bootstrap tag (var.image_tag). See ADR-0012.
@@ -11,33 +16,42 @@ resource "azurerm_container_app" "auth_api" {
     ignore_changes = [template[0].container[0].image]
   }
 
+  # Secrets resolve from Key Vault at runtime through the user-assigned identity (ADR-0013) — no
+  # plaintext value enters this configuration or the Terraform state.
   secret {
-    name  = "connection-string-auth"
-    value = var.connection_string_auth
+    name                = "connection-string-auth"
+    key_vault_secret_id = local.kv_secret_id["connection-string-auth"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
   secret {
-    name  = "openiddict-signing-key"
-    value = var.openiddict_signing_key_rsa_private_key_xml
+    name                = "openiddict-signing-key"
+    key_vault_secret_id = local.kv_secret_id["openiddict-signing-key"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
   secret {
-    name  = "openiddict-encryption-key"
-    value = var.openiddict_encryption_key
+    name                = "openiddict-encryption-key"
+    key_vault_secret_id = local.kv_secret_id["openiddict-encryption-key"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
   secret {
-    name  = "openiddict-api-client-secret"
-    value = var.openiddict_api_client_secret
+    name                = "openiddict-api-client-secret"
+    key_vault_secret_id = local.kv_secret_id["openiddict-api-client-secret"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
   secret {
-    name  = "smtp-username"
-    value = var.smtp_username
+    name                = "smtp-username"
+    key_vault_secret_id = local.kv_secret_id["smtp-username"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
   secret {
-    name  = "smtp-password"
-    value = var.smtp_password
+    name                = "smtp-password"
+    key_vault_secret_id = local.kv_secret_id["smtp-password"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
   secret {
-    name  = "admin-password"
-    value = var.admin_password
+    name                = "admin-password"
+    key_vault_secret_id = local.kv_secret_id["admin-password"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
 
   template {
@@ -205,6 +219,11 @@ resource "azurerm_container_app" "tms_api" {
   resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
   revision_mode                = "Single"
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [data.azurerm_user_assigned_identity.aca.id]
+  }
+
   # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
   # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
   # bootstrap tag (var.image_tag). See ADR-0012.
@@ -212,9 +231,11 @@ resource "azurerm_container_app" "tms_api" {
     ignore_changes = [template[0].container[0].image]
   }
 
+  # Secret resolves from Key Vault at runtime through the user-assigned identity (ADR-0013).
   secret {
-    name  = "connection-string-translation"
-    value = var.connection_string_translation
+    name                = "connection-string-translation"
+    key_vault_secret_id = local.kv_secret_id["connection-string-translation"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
 
   template {

--- a/iac/keyvault.tf
+++ b/iac/keyvault.tf
@@ -1,0 +1,35 @@
+# Azure Key Vault is the single source of truth for the production app secrets (ADR-0013). The Vault,
+# its secrets, the user-assigned identity, and the identity's "Key Vault Secrets User" role assignment
+# are foundational infrastructure — seeded out-of-band by scripts/seed-keyvault.{sh,ps1} (like the
+# tfstate backend storage account), so the CI deploy principal never needs RBAC-admin and no plaintext
+# secret value ever enters this configuration or the Terraform state. Here Terraform only data-reads
+# them and builds the versionless secret URIs that the ACA apps + migrator job reference via the
+# identity.
+
+data "azurerm_key_vault" "secrets" {
+  name                = var.key_vault_name
+  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+}
+
+data "azurerm_user_assigned_identity" "aca" {
+  name                = var.aca_identity_name
+  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+}
+
+locals {
+  # Versionless Key Vault secret URIs. ACA resolves the current version on each revision, so a
+  # rotation (a new secret version set by the seed script) is picked up on the next deployment
+  # without touching Terraform. Names must match the secrets seeded by scripts/seed-keyvault.{sh,ps1}.
+  kv_secret_id = {
+    for name in [
+      "connection-string-translation",
+      "connection-string-auth",
+      "openiddict-signing-key",
+      "openiddict-encryption-key",
+      "openiddict-api-client-secret",
+      "smtp-username",
+      "smtp-password",
+      "admin-password",
+    ] : name => "${data.azurerm_key_vault.secrets.vault_uri}secrets/${name}"
+  }
+}

--- a/iac/migrator-job.tf
+++ b/iac/migrator-job.tf
@@ -12,14 +12,23 @@ resource "azurerm_container_app_job" "migrator" {
     replica_completion_count = 1
   }
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [data.azurerm_user_assigned_identity.aca.id]
+  }
+
+  # Secrets resolve from Key Vault at runtime through the user-assigned identity (ADR-0013) — no
+  # plaintext value enters this configuration or the Terraform state.
   secret {
-    name  = "connection-string-translation"
-    value = var.connection_string_translation
+    name                = "connection-string-translation"
+    key_vault_secret_id = local.kv_secret_id["connection-string-translation"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
 
   secret {
-    name  = "connection-string-auth"
-    value = var.connection_string_auth
+    name                = "connection-string-auth"
+    key_vault_secret_id = local.kv_secret_id["connection-string-auth"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
   }
 
   template {

--- a/iac/vars.tf
+++ b/iac/vars.tf
@@ -21,46 +21,16 @@ variable "subscription_id" {
   description = "The Azure subscription id"
 }
 
-variable "connection_string_translation" {
+variable "key_vault_name" {
   type        = string
-  description = "Npgsql connection string for the TMS (translation) database"
-  sensitive   = true
+  description = "Name of the Key Vault that holds the production app secrets (ADR-0013). Seeded out-of-band by scripts/seed-keyvault.{sh,ps1}; Terraform only data-references it."
+  default     = "lotrotms-kv-prod"
 }
 
-variable "connection_string_auth" {
+variable "aca_identity_name" {
   type        = string
-  description = "Npgsql connection string for the Auth database"
-  sensitive   = true
-}
-
-variable "openiddict_signing_key_rsa_private_key_xml" {
-  type        = string
-  description = "Base64 of RSA.ToXmlString(true) for the OpenIddict signing key"
-  sensitive   = true
-}
-
-variable "openiddict_encryption_key" {
-  type        = string
-  description = "Base64 of a 32-byte OpenIddict encryption key"
-  sensitive   = true
-}
-
-variable "openiddict_api_client_secret" {
-  type        = string
-  description = "OpenIddict API client secret shared with the service client"
-  sensitive   = true
-}
-
-variable "smtp_username" {
-  type        = string
-  description = "Brevo SMTP username"
-  sensitive   = true
-}
-
-variable "smtp_password" {
-  type        = string
-  description = "Brevo SMTP key used as the SMTP password"
-  sensitive   = true
+  description = "Name of the user-assigned managed identity the ACA apps + migrator job assume to read secrets from the Key Vault. Seeded out-of-band by scripts/seed-keyvault.{sh,ps1}; Terraform only data-references it."
+  default     = "lotrotms-aca-prod"
 }
 
 variable "smtp_sender_email" {
@@ -76,10 +46,4 @@ variable "admin_username" {
 variable "admin_email" {
   type        = string
   description = "Seeded admin email"
-}
-
-variable "admin_password" {
-  type        = string
-  description = "Seeded admin password"
-  sensitive   = true
 }

--- a/scripts/seed-keyvault.ps1
+++ b/scripts/seed-keyvault.ps1
@@ -1,0 +1,130 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Seeds Azure Key Vault as the single source of truth for the TMS production secrets (ADR-0013).
+    PowerShell twin of scripts/seed-keyvault.sh — keep the two in lock-step.
+
+.DESCRIPTION
+    Idempotent — safe to re-run for bring-up AND for rotation. Ensures, in order:
+      1. the Key Vault                    (RBAC-authorization mode, soft-delete on)
+      2. a user-assigned managed identity (the one the ACA apps + migrator job assume)
+      3. "Key Vault Secrets User"   on the Vault for that identity   (data-plane read at runtime)
+      4. "Key Vault Secrets Officer" on the Vault for the caller     (so this script can set secrets)
+      5. the 8 secret values
+
+    Terraform (iac/) only data-references the Vault + identity and wires the ACA secret references;
+    it never receives a plaintext value, so nothing secret rests on disk or in the Terraform state.
+
+    Secret VALUES come from environment variables (never an argument, never a committed file):
+      SEED_CONNECTION_STRING_TRANSLATION  -> connection-string-translation
+      SEED_CONNECTION_STRING_AUTH         -> connection-string-auth
+      SEED_OPENIDDICT_SIGNING_KEY         -> openiddict-signing-key
+      SEED_OPENIDDICT_ENCRYPTION_KEY      -> openiddict-encryption-key
+      SEED_OPENIDDICT_API_CLIENT_SECRET   -> openiddict-api-client-secret
+      SEED_SMTP_USERNAME                  -> smtp-username
+      SEED_SMTP_PASSWORD                  -> smtp-password
+      SEED_ADMIN_PASSWORD                 -> admin-password
+
+    Usage (one-time bring-up + every rotation):
+      az login                                       # an Owner / User Access Administrator on the sub
+      $env:SEED_CONNECTION_STRING_TRANSLATION = '…'   # … set all 8 SEED_* …
+      ./scripts/seed-keyvault.ps1
+
+    Overridable (defaults match iac/): KV_RESOURCE_GROUP, KV_LOCATION, KV_NAME, KV_IDENTITY_NAME.
+
+    Requires: az (Azure CLI), logged in to the prod subscription.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$ResourceGroup = if ($env:KV_RESOURCE_GROUP) { $env:KV_RESOURCE_GROUP } else { 'rg-lotrotms-prod-polc-001' }
+$Location      = if ($env:KV_LOCATION)       { $env:KV_LOCATION }       else { 'polandcentral' }
+$VaultName     = if ($env:KV_NAME)           { $env:KV_NAME }           else { 'lotrotms-kv-prod' }
+$IdentityName  = if ($env:KV_IDENTITY_NAME)  { $env:KV_IDENTITY_NAME }  else { 'lotrotms-aca-prod' }
+
+# KV secret name -> SEED_* env var holding its value. Keep the names in sync with the ACA
+# `secret { name = ... }` blocks in iac/azure-container-apps.tf + iac/migrator-job.tf.
+$Secrets = [ordered]@{
+    'connection-string-translation' = 'SEED_CONNECTION_STRING_TRANSLATION'
+    'connection-string-auth'        = 'SEED_CONNECTION_STRING_AUTH'
+    'openiddict-signing-key'        = 'SEED_OPENIDDICT_SIGNING_KEY'
+    'openiddict-encryption-key'     = 'SEED_OPENIDDICT_ENCRYPTION_KEY'
+    'openiddict-api-client-secret'  = 'SEED_OPENIDDICT_API_CLIENT_SECRET'
+    'smtp-username'                 = 'SEED_SMTP_USERNAME'
+    'smtp-password'                 = 'SEED_SMTP_PASSWORD'
+    'admin-password'                = 'SEED_ADMIN_PASSWORD'
+}
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) { throw 'Azure CLI (az) is not installed.' }
+az account show 1>$null 2>$null
+if ($LASTEXITCODE -ne 0) { throw "Not logged in — run 'az login' against the prod subscription." }
+
+$missing = $Secrets.Values | Where-Object { -not [Environment]::GetEnvironmentVariable($_) }
+if ($missing) { throw "Missing secret env var(s): $($missing -join ', ')" }
+
+Write-Host "==> Subscription: $(az account show --query name -o tsv) ($(az account show --query id -o tsv))"
+Write-Host "==> Resource group: $ResourceGroup | Vault: $VaultName | Identity: $IdentityName"
+
+# 1. Key Vault (idempotent). RBAC authorization is the current best practice.
+az keyvault show -n $VaultName -g $ResourceGroup 1>$null 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "==> Vault $VaultName already exists — skipping create."
+}
+else {
+    Write-Host "==> Creating Vault $VaultName …"
+    az keyvault create -n $VaultName -g $ResourceGroup -l $Location --sku standard `
+        --enable-rbac-authorization true --retention-days 90 -o none
+}
+$VaultId = az keyvault show -n $VaultName -g $ResourceGroup --query id -o tsv
+
+# 2. User-assigned managed identity (idempotent).
+az identity show -n $IdentityName -g $ResourceGroup 1>$null 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "==> Identity $IdentityName already exists — skipping create."
+}
+else {
+    Write-Host "==> Creating user-assigned identity $IdentityName …"
+    az identity create -n $IdentityName -g $ResourceGroup -l $Location -o none
+}
+$IdentityPrincipalId = az identity show -n $IdentityName -g $ResourceGroup --query principalId -o tsv
+$IdentityResourceId  = az identity show -n $IdentityName -g $ResourceGroup --query id -o tsv
+
+# 3 + 4. Role assignments (idempotent — az is a no-op when the assignment already exists).
+Write-Host "==> Granting 'Key Vault Secrets User' to the identity …"
+az role assignment create --assignee-object-id $IdentityPrincipalId --assignee-principal-type ServicePrincipal `
+    --role 'Key Vault Secrets User' --scope $VaultId -o none
+
+$CallerObjectId = az ad signed-in-user show --query id -o tsv 2>$null
+if ($CallerObjectId) {
+    Write-Host "==> Granting 'Key Vault Secrets Officer' to the caller (to set secrets) …"
+    az role assignment create --assignee-object-id $CallerObjectId --assignee-principal-type User `
+        --role 'Key Vault Secrets Officer' --scope $VaultId -o none
+}
+else {
+    Write-Warning "Could not resolve the caller object id (service principal?). Ensure the caller holds 'Key Vault Secrets Officer' on $VaultName before secrets can be set."
+}
+
+# 5. Set the secrets. Data-plane RBAC can take a minute to propagate after the role assignment above,
+#    so the first set is retried until it is authorized.
+function Set-KvSecret([string]$Name, [string]$Value) {
+    foreach ($attempt in 1..18) {
+        az keyvault secret set --vault-name $VaultName --name $Name --value $Value -o none 2>$null
+        if ($LASTEXITCODE -eq 0) { return }
+        Write-Host "   …waiting for data-plane RBAC to propagate (attempt $attempt) …"
+        Start-Sleep -Seconds 10
+    }
+    throw "Could not set secret '$Name' — the caller still lacks data-plane access on $VaultName."
+}
+
+foreach ($name in $Secrets.Keys) {
+    $value = [Environment]::GetEnvironmentVariable($Secrets[$name])
+    Write-Host "==> Setting secret $name …"
+    Set-KvSecret $name $value
+}
+
+Write-Host ''
+Write-Host 'Done. Key Vault is seeded.'
+Write-Host "  key_vault_name    = $VaultName"
+Write-Host "  aca_identity_name = $IdentityName"
+Write-Host "  identity id       = $IdentityResourceId"
+Write-Host 'Terraform reads these via the data sources in iac/keyvault.tf (defaults already match).'

--- a/scripts/seed-keyvault.sh
+++ b/scripts/seed-keyvault.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Seeds Azure Key Vault as the single source of truth for the TMS production secrets (ADR-0013).
+#
+# Idempotent — safe to re-run for bring-up AND for rotation. Ensures, in order:
+#   1. the Key Vault                    (RBAC-authorization mode, soft-delete on)
+#   2. a user-assigned managed identity (the one the ACA apps + migrator job assume)
+#   3. "Key Vault Secrets User"  on the Vault for that identity   (data-plane read at runtime)
+#   4. "Key Vault Secrets Officer" on the Vault for the caller    (so this script can set secrets)
+#   5. the 8 secret values
+#
+# Terraform (iac/) only data-references the Vault + identity and wires the ACA secret references;
+# it never receives a plaintext value, so nothing secret rests on disk or in the Terraform state.
+#
+# Secret VALUES come from environment variables (never an argument, never a committed file):
+#   SEED_CONNECTION_STRING_TRANSLATION  -> connection-string-translation
+#   SEED_CONNECTION_STRING_AUTH         -> connection-string-auth
+#   SEED_OPENIDDICT_SIGNING_KEY         -> openiddict-signing-key
+#   SEED_OPENIDDICT_ENCRYPTION_KEY      -> openiddict-encryption-key
+#   SEED_OPENIDDICT_API_CLIENT_SECRET   -> openiddict-api-client-secret
+#   SEED_SMTP_USERNAME                  -> smtp-username
+#   SEED_SMTP_PASSWORD                  -> smtp-password
+#   SEED_ADMIN_PASSWORD                 -> admin-password
+#
+# Usage (one-time bring-up + every rotation):
+#   az login                                       # an Owner / User Access Administrator on the sub
+#   export SEED_CONNECTION_STRING_TRANSLATION=...   # … export all 8 SEED_* …
+#   scripts/seed-keyvault.sh
+#
+# Overridable (defaults match iac/): KV_RESOURCE_GROUP, KV_LOCATION, KV_NAME, KV_IDENTITY_NAME.
+# The PowerShell twin scripts/seed-keyvault.ps1 must stay in lock-step with this file.
+#
+# Requires: az (Azure CLI), logged in to the prod subscription.
+
+set -euo pipefail
+
+RESOURCE_GROUP="${KV_RESOURCE_GROUP:-rg-lotrotms-prod-polc-001}"
+LOCATION="${KV_LOCATION:-polandcentral}"
+VAULT_NAME="${KV_NAME:-lotrotms-kv-prod}"
+IDENTITY_NAME="${KV_IDENTITY_NAME:-lotrotms-aca-prod}"
+
+# KV secret name  <-  SEED_* env var holding its value. Keep the names in sync with the ACA
+# `secret { name = ... }` blocks in iac/azure-container-apps.tf + iac/migrator-job.tf.
+SECRETS=(
+  "connection-string-translation:SEED_CONNECTION_STRING_TRANSLATION"
+  "connection-string-auth:SEED_CONNECTION_STRING_AUTH"
+  "openiddict-signing-key:SEED_OPENIDDICT_SIGNING_KEY"
+  "openiddict-encryption-key:SEED_OPENIDDICT_ENCRYPTION_KEY"
+  "openiddict-api-client-secret:SEED_OPENIDDICT_API_CLIENT_SECRET"
+  "smtp-username:SEED_SMTP_USERNAME"
+  "smtp-password:SEED_SMTP_PASSWORD"
+  "admin-password:SEED_ADMIN_PASSWORD"
+)
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+command -v az >/dev/null 2>&1 || die "Azure CLI (az) is not installed."
+az account show >/dev/null 2>&1 || die "Not logged in — run 'az login' against the prod subscription."
+
+missing=()
+for pair in "${SECRETS[@]}"; do
+  var="${pair#*:}"
+  [ -n "${!var:-}" ] || missing+=("$var")
+done
+[ "${#missing[@]}" -eq 0 ] || die "Missing secret env var(s): ${missing[*]}"
+
+echo "==> Subscription: $(az account show --query name -o tsv) ($(az account show --query id -o tsv))"
+echo "==> Resource group: ${RESOURCE_GROUP} | Vault: ${VAULT_NAME} | Identity: ${IDENTITY_NAME}"
+
+# 1. Key Vault (idempotent: create only if absent). RBAC authorization is the current best practice.
+if az keyvault show -n "$VAULT_NAME" -g "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "==> Vault ${VAULT_NAME} already exists — skipping create."
+else
+  echo "==> Creating Vault ${VAULT_NAME} …"
+  az keyvault create \
+    -n "$VAULT_NAME" \
+    -g "$RESOURCE_GROUP" \
+    -l "$LOCATION" \
+    --sku standard \
+    --enable-rbac-authorization true \
+    --retention-days 90 \
+    -o none
+fi
+VAULT_ID="$(az keyvault show -n "$VAULT_NAME" -g "$RESOURCE_GROUP" --query id -o tsv)"
+
+# 2. User-assigned managed identity (idempotent).
+if az identity show -n "$IDENTITY_NAME" -g "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "==> Identity ${IDENTITY_NAME} already exists — skipping create."
+else
+  echo "==> Creating user-assigned identity ${IDENTITY_NAME} …"
+  az identity create -n "$IDENTITY_NAME" -g "$RESOURCE_GROUP" -l "$LOCATION" -o none
+fi
+IDENTITY_PRINCIPAL_ID="$(az identity show -n "$IDENTITY_NAME" -g "$RESOURCE_GROUP" --query principalId -o tsv)"
+IDENTITY_RESOURCE_ID="$(az identity show -n "$IDENTITY_NAME" -g "$RESOURCE_GROUP" --query id -o tsv)"
+
+# 3 + 4. Role assignments (idempotent — az is a no-op when the assignment already exists).
+echo "==> Granting 'Key Vault Secrets User' to the identity …"
+az role assignment create \
+  --assignee-object-id "$IDENTITY_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --role "Key Vault Secrets User" \
+  --scope "$VAULT_ID" \
+  -o none
+
+CALLER_OBJECT_ID="$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)"
+if [ -n "$CALLER_OBJECT_ID" ]; then
+  echo "==> Granting 'Key Vault Secrets Officer' to the caller (to set secrets) …"
+  az role assignment create \
+    --assignee-object-id "$CALLER_OBJECT_ID" \
+    --assignee-principal-type User \
+    --role "Key Vault Secrets Officer" \
+    --scope "$VAULT_ID" \
+    -o none
+else
+  echo "WARNING: could not resolve the caller object id (service principal?). Ensure the caller holds" >&2
+  echo "         'Key Vault Secrets Officer' on ${VAULT_NAME} before secrets can be set." >&2
+fi
+
+# 5. Set the secrets. Data-plane RBAC can take a minute to propagate after the role assignment above,
+#    so the first set is retried until it is authorized.
+set_secret() {
+  local name="$1" value="$2" attempt
+  for attempt in $(seq 1 18); do
+    if az keyvault secret set --vault-name "$VAULT_NAME" --name "$name" --value "$value" -o none 2>/dev/null; then
+      return 0
+    fi
+    echo "   …waiting for data-plane RBAC to propagate (attempt ${attempt}) …"
+    sleep 10
+  done
+  die "Could not set secret '${name}' — the caller still lacks data-plane access on ${VAULT_NAME}."
+}
+
+for pair in "${SECRETS[@]}"; do
+  name="${pair%%:*}"
+  var="${pair#*:}"
+  echo "==> Setting secret ${name} …"
+  set_secret "$name" "${!var}"
+done
+
+echo ""
+echo "Done. Key Vault is seeded."
+echo "  key_vault_name    = ${VAULT_NAME}"
+echo "  aca_identity_name = ${IDENTITY_NAME}"
+echo "  identity id       = ${IDENTITY_RESOURCE_ID}"
+echo "Terraform reads these via the data sources in iac/keyvault.tf (defaults already match)."


### PR DESCRIPTION
## What

Azure **Key Vault** becomes the single source of truth for the 8 prod app secrets (ADR-0013). The
ACA apps + migrator job read them at runtime through a **user-assigned managed identity** via
`secret { key_vault_secret_id, identity }`. Terraform only wires the **versionless** secret URIs — it
never receives a plaintext value, so the state stays clean and the CI deploy principal keeps needing
only **Contributor** (the role assignment is foundational, seeded out-of-band).

Removes plaintext from all three resting places at once: **local disk** (`iac/terraform.tfvars`,
deleted), the **Terraform state** (no value flows through `var.*` anymore), and **GitHub Secrets**
(the 6 secret `TF_VAR_*` are gone — those repo Secrets can now be deleted).

## Changes

- `iac/keyvault.tf` (new) — `data` sources for the Vault + identity; versionless secret-URI locals
- `iac/azure-container-apps.tf` + `iac/migrator-job.tf` — `identity {}` + `secret { key_vault_secret_id, identity }` (auth ×7, tms ×1, migrator ×2; frontend has no secrets)
- `iac/vars.tf` — drop the 8 sensitive variables; add non-secret `key_vault_name` + `aca_identity_name`
- `.github/workflows/infra.yml` — drop the 6 secret `TF_VAR_*` envs
- `scripts/seed-keyvault.{sh,ps1}` (new) — idempotent Vault + identity + role + secrets bring-up/rotation tool
- `iac/terraform.tfvars` deleted (was untracked; values now live only in the Vault)
- docs — ADR-0013, runbook seed step + secret matrix, bring-up-plan superseding note

## Already applied + verified on prod

The Vault was seeded and the reviewed plan (`0 to add, 3 to change, 0 to destroy`) was applied to
`rg-lotrotms-prod-polc-001`. Verified live:

- `az containerapp show` — auth-api/tms-api/migrator carry the `UserAssigned` identity and every
  secret is `keyVaultUrl`-backed (no inline values).
- Cold-start health: `auth /health/ready` **200** (proves all 7 secrets — DB, the 3 OpenIddict keys,
  SMTP, admin password — resolve from the Vault at startup) and `tms /health/ready` **200**.

So the post-merge `infra.yml` apply is a **no-op convergence** (state already matches).

## App code unchanged

Apps still read the same env vars; only the IaC wiring changed (ADR-0008 neutrality contract holds).

## Operator follow-up (optional)

The 6 now-unused repo Secrets (`CONNECTION_STRING_*`, `OPENIDDICT_*`, `SMTP_USERNAME/PASSWORD`,
`ADMIN_PASSWORD`) can be deleted. Rotation from now on = re-run `scripts/seed-keyvault.sh` with new
`SEED_*` values.

Closes #222
