### PR TITLE
#221: purge stale lotro.koniec.dev → live prod domain lotro-translator.pl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,8 @@ AUTH_ADMIN_PASSWORD=
 #   OpenIddict__EncryptionKey__Key                    base64 of a >=32-byte key
 #   OpenIddict__SigningKey__RsaPrivateKeyXml          base64 of RSA.ToXmlString(true), >=2048-bit
 #   OpenIddict__ApiClientSecret                       >=32 characters
-#   OpenIddict__Issuer                                public token issuer URL (e.g. https://auth.lotro.koniec.dev)
-#   OpenIddict__WebClient__RedirectUris__0            web client OAuth callback (e.g. https://lotro.koniec.dev/callback)
-#   OpenIddict__WebClient__PostLogoutRedirectUris__0  post-logout URL (e.g. https://lotro.koniec.dev)
+#   OpenIddict__Issuer                                public token issuer URL (e.g. https://auth.lotro-translator.pl)
+#   OpenIddict__WebClient__RedirectUris__0            web client OAuth callback (e.g. https://lotro-translator.pl/callback)
+#   OpenIddict__WebClient__PostLogoutRedirectUris__0  post-logout URL (e.g. https://lotro-translator.pl)
 #   Email__Host / Email__SenderEmail / Email__Sender  real SMTP host + sender identity
 #   Auth__Issuer (tms-api)                            the same public issuer URL the tokens carry

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -39,7 +39,7 @@ OpenIddict__ApiClientSecret=
 Email__Host=mailpit
 Email__Port=1025
 Email__Mode=None
-Email__SenderEmail=no-reply@lotro.koniec.dev
+Email__SenderEmail=no-reply@lotro-translator.pl
 Email__Sender=LOTRO PL
 # Optional SMTP auth — leave blank for an unauthenticated relay (e.g. mailpit). If Username is set,
 # Password is required.

--- a/docs/deployment/azure-supabase-bring-up-plan.md
+++ b/docs/deployment/azure-supabase-bring-up-plan.md
@@ -8,8 +8,8 @@
 > live only in Azure Key Vault (seeded by `scripts/seed-keyvault.{sh,ps1}`), read at runtime via a
 > managed identity — **not** in `iac/terraform.tfvars`, the TF state, or GitHub Secrets. Read every
 > `terraform.tfvars`/`TF_VAR_*`-secret reference below as "set via the Key Vault seed step instead".
-> The historical `*.lotro.koniec.dev` and `rg-…-dev-…` strings below are from the original plan; read
-> them as the live domain / RG.
+> The historical `rg-…-dev-…` strings below are from the original plan; read them as the live RG
+> (`rg-lotrotms-prod-polc-001`).
 
 > **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development`
 > (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use
@@ -274,17 +274,17 @@ az containerapp job execution list -n lotrotms-migrator-prod -g rg-lotrotms-dev-
 
 Set these to the final public origins **now** so you configure them once (changing them later forces
 re-registering redirect URIs). Target origins:
-- frontend → `https://lotro.koniec.dev`
-- auth → `https://auth.lotro.koniec.dev`
-- tms → `https://tms.lotro.koniec.dev`
+- frontend → `https://lotro-translator.pl`
+- auth → `https://auth.lotro-translator.pl`
+- tms → `https://tms.lotro-translator.pl`
 
-- [ ] **6.1 🤖 auth-api:** `OpenIddict__Issuer=https://auth.lotro.koniec.dev`,
-  `OpenIddict__WebClient__RedirectUris__0=https://lotro.koniec.dev/callback`,
-  `…PostLogoutRedirectUris__0=https://lotro.koniec.dev`, `Cors__AllowedOrigins__0=https://lotro.koniec.dev`.
-- [ ] **6.2 🤖 tms-api:** `Auth__Issuer=https://auth.lotro.koniec.dev` (byte-identical to auth's
-  Issuer), `Auth__Authority=https://auth.lotro.koniec.dev`, `Cors__AllowedOrigins__0=https://lotro.koniec.dev`.
-- [ ] **6.3 🤖 frontend:** `AuthSystem__Authority` + `AuthSystem__BaseUrl=https://auth.lotro.koniec.dev(/)`,
-  `TranslationSystem__BaseUrl=https://tms.lotro.koniec.dev/`, `AuthSystem__ClientId=lotrokoniecdev-web`.
+- [ ] **6.1 🤖 auth-api:** `OpenIddict__Issuer=https://auth.lotro-translator.pl`,
+  `OpenIddict__WebClient__RedirectUris__0=https://lotro-translator.pl/callback`,
+  `…PostLogoutRedirectUris__0=https://lotro-translator.pl`, `Cors__AllowedOrigins__0=https://lotro-translator.pl`.
+- [ ] **6.2 🤖 tms-api:** `Auth__Issuer=https://auth.lotro-translator.pl` (byte-identical to auth's
+  Issuer), `Auth__Authority=https://auth.lotro-translator.pl`, `Cors__AllowedOrigins__0=https://lotro-translator.pl`.
+- [ ] **6.3 🤖 frontend:** `AuthSystem__Authority` + `AuthSystem__BaseUrl=https://auth.lotro-translator.pl(/)`,
+  `TranslationSystem__BaseUrl=https://tms.lotro-translator.pl/`, `AuthSystem__ClientId=lotrokoniecdev-web`.
 - [ ] **6.4 🤖 Re-check the 4 consistency rules** (runbook): issuer==iss, redirect URIs exact (scheme/
   host/slash), CORS bare origin (lowercase, no trailing slash), authority is `https`.
 
@@ -294,20 +294,20 @@ re-registering redirect URIs). Target origins:
 
 **Files:** none (DNS at registrar + `az` binding). Done via `az` (simpler than TF for the cert dance).
 
-For each of `lotro` / `auth` / `tms`.lotro.koniec.dev → its ACA app:
+For each of `lotro` / `auth` / `tms`.lotro-translator.pl → its ACA app:
 
 - [ ] **7.1 👤 Add DNS records** at your `koniec.dev` provider: a `CNAME` from the subdomain to the
   app's `*.azurecontainerapps.io` FQDN, plus the `asuid.<sub>` `TXT` validation record ACA prints.
 - [ ] **7.2 👤 Bind + provision the free managed cert:**
 
 ```bash
-az containerapp hostname add  -n lotrotms-frontend-prod -g rg-lotrotms-dev-polc-001 --hostname lotro.koniec.dev
-az containerapp hostname bind -n lotrotms-frontend-prod -g rg-lotrotms-dev-polc-001 --hostname lotro.koniec.dev \
+az containerapp hostname add  -n lotrotms-frontend-prod -g rg-lotrotms-dev-polc-001 --hostname lotro-translator.pl
+az containerapp hostname bind -n lotrotms-frontend-prod -g rg-lotrotms-dev-polc-001 --hostname lotro-translator.pl \
   --environment lotrotmsenvprod --validation-method CNAME
-# repeat for auth.lotro.koniec.dev → -auth-api, tms.lotro.koniec.dev → -tms-api
+# repeat for auth.lotro-translator.pl → -auth-api, tms.lotro-translator.pl → -tms-api
 ```
 
-- [ ] **7.3 👤 Browser login smoke:** open `https://lotro.koniec.dev`, complete an OIDC login.
+- [ ] **7.3 👤 Browser login smoke:** open `https://lotro-translator.pl`, complete an OIDC login.
 
 ---
 
@@ -334,9 +334,9 @@ resets the timer on **both** projects.
 ```bash
 cd ~/RiderProjects/LotroKoniecDev
 SMOKE_CLIENT_SECRET="<OpenIddict__ApiClientSecret from tfvars>" scripts/smoke.sh \
-  --auth-url https://auth.lotro.koniec.dev \
-  --tms-url  https://tms.lotro.koniec.dev \
-  --frontend-url https://lotro.koniec.dev
+  --auth-url https://auth.lotro-translator.pl \
+  --tms-url  https://tms.lotro-translator.pl \
+  --frontend-url https://lotro-translator.pl
 ```
 
 Expect ✓ on legs 1–3; **leg 4 may `⚠` 404** until you import data (next step). A **401 on leg 3 with a
@@ -362,6 +362,5 @@ valid token = issuer/audience/JWKS mismatch** → revisit Phase 6.
 - Secret leak (tfstate) → Phase 1.1. ✅  MSSQL/ACR removal → Phase 1.2. ✅
 - Supabase pause → Phase 8. ✅  OIDC consistency → Phase 6. ✅
 
-**Open decision (yours, low-stakes):** custom domain scheme — `lotro.koniec.dev` (used throughout, to
-match the runbook placeholders) vs `app.lotro.koniec.dev`. Pick before Phase 6 (it's the redirect/CORS
-origin). Default assumed: `lotro.koniec.dev`.
+**Resolved (was an open decision):** custom domain scheme — the apex `lotro-translator.pl` (used
+throughout) won over `app.lotro-translator.pl`; it is the live redirect/CORS origin.

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -61,8 +61,8 @@ table per service.
   `launchSettings.json`; only postgres / migrator / mailpit / aspire are set by `compose.yaml`.
 - **Staging / Production** are structurally identical — same required set, same sources; they differ
   only in **hostnames** (use the environment's own domain) and **secret values**. This column shows
-  **production placeholders**; substitute `lotro.koniec.dev` with your environment's domain (e.g. a
-  `*.staging.lotro.koniec.dev` for staging). The local production-parity stack
+  **production placeholders**; substitute `lotro-translator.pl` with your environment's domain (e.g. a
+  `*.staging.lotro-translator.pl` for staging). The local production-parity stack
   (`compose.prod.yaml`) wires the very same keys with `*.lotro.test` hostnames.
 
 Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:AccessTokenLifetimeMinutes`
@@ -71,8 +71,8 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 
 > ⚠️ **Live prod domain is `lotro-translator.pl`** — auth → `https://auth.lotro-translator.pl`,
 > tms → `https://tms.lotro-translator.pl`, frontend → `https://lotro-translator.pl`; live RG
-> `rg-lotrotms-prod-polc-001`. The `*.lotro.koniec.dev` strings in the tables below are historical
-> placeholders — read each as the live domain (or your own environment's).
+> `rg-lotrotms-prod-polc-001`. The tables below show these live production values directly; for
+> staging substitute your environment's own domain.
 
 ### auth-api
 
@@ -81,19 +81,19 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 | `ASPNETCORE_ENVIRONMENT` | `Development` | `Production` | ✅ all | plain | Gates fail-fast validation, ephemeral-vs-real keys, the CORS policy. |
 | `ASPNETCORE_URLS` | `https://localhost:5003` (launchSettings) | `http://+:8080` | ✅ all | plain | Host dev Kestrel (native dev cert); prod serves HTTP only (the ingress owns TLS). |
 | `ConnectionStrings__AuthDatabase` | `…;Database=lotro_auth;…;Password=changeme` (appsettings.Development) | `Host=…;Database=lotro_auth;Username=…;Password=…;Ssl Mode=Require;Trust Server Certificate=true` | ✅ all | **secret** | Carries the DB password. Host dev hits the compose Postgres on `localhost:5432`. Managed DB: keep `Ssl Mode=Require`, drop `Trust Server Certificate`. |
-| `OpenIddict__Issuer` | `https://localhost:5003` | `https://auth.lotro.koniec.dev` | ✅ non-dev | plain | **THE token `iss`.** Absolute http(s), no `localhost`. Must equal tms `Auth__Issuer`. |
+| `OpenIddict__Issuer` | `https://localhost:5003` | `https://auth.lotro-translator.pl` | ✅ non-dev | plain | **THE token `iss`.** Absolute http(s), no `localhost`. Must equal tms `Auth__Issuer`. |
 | `OpenIddict__SigningKey__RsaPrivateKeyXml` | — (ephemeral) | base64 of RSA XML (≥2048-bit) | ✅ non-dev | **secret** | Generate with `gen-openiddict-keys`. |
 | `OpenIddict__EncryptionKey__Key` | — (ephemeral) | base64 of a ≥32-byte key | ✅ non-dev | **secret** | Generate with `gen-openiddict-keys`. |
 | `OpenIddict__ApiClientSecret` | `dev-api-secret-min-32-characters-long` | ≥32-char random secret | ✅ non-dev | **secret** | Generate with `gen-openiddict-keys`. Shared with the service client. |
-| `OpenIddict__WebClient__RedirectUris__0` | `https://localhost:7017/callback` | `https://lotro.koniec.dev/callback` | ✅ non-dev | plain | MUST equal the Frontend callback (its public origin + `AuthSystem__CallbackPath`). |
-| `OpenIddict__WebClient__PostLogoutRedirectUris__0` | `https://localhost:7017` | `https://lotro.koniec.dev` | ✅ non-dev | plain | Frontend post-logout return URL. |
-| `Cors__AllowedOrigins__0` | — (AllowAnyOrigin) | `https://lotro.koniec.dev` | ✅ non-dev | plain | Bare origin = Frontend public URL. Lowercase, no port-if-default, no path/slash. |
+| `OpenIddict__WebClient__RedirectUris__0` | `https://localhost:7017/callback` | `https://lotro-translator.pl/callback` | ✅ non-dev | plain | MUST equal the Frontend callback (its public origin + `AuthSystem__CallbackPath`). |
+| `OpenIddict__WebClient__PostLogoutRedirectUris__0` | `https://localhost:7017` | `https://lotro-translator.pl` | ✅ non-dev | plain | Frontend post-logout return URL. |
+| `Cors__AllowedOrigins__0` | — (AllowAnyOrigin) | `https://lotro-translator.pl` | ✅ non-dev | plain | Bare origin = Frontend public URL. Lowercase, no port-if-default, no path/slash. |
 | `DataProtection__KeyRingPath` | — (host default) | `/keys` | ✅ non-dev | plain | Persistent, replica-shared volume; else logins/antiforgery/reset links break on deploy/scale. |
 | `Email__Host` | `mailpit` | `smtp.sendgrid.net` | ✅ all | plain | SMTP host. Validated on start (every environment). |
 | `Email__Port` | `1025` | `587` | ✅ all | plain | 1–65535. |
 | `Email__Mode` | `None` | `StartTls` | ✅ all | plain | One of `None` / `StartTls` / `TLS`. |
-| `Email__SenderEmail` | `noreply@lotro.koniec.dev` | `no-reply@lotro.koniec.dev` | ✅ all | plain | Must be a valid email. |
-| `Email__Sender` | `lotro.koniec.dev` | `LOTRO PL` | ✅ all | plain | Display name. |
+| `Email__SenderEmail` | `noreply@lotro-translator.pl` | `no-reply@lotro-translator.pl` | ✅ all | plain | Must be a valid email. |
+| `Email__Sender` | `lotro-translator.pl` | `LOTRO PL` | ✅ all | plain | Display name. |
 | `Email__Username` / `Email__Password` | — | provider credentials | optional¹ | **secret** (Password) | ¹If `Username` is set, `Password` is required. |
 | `AdminUser__Username` / `AdminUser__Email` / `AdminUser__Password` | from `AUTH_ADMIN_*` | from `AUTH_ADMIN_*` | optional | **secret** (Password) | Seeds one admin on first boot; leave blank to skip. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://aspire-dashboard:18889` | OTLP collector URL | optional | plain | Empty = telemetry export disabled. |
@@ -106,10 +106,10 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 | `ASPNETCORE_ENVIRONMENT` | `Development` | `Production` | ✅ all | plain | Gates fail-fast validation + the CORS policy. |
 | `ASPNETCORE_URLS` | `https://localhost:5002` (launchSettings) | `http://+:8080` | ✅ all | plain | Host dev Kestrel (native dev cert); prod serves HTTP only (ingress owns TLS). |
 | `ConnectionStrings__TranslationDatabase` | `…;Database=lotro_translation;…;Password=changeme` (appsettings.Development) | `Host=…;Database=lotro_translation;Username=…;Password=…;Ssl Mode=Require;Trust Server Certificate=true` | ✅ all | **secret** | TMS write context. Host dev hits the compose Postgres on `localhost:5432`. Managed DB swap = change just this value. |
-| `Auth__Issuer` | `https://localhost:5003` | `https://auth.lotro.koniec.dev` | ✅ all | plain | MUST equal auth `OpenIddict__Issuer` (the token `iss`); tokens are rejected otherwise. |
-| `Auth__Authority` | — (unset → falls back to `Issuer`, `https://localhost:5003`) | `https://auth.lotro.koniec.dev` | optional² | plain | Back-channel for OIDC metadata + JWKS. ²Unset → falls back to `Issuer`; the dev host run relies on that fallback to reach the host auth Kestrel. Prod: must be `https` (OpenIddict rejects plain HTTP) and reachable from the container. |
+| `Auth__Issuer` | `https://localhost:5003` | `https://auth.lotro-translator.pl` | ✅ all | plain | MUST equal auth `OpenIddict__Issuer` (the token `iss`); tokens are rejected otherwise. |
+| `Auth__Authority` | — (unset → falls back to `Issuer`, `https://localhost:5003`) | `https://auth.lotro-translator.pl` | optional² | plain | Back-channel for OIDC metadata + JWKS. ²Unset → falls back to `Issuer`; the dev host run relies on that fallback to reach the host auth Kestrel. Prod: must be `https` (OpenIddict rejects plain HTTP) and reachable from the container. |
 | `Auth__Audience` | `lotrokoniecdev-api` | `lotrokoniecdev-api` | ✅ all | plain | Default in base `appsettings.json`. |
-| `Cors__AllowedOrigins__0` | — (AllowAnyOrigin) | `https://lotro.koniec.dev` | ✅ non-dev | plain | Bare origin = Frontend public URL. |
+| `Cors__AllowedOrigins__0` | — (AllowAnyOrigin) | `https://lotro-translator.pl` | ✅ non-dev | plain | Bare origin = Frontend public URL. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` | aspire / `grpc` | collector / `grpc` | optional | plain | Empty endpoint = export disabled. |
 | `Bootstrap__Enabled` | `false` | `false` | optional | plain | One-time DB seed of the first export (spec 0001). Off by default. |
 | `Bootstrap__GameVersion` / `Bootstrap__ExportedTextPath` / `Bootstrap__PolishTextPath` | — / — / `/app/translations/polish.txt` | as needed | optional | plain | Only consulted when `Bootstrap__Enabled=true`. |
@@ -124,13 +124,13 @@ Staging/Production.
 |---|---|---|---|---|---|
 | `ASPNETCORE_ENVIRONMENT` | `Development` | `Production` | ✅ all | plain | Gates the DP keyring guard. |
 | `ASPNETCORE_URLS` | `https://localhost:7017` (launchSettings) | `http://+:8080` | ✅ all | plain | Prod serves HTTP only (ingress owns TLS). |
-| `AuthSystem__Authority` | `https://localhost:5003` | `https://auth.lotro.koniec.dev` | ✅ all | plain | Drives the `/authorize` redirect (front-channel) **and** discovery/token (back-channel). |
-| `AuthSystem__BaseUrl` | `https://localhost:5003/` | `https://auth.lotro.koniec.dev/` | ✅ all | plain | Auth origin (trailing slash). |
+| `AuthSystem__Authority` | `https://localhost:5003` | `https://auth.lotro-translator.pl` | ✅ all | plain | Drives the `/authorize` redirect (front-channel) **and** discovery/token (back-channel). |
+| `AuthSystem__BaseUrl` | `https://localhost:5003/` | `https://auth.lotro-translator.pl/` | ✅ all | plain | Auth origin (trailing slash). |
 | `AuthSystem__ClientId` | `lotrokoniecdev-web` | `lotrokoniecdev-web` | ✅ all | plain | Must match the OpenIddict web-client id. |
 | `AuthSystem__CallbackPath` | `/callback` | `/callback` | ✅ all | plain | Origin + this MUST be registered in auth `RedirectUris`. |
 | `AuthSystem__SignedOutCallbackPath` | `/signout-callback-oidc` | `/signout-callback-oidc` | ✅ all | plain | Origin + this MUST be in auth `PostLogoutRedirectUris`. |
 | `AuthSystem__Scopes` | `openid,email,profile,roles,api,offline_access` | same | ✅ all | plain | At least one scope. |
-| `TranslationSystem__BaseUrl` | `https://localhost:5002/` | `https://tms.lotro.koniec.dev/` | ✅ all | plain | TMS API origin (trailing slash). |
+| `TranslationSystem__BaseUrl` | `https://localhost:5002/` | `https://tms.lotro-translator.pl/` | ✅ all | plain | TMS API origin (trailing slash). |
 | `DataProtection__KeyRingPath` | — (host default) | `/keys` | ✅ non-dev | plain | Persistent, replica-shared volume (ADR-0005); else antiforgery + auth cookies break on deploy/scale. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` | — | collector / `grpc` | optional | plain | Empty endpoint = export disabled. |
 
@@ -558,9 +558,9 @@ worth knowing before you read a result:
 ```bash
 # A real environment (publicly-trusted ingress cert — no --insecure needed):
 SMOKE_CLIENT_SECRET="$OPENIDDICT_API_CLIENT_SECRET" scripts/smoke.sh \
-  --auth-url     https://auth.lotro.koniec.dev \
-  --tms-url      https://tms.lotro.koniec.dev \
-  --frontend-url https://lotro.koniec.dev
+  --auth-url     https://auth.lotro-translator.pl \
+  --tms-url      https://tms.lotro-translator.pl \
+  --frontend-url https://lotro-translator.pl
 # PowerShell twin: $env:SMOKE_CLIENT_SECRET='…'; scripts/smoke.ps1 -AuthUrl … -TmsUrl … -FrontendUrl …
 
 # The local prod-parity stack (compose.prod.yaml): client secret is the generated value in .env.prod;

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -28,7 +28,7 @@
 .EXAMPLE
     # A real environment (publicly-trusted ingress cert — no -Insecure):
     $env:SMOKE_CLIENT_SECRET = '...'
-    ./scripts/smoke.ps1 -AuthUrl https://auth.lotro.koniec.dev -TmsUrl https://tms.lotro.koniec.dev -FrontendUrl https://lotro.koniec.dev
+    ./scripts/smoke.ps1 -AuthUrl https://auth.lotro-translator.pl -TmsUrl https://tms.lotro-translator.pl -FrontendUrl https://lotro-translator.pl
 
 .EXAMPLE
     # The local dev stack (host Kestrels + untrusted dev cert):

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -48,9 +48,9 @@ Options:
 Examples:
   # A real environment (publicly-trusted ingress cert — no --insecure):
   SMOKE_CLIENT_SECRET=… scripts/smoke.sh \
-    --auth-url https://auth.lotro.koniec.dev \
-    --tms-url  https://tms.lotro.koniec.dev \
-    --frontend-url https://lotro.koniec.dev
+    --auth-url https://auth.lotro-translator.pl \
+    --tms-url  https://tms.lotro-translator.pl \
+    --frontend-url https://lotro-translator.pl
 
   # The local dev stack (host Kestrels + untrusted dev cert):
   scripts/smoke.sh \

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmail.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmail.cshtml
@@ -9,7 +9,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Potwierdzenie e-maila — lotro.koniec.dev</title>
+    <title>Potwierdzenie e-maila — lotro-translator.pl</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
@@ -291,9 +291,9 @@
 <body>
     <div class="app">
         <div class="auth-top">
-            <a href="https://lotro.koniec.dev" class="brand">
+            <a href="https://lotro-translator.pl" class="brand">
                 <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
-                <span class="brand-text">lotro<span class="brand-accent">koniec</span>.dev</span>
+                <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
         </div>
@@ -368,7 +368,7 @@
         </div>
 
         <footer class="foot">
-            <p>lotro.koniec.dev — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
+            <p>lotro-translator.pl — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
         </footer>
     </div>
 </body>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ForgotPassword.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ForgotPassword.cshtml
@@ -9,7 +9,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Reset hasła — lotro.koniec.dev</title>
+    <title>Reset hasła — lotro-translator.pl</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
@@ -353,9 +353,9 @@
 <body>
     <div class="app">
         <div class="auth-top">
-            <a href="https://lotro.koniec.dev" class="brand">
+            <a href="https://lotro-translator.pl" class="brand">
                 <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
-                <span class="brand-text">lotro<span class="brand-accent">koniec</span>.dev</span>
+                <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
         </div>
@@ -440,7 +440,7 @@
         </div>
 
         <footer class="foot">
-            <p>lotro.koniec.dev — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
+            <p>lotro-translator.pl — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
         </footer>
     </div>
 </body>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
@@ -12,7 +12,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Zaloguj się — lotro.koniec.dev</title>
+    <title>Zaloguj się — lotro-translator.pl</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
@@ -473,7 +473,7 @@
     <div class="app">
         <header class="auth-top">
             <div class="container">
-                <a href="https://lotro.koniec.dev" class="brand">
+                <a href="https://lotro-translator.pl" class="brand">
                     <span class="brand-mark" aria-hidden="true">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10" />
@@ -482,7 +482,7 @@
                             <circle cx="11" cy="17" r="0.6" fill="currentColor"/>
                         </svg>
                     </span>
-                    <span>lotro<span class="brand-accent">koniec</span>.dev</span>
+                    <span>lotro-<span class="brand-accent">translator</span>.pl</span>
                 </a>
             </div>
         </header>
@@ -492,7 +492,7 @@
                 <div class="auth-intro">
                     <div>
                         <p class="eyebrow">DOSTĘP DO KONTA</p>
-                        <h1>Zaloguj się do lotro.koniec.dev</h1>
+                        <h1>Zaloguj się do lotro-translator.pl</h1>
                     </div>
                     <p class="lede">Zaloguj się, aby tłumaczyć teksty gry, przeglądać postępy i zatwierdzać gotowe wpisy.</p>
                     <ul class="auth-perks">
@@ -653,7 +653,7 @@
         </section>
 
         <footer class="foot">
-            <p>lotro.koniec.dev — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
+            <p>lotro-translator.pl — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
         </footer>
     </div>
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
@@ -9,7 +9,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Polityka prywatności — lotro.koniec.dev</title>
+    <title>Polityka prywatności — lotro-translator.pl</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
@@ -218,9 +218,9 @@
 <body>
     <div class="app">
         <div class="auth-top">
-            <a href="https://lotro.koniec.dev" class="brand">
+            <a href="https://lotro-translator.pl" class="brand">
                 <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
-                <span class="brand-text">lotro<span class="brand-accent">koniec</span>.dev</span>
+                <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
         </div>
@@ -230,10 +230,10 @@
             <h1>Polityka prywatności</h1>
             <p class="updated">Ostatnia aktualizacja: 8 czerwca 2026</p>
 
-            <p>Niniejsza polityka opisuje, w jaki sposób serwis <strong>lotro.koniec.dev</strong> przetwarza dane osobowe użytkowników zgodnie z Rozporządzeniem Parlamentu Europejskiego i Rady (UE) 2016/679 (RODO). Korzystając z serwisu, akceptujesz zasady opisane poniżej.</p>
+            <p>Niniejsza polityka opisuje, w jaki sposób serwis <strong>lotro-translator.pl</strong> przetwarza dane osobowe użytkowników zgodnie z Rozporządzeniem Parlamentu Europejskiego i Rady (UE) 2016/679 (RODO). Korzystając z serwisu, akceptujesz zasady opisane poniżej.</p>
 
             <h2><span class="sec-num">01</span> Administrator danych</h2>
-            <p>Administratorem Twoich danych osobowych jest społeczność <strong>lotro.koniec.dev</strong> — niekomercyjny projekt polskiego tłumaczenia gry The Lord of the Rings Online. W sprawach dotyczących ochrony danych skontaktujesz się z nami pod adresem <a href="mailto:rodo@@lotro.koniec.dev">rodo@@lotro.koniec.dev</a>.</p>
+            <p>Administratorem Twoich danych osobowych jest społeczność <strong>lotro-translator.pl</strong> — niekomercyjny projekt polskiego tłumaczenia gry The Lord of the Rings Online. W sprawach dotyczących ochrony danych skontaktujesz się z nami pod adresem <a href="mailto:koniecdev@@gmail.com">koniecdev@@gmail.com</a>.</p>
 
             <h2><span class="sec-num">02</span> Zakres przetwarzanych danych</h2>
             <p>Przetwarzamy wyłącznie dane niezbędne do działania serwisu:</p>
@@ -260,7 +260,7 @@
             <p>Dane konta przechowujemy przez czas jego istnienia. Po usunięciu konta dane osobowe są anonimizowane, a wkład tłumaczeniowy pozostaje w serwisie wyłącznie z nieprzypisywalnym identyfikatorem. Dane techniczne usuwamy po wygaśnięciu uzasadnionego okresu bezpieczeństwa.</p>
 
             <h2><span class="sec-num">06</span> Kontakt</h2>
-            <p>Pytania dotyczące przetwarzania danych lub realizacji praw kieruj na adres <a href="mailto:rodo@@lotro.koniec.dev">rodo@@lotro.koniec.dev</a>. Przysługuje Ci również prawo wniesienia skargi do Prezesa Urzędu Ochrony Danych Osobowych.</p>
+            <p>Pytania dotyczące przetwarzania danych lub realizacji praw kieruj na adres <a href="mailto:koniecdev@@gmail.com">koniecdev@@gmail.com</a>. Przysługuje Ci również prawo wniesienia skargi do Prezesa Urzędu Ochrony Danych Osobowych.</p>
 
             <div class="prose-card">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
@@ -272,7 +272,7 @@
         </div>
 
         <footer class="foot">
-            <p>lotro.koniec.dev — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
+            <p>lotro-translator.pl — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
         </footer>
     </div>
 </body>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
@@ -12,7 +12,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Załóż konto — lotro.koniec.dev</title>
+    <title>Załóż konto — lotro-translator.pl</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
@@ -438,9 +438,9 @@
 <body>
     <div class="app">
         <div class="auth-top">
-            <a href="https://lotro.koniec.dev" class="brand">
+            <a href="https://lotro-translator.pl" class="brand">
                 <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
-                <span class="brand-text">lotro<span class="brand-accent">koniec</span>.dev</span>
+                <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="@loginUrl" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
         </div>
@@ -571,7 +571,7 @@
         </div>
 
         <footer class="foot">
-            <p>lotro.koniec.dev — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
+            <p>lotro-translator.pl — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
         </footer>
     </div>
 </body>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml
@@ -9,7 +9,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Nowe hasło — lotro.koniec.dev</title>
+    <title>Nowe hasło — lotro-translator.pl</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
@@ -364,9 +364,9 @@
 <body>
     <div class="app">
         <div class="auth-top">
-            <a href="https://lotro.koniec.dev" class="brand">
+            <a href="https://lotro-translator.pl" class="brand">
                 <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
-                <span class="brand-text">lotro<span class="brand-accent">koniec</span>.dev</span>
+                <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
         </div>
@@ -492,7 +492,7 @@
         </div>
 
         <footer class="foot">
-            <p>lotro.koniec.dev — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
+            <p>lotro-translator.pl — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
         </footer>
     </div>
 </body>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountConfirmationEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountConfirmationEmailSender.cs
@@ -27,7 +27,7 @@ internal sealed class AccountConfirmationEmailSender : IAccountConfirmationEmail
         string link = WebUtility.HtmlEncode(rawLink);
 
         string emailBody =
-            $"Dziękujemy za rejestracje na platformie lotro.koniec.dev. Prosimy o kliknięcie w ten link, aby potwierdzić konto: <a href='{link}'>link</a>";
+            $"Dziękujemy za rejestracje na platformie lotro-translator.pl. Prosimy o kliknięcie w ten link, aby potwierdzić konto: <a href='{link}'>link</a>";
 
         using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
         {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetEmailSender.cs
@@ -27,7 +27,7 @@ internal sealed class PasswordResetEmailSender : IPasswordResetEmailSender
         string link = WebUtility.HtmlEncode(rawLink);
 
         string emailBody =
-            $"Otrzymaliśmy prośbę o zresetowanie hasła do Twojego konta na lotro.koniec.dev. Kliknij w poniższy link, aby ustawić nowe hasło: <a href='{link}'>link</a>";
+            $"Otrzymaliśmy prośbę o zresetowanie hasła do Twojego konta na lotro-translator.pl. Kliknij w poniższy link, aby ustawić nowe hasło: <a href='{link}'>link</a>";
 
         using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
         {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/CorsSettingsValidator.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/CorsSettingsValidator.cs
@@ -35,7 +35,7 @@ internal sealed class CorsSettingsValidator : IValidateOptions<CorsSettings>
                 $"{CorsSettings.ConfigurationSection}:{nameof(CorsSettings.AllowedOrigins)} must contain at least one " +
                 $"origin in {_environment.EnvironmentName}. Inject it via the " +
                 $"{CorsSettings.ConfigurationSection}__{nameof(CorsSettings.AllowedOrigins)}__0 environment variable " +
-                "(e.g. https://lotro.koniec.dev).");
+                "(e.g. https://lotro-translator.pl).");
         }
 
         foreach (string origin in options.AllowedOrigins)
@@ -45,7 +45,7 @@ internal sealed class CorsSettingsValidator : IValidateOptions<CorsSettings>
                 errors.Add(
                     $"{CorsSettings.ConfigurationSection}:{nameof(CorsSettings.AllowedOrigins)} entry '{origin}' must be " +
                     "a bare absolute http(s) origin — lowercase scheme and host, no default port, and no userinfo, " +
-                    "path, query, or trailing slash (e.g. https://lotro.koniec.dev).");
+                    "path, query, or trailing slash (e.g. https://lotro-translator.pl).");
             }
         }
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/OpenIddictSettingsValidator.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/OpenIddictSettingsValidator.cs
@@ -73,13 +73,13 @@ internal sealed class OpenIddictSettingsValidator : IValidateOptions<OpenIddictS
                 $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.Issuer)} must be set in "
                 + $"{_environment.EnvironmentName}. Inject the public token issuer URL via the "
                 + $"{OpenIddictSettings.ConfigurationSection}__{nameof(OpenIddictSettings.Issuer)} environment "
-                + "variable (e.g. https://auth.lotro.koniec.dev).");
+                + "variable (e.g. https://auth.lotro-translator.pl).");
         }
         else if (!BeAbsoluteHttpUrl(options.Issuer))
         {
             errors.Add(
                 $"{OpenIddictSettings.ConfigurationSection}:{nameof(OpenIddictSettings.Issuer)} must be an absolute "
-                + $"http(s) URL in {_environment.EnvironmentName} (e.g. https://auth.lotro.koniec.dev).");
+                + $"http(s) URL in {_environment.EnvironmentName} (e.g. https://auth.lotro-translator.pl).");
         }
         else if (options.Issuer.Contains("localhost", StringComparison.OrdinalIgnoreCase))
         {
@@ -96,7 +96,7 @@ internal sealed class OpenIddictSettingsValidator : IValidateOptions<OpenIddictS
                 + $"{_environment.EnvironmentName}. Inject the web client OAuth callback URL(s) via the "
                 + $"{OpenIddictSettings.ConfigurationSection}__{nameof(OpenIddictSettings.WebClient)}__"
                 + $"{nameof(WebClientSettings.RedirectUris)}__0 environment variable "
-                + "(e.g. https://lotro.koniec.dev/callback).");
+                + "(e.g. https://lotro-translator.pl/callback).");
         }
 
         foreach (string redirectUri in options.WebClient.RedirectUris)
@@ -118,7 +118,7 @@ internal sealed class OpenIddictSettingsValidator : IValidateOptions<OpenIddictS
                 + $"{_environment.EnvironmentName}. Inject the web client post-logout URL(s) via the "
                 + $"{OpenIddictSettings.ConfigurationSection}__{nameof(OpenIddictSettings.WebClient)}__"
                 + $"{nameof(WebClientSettings.PostLogoutRedirectUris)}__0 environment variable "
-                + "(e.g. https://lotro.koniec.dev).");
+                + "(e.g. https://lotro-translator.pl).");
         }
 
         foreach (string postLogoutRedirectUri in options.WebClient.PostLogoutRedirectUris)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.Development.json
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.Development.json
@@ -65,8 +65,8 @@
     "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"]
   },
   "Email": {
-    "SenderEmail": "noreply@lotro.koniec.dev",
-    "Sender": "lotro.koniec.dev",
+    "SenderEmail": "noreply@lotro-translator.pl",
+    "Sender": "lotro-translator.pl",
     "Host": "localhost",
     "Port": 1025,
     "Mode": "None",

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Settings/CorsSettingsValidator.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Settings/CorsSettingsValidator.cs
@@ -35,7 +35,7 @@ internal sealed class CorsSettingsValidator : IValidateOptions<CorsSettings>
                 $"{CorsSettings.ConfigurationSection}:{nameof(CorsSettings.AllowedOrigins)} must contain at least one " +
                 $"origin in {_environment.EnvironmentName}. Inject it via the " +
                 $"{CorsSettings.ConfigurationSection}__{nameof(CorsSettings.AllowedOrigins)}__0 environment variable " +
-                "(e.g. https://lotro.koniec.dev).");
+                "(e.g. https://lotro-translator.pl).");
         }
 
         foreach (string origin in options.AllowedOrigins)
@@ -45,7 +45,7 @@ internal sealed class CorsSettingsValidator : IValidateOptions<CorsSettings>
                 errors.Add(
                     $"{CorsSettings.ConfigurationSection}:{nameof(CorsSettings.AllowedOrigins)} entry '{origin}' must be " +
                     "a bare absolute http(s) origin — lowercase scheme and host, no default port, and no userinfo, " +
-                    "path, query, or trailing slash (e.g. https://lotro.koniec.dev).");
+                    "path, query, or trailing slash (e.g. https://lotro-translator.pl).");
             }
         }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -46,13 +46,13 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
                 { "OpenIddict:WebClient:RedirectUris:0", "https://localhost:5001/callback" },
                 { "OpenIddict:WebClient:PostLogoutRedirectUris:0", "https://localhost:5001" },
                 { "AdminUser:Username", "seeded-admin" },
-                { "AdminUser:Email", "admin@lotro.koniec.dev" },
+                { "AdminUser:Email", "admin@lotro-translator.pl" },
                 { "AdminUser:Password", "AdminTest123!" },
                 // Email identity is no longer baked into base appsettings.json (M6-06); supply it here
                 // so the unconditional EmailOptionsValidator passes at startup (the senders themselves
                 // are replaced with spies below, so these values are never used to send mail).
-                { "Email:SenderEmail", "noreply@lotro.koniec.dev" },
-                { "Email:Sender", "lotro.koniec.dev" },
+                { "Email:SenderEmail", "noreply@lotro-translator.pl" },
+                { "Email:Sender", "lotro-translator.pl" },
                 { "Email:Host", "localhost" },
             });
         });

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AdminSeedingTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AdminSeedingTests.cs
@@ -11,7 +11,7 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
 
 public sealed class AdminSeedingTests : EndpointsTestBase
 {
-    private const string AdminEmail = "admin@lotro.koniec.dev";
+    private const string AdminEmail = "admin@lotro-translator.pl";
     private const string AdminUsername = "seeded-admin";
     private const string AdminPassword = "AdminTest123!";
 
@@ -69,7 +69,7 @@ public sealed class AdminSeedingTests : EndpointsTestBase
             ApplicationUser squatter = new()
             {
                 UserName = AdminUsername,
-                Email = "squatter@lotro.koniec.dev",
+                Email = "squatter@lotro-translator.pl",
                 EmailConfirmed = true
             };
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
@@ -66,7 +66,7 @@ public sealed class ForwardedHeadersTests : EndpointsTestBase
         // Arrange
         using HttpRequestMessage request = HateoasRequest();
         request.Headers.Add("X-Forwarded-Proto", "https");
-        request.Headers.Add("X-Forwarded-Host", "auth.lotro.koniec.dev");
+        request.Headers.Add("X-Forwarded-Host", "auth.lotro-translator.pl");
 
         // Act
         DiscoveryResponse response = await SendDiscoveryAsync(request);
@@ -77,7 +77,7 @@ public sealed class ForwardedHeadersTests : EndpointsTestBase
         {
             Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
             uri!.Scheme.ShouldBe("https");
-            uri.Host.ShouldBe("auth.lotro.koniec.dev");
+            uri.Host.ShouldBe("auth.lotro-translator.pl");
         }
     }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/CorsSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/CorsSettingsValidatorTests.cs
@@ -52,7 +52,7 @@ public sealed class CorsSettingsValidatorTests
         CorsSettingsValidator validator = CreateValidator(Production);
         CorsSettings settings = new()
         {
-            AllowedOrigins = ["https://lotro.koniec.dev", "https://staging.lotro.koniec.dev"]
+            AllowedOrigins = ["https://lotro-translator.pl", "https://staging.lotro-translator.pl"]
         };
 
         ValidateOptionsResult result = validator.Validate(name: null, settings);
@@ -64,10 +64,10 @@ public sealed class CorsSettingsValidatorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("not-a-url")]
-    [InlineData("ftp://lotro.koniec.dev")]
-    [InlineData("https://lotro.koniec.dev/")]
-    [InlineData("https://lotro.koniec.dev/api")]
-    [InlineData("https://user:pass@lotro.koniec.dev")]
+    [InlineData("ftp://lotro-translator.pl")]
+    [InlineData("https://lotro-translator.pl/")]
+    [InlineData("https://lotro-translator.pl/api")]
+    [InlineData("https://user:pass@lotro-translator.pl")]
     public void Validate_ProductionWithMalformedOrigin_FailsNamingTheKey(string? origin)
     {
         CorsSettingsValidator validator = CreateValidator(Production);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/EmailOptionsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/EmailOptionsValidatorTests.cs
@@ -41,7 +41,7 @@ public sealed class EmailOptionsValidatorTests
 
     private static EmailOptions Options(string host = "mailpit") => new()
     {
-        SenderEmail = "no-reply@lotro.koniec.dev",
+        SenderEmail = "no-reply@lotro-translator.pl",
         Sender = "LotroKoniecDev",
         Host = host,
         Port = 587,

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/OpenIddictSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/OpenIddictSettingsValidatorTests.cs
@@ -23,12 +23,12 @@ public sealed class OpenIddictSettingsValidatorTests
     private const string ValidEncryptionKey = "dummy-non-empty-encryption-key";
     private const string ValidSigningKeyXml = "dummy-non-empty-signing-key-xml";
     private const string ValidApiClientSecret = "a-strong-and-sufficiently-long-secret-value";
-    private const string ValidIssuer = "https://auth.lotro.koniec.dev";
+    private const string ValidIssuer = "https://auth.lotro-translator.pl";
 
     // Redirect URIs are full callback URLs (path included), so they are validated as absolute http(s)
     // URLs — not as bare CORS origins.
-    private static readonly string[] ValidRedirectUris = ["https://lotro.koniec.dev/callback"];
-    private static readonly string[] ValidPostLogoutRedirectUris = ["https://lotro.koniec.dev"];
+    private static readonly string[] ValidRedirectUris = ["https://lotro-translator.pl/callback"];
+    private static readonly string[] ValidPostLogoutRedirectUris = ["https://lotro-translator.pl"];
 
     [Theory]
     [InlineData(Development)]
@@ -175,8 +175,8 @@ public sealed class OpenIddictSettingsValidatorTests
 
     [Theory]
     [InlineData("not-a-url")]
-    [InlineData("ftp://auth.lotro.koniec.dev")]
-    [InlineData("auth.lotro.koniec.dev")]
+    [InlineData("ftp://auth.lotro-translator.pl")]
+    [InlineData("auth.lotro-translator.pl")]
     public void Validate_ProductionWithNonHttpIssuer_FailsNamingTheKey(string issuer)
     {
         OpenIddictSettingsValidator validator = CreateValidator(Production);
@@ -260,8 +260,8 @@ public sealed class OpenIddictSettingsValidatorTests
 
     [Theory]
     [InlineData("not-a-url")]
-    [InlineData("ftp://lotro.koniec.dev/callback")]
-    [InlineData("lotro.koniec.dev/callback")]
+    [InlineData("ftp://lotro-translator.pl/callback")]
+    [InlineData("lotro-translator.pl/callback")]
     public void Validate_ProductionWithNonHttpRedirectUri_FailsNamingTheKey(string redirectUri)
     {
         OpenIddictSettingsValidator validator = CreateValidator(Production);
@@ -293,8 +293,8 @@ public sealed class OpenIddictSettingsValidatorTests
 
     [Theory]
     [InlineData("not-a-url")]
-    [InlineData("ftp://lotro.koniec.dev")]
-    [InlineData("lotro.koniec.dev")]
+    [InlineData("ftp://lotro-translator.pl")]
+    [InlineData("lotro-translator.pl")]
     public void Validate_ProductionWithNonHttpPostLogoutRedirectUri_FailsNamingTheKey(string postLogoutRedirectUri)
     {
         OpenIddictSettingsValidator validator = CreateValidator(Production);

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
@@ -76,7 +76,7 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
     private const string WebClientId = "lotrokoniecdev-web";
 
     private const string AdminUsername = "fe-e2e-admin";
-    private const string AdminEmail = "fe-e2e-admin@lotro.koniec.dev";
+    private const string AdminEmail = "fe-e2e-admin@lotro-translator.pl";
     private const string AdminPassword = "FeE2eAdminPass123!";
 
     private string _certPem = null!;
@@ -195,8 +195,8 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
             .WithEnvironment("AdminUser__Username", AdminUsername)
             .WithEnvironment("AdminUser__Email", AdminEmail)
             .WithEnvironment("AdminUser__Password", AdminPassword)
-            .WithEnvironment("Email__SenderEmail", "noreply@lotro.koniec.dev")
-            .WithEnvironment("Email__Sender", "lotro.koniec.dev")
+            .WithEnvironment("Email__SenderEmail", "noreply@lotro-translator.pl")
+            .WithEnvironment("Email__Sender", "lotro-translator.pl")
             .WithEnvironment("Email__Host", "mailpit")
             .WithEnvironment("Email__Port", MailpitSmtpPort.ToString(CultureInfo.InvariantCulture))
             .WithEnvironment("Email__Mode", "None")

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
@@ -94,7 +94,7 @@ public sealed class ForwardedHeadersTests : IAsyncLifetime
         using HttpClient client = TranslatorClient();
         using HttpRequestMessage request = HateoasRequest($"{Route}/{id.Value}");
         request.Headers.Add("X-Forwarded-Proto", "https");
-        request.Headers.Add("X-Forwarded-Host", "tms.lotro.koniec.dev");
+        request.Headers.Add("X-Forwarded-Host", "tms.lotro-translator.pl");
 
         // Act
         GameVersionResponse response = await SendHateoasAsync<GameVersionResponse>(client, request);
@@ -103,7 +103,7 @@ public sealed class ForwardedHeadersTests : IAsyncLifetime
         LinkDto selfLink = response.Links.ShouldHaveSingleItem();
         Uri.TryCreate(selfLink.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
         uri!.Scheme.ShouldBe("https");
-        uri.Host.ShouldBe("tms.lotro.koniec.dev");
+        uri.Host.ShouldBe("tms.lotro-translator.pl");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
@@ -22,7 +22,7 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
     public const string TestIssuer = "https://localhost:5003";
     public const string TestAudience = "lotrokoniecdev-api";
     public const string TestUserDisplayName = "integration-test-user";
-    public const string TestUserEmail = "translator@lotro.koniec.dev";
+    public const string TestUserEmail = "translator@lotro-translator.pl";
 
     private static readonly SymmetricSecurityKey TestSigningKey =
         new("integration-test-signing-key-32-bytes!!"u8.ToArray());

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/AuthSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/AuthSettingsValidatorTests.cs
@@ -45,8 +45,8 @@ public sealed class AuthSettingsValidatorTests
 
     [Theory]
     [InlineData("not-a-url")]
-    [InlineData("ftp://auth.lotro.koniec.dev")]
-    [InlineData("auth.lotro.koniec.dev")]
+    [InlineData("ftp://auth.lotro-translator.pl")]
+    [InlineData("auth.lotro-translator.pl")]
     public void Validate_WithNonHttpIssuer_FailsNamingTheKey(string issuer)
     {
         AuthSettings settings = Settings(issuer: issuer);
@@ -75,7 +75,7 @@ public sealed class AuthSettingsValidatorTests
 
     [Theory]
     [InlineData("not-a-url")]
-    [InlineData("ftp://auth.lotro.koniec.dev")]
+    [InlineData("ftp://auth.lotro-translator.pl")]
     public void Validate_WithNonHttpAuthority_FailsNamingTheKey(string authority)
     {
         AuthSettings settings = Settings(authority: authority);
@@ -88,9 +88,9 @@ public sealed class AuthSettingsValidatorTests
     }
 
     private static AuthSettings Settings(
-        string issuer = "https://auth.lotro.koniec.dev",
+        string issuer = "https://auth.lotro-translator.pl",
         string audience = "lotrokoniecdev-api",
-        string? authority = "https://auth.lotro.koniec.dev") => new()
+        string? authority = "https://auth.lotro-translator.pl") => new()
     {
         Issuer = issuer,
         Audience = audience,

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Settings/CorsSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Settings/CorsSettingsValidatorTests.cs
@@ -58,7 +58,7 @@ public sealed class CorsSettingsValidatorTests
     public void Validate_ProductionWithSingleValidOrigin_Succeeds()
     {
         CorsSettingsValidator validator = CreateValidator(Production);
-        CorsSettings settings = new() { AllowedOrigins = ["https://lotro.koniec.dev"] };
+        CorsSettings settings = new() { AllowedOrigins = ["https://lotro-translator.pl"] };
 
         ValidateOptionsResult result = validator.Validate(name: null, settings);
 
@@ -71,7 +71,7 @@ public sealed class CorsSettingsValidatorTests
         CorsSettingsValidator validator = CreateValidator(Production);
         CorsSettings settings = new()
         {
-            AllowedOrigins = ["https://lotro.koniec.dev", "https://staging.lotro.koniec.dev", "http://localhost:7017"]
+            AllowedOrigins = ["https://lotro-translator.pl", "https://staging.lotro-translator.pl", "http://localhost:7017"]
         };
 
         ValidateOptionsResult result = validator.Validate(name: null, settings);
@@ -84,10 +84,10 @@ public sealed class CorsSettingsValidatorTests
     [InlineData("")]
     [InlineData("not-a-url")]
     [InlineData("/relative/path")]
-    [InlineData("ftp://lotro.koniec.dev")]
-    [InlineData("https://lotro.koniec.dev/")]
-    [InlineData("https://lotro.koniec.dev/api")]
-    [InlineData("https://user:pass@lotro.koniec.dev")]
+    [InlineData("ftp://lotro-translator.pl")]
+    [InlineData("https://lotro-translator.pl/")]
+    [InlineData("https://lotro-translator.pl/api")]
+    [InlineData("https://user:pass@lotro-translator.pl")]
     public void Validate_ProductionWithMalformedOrigin_FailsNamingTheKey(string? origin)
     {
         CorsSettingsValidator validator = CreateValidator(Production);
@@ -106,7 +106,7 @@ public sealed class CorsSettingsValidatorTests
     public void Validate_ProductionWithOneValidAndOneMalformedOrigin_Fails()
     {
         CorsSettingsValidator validator = CreateValidator(Production);
-        CorsSettings settings = new() { AllowedOrigins = ["https://lotro.koniec.dev", "https://bad.example/path"] };
+        CorsSettings settings = new() { AllowedOrigins = ["https://lotro-translator.pl", "https://bad.example/path"] };
 
         ValidateOptionsResult result = validator.Validate(name: null, settings);
 

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslatorAggregate/ValueObjects/EmailTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslatorAggregate/ValueObjects/EmailTests.cs
@@ -6,7 +6,7 @@ namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates.Tr
 public sealed class EmailTests
 {
     [Theory]
-    [InlineData("translator@lotro.koniec.dev")]
+    [InlineData("translator@lotro-translator.pl")]
     [InlineData("a.b+tag@sub.example.co")]
     public void Create_WithValidValue_ShouldSucceed(string value)
     {

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
@@ -51,7 +51,7 @@ public abstract class E2ETestBase : IAsyncLifetime
     protected async Task<RegisteredTranslator> RegisterAndLoginTranslatorAsync()
     {
         string username = $"translator_{Faker.Random.AlphaNumeric(10)}";
-        string email = $"{username}@lotro.koniec.dev";
+        string email = $"{username}@lotro-translator.pl";
 
         RegisterRequest request = new(
             username,

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
@@ -41,7 +41,7 @@ public sealed class E2ETestFixture : IAsyncLifetime
     /// <c>Admin</c> role — so a password-grant login yields a real Admin token without the email-confirmation dance.
     /// </summary>
     public const string AdminUsername = "e2e-admin";
-    public const string AdminEmail = "e2e-admin@lotro.koniec.dev";
+    public const string AdminEmail = "e2e-admin@lotro-translator.pl";
     public const string AdminPassword = "E2eAdminPass123!";
 
     /// <summary>The public, password-grant OpenIddict client seeded only under the <c>Testing</c> environment.</summary>
@@ -164,8 +164,8 @@ public sealed class E2ETestFixture : IAsyncLifetime
             // so a freshly-registered translator can log in without the email round-trip. The sender identity is
             // no longer baked into base appsettings.json (M6-06), so it is injected here too — otherwise the
             // unconditional EmailOptionsValidator would abort auth-api startup.
-            .WithEnvironment("Email__SenderEmail", "noreply@lotro.koniec.dev")
-            .WithEnvironment("Email__Sender", "lotro.koniec.dev")
+            .WithEnvironment("Email__SenderEmail", "noreply@lotro-translator.pl")
+            .WithEnvironment("Email__Sender", "lotro-translator.pl")
             .WithEnvironment("Email__Host", "localhost")
             .WithEnvironment("Email__Port", "2525")
             .WithWaitStrategy(Wait.ForUnixContainer()


### PR DESCRIPTION
## What & why

The live production domain is **lotro-translator.pl** (Azure ACA — already wired in `iac/` and
`.github/workflows/`). **lotro.koniec.dev** was an abandoned earlier plan that had leaked across
app code, tests and docs. This purges it repo-wide so the codebase matches the real prod domain.
(Note: issue #221's title is phrased in reverse — the agreed direction is `koniec.dev → translator.pl`.)

## Changes
- **130 occurrences / 32 files** swept `lotro.koniec.dev` → `lotro-translator.pl`: AuthSystem auth
  pages, email senders, CORS/OpenIddict validators, `appsettings.Development.json`; TranslationSystem
  CORS validator; all affected tests; `scripts/smoke.{sh,ps1}`; `.env.example`, `.env.prod.example`; docs.
- Fixed the **split-`<span>` brand wordmark** on all 6 auth pages (invisible to grep — `lotro`+`koniec`+`.dev`):
  now `lotro-translator.pl`.
- Reworded now-obsolete "historical placeholder" disclaimers in `runbook.md` + the bring-up plan and
  marked the bring-up "open decision" resolved — docs no longer contradict the live domain.
- Repointed the privacy-policy **RODO contact** → `koniecdev@gmail.com` (the verified Brevo sender;
  the old `rodo@…` mailbox never existed).

## Out of scope / left as history
- ADR-0008 / ADR-0012 mentions + bare `koniec.dev` DNS refs (immutable historical record).
- `*.lotro.test` (local prod-parity stack — separate TLD).
- `iac/` + `.github/workflows/` — already on the live domain, correctly untouched.

## Verification
- `dotnet build LotroKoniecDev.slnx` — 0 warnings, 0 errors.
- TMS unit: 140 + 131 pass. AuthSystem integration (affected): 56 pass. TMS integration ForwardedHeaders: 4 pass.
- `code-reviewer` agent: clean after the wordmark fix.

## Note (email audit — separate follow-up)
Prod email runs on **Brevo** with sender `koniecdev@gmail.com` (GH Variable `SMTP_SENDER_EMAIL`),
independent of this rename. Optional future polish: authenticate `lotro-translator.pl` in Brevo
(SPF/DKIM/DMARC) and switch the sender to `no-reply@lotro-translator.pl`.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
