### PR TITLE
chore(compose): bump dev + parity Postgres 17 → 18 for prod parity

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -25,7 +25,7 @@ name: lotrokoniecdev-prod
 
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     # Copy the mounted certs to a postgres-owned path, fix key perms (Postgres refuses a key it can
     # read but does not own / that is group/world-readable), then hand off to the stock entrypoint
     # with ssl=on. Self-signed server cert; the app connects with Trust Server Certificate=true.
@@ -45,7 +45,10 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: lotro_translation
     volumes:
-      - lotrokoniecdev-prod-postgres-data:/var/lib/postgresql/data
+      # PG18 moved PGDATA to /var/lib/postgresql/18/docker and the VOLUME to /var/lib/postgresql;
+      # mount the directory itself (not .../data). The entrypoint above still copies the SSL certs
+      # to /var/lib/postgresql/ (now the volume root, alongside the 18/ data subdir) — paths unchanged.
+      - lotrokoniecdev-prod-postgres-data:/var/lib/postgresql
       - ./.docker/prod-https:/certs-src:ro
       - ./scripts/init-postgres.sh:/docker-entrypoint-initdb.d/10-init-databases.sh:ro
     healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ name: lotrokoniecdev
 
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -10,7 +10,9 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - lotrokoniecdev-postgres-data:/var/lib/postgresql/data
+      # PG18 moved PGDATA to /var/lib/postgresql/18/docker and the VOLUME to /var/lib/postgresql;
+      # mount the directory itself (not .../data) so the data subdir is persisted across recreates.
+      - lotrokoniecdev-postgres-data:/var/lib/postgresql
       - ./scripts/init-postgres.sh:/docker-entrypoint-initdb.d/10-init-databases.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d lotro_translation"]


### PR DESCRIPTION
Aligns the dev (`compose.yaml`) and production-parity (`compose.prod.yaml`) stacks to **PostgreSQL 18**, matching prod after the Supabase → Neon migration (ADR-0014, PG 18).

**Why the volume mount target changes:** PG 18's image moved the default `PGDATA` to `/var/lib/postgresql/18/docker` and the `VOLUME` to `/var/lib/postgresql`. Mounting the named volume at the old `/var/lib/postgresql/data` would leave the data outside the volume (lost on recreate), so both files now mount at `/var/lib/postgresql`. The prod SSL-cert copy path `/var/lib/postgresql/postgres.crt` is unchanged (now the volume root, beside the `18/` data subdir).

**Verified:** isolated `postgres:18-alpine` boot with the new mount creates both `lotro_translation` + `lotro_auth` via `init-postgres.sh`, data at `/var/lib/postgresql/18/docker` (`PG_VERSION=18`).

**Heads-up for devs:** after pulling, run `docker compose down -v` before `up` — the old PG 17 volume layout isn't read by PG 18 (dev DB re-inits fresh, which is fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)