### PR TITLE
docs(neon-migration-plan): fix frontend smoke URL app. → apex

### DIFF
--- a/docs/deployment/neon-migration-plan.md
+++ b/docs/deployment/neon-migration-plan.md
@@ -241,14 +241,14 @@ psql "$ConnectionStrings__AuthDatabase"        -c 'SELECT "MigrationId" FROM aut
 scripts/smoke.sh \
   --auth-url     https://auth.lotro-translator.pl \
   --tms-url      https://tms.lotro-translator.pl \
-  --frontend-url https://app.lotro-translator.pl \
+  --frontend-url https://lotro-translator.pl \
   --client-secret "$SMOKE_CLIENT_SECRET"
 ```
 
   All four legs green (health · client-credentials token · tms accepts the token = 403-not-401 ·
   distribution ETag/304; leg 4 may WARN if no artifact is seeded — that is still "up").
 
-- [ ] **5.2 Browser login** at `https://app.lotro-translator.pl` with the seeded admin
+- [ ] **5.2 Browser login** at `https://lotro-translator.pl` with the seeded admin
   (`admin-password` from Key Vault) — confirms `auth-api` re-seeded the admin into Neon.
 
 - [ ] **5.3 Health probes:**


### PR DESCRIPTION
Two-line doc fix. `neon-migration-plan.md` Phase 5.1 (`--frontend-url`) and 5.2 (browser login) pointed at `https://app.lotro-translator.pl`, but the live frontend origin is the **apex** `https://lotro-translator.pl` (ACA custom domain; `app.` has no DNS record).

Found during the Neon cutover: the smoke health leg failed with a DNS resolution error against `app.`, and passed against the apex. The custom-domain decision is already recorded as "apex won over `app.`" in `azure-supabase-bring-up-plan.md`; `runbook.md` and `scripts/smoke.sh` were already correct — only this plan doc was stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)