### PR TITLE
Make Frontend.E2E Playwright version resilient: derive browser image tag from the client

### DIFF
--- a/docs/adr/0015-derive-cross-boundary-dependency-versions.md
+++ b/docs/adr/0015-derive-cross-boundary-dependency-versions.md
@@ -1,0 +1,141 @@
+# ADR-0015: Derive cross-boundary dependency versions at runtime instead of hard-coding them (Playwright browser image ⇄ client)
+
+**Status:** Accepted
+**Date:** 2026-06-30
+**Decision-makers:** Solo maintainer
+**Related:** ADR-0009 (browser E2E via Testcontainers + Playwright — establishes the in-container
+browser-server the client connects to over WebSocket); the trigger was PR #236 (Dependabot
+`nuget-minor-patch` group), the fix + this ADR landed in PR #242; `tests/CLAUDE.md` (Frontend Browser
+E2E section).
+
+## Context
+
+The Frontend browser-E2E stack (ADR-0009) runs Chromium in a **container** — image
+`mcr.microsoft.com/playwright:v{X}-noble` — and the host `Microsoft.Playwright` **client** connects
+to its in-container `run-server` over a WebSocket. The two must speak the **same wire protocol**: a
+version mismatch makes `Chromium.ConnectAsync` fail the WS upgrade with **HTTP 428 Precondition
+Required** ("Playwright version mismatch: server vA, client vB") during fixture init, taking the
+whole suite down.
+
+So the Playwright version is **one fact with two carriers, coupled across a process boundary**:
+
+1. the `Microsoft.Playwright` **package version** (`Directory.Packages.props`), maintained by
+   **Dependabot**, and
+2. the browser-server **image tag** — until now a hard-coded `const string` in
+   `PlaywrightStackFixture`.
+
+Dependabot bumps (1) but cannot see (2): the version inside a C# string literal is opaque to it. PR
+**#236** bumped the client `1.60.0 → 1.61.0`; the image const stayed `v1.60.0-noble`; the next
+Frontend.E2E run broke with 428 — and because the suite is **off the PR gate by name** (ADR-0009),
+the drift was invisible until someone ran it. A one-line const bump unbreaks it once, but the smell
+guarantees a recurrence on the **next** Playwright bump. This is the general anti-pattern: *a value
+that must track a Dependabot-managed dependency, hidden where the bot that maintains the dependency
+can't reach it.*
+
+A tempting "single source of truth" — read the driver version the client embeds
+(`.playwright/package/package.json`) — is a **trap**: the `1.61.0` client embeds a driver labelled
+`1.61.1-beta-…`, which maps to no published image. The image tags Microsoft publishes track the
+**release/package version** (`v1.61.0-noble`), which is what the assembly reports.
+
+## Decision
+
+### 1. Derive the image tag from the client; never hard-code it
+
+`PlaywrightBrowserImage.Tag` builds `mcr.microsoft.com/playwright:v{version}-noble` from the resolved
+`Microsoft.Playwright` **AssemblyVersion** (`Assembly.GetName().Version`, e.g. `1.61.0.0 → 1.61.0`).
+The fixture consumes `PlaywrightBrowserImage.Tag`; the const is gone. The package version is now the
+**single source of truth** — Dependabot bumps it, the image follows on the next run, and the two can
+never drift apart again.
+
+### 2. Key off AssemblyVersion — not InformationalVersion, not the embedded driver
+
+Two version carriers in the package are **traps**: the embedded driver build is a `-beta`
+(`1.61.1-beta-…`) with no matching image, and — found the hard way here — `Microsoft.Playwright`'s
+`AssemblyInformationalVersion` is a frozen **`1.0.0` placeholder** (`1.0.0+sha`), so a derivation
+keyed off it silently yields the unpullable `v1.0.0-noble`. Only `AssemblyVersion` / `FileVersion`
+carry the real release (`1.61.0`). Derivation reads **AssemblyVersion** (`ToString(3)`), strips any
+SemVer build metadata defensively (`1.61.0+sha → 1.61.0`), and keeps `-noble` as a deliberate
+constant — only the **version** is derived.
+
+### 3. Lock the derivation with pure unit tests; no separate gate "drift guard"
+
+`PlaywrightBrowserImageTests` (Docker-free — joins no collection) pins the derivation: base, a future
+version, build-metadata stripping, the null/empty guards, and that `Tag` tracks the actually-loaded
+client **cross-checked against an independent source (FileVersion)**. That independence is the point:
+the first cut of this test compared `Tag` to the *same* InformationalVersion the (then-buggy) code
+read, so it tautologically passed at `v1.0.0-noble` and only the end-to-end image pull caught it.
+A gate-level "is the literal tag == the package version?" guard is **deliberately not added**:
+derivation **eliminates** the drift class by construction, so there is nothing left to detect, and
+putting it on the PR gate would drag the E2E project's Testcontainers/Playwright dependencies onto the
+gate for zero benefit.
+
+### 4. Generalize the principle
+
+A value that must stay in lockstep with a **Dependabot-managed dependency across a process or artifact
+boundary** is **derived from that dependency at build/runtime**, not duplicated as a literal the bot
+can't update. (Out of scope here but flagged by the same lens: `axllent/mailpit:latest` is the
+*opposite* smell — an unpinned tag — and is left as-is for now.)
+
+## Consequences
+
+### Positive
+
+- **Zero-touch on Playwright bumps.** Dependabot's PR is now self-sufficient; the browser image
+  tracks the client automatically. The recurrence is designed out, not patched.
+- **Symmetric with existing code.** The `run-server` command already reads its `driverVersion`
+  dynamically from the image; the tag now resolves dynamically from the client — both sides key off
+  one version.
+- **Failures get louder, not quieter.** The only residual risk — a release with no matching
+  `-noble` image — surfaces immediately at fixture init as a clear image-pull error, strictly better
+  than today's silent protocol drift caught off-gate.
+
+### Negative / Accepted Trade-offs
+
+- **Assumes `v{version}-noble` is published per release.** True for Microsoft's images; if it ever
+  isn't, the pull fails loudly with an obvious cause (acceptable, and self-explaining).
+- **The derivation tests live in the off-gate E2E project**, so they run in `e2e.yml` / local E2E,
+  not on the PR gate. Accepted: derivation removes the drift the gate would have guarded, and the
+  end-to-end `ConnectAsync` is the real proof.
+- **Reflection at fixture startup** to read the assembly version — trivial, once per run.
+
+## Alternatives Considered
+
+### A. Derive the tag from the client assembly version (this ADR)
+
+Chosen. Single source of truth, zero-touch, eliminates the failure class.
+
+### B. Keep the literal tag + a gate guard asserting it equals the package version
+
+Rejected as primary. Still a manual bump after every Dependabot PR (only louder/earlier), becomes a
+tautology the moment you derive, and on-gate placement would couple the fast gate to E2E
+dependencies. Its useful kernel — locking the logic — survives as the derivation unit tests.
+
+### C. Move the image into a Dockerfile/compose tracked by Dependabot's `docker` ecosystem
+
+Rejected. It would produce **two independent** Dependabot PRs (nuget + docker) that can merge at
+different times → a transient-breakage window. It tracks the two versions in parallel instead of
+**coupling** them.
+
+### D. Pin the client back to match the image
+
+Rejected. Fights Dependabot and reverts a wanted update; treats the symptom (client moved) instead of
+the cause (a second, hidden source of truth).
+
+## Implementation Notes
+
+- `tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightBrowserImage.cs` — the
+  derivation (`Tag`, pure `BuildTag`, `ResolveClientVersion`).
+- `tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightBrowserImageTests.cs` — pure,
+  Docker-free locks for the derivation logic.
+- `tests/.../PlaywrightStackFixture.cs` — consumes `PlaywrightBrowserImage.Tag`; the hard-coded
+  `PlaywrightImage` const is removed.
+- The zero-warning solution build compiles the E2E project, so the helper + tests are covered by the
+  build gate even though the suite itself runs off-gate (ADR-0009).
+
+## References
+
+- ADR-0009 — browser E2E via Testcontainers + Playwright (the in-container browser-server stack)
+- PR #236 — the Dependabot `Microsoft.Playwright` 1.60.0 → 1.61.0 bump that exposed the drift
+- PR #242 — this fix + ADR
+- `tests/CLAUDE.md` — Frontend Browser E2E Tests section
+- Playwright docs — versioned `mcr.microsoft.com/playwright` images; client/server protocol must match

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightBrowserImage.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightBrowserImage.cs
@@ -1,0 +1,45 @@
+using Microsoft.Playwright;
+
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// Resolves the Playwright browser-server image tag from the referenced <c>Microsoft.Playwright</c>
+/// client, instead of hard-coding it. The in-container <c>run-server</c> must speak the client's wire
+/// protocol — a version mismatch fails
+/// <see cref="IBrowserType.ConnectAsync(string, BrowserTypeConnectOptions)"/> with HTTP 428 — and
+/// Microsoft publishes one image per release as <c>v{version}-{os}</c>. Deriving the tag keeps a
+/// single source of truth in the package version: when Dependabot bumps the client the image follows
+/// automatically, so the two can never drift apart (see ADR-0015).
+/// </summary>
+internal static class PlaywrightBrowserImage
+{
+    private const string Repository = "mcr.microsoft.com/playwright";
+    private const string OperatingSystemVariant = "noble";
+
+    /// <summary>The browser-server image tag matching the referenced <c>Microsoft.Playwright</c> client.</summary>
+    internal static string Tag => BuildTag(ResolveClientVersion());
+
+    /// <summary>
+    /// Builds the <c>v{version}-{os}</c> image tag for a client version, dropping any SemVer build
+    /// metadata (<c>1.61.0+sha</c> becomes <c>1.61.0</c>) so it matches a tag Microsoft publishes.
+    /// </summary>
+    internal static string BuildTag(string clientVersion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientVersion);
+
+        string version = clientVersion.Split('+')[0].Trim();
+
+        return $"{Repository}:v{version}-{OperatingSystemVariant}";
+    }
+
+    private static string ResolveClientVersion()
+    {
+        // Microsoft.Playwright ships a placeholder "1.0.0" InformationalVersion; the real release
+        // (e.g. 1.61.0) — the version its published images are tagged with — lives in the assembly
+        // version. Key off that, not InformationalVersion, so the derived tag tracks the package.
+        Version version = typeof(IPlaywright).Assembly.GetName().Version
+            ?? throw new InvalidOperationException("The Microsoft.Playwright assembly has no version.");
+
+        return version.ToString(3);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightBrowserImageTests.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightBrowserImageTests.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+using Microsoft.Playwright;
+using Shouldly;
+
+namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// Locks the browser-image tag derivation so a <c>Microsoft.Playwright</c> bump can never silently
+/// drift the in-container server's protocol away from the client (the failure mode behind ADR-0015).
+/// Pure and Docker-free — it joins no collection, so it never boots the stack fixture.
+/// </summary>
+public sealed class PlaywrightBrowserImageTests
+{
+    [Theory]
+    [InlineData("1.61.0", "mcr.microsoft.com/playwright:v1.61.0-noble")]
+    [InlineData("1.62.3", "mcr.microsoft.com/playwright:v1.62.3-noble")]
+    [InlineData("1.61.0+build.7sha", "mcr.microsoft.com/playwright:v1.61.0-noble")]
+    public void BuildTag_ForClientVersion_ReturnsMatchingNobleImageTag(string clientVersion, string expectedTag)
+    {
+        string tag = PlaywrightBrowserImage.BuildTag(clientVersion);
+
+        tag.ShouldBe(expectedTag);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildTag_ForMissingClientVersion_Throws(string? clientVersion)
+    {
+        Should.Throw<ArgumentException>(() => PlaywrightBrowserImage.BuildTag(clientVersion!));
+    }
+
+    [Fact]
+    public void Tag_TracksTheClientReleaseVersion_NotThePlaceholderInformationalVersion()
+    {
+        // Cross-check against an INDEPENDENT source (FileVersion): Microsoft.Playwright's
+        // InformationalVersion is a "1.0.0" placeholder, so a derivation keyed off it would yield the
+        // unpullable v1.0.0-noble. FileVersion carries the real release, matching the published tags.
+        Version releaseVersion = new(FileVersionInfo
+            .GetVersionInfo(typeof(IPlaywright).Assembly.Location)
+            .FileVersion!);
+
+        PlaywrightBrowserImage.Tag.ShouldBe($"mcr.microsoft.com/playwright:v{releaseVersion.ToString(3)}-noble");
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
@@ -34,7 +34,7 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
     private const string MailpitImage = "axllent/mailpit:latest";
 
     // Pinned to match the Microsoft.Playwright client version, so ConnectAsync speaks the same protocol.
-    private const string PlaywrightImage = "mcr.microsoft.com/playwright:v1.60.0-noble";
+    private const string PlaywrightImage = "mcr.microsoft.com/playwright:v1.61.0-noble";
     private const int PlaywrightPort = 8080;
 
     /// <summary>

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
@@ -33,8 +33,6 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
     private const string MigratorImage = "lotrokoniecdev-migrator:fe-e2e";
     private const string MailpitImage = "axllent/mailpit:latest";
 
-    // Pinned to match the Microsoft.Playwright client version, so ConnectAsync speaks the same protocol.
-    private const string PlaywrightImage = "mcr.microsoft.com/playwright:v1.61.0-noble";
     private const int PlaywrightPort = 8080;
 
     /// <summary>
@@ -279,7 +277,7 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
         // bound server is unreachable through the published port (so ConnectAsync would hang too). Its
         // wait strategies are append-only, so the broken probe can't be replaced. Binding 0.0.0.0 fixes
         // both: the WebSocket server is reachable via the mapped port and logs the address we wait on.
-        _playwrightContainer = new ContainerBuilder(PlaywrightImage)
+        _playwrightContainer = new ContainerBuilder(PlaywrightBrowserImage.Tag)
             .WithNetwork(_network)
             .WithEntrypoint("/bin/sh", "-c")
             .WithCommand(PlaywrightServerCommand)
@@ -345,10 +343,24 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
         }
         catch (Exception ex)
         {
-            (string? stdout, string? stderr) = await container.GetLogsAsync();
+            // Never let log retrieval mask the real failure: a container that died before it was
+            // created has no Id, so GetLogsAsync would itself throw and swallow ex.
             throw new InvalidOperationException(
                 $"Container '{name}' failed to reach its ready state within the timeout.\n" +
-                $"Stdout:\n{stdout}\nStderr:\n{stderr}", ex);
+                $"{await TryGetLogsAsync(container)}", ex);
+        }
+    }
+
+    private static async Task<string> TryGetLogsAsync(IContainer container)
+    {
+        try
+        {
+            (string stdout, string stderr) = await container.GetLogsAsync();
+            return $"Stdout:\n{stdout}\nStderr:\n{stderr}";
+        }
+        catch (Exception ex)
+        {
+            return $"(container logs unavailable: {ex.Message})";
         }
     }
 


### PR DESCRIPTION
## Problem

The off-gate `Frontend.E2E` browser suite connects a `Microsoft.Playwright` **client** to an
in-container Playwright **browser-server image**; the two must speak the same protocol or
`Chromium.ConnectAsync` fails the WS upgrade with **HTTP 428**. The image tag was a hard-coded `const`
in `PlaywrightStackFixture`, so when **#236** (Dependabot) bumped the client `1.60.0 → 1.61.0`, the
image stayed `v1.60.0-noble` and the suite broke. A one-line bump fixes it once, but the smell
guarantees a recurrence on the next Playwright bump: *one version, two carriers, one of them invisible
to the bot that maintains the other.*

## Solution — derive the tag from the client (single source of truth)

`PlaywrightBrowserImage.Tag` builds `mcr.microsoft.com/playwright:v{version}-noble` from the resolved
`Microsoft.Playwright` **AssemblyVersion**, so Dependabot's bump carries the image with it — zero-touch,
and the two can't drift apart again.

A non-obvious gotcha (found the hard way in this PR — see the commit trail): `Microsoft.Playwright`
ships a frozen **`1.0.0` placeholder** `InformationalVersion`, so the obvious derivation silently
produced the **unpullable `v1.0.0-noble`**. The real release lives in `AssemblyVersion` / `FileVersion`.
The fix keys off `AssemblyVersion`; the unit test cross-checks an **independent** source (`FileVersion`)
so it can't tautologically pass on a wrong-source bug — the first cut did, and only the end-to-end image
pull caught it.

## Also: stop the boot diagnostics from masking real errors

`StartWithDiagnosticsAsync` called `GetLogsAsync()` in its catch block, but a container that failed
before creation has no Id, so `GetLogsAsync` itself threw and **swallowed the real `StartAsync`
exception**. Guarded it (`TryGetLogsAsync`) so the actual cause always surfaces — this is exactly what
exposed the `v1.0.0-noble` pull error.

## ADR

`docs/adr/0015` records the generalizable principle — *a value that must track a Dependabot-managed
dependency across a process/artifact boundary is derived at runtime, never hard-coded* — plus the
AssemblyVersion / InformationalVersion / driver-version traps and the tautology lesson.

## Verification (local — macOS arm64 + Docker, off `origin/main` @ 8810dc8)

- **Frontend.E2E: 8 passed** — 7 pure, Docker-free derivation tests + the full
  register → confirm → login → logout browser flow, with the derived `v1.61.0-noble`.
- **Solution build 0/0**; **853** unit + **315** integration already green and unaffected (this is a
  test-only + ADR change, off the PR gate's build / unit / integration / SSR scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
