### PR TITLE
audit 0001 H6: pin Actions to SHA + base images to digest (+ unblock Dependabot infra plan)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,14 +68,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       # Log in to GHCR with the workflow's own scoped token — no stored secret.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Derive image tags & labels
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}
           # `latest` is added explicitly below (default-branch only), never auto-applied to tags.
@@ -96,7 +96,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build & push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       # GITHUB_SHA / INPUT_IMAGE_TAG go through the environment (never interpolated into run:) — the
       # SHA is trusted hex, the input cannot inject shell. `sha-<short>` mirrors docker/metadata type=sha.
@@ -163,7 +163,7 @@ jobs:
           printf 'Deploying image tag: %s\n' "$tag"
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       # Same Static-SSR gate as pr-verify — backstops direct pushes to main.
       - name: Pure-SSR guard
         run: ./scripts/check-ssr-purity.sh
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: '10.0.100'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,15 +42,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           languages: csharp
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           category: "/language:csharp"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,15 +27,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: '10.0.100'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
@@ -60,15 +60,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: '10.0.100'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,12 +23,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           # Full history so the scan covers every commit in the push / PR range.
           fetch-depth: 0
 
       - name: gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -48,8 +48,10 @@ jobs:
   plan:
     name: terraform plan
     # Activation switch (see runbook): until CD_ENABLED=true the Azure-touching jobs are skipped, so
-    # an iac/** PR stays green before the one-time OIDC/secret setup is done.
-    if: vars.CD_ENABLED == 'true' && github.event_name == 'pull_request'
+    # an iac/** PR stays green before the one-time OIDC/secret setup is done. Dependabot PRs are also
+    # skipped: they run without repository secrets, so the Azure OIDC login (client-id/tenant-id) can
+    # never succeed there — and granting them Azure access would be a privilege escalation anyway.
+    if: vars.CD_ENABLED == 'true' && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     defaults:

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -6,7 +6,7 @@ name: Infra (Terraform)
 #   * push to main touching iac/**  → terraform APPLY behind the `production` approval gate.
 #   * workflow_dispatch             → manual APPLY behind the same gate.
 #
-# Auth: Azure OIDC federation (azure/login@v2) — no stored client secret; the azurerm provider AND
+# Auth: Azure OIDC federation (azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0) — no stored client secret; the azurerm provider AND
 # the azurerm state backend both authenticate via the resulting Azure CLI session (use_cli default).
 # App secrets are NOT Terraform inputs anymore: they live in Azure Key Vault and the ACA apps read them
 # via a managed identity (ADR-0013), so only the non-secret inputs (iac/vars.tf) arrive as TF_VAR_*
@@ -57,17 +57,17 @@ jobs:
         working-directory: iac
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.15.7
 
@@ -104,17 +104,17 @@ jobs:
         working-directory: iac
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.15.7
 

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -45,15 +45,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: '10.0.100'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj', '.config/dotnet-tools.json') }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload mutation report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: stryker-report-${{ matrix.name }}-${{ github.run_number }}
           path: ${{ matrix.working-directory }}/StrykerOutput/

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       # Fast, dependency-free gate: the Frontend must stay Static SSR. Runs before
       # the .NET setup so a stray @rendermode/@onclick fails in seconds, not minutes.
@@ -37,12 +37,12 @@ jobs:
         run: ./scripts/check-ssr-purity.sh
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: '10.0.100'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       # Inputs/secret are passed through the environment (never interpolated into the run: script)
       # so an input value cannot inject shell, and the secret never reaches a log line. smoke.sh

--- a/Dockerfile.migrator
+++ b/Dockerfile.migrator
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5
 
 WORKDIR /app
 

--- a/Dockerfile.migrator.prod
+++ b/Dockerfile.migrator.prod
@@ -20,7 +20,7 @@
 ARG BUILD_CONFIGURATION=Release
 ARG TARGET_RUNTIME=linux-x64
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS build
 ARG BUILD_CONFIGURATION
 ARG TARGET_RUNTIME
 WORKDIR /src
@@ -71,7 +71,7 @@ RUN dotnet ef migrations bundle \
 # libgssapi-krb5-2 lets Npgsql negotiate GSSAPI cleanly (some Postgres hosts advertise it); without
 # it Npgsql logs a noisy `libgssapi_krb5.so.2: cannot open shared object file` before falling back to
 # password auth. Installing it keeps the migrator output clean and works against GSSAPI-capable hosts.
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0 AS final
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0@sha256:ebf77bcda11592a859834333025c23c44a812d7a120c7bf290a19ca32697c40e AS final
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libgssapi-krb5-2 \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5
 
 WORKDIR /app
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
@@ -1,11 +1,11 @@
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:7644f992230d35cf230017189d4038c0ae0f7388b13f4f7ae1900a155bafb597 AS base
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 

--- a/src/Frontend/LotroKoniecDev.Frontend/Dockerfile
+++ b/src/Frontend/LotroKoniecDev.Frontend/Dockerfile
@@ -1,11 +1,11 @@
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:7644f992230d35cf230017189d4038c0ae0f7388b13f4f7ae1900a155bafb597 AS base
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
@@ -1,11 +1,11 @@
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:7644f992230d35cf230017189d4038c0ae0f7388b13f4f7ae1900a155bafb597 AS base
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 


### PR DESCRIPTION
Implements **H6** from `docs/audits/0001-infrastructure-audit.md` (supply-chain hardening),
plus the one CI fix needed for the Dependabot flow H6 relies on to actually go green.

## 1. GitHub Actions → full commit SHA (9 workflows, 13 unique actions)
`@vN` → `@<40-char-sha> # vX.Y.Z`, e.g. `actions/checkout@93cb6ef… # v5.0.1`.
Each SHA is the commit the tag currently resolves to (GitHub API, 2026-06-29).
The local reusable workflow `uses: ./.github/workflows/smoke.yml` is left as-is
(not a third-party action).

## 2. Docker base images → sha256 digest (6 Dockerfiles, 10 FROM lines)
`mcr.microsoft.com/dotnet/{sdk,runtime-deps,aspnet}:10.0` → `…:10.0@sha256:…`.
Digests are the multi-arch **manifest-list** digests (verified `manifest.list.v2`),
so images stay multi-platform. Local stage refs (`FROM build` / `FROM base`) untouched.

## 3. Skip the Azure-OIDC `terraform plan` job on Dependabot PRs
Dependabot runs have **no access to repository secrets**, so `secrets.AZURE_*` are empty
and `azure/login` fails (`Not all values are present. Ensure 'client-id' and 'tenant-id'
are supplied.`). Proven: the github-actions group-bump PR's infra run logged an empty
`ARM_SUBSCRIPTION_ID` while the `vars.*` inputs were populated. Every Dependabot action
bump edits a workflow file → triggers this job → red. Guarded with
`github.actor != 'dependabot[bot]'` (the job can't auth there, and giving Dependabot an
Azure-OIDC session would be a privilege escalation). The `azure/login@v3` in that PR was a
**red herring** — v3 takes the same `client-id`/`tenant-id`/`subscription-id` inputs; the
failure was purely the missing secrets.

## Why
A floating ref (`@v5`, `:10.0`) is re-pointable by the publisher. In workflows holding
`id-token: write` + GHCR `packages: write` + Azure OIDC that is a classic supply-chain
vector (tj-actions class); for base images it breaks build reproducibility and lets a
poisoned layer land silently. Pinning closes both and restores the "immutable per-commit
image" guarantee of ADR-0012. Dependabot keeps the pins fresh going forward.

## Verification
- All 36 `uses:` refs SHA-pinned or local (grep: zero leftover `@vN`); 9 workflow YAMLs parse clean.
- All 10 external `FROM` lines digest-pinned; every digest addressable by digest on MCR (HTTP 200).
- `dotnet build LotroKoniecDev.slnx -c Release` → **0 warnings, 0 errors**.
- Infra `terraform plan` is green on this PR's own run (non-Dependabot actor); the guard only adds a Dependabot skip.

## Note on the Dependabot version-bump PR
PR #230 ("Bump the github-actions group with 9 updates") becomes redundant once this merges —
it bumps the same actions to plain tags, whereas this pins all 13 to SHA. After merge, Dependabot
recreates its PR as a SHA→SHA bump against the pinned baseline, and it will go green (plan now skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)