### PR TITLE
audit 0001 H7: health-gated rollout (deploy 0% → smoke → 100%) + auto-rollback + frontend readiness

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,17 +1,28 @@
 name: CD
 
-# Continuous delivery + deployment for the TMS (ADR-0012, amended 2026-06-29 — audit 0001 C2).
+# Continuous delivery + deployment for the TMS (ADR-0012, amended 2026-06-29 audit 0001 C2,
+# 2026-06-30 audit 0001 H7 — health-gated rollout).
 #
 #   gate           → CI-success gate. CD is TRIGGERED BY the CI workflow finishing (workflow_run); it
 #                    proceeds only when CI concluded `success` on main, and pins the exact tested
 #                    commit (head_sha) for everything downstream. Dispatch / v* tags pass through.
 #   build-and-push → publishes the four OCI images to GHCR (the deployment unit; ADR-0008 §1/§6).
-#   deploy-prod    → rolls them out to Azure Container Apps, BEHIND a manual approval gate.
-#   smoke          → post-deploy end-to-end signal (reusable smoke.yml).
+#   deploy-prod    → rolls each app out as a NEW revision at 0% traffic (multiple-revision mode),
+#                    BEHIND a manual approval gate; waits for the candidate (incl. frontend) readiness.
+#   smoke          → smokes the 0%-traffic CANDIDATE through its private label FQDN, before any shift.
+#   promote        → only a green candidate smoke shifts 100% of traffic onto the candidate.
+#   smoke-prod     → post-promotion confirmation on the real production origins.
+#   rollback       → on ANY failure once a candidate exists, restores traffic to the previous revision.
 #
 # The deployment unit is an immutable per-commit image (`sha-<short>`); the rolling tag is owned by
-# THIS pipeline (`az containerapp update`), not Terraform — the ACA resources ignore image drift
-# (iac/, lifecycle.ignore_changes). `latest` still tracks the tip of main for humans pulling by hand.
+# THIS pipeline (`az containerapp update`), not Terraform — the ACA resources ignore image + traffic
+# drift (iac/, lifecycle.ignore_changes). `latest` still tracks the tip of main for humans by hand.
+#
+# Health-gated rollout (audit 0001 H7): traffic NEVER jumps onto an unverified revision. Each app is
+# deployed as a candidate revision receiving 0% production traffic, reachable only through a private
+# `<app>---cd-candidate.<env-domain>` label FQDN. Smoke runs against that candidate first; only then
+# does `promote` shift 100% of traffic to it. The previous revision is kept (0% traffic, scales to
+# zero) so a failure rolls straight back to it — no window where users hit a bad revision.
 #
 # CI is a hard pre-condition of deploy (audit 0001 C2): a push to main no longer triggers CD
 # directly. CD waits for the CI workflow (Release build + unit + integration) to finish, and only a
@@ -52,6 +63,13 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAMESPACE: ${{ github.repository_owner }}
+  # Prod ACA targets, shared by deploy-prod / promote / rollback (non-secret).
+  RESOURCE_GROUP: rg-lotrotms-prod-polc-001
+  AUTH_APP: lotrotms-auth-api-prod
+  TMS_APP: lotrotms-tms-api-prod
+  FRONTEND_APP: lotrotms-frontend-prod
+  # Label that gives the 0%-traffic candidate a private FQDN for smoke (health-gated rollout).
+  CANDIDATE_LABEL: cd-candidate
 
 jobs:
   # CI-success gate (audit 0001 C2). Reached via workflow_run, this decides whether the deploy
@@ -222,7 +240,7 @@ jobs:
       && needs.gate.outputs.proceed == 'true'
       && (github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     # The `production` environment carries the required-reviewer rule: this job PAUSES here until a
     # human approves the release. That is the "approve a release manually in GitHub" control.
     environment:
@@ -237,13 +255,19 @@ jobs:
       contents: read # checkout (scripts/)
       id-token: write # Azure OIDC federation — short-lived token, no stored client secret
     env:
-      RESOURCE_GROUP: rg-lotrotms-prod-polc-001
-      AUTH_APP: lotrotms-auth-api-prod
-      TMS_APP: lotrotms-tms-api-prod
-      FRONTEND_APP: lotrotms-frontend-prod
       MIGRATOR_JOB: lotrotms-migrator-prod
-      AUTH_URL: https://auth.lotro-translator.pl
-      TMS_URL: https://tms.lotro-translator.pl
+    # Candidate (0%-traffic) revision URLs + the previous/candidate revision names flow to the smoke,
+    # promote and rollback jobs (health-gated rollout — ADR-0012 §5 amendment, audit 0001 H7).
+    outputs:
+      auth_candidate_url: ${{ steps.rollout.outputs.auth_candidate_url }}
+      tms_candidate_url: ${{ steps.rollout.outputs.tms_candidate_url }}
+      frontend_candidate_url: ${{ steps.rollout.outputs.frontend_candidate_url }}
+      auth_prev_rev: ${{ steps.rollout.outputs.auth_prev_rev }}
+      tms_prev_rev: ${{ steps.rollout.outputs.tms_prev_rev }}
+      frontend_prev_rev: ${{ steps.rollout.outputs.frontend_prev_rev }}
+      auth_candidate_rev: ${{ steps.rollout.outputs.auth_candidate_rev }}
+      tms_candidate_rev: ${{ steps.rollout.outputs.tms_candidate_rev }}
+      frontend_candidate_rev: ${{ steps.rollout.outputs.frontend_candidate_rev }}
 
     steps:
       # Same commit pin as build-and-push (the tested commit), so any repo file this job reads
@@ -308,51 +332,222 @@ jobs:
           fi
           echo "Migrations applied."
 
-      # Single-revision apps: changing the image rolls traffic to a new revision pinned to this SHA.
-      - name: Roll the three web apps to the new image
+      # Health-gated rollout (ADR-0012 §5 amendment, audit 0001 H7). Multiple-revision mode: deploy
+      # each app as a NEW revision receiving 0% production traffic, reachable only via a private label
+      # FQDN. The candidate is smoked BEFORE any traffic shift (smoke + promote jobs), so a bad
+      # release never serves a user.
+      - name: Deploy candidate revisions (0% traffic) and label them for smoke
+        id: rollout
         env:
           TAG: ${{ steps.tag.outputs.tag }}
+          SHORT_SHA: ${{ needs.gate.outputs.short_sha }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          roll() {
-            app="$1"; image="$2"
+          # DNS-safe, unique-per-attempt revision suffix: starts with a letter, [a-z0-9-] only, no '--'.
+          suffix="c${SHORT_SHA}-${RUN_ID}-${RUN_ATTEMPT}"
+          deploy_candidate() {
+            prefix="$1"; app="$2"; image="$3"
             img="${REGISTRY}/${IMAGE_NAMESPACE}/${image}:${TAG}"
-            echo "::group::Rolling ${app} → ${img}"
-            az containerapp update -n "$app" -g "$RESOURCE_GROUP" --image "$img" -o none
-            echo "::endgroup::"
-          }
-          roll "$AUTH_APP" lotrokoniecdev-auth-api
-          roll "$TMS_APP" lotrokoniecdev-tms-api
-          roll "$FRONTEND_APP" lotrokoniecdev-frontend
+            echo "::group::Deploy candidate for ${app} (${img})"
 
-      # Cold-start tolerant: poll readiness before handing off to the smoke job.
-      - name: Wait for readiness
+            # The revision currently serving production traffic — the rollback anchor; it keeps 100%
+            # of traffic throughout smoke. Highest-weight entry = production; a null name means the
+            # bootstrap latest_revision weight (first rollout) → fall back to the single live revision.
+            prev="$(az containerapp ingress traffic show -n "$app" -g "$RESOURCE_GROUP" \
+                      --query "reverse(sort_by(@, &weight))[0].revisionName" -o tsv 2>/dev/null | tr -d '\r' || true)"
+            if [ -z "$prev" ] || [ "$prev" = "null" ]; then
+              prev="$(az containerapp show -n "$app" -g "$RESOURCE_GROUP" \
+                        --query properties.latestReadyRevisionName -o tsv | tr -d '\r')"
+            fi
+            echo "  previous (production) revision: ${prev}"
+
+            # Pin 100% to the current revision so the new one is created at 0% (also converts any
+            # bootstrap latest_revision weight to the name-pinned weight the pipeline controls).
+            az containerapp ingress traffic set -n "$app" -g "$RESOURCE_GROUP" \
+              --revision-weight "${prev}=100" -o none
+
+            # Create the candidate from the tested image — 0% traffic in multiple-revision mode.
+            az containerapp update -n "$app" -g "$RESOURCE_GROUP" \
+              --image "$img" --revision-suffix "$suffix" -o none
+            candidate="${app}--${suffix}"
+            echo "  candidate revision: ${candidate}"
+
+            # Label gives the candidate a private FQDN for smoke WITHOUT taking production traffic.
+            az containerapp revision label add -n "$app" -g "$RESOURCE_GROUP" \
+              --label "$CANDIDATE_LABEL" --revision "$candidate" --yes -o none
+
+            # Candidate label FQDN = <app>---<label>.<envDefaultDomain>; derive the domain from the
+            # app's own default FQDN (<app>.<envDefaultDomain>) so no environment name is hardcoded.
+            app_fqdn="$(az containerapp show -n "$app" -g "$RESOURCE_GROUP" \
+                          --query properties.configuration.ingress.fqdn -o tsv | tr -d '\r')"
+            domain="${app_fqdn#*.}"
+            candidate_url="https://${app}---${CANDIDATE_LABEL}.${domain}"
+            echo "  candidate URL: ${candidate_url}"
+            echo "::endgroup::"
+
+            {
+              printf '%s_prev_rev=%s\n' "$prefix" "$prev"
+              printf '%s_candidate_rev=%s\n' "$prefix" "$candidate"
+              printf '%s_candidate_url=%s\n' "$prefix" "$candidate_url"
+            } >> "$GITHUB_OUTPUT"
+          }
+          deploy_candidate auth "$AUTH_APP" lotrokoniecdev-auth-api
+          deploy_candidate tms "$TMS_APP" lotrokoniecdev-tms-api
+          deploy_candidate frontend "$FRONTEND_APP" lotrokoniecdev-frontend
+
+      # Cold-start tolerant readiness against the CANDIDATE revisions. At 0% traffic with
+      # min_replicas=0 the label-FQDN request itself wakes the revision from scale-to-zero; the
+      # generous budget absorbs that cold start. Frontend is polled too (audit 0001 H7): it is a
+      # Static-SSR app with no /health endpoint, so a 2xx/3xx on '/' is its readiness signal.
+      - name: Wait for candidate readiness (incl. frontend)
+        env:
+          AUTH_CANDIDATE_URL: ${{ steps.rollout.outputs.auth_candidate_url }}
+          TMS_CANDIDATE_URL: ${{ steps.rollout.outputs.tms_candidate_url }}
+          FRONTEND_CANDIDATE_URL: ${{ steps.rollout.outputs.frontend_candidate_url }}
         run: |
           set -euo pipefail
           wait_ready() {
-            name="$1"; url="$2"
-            echo "::group::Waiting for ${name} readiness: ${url}"
-            for _ in $(seq 1 40); do
-              code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 10 "$url" || true)
+            name="$1"; url="$2"; lo="$3"; hi="$4"
+            echo "::group::Waiting for ${name} candidate readiness: ${url}"
+            for _ in $(seq 1 60); do
+              code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$url" || echo 000)
               echo "  ${name} → ${code}"
-              if [ "$code" = "200" ]; then echo "::endgroup::"; return 0; fi
+              if [ "$code" -ge "$lo" ] 2>/dev/null && [ "$code" -le "$hi" ] 2>/dev/null; then
+                echo "::endgroup::"; return 0
+              fi
               sleep 10
             done
             echo "::endgroup::"
-            echo "::error::${name} did not become ready: ${url}"
+            echo "::error::${name} candidate did not become ready: ${url}"
             return 1
           }
-          wait_ready auth "${AUTH_URL}/health/ready"
-          wait_ready tms "${TMS_URL}/health/ready"
+          wait_ready auth "${AUTH_CANDIDATE_URL}/health/ready" 200 200
+          wait_ready tms "${TMS_CANDIDATE_URL}/health/ready" 200 200
+          wait_ready frontend "${FRONTEND_CANDIDATE_URL}/" 200 399
 
+  # Smoke the CANDIDATE revisions via their private label FQDNs BEFORE any production traffic shift
+  # (audit 0001 H7). A red smoke here means the new revision never served a user: promote is skipped
+  # and the rollback job retires the candidate, leaving 100% of traffic on the previous revision.
   smoke:
-    name: Post-deploy smoke
+    name: Smoke candidate (pre-promotion)
     needs: deploy-prod
-    # The documented "call the smoke job at the end of the deploy workflow" (runbook). secrets:
-    # inherit passes the repo SMOKE_CLIENT_SECRET to the reusable workflow.
+    uses: ./.github/workflows/smoke.yml
+    secrets: inherit
+    with:
+      auth_url: ${{ needs.deploy-prod.outputs.auth_candidate_url }}
+      tms_url: ${{ needs.deploy-prod.outputs.tms_candidate_url }}
+      frontend_url: ${{ needs.deploy-prod.outputs.frontend_candidate_url }}
+
+  # The "→ 100%" leg: only a green candidate smoke shifts production traffic onto the candidate. The
+  # previous revision is kept at 0% (it scales to zero on its own) as an instant rollback target.
+  promote:
+    name: Promote candidate to 100% traffic
+    needs: [deploy-prod, smoke]
+    if: ${{ vars.CD_ENABLED == 'true' && needs.deploy-prod.result == 'success' && needs.smoke.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    # Same group as deploy-prod / rollback → all prod-mutating jobs serialize; never cancel mid-shift.
+    concurrency:
+      group: cd-deploy-prod
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write # Azure OIDC federation
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Shift 100% of traffic to the smoked candidates
+        env:
+          AUTH_PREV: ${{ needs.deploy-prod.outputs.auth_prev_rev }}
+          TMS_PREV: ${{ needs.deploy-prod.outputs.tms_prev_rev }}
+          FRONTEND_PREV: ${{ needs.deploy-prod.outputs.frontend_prev_rev }}
+          AUTH_CANDIDATE: ${{ needs.deploy-prod.outputs.auth_candidate_rev }}
+          TMS_CANDIDATE: ${{ needs.deploy-prod.outputs.tms_candidate_rev }}
+          FRONTEND_CANDIDATE: ${{ needs.deploy-prod.outputs.frontend_candidate_rev }}
+        run: |
+          set -euo pipefail
+          promote() {
+            app="$1"; prev="$2"; candidate="$3"
+            echo "::group::Promote ${app}: ${candidate} → 100% (was ${prev})"
+            az containerapp ingress traffic set -n "$app" -g "$RESOURCE_GROUP" \
+              --revision-weight "${prev}=0" "${candidate}=100" -o none
+            # The candidate label has done its job (smoke) — drop it so production isn't tagged as a
+            # candidate; the next rollout recreates it on the next candidate.
+            az containerapp revision label remove -n "$app" -g "$RESOURCE_GROUP" \
+              --label "$CANDIDATE_LABEL" -o none || true
+            echo "::endgroup::"
+          }
+          promote "$AUTH_APP" "$AUTH_PREV" "$AUTH_CANDIDATE"
+          promote "$TMS_APP" "$TMS_PREV" "$TMS_CANDIDATE"
+          promote "$FRONTEND_APP" "$FRONTEND_PREV" "$FRONTEND_CANDIDATE"
+
+  # Final confirmation on the REAL production origins after the shift (custom domain + cert + routing
+  # — the only legs a candidate label FQDN can't exercise). A red here trips the rollback job.
+  smoke-prod:
+    name: Smoke production (post-promotion)
+    needs: promote
     uses: ./.github/workflows/smoke.yml
     secrets: inherit
     with:
       auth_url: https://auth.lotro-translator.pl
       tms_url: https://tms.lotro-translator.pl
       frontend_url: https://lotro-translator.pl
+
+  # Auto-rollback (audit 0001 H7). Fires on ANY rollout failure once candidates exist. It restores
+  # 100% of traffic to the previous revision and retires the candidate — safe in every phase:
+  #   * pre-promotion failure  → traffic was already on prev (idempotent); candidate deactivated.
+  #   * post-promotion failure → traffic is forced back from the candidate to prev (true rollback).
+  rollback:
+    name: Roll back on failure
+    needs: [deploy-prod, smoke, promote, smoke-prod]
+    if: ${{ always() && vars.CD_ENABLED == 'true' && needs.deploy-prod.outputs.auth_candidate_rev != '' && (needs.deploy-prod.result == 'failure' || needs.smoke.result == 'failure' || needs.promote.result == 'failure' || needs.smoke-prod.result == 'failure') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    concurrency:
+      group: cd-deploy-prod
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write # Azure OIDC federation
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Restore previous revisions and retire candidates
+        env:
+          AUTH_PREV: ${{ needs.deploy-prod.outputs.auth_prev_rev }}
+          TMS_PREV: ${{ needs.deploy-prod.outputs.tms_prev_rev }}
+          FRONTEND_PREV: ${{ needs.deploy-prod.outputs.frontend_prev_rev }}
+          AUTH_CANDIDATE: ${{ needs.deploy-prod.outputs.auth_candidate_rev }}
+          TMS_CANDIDATE: ${{ needs.deploy-prod.outputs.tms_candidate_rev }}
+          FRONTEND_CANDIDATE: ${{ needs.deploy-prod.outputs.frontend_candidate_rev }}
+        run: |
+          set -euo pipefail
+          roll_back() {
+            app="$1"; prev="$2"; candidate="$3"
+            if [ -z "$candidate" ]; then echo "  ${app}: no candidate created — nothing to roll back"; return 0; fi
+            echo "::group::Roll back ${app} → ${prev}"
+            if [ -n "$prev" ]; then
+              az containerapp ingress traffic set -n "$app" -g "$RESOURCE_GROUP" \
+                --revision-weight "${prev}=100" "${candidate}=0" -o none || true
+            fi
+            az containerapp revision deactivate -n "$app" -g "$RESOURCE_GROUP" --revision "$candidate" -o none || true
+            az containerapp revision label remove -n "$app" -g "$RESOURCE_GROUP" --label "$CANDIDATE_LABEL" -o none || true
+            echo "::endgroup::"
+          }
+          roll_back "$AUTH_APP" "$AUTH_PREV" "$AUTH_CANDIDATE"
+          roll_back "$TMS_APP" "$TMS_PREV" "$TMS_CANDIDATE"
+          roll_back "$FRONTEND_APP" "$FRONTEND_PREV" "$FRONTEND_CANDIDATE"
+          echo "::error::Rollout failed — production traffic restored to the previous revisions; candidates deactivated."
+          exit 1

--- a/docs/adr/0012-continuous-deployment-pipeline.md
+++ b/docs/adr/0012-continuous-deployment-pipeline.md
@@ -83,6 +83,32 @@ snapshot before applying in a real environment).
 readiness wait. A failed smoke marks the release failed and visible (the documented "call the smoke
 job at the end of the deploy workflow").
 
+**Amendment (2026-06-30, audit 0001 H7 — health-gated rollout, supersedes the single-revision
+rollout below).** The rollout is no longer "`az containerapp update` → 100% of traffic onto the new
+revision immediately, smoke afterwards". The three web apps run in **multiple-revision mode**
+(`iac/azure-container-apps.tf`: `revision_mode = "Multiple"`, and `lifecycle.ignore_changes` now also
+covers `ingress[0].traffic_weight` — Terraform seeds only the initial `latest_revision = true` weight;
+the pipeline owns per-deploy traffic, mirroring the §2 image split). Per deploy, `deploy-prod` pins
+100% of traffic to the current revision, then creates each app's new revision with `--revision-suffix`
+so it lands at **0% traffic**, labels it `cd-candidate`, and waits for the candidate's readiness —
+**including the frontend** (previously only auth + tms were polled; the frontend, a Static-SSR app
+with no `/health`, is checked for a 2xx/3xx on `/`). The `smoke` job then exercises the candidate
+through its private `…---cd-candidate.<env-domain>` label FQDN (valid wildcard cert; the token
+round-trip works cross-revision because the OpenIddict signing key is shared via Key Vault and the
+issuer is pinned). Only a green candidate smoke runs `promote`, which shifts 100% of traffic onto the
+candidate (`ingress traffic set --revision-weight <prev>=0 <candidate>=100`); `smoke-prod` then
+re-checks the real production origins (custom domain + cert + routing). On **any** failure the
+`rollback` job restores 100% of traffic to the previous revision and deactivates the candidate — safe
+in every phase (pre-promotion: traffic never moved; post-promotion: traffic is forced back). The net
+effect is the audit's "deploy at 0% → smoke → 100%": **traffic never lands on an unverified revision**,
+and there is no auto-rollback gap. `min_replicas` stays `0` (the audit's M3 reconciliation is left
+out of scope here): the 0%-traffic candidate is woken from scale-to-zero by the readiness/smoke
+requests to its label FQDN (Container Apps' documented direct-revision-access path), so no replica is
+paid for between deploys. One accepted consequence of decoupling the traffic shift from the image
+roll: during the smoke window the **previous** revision briefly serves on the freshly-migrated schema
+(the migration gate still runs first), which the project's forward-only / expand-contract discipline
+already assumes (ADR-0008 §6; audit C4).
+
 ### 6. Infra is also CI-managed, behind the same gate
 
 `infra.yml` runs `fmt -check` + `validate` + `plan` on PRs touching `iac/**` (preview in the run
@@ -118,8 +144,10 @@ Terraform. `infra.yml` needs the TF inputs, so the `iac/terraform.tfvars` values
 - **Single environment** (prod = staging): a bad release lands on the only environment. Mitigated by
   the migration gate + smoke + zero users + free breaking changes (ADR-0002). A real staging is a
   future ADR if users arrive.
-- **Single-revision rollout** (no blue/green traffic split). Fine at this scale; revisit if
-  zero-downtime becomes a requirement.
+- ~~**Single-revision rollout** (no blue/green traffic split). Fine at this scale; revisit if
+  zero-downtime becomes a requirement.~~ **Superseded (2026-06-30, audit 0001 H7):** the rollout is
+  now multiple-revision and health-gated — see the §5 amendment. Traffic shifts only onto a
+  candidate that passed smoke, with automatic rollback on failure.
 - **TF secrets now also live in GitHub** (besides the laptop). Accepted: scoped repo secrets,
   masked, never in git; the alternative (manual local apply forever) is worse.
 - **Forward-only migrations** (no automated rollback) — unchanged from ADR-0008 §6.

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -337,7 +337,9 @@ Ongoing delivery to the live Azure environment is automated (ADR-0012). Three wo
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `cd.yml` → `build-and-push` | push to main, `v*` tag | builds + pushes the 4 images to GHCR (`:sha-<short>`, `:latest` on main, semver on tags) |
-| `cd.yml` → `deploy-prod` | push to main / dispatch, **behind the `production` approval gate** | OIDC login → run migrator to success (**gate**) → `az containerapp update` the 3 apps to `:sha-<short>` → readiness wait → smoke |
+| `cd.yml` → `deploy-prod` | push to main / dispatch, **behind the `production` approval gate** | OIDC login → run migrator to success (**gate**) → deploy each app as a **candidate revision at 0% traffic** (multiple-revision mode, `--revision-suffix`) → label it `cd-candidate` → readiness wait on the candidate (incl. frontend) |
+| `cd.yml` → `smoke` → `promote` → `smoke-prod` | after `deploy-prod` | smoke the 0%-traffic candidate via its private `…---cd-candidate.<env-domain>` FQDN; only a green smoke shifts 100% of traffic onto it (`promote`); then `smoke-prod` re-checks the real production origins |
+| `cd.yml` → `rollback` | any rollout failure (once a candidate exists) | restores 100% of traffic to the previous revision and deactivates the candidate — no window where users hit a bad revision (audit 0001 H7) |
 | `infra.yml` | PR / push to `iac/**`, dispatch | `plan` on PRs (preview in run summary); **gated** `apply` on main |
 
 **The release control.** Every merge to main builds, then **waits at the `production` environment**
@@ -347,9 +349,15 @@ until you click — the safeguard for QA testing on prod. Approve when QA is fre
 **Deploy a specific build on demand.** Actions → *CD* → *Run workflow* → optional `image_tag`
 (`sha-<short>` or `vX.Y.Z`); empty = the chosen ref's commit. Still gated.
 
-**Roll back.** Re-run *CD* via dispatch with `image_tag` = the previous good `sha-<short>` (GHCR
-images are immutable). Approve. DB migrations are forward-only — roll the schema forward, not back
-(ADR-0008 §6); snapshot the DBs before a risky release.
+**Roll back.** A *failed* rollout rolls back **automatically** (audit 0001 H7): the health-gated
+pipeline shifts traffic only after the candidate passes smoke, and on any failure the `rollback` job
+restores 100% of traffic to the previous revision and deactivates the candidate — so a bad release
+never serves users. To revert a release *after* it was promoted, either re-run *CD* via dispatch with
+`image_tag` = the previous good `sha-<short>` (GHCR images are immutable) and approve, or — for an
+instant manual revert — shift traffic back to the still-present previous revision:
+`az containerapp ingress traffic set -n <app> -g <rg> --revision-weight <prev>=100 <candidate>=0`.
+DB migrations are forward-only — roll the schema forward, not back (ADR-0008 §6); snapshot the DBs
+before a risky release.
 
 ### One-time operator setup (your Azure + GitHub)
 
@@ -587,10 +595,12 @@ is the auth server's `OpenIddict__ApiClientSecret` (see [Generating secrets](#ge
 ### In CI
 
 The [`Smoke test`](../../.github/workflows/smoke.yml) workflow is **`workflow_call`-able and is
-called automatically by `cd.yml`'s `deploy-prod` after every prod rollout** (ADR-0012) — a deploy
-that comes up wrong fails loudly. It also stays runnable **on demand** (`workflow_dispatch` — enter
-the three URLs); the secret comes from the repository secret `SMOKE_CLIENT_SECRET`. See
-[Continuous deployment (CI/CD)](#continuous-deployment-cicd).
+called automatically by `cd.yml` twice per release** (ADR-0012, amended audit 0001 H7): once against
+the **0%-traffic candidate** (its private `…---cd-candidate.<env-domain>` FQDN) **before** any traffic
+shift — a red smoke here means promotion is skipped and the candidate is rolled back, so a broken
+build never serves a user — and once against the **real production origins** after promotion. It also
+stays runnable **on demand** (`workflow_dispatch` — enter the three URLs); the secret comes from the
+repository secret `SMOKE_CLIENT_SECRET`. See [Continuous deployment (CI/CD)](#continuous-deployment-cicd).
 
 ## See also
 

--- a/iac/azure-container-apps.tf
+++ b/iac/azure-container-apps.tf
@@ -2,7 +2,7 @@ resource "azurerm_container_app" "auth_api" {
   name                         = "lotrotms-auth-api-${var.env_id}"
   container_app_environment_id = azurerm_container_app_environment.app_env.id
   resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
-  revision_mode                = "Single"
+  revision_mode                = "Multiple"
 
   identity {
     type         = "UserAssigned"
@@ -11,9 +11,17 @@ resource "azurerm_container_app" "auth_api" {
 
   # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
   # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
-  # bootstrap tag (var.image_tag). See ADR-0012.
+  # bootstrap tag (var.image_tag). See ADR-0012 §2.
+  #
+  # Traffic weights are likewise owned by the CD health-gated rollout (ADR-0012 §5 amendment, audit
+  # 0001 H7): each deploy creates a candidate revision at 0% traffic, smokes it, then shifts 100% to
+  # it. Terraform only seeds the initial weight below (latest_revision = true) so a freshly-created
+  # app serves its first revision; it must NOT revert the pipeline's per-deploy traffic decisions.
   lifecycle {
-    ignore_changes = [template[0].container[0].image]
+    ignore_changes = [
+      template[0].container[0].image,
+      ingress[0].traffic_weight,
+    ]
   }
 
   # Secrets resolve from Key Vault at runtime through the user-assigned identity (ADR-0013) — no
@@ -217,7 +225,7 @@ resource "azurerm_container_app" "tms_api" {
   name                         = "lotrotms-tms-api-${var.env_id}"
   container_app_environment_id = azurerm_container_app_environment.app_env.id
   resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
-  revision_mode                = "Single"
+  revision_mode                = "Multiple"
 
   identity {
     type         = "UserAssigned"
@@ -226,9 +234,17 @@ resource "azurerm_container_app" "tms_api" {
 
   # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
   # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
-  # bootstrap tag (var.image_tag). See ADR-0012.
+  # bootstrap tag (var.image_tag). See ADR-0012 §2.
+  #
+  # Traffic weights are likewise owned by the CD health-gated rollout (ADR-0012 §5 amendment, audit
+  # 0001 H7): each deploy creates a candidate revision at 0% traffic, smokes it, then shifts 100% to
+  # it. Terraform only seeds the initial weight below (latest_revision = true) so a freshly-created
+  # app serves its first revision; it must NOT revert the pipeline's per-deploy traffic decisions.
   lifecycle {
-    ignore_changes = [template[0].container[0].image]
+    ignore_changes = [
+      template[0].container[0].image,
+      ingress[0].traffic_weight,
+    ]
   }
 
   # Secret resolves from Key Vault at runtime through the user-assigned identity (ADR-0013).
@@ -338,13 +354,21 @@ resource "azurerm_container_app" "frontend" {
   name                         = "lotrotms-frontend-${var.env_id}"
   container_app_environment_id = azurerm_container_app_environment.app_env.id
   resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
-  revision_mode                = "Single"
+  revision_mode                = "Multiple"
 
   # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
   # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
-  # bootstrap tag (var.image_tag). See ADR-0012.
+  # bootstrap tag (var.image_tag). See ADR-0012 §2.
+  #
+  # Traffic weights are likewise owned by the CD health-gated rollout (ADR-0012 §5 amendment, audit
+  # 0001 H7): each deploy creates a candidate revision at 0% traffic, smokes it, then shifts 100% to
+  # it. Terraform only seeds the initial weight below (latest_revision = true) so a freshly-created
+  # app serves its first revision; it must NOT revert the pipeline's per-deploy traffic decisions.
   lifecycle {
-    ignore_changes = [template[0].container[0].image]
+    ignore_changes = [
+      template[0].container[0].image,
+      ingress[0].traffic_weight,
+    ]
   }
 
   template {


### PR DESCRIPTION
## What & why

Implements **H7** from [`docs/audits/0001-infrastructure-audit.md`](docs/audits/0001-infrastructure-audit.md): the ACA rollout was not health-gated and had no auto-rollback — `az containerapp update` shifted **100% of traffic onto the new revision immediately** and smoke ran *after* the traffic was already live (and only auth + tms were polled for readiness, never the frontend).

This moves the rollout to a **multiple-revision, health-gated blue-green** flow: **deploy at 0% → smoke the candidate → shift to 100%**, with automatic rollback on any failure. Traffic never lands on an unverified revision.

## How it works now

```
deploy-prod : migrator gate → per app: pin 100% to current rev → deploy candidate
              (--revision-suffix) at 0% traffic → label cd-candidate → wait readiness
              of the CANDIDATE (auth, tms AND frontend)
smoke       : smoke the candidate via its private <app>---cd-candidate.<env-domain> FQDN
promote     : ONLY on green smoke → ingress traffic set <prev>=0 <candidate>=100
smoke-prod  : re-check the real production origins after the shift
rollback    : on ANY failure → restore <prev>=100 <candidate>=0 + deactivate candidate
```

The previous revision is kept (0% traffic; it scales to zero on its own) as an instant rollback target. The candidate's token round-trip works cross-revision because the OpenIddict signing key is shared via Key Vault and the issuer is pinned.

## Changes

- **`.github/workflows/cd.yml`** — `deploy-prod` reworked (candidate at 0% + frontend readiness); new `promote`, `smoke-prod`, `rollback` jobs; candidate URLs flow as job outputs to the smoke job; prod ACA targets + `CANDIDATE_LABEL` hoisted to workflow env; deploy-prod timeout 30→45 min (sequential cold-start readiness of 3 candidates).
- **`iac/azure-container-apps.tf`** — `revision_mode = "Multiple"` on auth/tms/frontend; `lifecycle.ignore_changes` now also covers `ingress[0].traffic_weight` (CD owns per-deploy traffic; TF seeds only the initial `latest_revision = true` weight).
- **`docs/adr/0012-continuous-deployment-pipeline.md`** — §5 amendment recording the health-gated rollout; the "single-revision rollout" trade-off marked superseded.
- **`docs/deployment/runbook.md`** — CD job table, roll-back, and the smoke "In CI" section updated.

## Security note (GitHub Actions)

All GitHub-context values (short_sha, run id/attempt, candidate URLs) pass through `env:` and are used as `$VAR` in scripts — never interpolated into `run:`. No untrusted event input (issue/PR titles, etc.) is used.

## Verification

- `terraform fmt -check -recursive iac/` → clean; `terraform validate` → **Success**.
- Workflow YAML parsed + job-graph structural check: every `needs` resolves; every `${{ needs.X }}` reference is declared in that job's `needs`; reusable-call jobs (`smoke`, `smoke-prod`) have `uses` not `runs-on`.
- Azure CLI semantics confirmed against MS Learn: new revision in multiple mode lands at **0% traffic**; label FQDN (`<app>---<label>.<domain>`) gives direct candidate access under the env wildcard cert; `ingress traffic set --revision-weight`; `revision label add --yes`; `revision activate/deactivate`.

## ⚠️ Deploy ordering (one-time)

Apply the IaC change (`revision_mode = "Multiple"`) **before** the first health-gated `deploy-prod` run. If an app is still in `Single` mode, the `ingress traffic set` step fails fast and the deploy aborts safely (traffic stays on the previous revision) — re-run after `terraform apply`. `min_replicas` is intentionally left at `0` (audit **M3** is out of scope here); the 0%-traffic candidate is woken from scale-to-zero by the readiness/smoke requests to its label FQDN.

Ref: `docs/audits/0001-infrastructure-audit.md` (H7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
