### PR TITLE
audit 0001 M5/M6/M7/M15/M16: log PII redaction, Frontend security headers + HSTS, IaC/build pins

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,12 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <AnalysisLevel>latest</AnalysisLevel>
+    <!-- Pin the language and analyzer bands instead of `latest` (audit #0001 / M16) so an SDK bump
+         can't silently change the active C# version or analyzer set under TreatWarningsAsErrors. C# 14
+         is required by the `extension(...)` members used across the codebase, and 10.0 is the .NET 10
+         analyzer wave; both match the SDK pinned in CI (10.0.100). -->
+    <LangVersion>14</LangVersion>
+    <AnalysisLevel>10.0</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- NuGet vulnerability audit (audit #0001 / H1): restore reports advisories on direct AND

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -103,6 +103,9 @@
   <Folder Name="/tests/SharedKernel/">
     <Project Path="tests/LotroKoniecDev.SharedKernel.Tests.Unit/LotroKoniecDev.SharedKernel.Tests.Unit.csproj" />
   </Folder>
+  <Folder Name="/tests/Utilities/">
+    <Project Path="tests/LotroKoniecDev.Logging.Tests.Unit/LotroKoniecDev.Logging.Tests.Unit.csproj" />
+  </Folder>
   <Folder Name="/tests/TranslationSystem/">
     <Project Path="tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj" />

--- a/iac/setup.tf
+++ b/iac/setup.tf
@@ -1,4 +1,8 @@
 terraform {
+  # Pin the Terraform core version band (audit #0001 / M15) so a stray CLI version can't silently
+  # apply against this state. Matches the 1.15.7 pinned in the CI workflow (.github/workflows/infra.yml).
+  required_version = "~> 1.15"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -17,6 +17,7 @@ using LotroKoniecDev.AuthSystem.API.Health;
 using LotroKoniecDev.AuthSystem.API.Middleware;
 using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Persistence.Settings;
+using LotroKoniecDev.Logging.Redaction;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
@@ -257,8 +258,17 @@ try
 
     app.UseSerilogRequestLogging(options =>
     {
+        // Redact the request log (audit #0001 / M5): keep RequestPath query-free and log the query
+        // separately with secrets stripped and e-mails masked, so no OAuth code/token or PII is persisted.
+        options.IncludeQueryInRequestPath = false;
+        options.MessageTemplate =
+            "HTTP {RequestMethod} {RequestPath}{RequestQuery} responded {StatusCode} in {Elapsed:0.0000} ms";
         options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
         {
+            diagnosticContext.Set(
+                "RequestQuery",
+                SensitiveDataRedactor.RedactQueryString(httpContext.Request.QueryString.Value));
+
             if (httpContext.Items.TryGetValue("CorrelationId", out object? correlationId))
             {
                 diagnosticContext.Set("CorrelationId", correlationId);

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Security/SecurityHeadersExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Security/SecurityHeadersExtensions.cs
@@ -1,0 +1,13 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.Security;
+
+internal static class SecurityHeadersExtensions
+{
+    extension(IApplicationBuilder app)
+    {
+        public IApplicationBuilder UseSecurityHeaders()
+        {
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+            return app;
+        }
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Security/SecurityHeadersMiddleware.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Security/SecurityHeadersMiddleware.cs
@@ -1,0 +1,78 @@
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.Extensions.Options;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Security;
+
+/// <summary>
+/// Stamps the browser-facing security response headers on every response (audit #0001 / M6): a
+/// Content-Security-Policy locked to <c>'self'</c> plus the auth origin and the Google Fonts hosts the
+/// layout loads, <c>X-Content-Type-Options: nosniff</c>, <c>Referrer-Policy: no-referrer</c>, and
+/// <c>X-Frame-Options: DENY</c> alongside the CSP <c>frame-ancestors 'none'</c>. The header set is
+/// computed once from configuration and written via <see cref="HttpResponse.OnStarting"/> so it also
+/// reaches re-executed error/status-code responses. Only registered outside Development, mirroring
+/// <c>UseHsts()</c>, so the host-run dev loop (and its hot-reload inline script) stays unchanged.
+/// </summary>
+internal sealed class SecurityHeadersMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IReadOnlyDictionary<string, string> _headers;
+
+    public SecurityHeadersMiddleware(RequestDelegate next, IOptions<AuthSystemSettings> authSettings)
+    {
+        _next = next;
+        _headers = BuildHeaders(authSettings.Value.Authority);
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        context.Response.OnStarting(() =>
+        {
+            IHeaderDictionary responseHeaders = context.Response.Headers;
+            foreach (KeyValuePair<string, string> header in _headers)
+            {
+                responseHeaders[header.Key] = header.Value;
+            }
+
+            return Task.CompletedTask;
+        });
+
+        await _next(context);
+    }
+
+    internal static IReadOnlyDictionary<string, string> BuildHeaders(string authority) =>
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Content-Security-Policy"] = BuildContentSecurityPolicy(AuthOrigin(authority)),
+            ["X-Content-Type-Options"] = "nosniff",
+            ["Referrer-Policy"] = "no-referrer",
+            ["X-Frame-Options"] = "DENY"
+        };
+
+    /// <summary>
+    /// Builds the CSP. <c>script-src</c> stays at <c>'self'</c> (Blazor's <c>blazor.web.js</c> and
+    /// streaming updates are external/markup, never inline script); <c>style-src</c> needs
+    /// <c>'unsafe-inline'</c> for the dynamic inline <c>style</c> width on the dashboard progress bar
+    /// and the Google Fonts stylesheet; the auth origin is admitted for <c>connect-src</c>/
+    /// <c>form-action</c> so the OIDC login flow is not blocked.
+    /// </summary>
+    internal static string BuildContentSecurityPolicy(string authOrigin) => string.Join("; ",
+    [
+        "default-src 'self'",
+        "base-uri 'self'",
+        "object-src 'none'",
+        "frame-ancestors 'none'",
+        "img-src 'self' data:",
+        "script-src 'self'",
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+        "font-src 'self' https://fonts.gstatic.com",
+        $"connect-src 'self' {authOrigin}",
+        $"form-action 'self' {authOrigin}"
+    ]);
+
+    /// <summary>
+    /// Reduces a configured authority URL to its bare origin (scheme + host + non-default port), which
+    /// is the form a CSP source expression accepts — no path, no trailing slash.
+    /// </summary>
+    internal static string AuthOrigin(string authority) =>
+        new Uri(authority).GetLeftPart(UriPartial.Authority);
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/LotroKoniecDev.Frontend.csproj
+++ b/src/Frontend/LotroKoniecDev.Frontend/LotroKoniecDev.Frontend.csproj
@@ -35,6 +35,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\TranslationSystem\LotroKoniecDev.TranslationSystem.Contracts\LotroKoniecDev.TranslationSystem.Contracts.csproj" />
         <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Hateoas.Abstractions\LotroKoniecDev.Hateoas.Abstractions.csproj" />
+        <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Logging\LotroKoniecDev.Logging.csproj" />
         <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Options\LotroKoniecDev.Options.csproj" />
     </ItemGroup>
 

--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -5,7 +5,9 @@ using LotroKoniecDev.Frontend.Components;
 using LotroKoniecDev.Frontend.Components.Pages.ImportExport;
 using LotroKoniecDev.Frontend.Infrastructure.Auth;
 using LotroKoniecDev.Frontend.Infrastructure.Errors;
+using LotroKoniecDev.Frontend.Infrastructure.Security;
 using LotroKoniecDev.Frontend.Settings;
+using LotroKoniecDev.Logging.Redaction;
 using LotroKoniecDev.Options;
 using LotroKoniecDev.TranslationSystem.Contracts.Import;
 using Microsoft.AspNetCore.Http.Features;
@@ -85,6 +87,16 @@ try
         options.KnownProxies.Clear();
     });
 
+    // HSTS hardening (audit #0001 / M7): a one-year max-age covering subdomains and flagged for the
+    // preload list. Only emitted by UseHsts() outside Development (the deployed stack is HTTPS-only
+    // behind the ingress); the dev host loop never sends it, so localhost HTTP is unaffected.
+    builder.Services.AddHsts(options =>
+    {
+        options.MaxAge = TimeSpan.FromDays(365);
+        options.IncludeSubDomains = true;
+        options.Preload = true;
+    });
+
     // The Blazor SSR import form (admin-only) uploads exported.txt, which is ~80 MB and grows — far
     // past Kestrel's 30 MB default body cap and the framework's multipart form-length limit. Lift both
     // to the shared upload ceiling so the whole file posts to this host in one request, then streams on
@@ -126,10 +138,20 @@ try
         app.UseForwardedHeaders();
     }
 
-    app.UseSerilogRequestLogging();
+    // Redact the request log (audit #0001 / M5): keep RequestPath query-free and log the query
+    // separately with secrets stripped and e-mails masked, so no OAuth code/token or PII is persisted.
+    app.UseSerilogRequestLogging(options =>
+    {
+        options.IncludeQueryInRequestPath = false;
+        options.MessageTemplate =
+            "HTTP {RequestMethod} {RequestPath}{RequestQuery} responded {StatusCode} in {Elapsed:0.0000} ms";
+        options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+            diagnosticContext.Set("RequestQuery", SensitiveDataRedactor.RedactQueryString(httpContext.Request.QueryString.Value));
+    });
 
     if (!app.Environment.IsDevelopment())
     {
+        app.UseSecurityHeaders();
         app.UseExceptionHandler("/Error", createScopeForErrors: true);
         app.UseHsts();
     }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
@@ -19,6 +19,7 @@ using LotroKoniecDev.TranslationSystem.API.Health;
 using LotroKoniecDev.TranslationSystem.API.Middleware;
 using LotroKoniecDev.TranslationSystem.API.Settings;
 using LotroKoniecDev.TranslationSystem.Persistence.Settings;
+using LotroKoniecDev.Logging.Redaction;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
@@ -185,8 +186,17 @@ try
 
     app.UseSerilogRequestLogging(options =>
     {
+        // Redact the request log (audit #0001 / M5): keep RequestPath query-free and log the query
+        // separately with secrets stripped and e-mails masked, so no OAuth code/token or PII is persisted.
+        options.IncludeQueryInRequestPath = false;
+        options.MessageTemplate =
+            "HTTP {RequestMethod} {RequestPath}{RequestQuery} responded {StatusCode} in {Elapsed:0.0000} ms";
         options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
         {
+            diagnosticContext.Set(
+                "RequestQuery",
+                SensitiveDataRedactor.RedactQueryString(httpContext.Request.QueryString.Value));
+
             if (httpContext.Items.TryGetValue("CorrelationId", out object? correlationId))
             {
                 diagnosticContext.Set("CorrelationId", correlationId);

--- a/src/Utilities/LotroKoniecDev.Logging/Redaction/SensitiveDataRedactor.cs
+++ b/src/Utilities/LotroKoniecDev.Logging/Redaction/SensitiveDataRedactor.cs
@@ -1,0 +1,118 @@
+using System.Collections.Frozen;
+using System.Text.RegularExpressions;
+
+namespace LotroKoniecDev.Logging.Redaction;
+
+/// <summary>
+/// Scrubs secrets and personal data out of request-log fields before they reach a sink (audit #0001 /
+/// M5). Values of OAuth/OIDC and credential query parameters (e.g. <c>code</c>, <c>access_token</c>,
+/// <c>password</c>) are replaced wholesale, and any e-mail address surviving in a non-sensitive value
+/// has its local part masked, so neither a replayable token nor a piece of PII is persisted in plain
+/// text. All methods are total — a logging hot path must never throw — and operate on the raw query
+/// string without decoding, which is sufficient because query e-mails carry a literal <c>@</c>.
+/// </summary>
+public static partial class SensitiveDataRedactor
+{
+    private const string RedactedValue = "***";
+
+    /// <summary>
+    /// Query-parameter names whose value is a secret and must never be logged. Matched
+    /// case-insensitively against the percent-decoded parameter name. This is an exact allowlist:
+    /// any new credential-bearing query parameter (a new OAuth/OIDC grant, hint, or assertion) MUST
+    /// be added here, or its value will be logged in clear.
+    /// </summary>
+    private static readonly FrozenSet<string> SensitiveQueryKeys = new[]
+    {
+        "code",
+        "token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "id_token_hint",
+        "client_assertion",
+        "password",
+        "pwd",
+        "secret",
+        "client_secret"
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Redacts a raw query string (with or without its leading <c>?</c>). Sensitive parameter values
+    /// become <c>***</c>; e-mail addresses in the remaining values are masked. Returns the redacted
+    /// query string keeping its leading <c>?</c>, or an empty string when there is no query.
+    /// </summary>
+    public static string RedactQueryString(string? queryString)
+    {
+        if (string.IsNullOrEmpty(queryString))
+        {
+            return string.Empty;
+        }
+
+        bool hasLeadingQuestionMark = queryString[0] == '?';
+        string body = hasLeadingQuestionMark ? queryString[1..] : queryString;
+
+        if (body.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        string[] pairs = body.Split('&');
+        for (int i = 0; i < pairs.Length; i++)
+        {
+            pairs[i] = RedactPair(pairs[i]);
+        }
+
+        string redactedBody = string.Join('&', pairs);
+        return hasLeadingQuestionMark ? "?" + redactedBody : redactedBody;
+    }
+
+    /// <summary>
+    /// Masks the local part of an e-mail, keeping only its first character (e.g.
+    /// <c>alice@example.com</c> becomes <c>a***@example.com</c>). Anything without a non-empty local
+    /// part and an <c>@</c> is treated as fully sensitive and replaced with <c>***</c>.
+    /// </summary>
+    public static string MaskEmail(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return RedactedValue;
+        }
+
+        int atIndex = value.IndexOf('@', StringComparison.Ordinal);
+        return atIndex <= 0 ? RedactedValue : string.Concat(value[0].ToString(), RedactedValue, value[atIndex..]);
+    }
+
+    private static string RedactPair(string pair)
+    {
+        int separatorIndex = pair.IndexOf('=', StringComparison.Ordinal);
+        if (separatorIndex < 0)
+        {
+            return pair;
+        }
+
+        string key = pair[..separatorIndex];
+
+        // Match against the percent-decoded key so an encoded variant (e.g. "%63ode" = "code") cannot
+        // slip a secret past the allowlist; the original key text is kept verbatim in the output.
+        if (SensitiveQueryKeys.Contains(Uri.UnescapeDataString(key)))
+        {
+            return key + "=" + RedactedValue;
+        }
+
+        string value = pair[(separatorIndex + 1)..];
+        return key + "=" + MaskEmailsIn(value);
+    }
+
+    private static string MaskEmailsIn(string value)
+    {
+        if (value.Length == 0 || !value.Contains('@', StringComparison.Ordinal))
+        {
+            return value;
+        }
+
+        return EmailRegex().Replace(value, match => MaskEmail(match.Value));
+    }
+
+    [GeneratedRegex(@"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", RegexOptions.CultureInvariant)]
+    private static partial Regex EmailRegex();
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Security/SecurityHeadersMiddlewareTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Security/SecurityHeadersMiddlewareTests.cs
@@ -1,0 +1,154 @@
+using LotroKoniecDev.Frontend.Infrastructure.Security;
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Security;
+
+public sealed class SecurityHeadersMiddlewareTests
+{
+    private const string AuthAuthority = "https://localhost:5003";
+
+    [Theory]
+    [InlineData("https://localhost:5003", "https://localhost:5003")]
+    [InlineData("https://localhost:5003/", "https://localhost:5003")]
+    [InlineData("https://auth.lotro-translator.pl", "https://auth.lotro-translator.pl")]
+    [InlineData("https://auth.example.com:8443/connect/authorize", "https://auth.example.com:8443")]
+    public void AuthOrigin_ReturnsSchemeHostAndPortWithoutPathOrTrailingSlash(string authority, string expected)
+    {
+        string result = SecurityHeadersMiddleware.AuthOrigin(authority);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("default-src 'self'")]
+    [InlineData("base-uri 'self'")]
+    [InlineData("object-src 'none'")]
+    [InlineData("frame-ancestors 'none'")]
+    [InlineData("img-src 'self' data:")]
+    [InlineData("script-src 'self'")]
+    public void BuildContentSecurityPolicy_ContainsTheLockedDownBaselineDirectives(string expectedDirective)
+    {
+        string policy = SecurityHeadersMiddleware.BuildContentSecurityPolicy(AuthAuthority);
+
+        policy.ShouldContain(expectedDirective);
+    }
+
+    [Fact]
+    public void BuildContentSecurityPolicy_AllowsTheAuthOriginForConnectAndFormAction()
+    {
+        string policy = SecurityHeadersMiddleware.BuildContentSecurityPolicy("https://localhost:5003");
+
+        policy.ShouldContain("connect-src 'self' https://localhost:5003");
+        policy.ShouldContain("form-action 'self' https://localhost:5003");
+    }
+
+    [Fact]
+    public void BuildContentSecurityPolicy_AllowsTheGoogleFontsOriginsTheLayoutDependsOn()
+    {
+        string policy = SecurityHeadersMiddleware.BuildContentSecurityPolicy(AuthAuthority);
+
+        policy.ShouldContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+        policy.ShouldContain("font-src 'self' https://fonts.gstatic.com");
+    }
+
+    [Fact]
+    public void BuildContentSecurityPolicy_DoesNotWeakenScriptSrcWithUnsafeInlineOrEval()
+    {
+        string policy = SecurityHeadersMiddleware.BuildContentSecurityPolicy(AuthAuthority);
+
+        policy.ShouldNotContain("script-src 'self' 'unsafe-inline'");
+        policy.ShouldNotContain("'unsafe-eval'");
+    }
+
+    [Fact]
+    public void BuildHeaders_SetsEveryRequiredSecurityHeader()
+    {
+        IReadOnlyDictionary<string, string> headers = SecurityHeadersMiddleware.BuildHeaders(AuthAuthority);
+
+        headers["X-Content-Type-Options"].ShouldBe("nosniff");
+        headers["Referrer-Policy"].ShouldBe("no-referrer");
+        headers["X-Frame-Options"].ShouldBe("DENY");
+        headers["Content-Security-Policy"].ShouldBe(SecurityHeadersMiddleware.BuildContentSecurityPolicy(AuthAuthority));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_StampsEverySecurityHeaderOnTheResponse()
+    {
+        RecordingResponseFeature responseFeature = new();
+        DefaultHttpContext context = BuildContext(responseFeature);
+        SecurityHeadersMiddleware middleware = new(_ => Task.CompletedTask, Microsoft.Extensions.Options.Options.Create(ValidAuthSettings()));
+
+        await middleware.InvokeAsync(context);
+        await responseFeature.FireOnStartingAsync();
+
+        IHeaderDictionary headers = responseFeature.Headers;
+        headers["Content-Security-Policy"].ToString()
+            .ShouldBe(SecurityHeadersMiddleware.BuildContentSecurityPolicy(AuthAuthority));
+        headers["X-Content-Type-Options"].ToString().ShouldBe("nosniff");
+        headers["Referrer-Policy"].ToString().ShouldBe("no-referrer");
+        headers["X-Frame-Options"].ToString().ShouldBe("DENY");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DefersHeaderWritingUntilTheResponseStarts()
+    {
+        RecordingResponseFeature responseFeature = new();
+        DefaultHttpContext context = BuildContext(responseFeature);
+        SecurityHeadersMiddleware middleware = new(_ => Task.CompletedTask, Microsoft.Extensions.Options.Options.Create(ValidAuthSettings()));
+
+        await middleware.InvokeAsync(context);
+
+        // Written via OnStarting (not eagerly), so re-executed error/status-code responses are covered too.
+        responseFeature.Headers.ContainsKey("Content-Security-Policy").ShouldBeFalse();
+
+        await responseFeature.FireOnStartingAsync();
+
+        responseFeature.Headers.ContainsKey("Content-Security-Policy").ShouldBeTrue();
+    }
+
+    private static DefaultHttpContext BuildContext(IHttpResponseFeature responseFeature)
+    {
+        FeatureCollection features = new();
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature());
+        features.Set(responseFeature);
+        return new DefaultHttpContext(features);
+    }
+
+    private static AuthSystemSettings ValidAuthSettings() => new()
+    {
+        BaseUrl = "https://localhost:5003/",
+        Authority = AuthAuthority,
+        ClientId = "lotrokoniecdev-web",
+        CallbackPath = "/callback",
+        SignedOutCallbackPath = "/signout-callback-oidc",
+        Scopes = ["openid"]
+    };
+
+    private sealed class RecordingResponseFeature : IHttpResponseFeature
+    {
+        private readonly List<(Func<object, Task> Callback, object State)> _onStarting = [];
+
+        public int StatusCode { get; set; } = StatusCodes.Status200OK;
+        public string? ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public Stream Body { get; set; } = Stream.Null;
+        public bool HasStarted { get; private set; }
+
+        public void OnStarting(Func<object, Task> callback, object state) => _onStarting.Add((callback, state));
+
+        public void OnCompleted(Func<object, Task> callback, object state)
+        {
+        }
+
+        public async Task FireOnStartingAsync()
+        {
+            HasStarted = true;
+            foreach ((Func<object, Task> callback, object state) in _onStarting)
+            {
+                await callback(state);
+            }
+        }
+    }
+}

--- a/tests/LotroKoniecDev.Logging.Tests.Unit/LotroKoniecDev.Logging.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.Logging.Tests.Unit/LotroKoniecDev.Logging.Tests.Unit.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>LotroKoniecDev.Logging.Tests.Unit</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+        <Using Include="Shouldly"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Utilities\LotroKoniecDev.Logging\LotroKoniecDev.Logging.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.Logging.Tests.Unit/Redaction/SensitiveDataRedactorTests.cs
+++ b/tests/LotroKoniecDev.Logging.Tests.Unit/Redaction/SensitiveDataRedactorTests.cs
@@ -1,0 +1,163 @@
+using LotroKoniecDev.Logging.Redaction;
+
+namespace LotroKoniecDev.Logging.Tests.Unit.Redaction;
+
+public sealed class SensitiveDataRedactorTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void RedactQueryString_EmptyOrNull_ReturnsEmptyString(string? queryString)
+    {
+        string result = SensitiveDataRedactor.RedactQueryString(queryString);
+
+        result.ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    [InlineData("?code=abc123", "?code=***")]
+    [InlineData("?token=abc123", "?token=***")]
+    [InlineData("?access_token=abc123", "?access_token=***")]
+    [InlineData("?refresh_token=abc123", "?refresh_token=***")]
+    [InlineData("?id_token=abc123", "?id_token=***")]
+    [InlineData("?password=hunter2", "?password=***")]
+    [InlineData("?pwd=hunter2", "?pwd=***")]
+    [InlineData("?secret=abc123", "?secret=***")]
+    [InlineData("?client_secret=abc123", "?client_secret=***")]
+    public void RedactQueryString_SensitiveKey_RedactsValue(string queryString, string expected)
+    {
+        string result = SensitiveDataRedactor.RedactQueryString(queryString);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("?CODE=abc123", "?CODE=***")]
+    [InlineData("?Token=abc123", "?Token=***")]
+    [InlineData("?Client_Secret=abc123", "?Client_Secret=***")]
+    public void RedactQueryString_SensitiveKeyDifferentCasing_StillRedactsValue(string queryString, string expected)
+    {
+        string result = SensitiveDataRedactor.RedactQueryString(queryString);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("?%63ode=secret", "?%63ode=***")]
+    [InlineData("?access%5Ftoken=abc123", "?access%5Ftoken=***")]
+    [InlineData("?CLIENT%5Fsecret=abc", "?CLIENT%5Fsecret=***")]
+    public void RedactQueryString_PercentEncodedSensitiveKey_StillRedactsValue(string queryString, string expected)
+    {
+        string result = SensitiveDataRedactor.RedactQueryString(queryString);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("?id_token_hint=eyJ.abc.def", "?id_token_hint=***")]
+    [InlineData("?client_assertion=eyJ.abc.def", "?client_assertion=***")]
+    public void RedactQueryString_OidcCredentialBearingKey_RedactsValue(string queryString, string expected)
+    {
+        string result = SensitiveDataRedactor.RedactQueryString(queryString);
+
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void RedactQueryString_BareQuestionMark_ReturnsEmptyString()
+    {
+        string result = SensitiveDataRedactor.RedactQueryString("?");
+
+        result.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void RedactQueryString_RepeatedSensitiveKey_RedactsEveryOccurrence()
+    {
+        string result = SensitiveDataRedactor.RedactQueryString("?code=first&code=second");
+
+        result.ShouldBe("?code=***&code=***");
+    }
+
+    [Fact]
+    public void RedactQueryString_OnlyRedactsSensitiveKeysAndLeavesOthersIntact()
+    {
+        string result = SensitiveDataRedactor.RedactQueryString("?lang=pl&code=abc123&page=2");
+
+        result.ShouldBe("?lang=pl&code=***&page=2");
+    }
+
+    [Fact]
+    public void RedactQueryString_NonSensitiveKey_IsLeftUnchanged()
+    {
+        string result = SensitiveDataRedactor.RedactQueryString("?lang=pl&page=2");
+
+        result.ShouldBe("?lang=pl&page=2");
+    }
+
+    [Fact]
+    public void RedactQueryString_ValueContainingEqualsSign_RedactsWholeValue()
+    {
+        string result = SensitiveDataRedactor.RedactQueryString("?code=aGVsbG8=d29ybGQ=");
+
+        result.ShouldBe("?code=***");
+    }
+
+    [Fact]
+    public void RedactQueryString_EmailValue_MasksLocalPart()
+    {
+        string result = SensitiveDataRedactor.RedactQueryString("?email=alice@example.com");
+
+        result.ShouldBe("?email=a***@example.com");
+    }
+
+    [Fact]
+    public void RedactQueryString_EmailInArbitraryParameterName_IsStillMasked()
+    {
+        string result = SensitiveDataRedactor.RedactQueryString("?username=bob.smith@contoso.co.uk&page=1");
+
+        result.ShouldBe("?username=b***@contoso.co.uk&page=1");
+    }
+
+    [Fact]
+    public void RedactQueryString_SensitiveKeyTakesPrecedenceOverEmailMasking()
+    {
+        string result = SensitiveDataRedactor.RedactQueryString("?login_hint=alice@example.com&code=alice@example.com");
+
+        result.ShouldBe("?login_hint=a***@example.com&code=***");
+    }
+
+    [Fact]
+    public void RedactQueryString_KeyWithoutValue_IsPreserved()
+    {
+        string result = SensitiveDataRedactor.RedactQueryString("?refresh&page=2");
+
+        result.ShouldBe("?refresh&page=2");
+    }
+
+    [Theory]
+    [InlineData("alice@example.com", "a***@example.com")]
+    [InlineData("b@c.com", "b***@c.com")]
+    [InlineData("bob.smith@contoso.co.uk", "b***@contoso.co.uk")]
+    [InlineData("alice+tag@example.com", "a***@example.com")]
+    public void MaskEmail_ValidEmail_MasksEverythingAfterTheFirstCharacterOfTheLocalPart(
+        string email,
+        string expected)
+    {
+        string result = SensitiveDataRedactor.MaskEmail(email);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("@example.com")]
+    [InlineData("not-an-email")]
+    public void MaskEmail_MissingLocalPartOrAtSign_ReturnsFullyRedacted(string value)
+    {
+        string result = SensitiveDataRedactor.MaskEmail(value);
+
+        result.ShouldBe("***");
+    }
+}


### PR DESCRIPTION
## What

Implements five hardening findings from `docs/audits/0001-infrastructure-audit.md` in one PR.

| Finding | Change |
|---|---|
| **M5** (all 3 apps) | PII/secret redaction in `UseSerilogRequestLogging` |
| **M6** (Frontend) | Security-headers middleware (CSP, nosniff, `frame-ancestors 'none'`, `Referrer-Policy`, `X-Frame-Options`) |
| **M7** (Frontend) | `AddHsts` — 1 year, `includeSubDomains`, `preload` |
| **M15** | `required_version = "~> 1.15"` in `iac/setup.tf` |
| **M16** | Pin `LangVersion`/`AnalysisLevel` to a band instead of `latest` |

## M5 — request-log redaction (auth-api · tms-api · frontend)

New pure, shared `SensitiveDataRedactor` (`src/Utilities/LotroKoniecDev.Logging/Redaction/`):
- strips the value of OAuth/credential query params (`code`, `token`, `access_token`, `refresh_token`, `id_token`, `password`, `pwd`, `secret`, `client_secret`) → `***` (case-insensitive),
- masks any e-mail in the remaining values (`alice@x.com` → `a***@x.com`, mirroring the AuthSystem `MaskEmail`),
- is total (never throws — it runs in a logging hot path).

Each app's `UseSerilogRequestLogging` now sets `IncludeQueryInRequestPath = false` (so the built-in `RequestPath` stays query-free) and logs the query separately via a redacted `{RequestQuery}` property. Auth/tms keep their existing `CorrelationId` enrichment. The raw query string never reaches a sink.

## M6 / M7 — Frontend security headers + HSTS

New `SecurityHeadersMiddleware` (`Infrastructure/Security/`) stamps, on every response, via `OnStarting` (so re-executed error/status responses are covered too):

```
Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none';
  frame-ancestors 'none'; img-src 'self' data:; script-src 'self';
  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
  font-src 'self' https://fonts.gstatic.com;
  connect-src 'self' <auth-origin>; form-action 'self' <auth-origin>
X-Content-Type-Options: nosniff
Referrer-Policy: no-referrer
X-Frame-Options: DENY
```

- The auth origin is derived from `AuthSystem:Authority` config (per-environment), reduced to scheme+host+port.
- `script-src 'self'` is **strict** (no `'unsafe-inline'`). Blazor's inline `<script type="importmap">` is therefore CSP-blocked — functionally harmless here (static SSR, no JS modules, no interactive render modes → the importmap is unused), at the cost of a cosmetic console violation. Kept strict deliberately for XSS defense-in-depth, since translators' submitted text is rendered. Revisit (nonce) if interactive render modes or collocated JS modules are added.
- `style-src 'unsafe-inline'` + the Google Fonts origins are required (App.razor loads Google Fonts; Dashboard has a dynamic inline `style` width) — removing them breaks the app.
- `AddHsts`: `MaxAge = 365d`, `IncludeSubDomains`, `Preload`.
- Both gated to `!IsDevelopment()`, mirroring the existing `UseHsts()`/`UseForwardedHeaders()`, so the host-run dev hot-reload loop is unchanged.

## M15 / M16 — IaC + build pins

- `iac/setup.tf`: `required_version = "~> 1.15"` (matches CI's pinned `1.15.7`).
- `Directory.Build.props`: `LangVersion=14`, `AnalysisLevel=10.0`. **Note:** the audit suggested `LangVersion=13`, but the codebase uses C# 14 `extension(...)` members (10+ files), so 13 would not compile. 14 is the correct .NET 10 band (CI pins SDK `10.0.100`).

## Scope note

M6/M7 are **Frontend-only**, matching the request ("we Frontendzie") and contrasting M5's "all 3 apps". Auth/tms still emit framework-default HSTS — hardening their HSTS is a trivial follow-up if wanted.

## Tests / verification

- New `LotroKoniecDev.Logging.Tests.Unit` (28 tests) — redactor matrix (every sensitive key, casing, email masking, precedence, malformed query). Auto-discovered by CI (`*.Tests.Unit.csproj`).
- New `SecurityHeadersMiddlewareTests` (14 tests, Frontend.Tests.Unit) — CSP directives, auth-origin extraction, fonts allowed, `script-src` not weakened, all headers present.
- TDD: every new function had a failing test first.
- Green: full Release build **0 warnings**; all unit suites; integration (auth 173, tms 142); SSR-purity gate; `terraform fmt -check` + `validate`.
- **Empirical:** ran the Frontend in a non-dev env and confirmed it emits exactly `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`, the full CSP, `nosniff`, `Referrer-Policy: no-referrer`, `X-Frame-Options: DENY`, and that the only inline script in the rendered page is the (deliberately-blocked) importmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
