### PR TITLE
audit 0001 M12/M13: shared prod-mutation concurrency (apply vs rollout) + migration poll budget tracks job replica timeout

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -323,10 +323,12 @@ jobs:
     environment:
       name: production
       url: https://lotro-translator.pl
-    # Never cancel a rollout in progress; queue instead. A waiting-for-approval run is superseded by
-    # the next one only after the running rollout finishes.
+    # Shared mutation lock with the infra.yml `apply` (audit 0001 M12): the `prod-mutation` group
+    # serializes this app rollout against `terraform apply`, so the two never mutate the same prod
+    # resources at once. Never cancel a rollout in progress; queue instead — a waiting-for-approval
+    # run is superseded by the next one only after the running rollout (or a competing apply) finishes.
     concurrency:
-      group: cd-deploy-prod
+      group: prod-mutation
       cancel-in-progress: false
     permissions:
       contents: read # checkout (scripts/)
@@ -399,9 +401,21 @@ jobs:
           az containerapp job update -n "$MIGRATOR_JOB" -g "$RESOURCE_GROUP" --image "$img" -o none
           echo "Starting migrator job…"
           az containerapp job start -n "$MIGRATOR_JOB" -g "$RESOURCE_GROUP" -o none
+          # Poll budget tracks the migrator job's OWN replica timeout (Terraform migrator-job.tf
+          # replica_timeout_in_seconds) instead of a hardcoded count, so the two can never drift
+          # (audit 0001 M13): a budget shorter than the job timeout would falsely fail a slow-but-
+          # valid migration the job itself still permits. We poll a margin PAST that timeout so the
+          # job reaches a terminal status (Failed/Degraded on timeout) before we give up — our loop
+          # is never the first to quit. Fall back to 1800s if the query yields no positive integer.
           echo "Waiting for the latest execution to complete…"
+          poll_interval=15
+          replica_timeout=$(az containerapp job show -n "$MIGRATOR_JOB" -g "$RESOURCE_GROUP" \
+            --query "properties.configuration.replicaTimeout" -o tsv 2>/dev/null | tr -d '\r' || true)
+          case "$replica_timeout" in '' | *[!0-9]*) replica_timeout=1800 ;; esac
+          poll_attempts=$(( (replica_timeout + 120 + poll_interval - 1) / poll_interval ))
+          echo "Polling up to ${poll_attempts}×${poll_interval}s (job replica timeout ${replica_timeout}s + margin)."
           status=""
-          for _ in $(seq 1 80); do
+          for _ in $(seq 1 "$poll_attempts"); do
             status=$(az containerapp job execution list -n "$MIGRATOR_JOB" -g "$RESOURCE_GROUP" \
               --query "sort_by([],&properties.startTime)[-1].properties.status" -o tsv 2>/dev/null || true)
             echo "  migrator status: ${status:-<pending>}"
@@ -409,7 +423,7 @@ jobs:
               Succeeded) break ;;
               Failed | Degraded | Canceled) echo "::error::Migration job ended: ${status}"; exit 1 ;;
             esac
-            sleep 15
+            sleep "$poll_interval"
           done
           if [ "$status" != "Succeeded" ]; then
             echo "::error::Migration job did not succeed within the time budget (status=${status:-none})."

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -29,10 +29,9 @@ permissions:
   contents: read
   id-token: write # Azure OIDC federation
 
-# Serialize infra runs per ref; never cancel an in-flight apply (state-lock also guards correctness).
-concurrency:
-  group: infra-${{ github.ref }}
-  cancel-in-progress: false
+# Concurrency is per-JOB, not workflow-wide (audit 0001 M12): the read-only `plan` stays on a
+# per-ref group while `apply` shares the `prod-mutation` group with the cd.yml prod rollout, so a
+# `terraform apply` and a `deploy-prod` rollout can never mutate the same prod resources at once.
 
 env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -54,6 +53,11 @@ jobs:
     if: vars.CD_ENABLED == 'true' && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    # Read-only plan: serialize per ref, independent of the prod-mutation group — a plan never mutates
+    # prod, so it must neither block nor queue behind a rollout/apply. No-cancel matches the apply job.
+    concurrency:
+      group: infra-plan-${{ github.ref }}
+      cancel-in-progress: false
     defaults:
       run:
         working-directory: iac
@@ -98,6 +102,13 @@ jobs:
     if: vars.CD_ENABLED == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # Shared mutation lock with the cd.yml prod rollout (audit 0001 M12): `apply` and `deploy-prod`
+    # share the `prod-mutation` group so Terraform and the app rollout never mutate the same prod
+    # resources concurrently. Never cancel an in-flight apply (state-lock also guards correctness); a
+    # competing rollout/apply queues until this finishes.
+    concurrency:
+      group: prod-mutation
+      cancel-in-progress: false
     # Same approval gate as the app rollout — a human approves before live infra changes.
     environment:
       name: production


### PR DESCRIPTION
Implements the **drobne CD** findings from `docs/audits/0001-infrastructure-audit.md`.

## M12 — shared `prod-mutation` concurrency (apply ↔ rollout)
The audit noted `cd.yml` (`cd-deploy-prod`) and `infra.yml` (`infra-${{ github.ref }}`) used **different** concurrency groups, so a `terraform apply` and an app `deploy-prod` rollout could mutate the same prod ACA resources **at the same time** — the `production` environment gate only controls *approval*, it does not serialize execution.

- `infra.yml`: concurrency moved from **workflow-level → per-job**. Read-only `plan` keeps its own per-ref group (`infra-plan-${{ github.ref }}`) so it never blocks/queues behind a rollout; mutating `apply` joins **`prod-mutation`**.
- `cd.yml`: `deploy-prod` group renamed `cd-deploy-prod` → **`prod-mutation`**.
- Both keep `cancel-in-progress: false` (an in-flight apply/rollout is never cancelled — the competitor queues). Bonus: also closes a latent gap where a `workflow_dispatch` apply on a non-`main` ref could run concurrently with a `main`-push apply (they shared no group before).

## M13 — migration poll budget tracks the job's own timeout
The poll loop was a hardcoded `80 × 15s = 20 min`, **shorter** than the migrator's `replica_timeout_in_seconds = 1800` (30 min) in `iac/migrator-job.tf`. On a slow run our poll gave up while the job was still legitimately running → misleading false failure.

Now the budget is **derived from the job's own `replicaTimeout`** (`az containerapp job show`) + a 120s margin, so we always outlast the job's own timeout and observe its terminal status. The Terraform value is the single source of truth → the two **can never drift again** (a future bump to 3600 auto-tracks with zero workflow change). Falls back to `1800` if the query yields no positive integer.

## M2 — already closed, no change needed
The audit cited `cd.yml (on: push)`, but the C2 fix (same day) rewired CD: it no longer triggers on `push: branches: [main]` — it triggers via `workflow_run` on **CI**, and CI already carries `paths-ignore` for docs (`ci.yml`). So a docs-only push runs no CI → emits no `workflow_run` → triggers no CD (the `cd.yml` header comment already records this). On top of that, `paths-ignore` is **not a valid filter on a `workflow_run` trigger**, so there is nothing correct to add to `cd.yml` for M2.

## Verification
- Both workflows parse (Ruby YAML); job→concurrency wiring asserted: exactly `deploy-prod` + `apply` share `prod-mutation`; `plan` isolated; `build-and-push`/`gate` untouched.
- M13 arithmetic + fallback unit-tested: `1800 → 1920s (32 min) > 1800s job timeout`; empty/garbage → `1800` fallback; `3600 → 3720s` (drift-free).
- No trailing whitespace; no untrusted input enters any `run:` (static group names + Azure-sourced, numerically-validated `replica_timeout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)