### PR TITLE
audit 0001 H3: cloud telemetry — ACA managed OpenTelemetry agent → Application Insights (traces+logs, via azapi)

### DIFF
--- a/docs/adr/0016-cloud-telemetry-via-aca-managed-otel-agent.md
+++ b/docs/adr/0016-cloud-telemetry-via-aca-managed-otel-agent.md
@@ -1,0 +1,163 @@
+# ADR-0016: Cloud telemetry via the ACA managed OpenTelemetry agent → Application Insights
+
+**Status:** Accepted
+**Date:** 2026-06-30
+**Decision-makers:** Solo maintainer
+**Related:** observability / `iac/` (`observability.tf`, `setup.tf`); ADR-0008 (cloud-agnostic
+deployment — app-code neutrality), ADR-0012 (CD pipeline — provider chosen = Azure/ACA), ADR-0013
+(Key Vault = source of truth for prod secrets); audit 0001 §H3 (+ §C3 sibling); issue #245
+
+## Context
+
+Audit 0001 §H3: all three web apps emit **clean, vendor-neutral OTLP** — OpenTelemetry traces +
+metrics and Serilog→OTLP logs — but the exporter is gated on `OTEL_EXPORTER_OTLP_ENDPOINT` (the
+`if (!IsNullOrWhiteSpace(otlpEndpoint))` guard in each app's `Program.cs`) and **no Container App
+sets that variable**. So in the cloud there are **zero traces, zero metrics, zero OTLP logs**;
+production runs on console logs to the
+Log Analytics workspace only — operationally near-blind (observability scored 1.5/5). Dev is already
+5/5 via the aspire-dashboard in `compose.yaml`. The app code is ready; this is pure infra.
+
+Forces and code facts that constrain the choice:
+
+- **App-code neutrality is a contract, not a preference (ADR-0008 §2):** no project references a
+  cloud-provider SDK; telemetry leaves *only* via OTLP. The vendor-neutral pipeline is a deliberate
+  strength — the owner's decision is to keep it untouched and add the Azure coupling **in infra
+  only**.
+- **The provider is chosen (ADR-0012):** all-in-Azure. The owner's call is to land telemetry in
+  **Application Insights** and keep everything in Azure, *without* coupling app code.
+- **azurerm 4.7.0 has no native block** for the Container Apps managed OpenTelemetry agent
+  (hashicorp/terraform-provider-azurerm#28217).
+- Existing infra to reuse: `azurerm_log_analytics_workspace.law` (`azure-law.tf`) and
+  `azurerm_container_app_environment.app_env` (`azure_container_app_env.tf`). Provider discipline is a
+  strength to preserve: exact-pinned providers + tracked lockfile (audit G20).
+
+## Decision
+
+### 1. Enable the ACA managed OpenTelemetry agent → App Insights (traces + logs), zero app change
+
+The agent is enabled at the **Container App Environment** level. It **injects
+`OTEL_EXPORTER_OTLP_ENDPOINT` into every container automatically**, so the apps' existing OTLP
+pipeline starts shipping to Application Insights with **no app or env-var change**. The clean
+`Program.cs` OTLP bootstrap stays exactly as is. App code remains cloud-agnostic (ADR-0008 §2 upheld —
+only infra couples to Azure).
+
+### 2. Application Insights is workspace-based, on the existing LAW, parametrized by `env_id`
+
+`azurerm_application_insights.app_insights` with `workspace_id = azurerm_log_analytics_workspace.law.id`
+(reuse the LAW — never a second workspace; classic non-workspace AI is retired by Azure),
+`application_type = "web"`, `name = "lotrotmsappinsights${var.env_id}"`, tagged like its siblings. No
+hardcoded `prod`.
+
+### 3. Configure the agent via the `azapi` provider (azurerm gap)
+
+`azapi_update_resource` **PATCHes only** the OTel properties onto `app_env`; azurerm — which has no
+schema for these fields — leaves them untouched (the augmentation pattern the azapi docs recommend
+for filling azurerm gaps). `azapi` is **exact-pinned `2.10.0`** (mirroring `azurerm = 4.7.0`, audit
+G20), with **multi-platform hashes** (`linux_amd64`/`darwin_arm64`/`windows_amd64`) committed to
+`.terraform.lock.hcl`.
+
+### 4. The api-version is a *preview* one (`2024-10-02-preview`), verified against the schema
+
+The OTel-agent properties (`appInsightsConfiguration` + `openTelemetryConfiguration`) are **not yet in
+the stable ARM surface**. Verified directly against the azapi 2.10.0 embedded schema: the stable
+`2024-03-01` and `2025-01-01` versions **reject** both properties, while the preview line
+(`2024-02-02-preview` … `2025-02-02-preview`) **accepts** them. `2024-10-02-preview` is the version
+Microsoft's ACA managed-OTel documentation uses. Revisit to a stable version once Azure GAs the agent.
+This is an empirical schema fact, not a guess; azapi **schema-validates the body at plan**, so a wrong
+api-version fails the `infra.yml` PR gate loudly rather than drifting silently. (This deliberately
+diverges from the ticket's suggested `2024-03-01` — that version does not carry the feature.)
+
+### 5. Traces + logs only — no metrics destination (YAGNI)
+
+The managed agent forwards **metrics only to OTLP/Datadog sinks, never to App Insights** — so
+`tracesConfiguration.destinations` and `logsConfiguration.destinations` are `["appInsights"]` and
+there is **no `metricsConfiguration`**. Metric-shaped signal comes from **ACA platform metrics** (the
+sibling audit 0001 §C3 alerting ticket) plus the request/dependency metrics App Insights
+**reconstructs from the traces**. A metrics destination is deferred until a real need appears.
+
+### 6. The connection string is wired directly (not via Key Vault), through `sensitive_body`
+
+The App Insights `connection_string` is a TF-native attribute already materialized in state; it is
+wired straight into the agent config. Unlike the app secrets (ADR-0013) it is an **ingestion key for a
+telemetry sink, not a KV-class credential** — no data access, blast radius is only skewed/forged
+telemetry — so Key Vault routing would add a secret + identity wiring for no real blast-radius
+reduction. It is passed via azapi `sensitive_body` so it never surfaces in plan/console output.
+
+## Consequences
+
+### Positive
+
+- Production gains **distributed traces + logs** (Application Map, end-to-end transaction search,
+  KQL over `requests`/`dependencies`/`traces`/`exceptions`) — audit §H3 closed — with **zero app
+  change**.
+- **App neutrality preserved (ADR-0008 §2):** no Azure SDK enters app code; the clean vendor-neutral
+  OTLP pipeline (a strength) is untouched. Re-pointing telemetry at another backend is an infra-only
+  edit.
+- Reuses the existing LAW and the exact-pin + tracked-lockfile discipline (audit G20); everything is
+  `env_id`-parametrized, so a future staging environment inherits it for free.
+
+### Negative / Accepted Trade-offs
+
+- **Infra now couples to Azure** (azapi + App Insights). Accepted — owner decision (all-in-Azure);
+  ADR-0008's neutrality is an *app-code* contract, which still holds. Infra was always Terraform-on-
+  Azure.
+- **A preview api-version sits in the critical infra path** — it may change or be deprecated.
+  Mitigated: it is schema-validated at plan, the provider is pinned, and the revisit-on-GA is recorded
+  here and in `observability.tf`.
+- **No OpenTelemetry metrics in App Insights** (agent limitation). Mitigated by platform metrics
+  (§C3) + trace-reconstructed request metrics.
+- The AI ingestion connection string lives in Terraform state (like every other materialized
+  attribute). Accepted — it is not a KV-class secret.
+
+## Alternatives Considered
+
+### A. ACA managed OTel agent → App Insights via `azapi` (this ADR)
+
+Chosen. Lands telemetry in App Insights with **zero app change**, keeps app code cloud-agnostic, reuses
+the LAW, and fills the azurerm gap with the standard azapi augmentation pattern.
+
+### B. Azure Monitor OpenTelemetry Distro (`Azure.Monitor.OpenTelemetry.AspNetCore`) in each app
+
+Rejected. Adds an Azure-specific package + bootstrap to **app code**, violating ADR-0008 §2 and
+discarding the clean vendor-neutral OTLP pipeline — the exact vendor-lock the owner called out. The
+managed agent gets the same data into App Insights without touching a single line of app code.
+
+### C. Self-hosted OpenTelemetry Collector (sidecar or standalone) exporting to App Insights
+
+Rejected. A whole component to run, scale, secure and upgrade, for zero present benefit over the
+managed agent at pre-release scale. YAGNI now; reconsider only if multi-backend fan-out or
+processing/sampling pipelines become a real need.
+
+### D. App Insights connection string via Key Vault (like the ADR-0013 secrets)
+
+Rejected. Over-engineered for a telemetry **ingestion key** (not a data-access credential): it is
+already a TF-native attribute in state, and KV routing adds a secret + identity wiring for no real
+blast-radius reduction. `sensitive_body` already keeps it out of plan output. Revisit if it ever
+graduates to secret-class.
+
+### E. Use a stable api-version (`2024-03-01` / `2025-01-01`)
+
+Rejected. Schema-verified that stable does **not** expose the agent properties; the preview line is
+the only path until Azure GAs the feature (Decision §4).
+
+## Implementation Notes
+
+- **New:** `iac/observability.tf` (`azurerm_application_insights.app_insights` +
+  `azapi_update_resource.app_env_otel`); this ADR.
+- **Changed:** `iac/setup.tf` (`azapi` in `required_providers` + provider block);
+  `iac/.terraform.lock.hcl` (azapi 2.10.0 multi-platform hashes); `docs/deployment/runbook.md`
+  (Observability section + metrics caveat).
+- **Unchanged (deliberately):** the three `Program.cs` OTLP bootstraps and every app project (no Azure
+  SDK — ADR-0008 §2); the LAW; the azurerm provider entry in the lockfile.
+
+## References
+
+- `docs/audits/0001-infrastructure-audit.md` — §H3 (telemetry connected to nothing in cloud), §C3
+  (alerting / platform-metrics sibling)
+- ADR-0008 — cloud-agnostic deployment & environment strategy (app-code neutrality upheld; only infra
+  couples)
+- ADR-0012 — continuous deployment pipeline (provider chosen = Azure / ACA)
+- ADR-0013 — Key Vault single source of truth for prod secrets (the scope boundary for §6's tradeoff)
+- issue #245 — audit 0001 H3 remediation (Tier D, observability)
+- hashicorp/terraform-provider-azurerm#28217 — no native azurerm block for ACA OTel config
+- Microsoft Learn — "Collect and read OpenTelemetry data in Azure Container Apps"

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -20,6 +20,7 @@
 - [Continuous deployment (CI/CD)](#continuous-deployment-cicd) — the automated rollout, the approval gate, and the one-time operator setup
 - [Database migrations](#database-migrations)
 - [Post-deploy smoke test](#post-deploy-smoke-test) — one command verifies a deployed environment end-to-end
+- [Observability](#observability) — where cloud traces + logs land, and the metrics caveat
 - [See also](#see-also)
 
 ## Services & the container contract
@@ -604,6 +605,31 @@ same [`Smoke test`](../../.github/workflows/smoke.yml) reusable workflow stays r
 (`workflow_dispatch` — enter the three URLs); the secret comes from the repository secret
 `SMOKE_CLIENT_SECRET`. See [Continuous deployment (CI/CD)](#continuous-deployment-cicd).
 
+## Observability
+
+In the cloud, telemetry flows through the **Container Apps managed OpenTelemetry agent** (enabled at
+the environment level in `iac/observability.tf`; ADR-0016) into **workspace-based Application
+Insights** (`lotrotmsappinsights<env_id>`, backed by the existing Log Analytics workspace). The agent
+injects `OTEL_EXPORTER_OTLP_ENDPOINT` into every container automatically, so the apps' existing OTLP
+pipeline ships **distributed traces + logs** without any app or env-var change. Dev is unaffected — it
+keeps using the aspire-dashboard from `compose.yaml`.
+
+**Where to look** (Azure Portal → the `lotrotmsappinsights<env_id>` resource):
+
+- **Application Map** — live service topology (frontend → tms-api → auth-api → Postgres) with
+  per-edge latency and failure rates.
+- **Transaction search** / **End-to-end transaction details** — individual request traces across the
+  three apps (drill into a single OIDC login or an import call).
+- **Logs (KQL)** — the `requests`, `dependencies`, `traces` and `exceptions` tables, queryable in
+  Application Insights or directly in the linked Log Analytics workspace.
+
+**Metrics caveat.** The managed agent forwards **traces + logs only** to Application Insights — it
+does **not** deliver OTel *metrics* there (the agent's metrics path targets only OTLP/Datadog sinks).
+So there are no OpenTelemetry metric series (runtime, EF, Npgsql counters) in App Insights. For
+metric-shaped signal rely on **ACA platform metrics** (CPU/memory/replica/request counts — the sibling
+audit 0001 C3 alerting ticket) plus the request/dependency metrics App Insights **reconstructs from
+the traces**. Adding a metrics destination is deferred until there is a real need (YAGNI).
+
 ## See also
 
 - [`.env.example`](../../.env.example) — the dev-compose env template (`scripts/up.sh` bootstraps `.env` from it).
@@ -613,5 +639,7 @@ same [`Smoke test`](../../.github/workflows/smoke.yml) reusable workflow stays r
   production-parity stacks; the literal env→container wiring this matrix abstracts.
 - [ADR-0008](../adr/0008-cloud-agnostic-deployment-and-environment-strategy.md) — the cloud-agnostic
   deployment & environment strategy this runbook operationalizes.
+- [ADR-0016](../adr/0016-cloud-telemetry-via-aca-managed-otel-agent.md) — cloud telemetry: the ACA
+  managed OpenTelemetry agent → Application Insights (the [Observability](#observability) section).
 - [`target-requirements.md`](target-requirements.md) — platform requirements + Azure⇄AWS service
   mapping (M6-12).

--- a/iac/.terraform.lock.hcl
+++ b/iac/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/azure/azapi" {
+  version     = "2.10.0"
+  constraints = "2.10.0"
+  hashes = [
+    "h1:D8Dvgr7kGq3ntUhGtwBL+pEeCLFbPw82/8hqQhusHvY=",
+    "h1:R6NYsRfXHXd5eNBFAG5gIyD8Um2nFgXiqB5Uz6vHAsA=",
+    "h1:VMEPYNpMeets2y6F8OIBPRI2xqg6/4w8OABcSvKKr+M=",
+    "zh:1e6513c791c6be1389fc4acb8ffdd5127dbf0f479bd0c0074d3a5b69edee2faa",
+    "zh:2ad99c9b656a1d796f4f0ae50d98064af0e42915bbb5a9e5a8db68ca633eceb3",
+    "zh:455fcbfe38cf9181fbd78a6a4a1e43ccafbb606757f4142c99a8ce4d0c80b34c",
+    "zh:46dcafe5495aa50984fd393e72d18d59370fd6bb36b44a0c6c034b82644fc7b7",
+    "zh:5b2f0acff55ee9f8896e11b14d0538fc929d7eee0d68a15644751ca8b6cbc2fc",
+    "zh:61e231f5c6d300404e1010aff9634638c533ba2a7279b85df43cff3aec60f1a9",
+    "zh:68d0aefbd2baf276a034037d6e8b7b9049af42e5745a6db1cbc3311b79de0e6d",
+    "zh:8b12924ee9125266d6aee30a818c1d90403eefad82753b5cd70c8c20ddbd3c98",
+    "zh:92f5643c18c67d3c4bd1b03c02bc7069b24936b2cb5fca58fb998452dfa46e04",
+    "zh:a7aa502ba10433dbe6695a0b903d642153a99540e4eba2befe97e3902fd98093",
+    "zh:c3f8155d5b609fa336eb79c7b67b75076d9c31c94e53d2f3d2b2e66b58e1a73f",
+    "zh:e670ae37ed1813e8e475962a109652a15a054111b2b2428435deab884937ff1e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.7.0"
   constraints = "4.7.0"

--- a/iac/observability.tf
+++ b/iac/observability.tf
@@ -1,0 +1,73 @@
+# Cloud telemetry for the three web apps (audit 0001 H3, ADR-0016).
+#
+# All three apps already emit clean, vendor-neutral OTLP (traces + Serilog->OTLP logs), but no
+# Container App sets OTEL_EXPORTER_OTLP_ENDPOINT, so in the cloud the telemetry goes nowhere. The
+# Container Apps *managed* OpenTelemetry agent closes that gap with zero app change: enabled at the
+# environment level it injects OTEL_EXPORTER_OTLP_ENDPOINT into every container automatically and
+# forwards traces + logs to Application Insights. The app code stays cloud-agnostic (ADR-0008 §2 —
+# only this infra couples to Azure).
+
+# Workspace-based Application Insights, backed by the existing Log Analytics workspace (audit 0001
+# H3 — reuse the LAW, never create a second workspace). Classic (non-workspace) AI is retired by
+# Azure, so workspace_id is mandatory.
+resource "azurerm_application_insights" "app_insights" {
+  name                = "lotrotmsappinsights${var.env_id}"
+  location            = azurerm_resource_group.rg-lotrotms-prod-polc-001.location
+  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  workspace_id        = azurerm_log_analytics_workspace.law.id
+  application_type    = "web"
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Enable the Container Apps managed OpenTelemetry agent on the managed environment. azurerm 4.7.0 has
+# no native block for this (hashicorp/terraform-provider-azurerm#28217), so it is patched on with
+# azapi: azapi_update_resource PATCHes only the properties in its body, and azurerm — which has no
+# schema for these OTel fields — leaves them untouched, the augmentation pattern the azapi docs
+# recommend for filling azurerm gaps.
+#
+# Metrics are intentionally NOT a destination: the managed agent forwards metrics only to
+# OTLP/Datadog sinks, never to App Insights (traces + logs only). Platform metrics (sibling audit
+# 0001 C3 ticket) cover that gap, and App Insights still reconstructs request metrics from the traces.
+#
+# Tradeoff — the App Insights connection string is wired straight from its TF-native attribute into
+# the agent config rather than routed through Key Vault. Unlike the app secrets (ADR-0013) it is an
+# ingestion key for a telemetry sink, not a KV-class credential (no data access, blast radius is only
+# skewed telemetry) and it is already materialized in state; direct wiring is simpler and acceptable.
+# It is passed via sensitive_body so it never surfaces in plan/console output.
+#
+# api-version: a *preview* version is required, not the stable 2024-03-01/2025-01-01 — the OTel-agent
+# properties (appInsightsConfiguration + openTelemetryConfiguration) are not yet in the stable ARM
+# surface (verified against the azapi 2.10.0 embedded schema: stable rejects them, the preview line
+# accepts them). 2024-10-02-preview is the version Microsoft's ACA managed-OTel docs use. Revisit to a
+# stable version once Azure GAs the agent (azapi schema-validates the body at plan, so a wrong version
+# fails the infra.yml gate loudly rather than drifting).
+resource "azapi_update_resource" "app_env_otel" {
+  type        = "Microsoft.App/managedEnvironments@2024-10-02-preview"
+  resource_id = azurerm_container_app_environment.app_env.id
+
+  body = {
+    properties = {
+      openTelemetryConfiguration = {
+        tracesConfiguration = {
+          destinations = ["appInsights"]
+        }
+        logsConfiguration = {
+          destinations = ["appInsights"]
+        }
+      }
+    }
+  }
+
+  sensitive_body = {
+    properties = {
+      appInsightsConfiguration = {
+        connectionString = azurerm_application_insights.app_insights.connection_string
+      }
+    }
+  }
+}

--- a/iac/setup.tf
+++ b/iac/setup.tf
@@ -8,6 +8,14 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "4.7.0"
     }
+    # azapi patches the Container Apps managed OpenTelemetry agent onto the managed environment
+    # (iac/observability.tf, ADR-0016): azurerm 4.7.0 has no native block for it
+    # (hashicorp/terraform-provider-azurerm#28217). Exact-pinned like azurerm above (audit 0001 G20);
+    # multi-platform hashes are tracked in .terraform.lock.hcl.
+    azapi = {
+      source  = "Azure/azapi"
+      version = "2.10.0"
+    }
   }
 
   backend "azurerm" {
@@ -23,5 +31,12 @@ provider "azurerm" {
 
   }
 
+  subscription_id = var.subscription_id
+}
+
+# Used only by iac/observability.tf to patch the managed environment's OpenTelemetry config. Shares
+# the azurerm OIDC Azure CLI session in CI (use_cli default, established by azure/login); the
+# subscription mirrors the azurerm provider above.
+provider "azapi" {
   subscription_id = var.subscription_id
 }


### PR DESCRIPTION
Closes #245

## What

Closes audit 0001 **§H3**: the three apps emit clean OTLP but no Container App sets `OTEL_EXPORTER_OTLP_ENDPOINT`, so cloud telemetry goes nowhere. This wires the **ACA managed OpenTelemetry agent** at the environment level → **workspace-based Application Insights** for **traces + logs**, with **zero app change** (the agent injects the endpoint). App code stays cloud-agnostic per ADR-0008 §2 — only infra couples to Azure. Decision recorded in **ADR-0016**.

## Changes (`iac/` + `docs/` only — no `src/`)

- **NEW `iac/observability.tf`** — `azurerm_application_insights` (workspace-based on the existing `law`, `application_type = "web"`, name `lotrotmsappinsights${var.env_id}`) + `azapi_update_resource` patching the managed env's `openTelemetryConfiguration` (`tracesConfiguration`/`logsConfiguration` destinations = `["appInsights"]`; connection string via `sensitive_body`).
- **`iac/setup.tf`** — `azapi` in `required_providers` (exact pin `2.10.0`, mirroring `azurerm = 4.7.0`) + an `azapi` provider block. azurerm 4.7.0 has no native block for the agent ([azurerm#28217](https://github.com/hashicorp/terraform-provider-azurerm/issues/28217)).
- **`iac/.terraform.lock.hcl`** — `azapi 2.10.0` multi-platform hashes (linux_amd64/darwin_arm64/windows_amd64); azurerm entry untouched.
- **NEW `docs/adr/0016-cloud-telemetry-via-aca-managed-otel-agent.md`**.
- **`docs/deployment/runbook.md`** — Observability section (Application Map / Transaction search / Logs) + metrics-limitation caveat + TOC/See-also links.

## Key decision — api-version is preview, not stable

The ticket suggested stable `2024-03-01`, but I **verified against the azapi 2.10.0 embedded schema** that stable (`2024-03-01` and `2025-01-01`) **rejects** `appInsightsConfiguration`/`openTelemetryConfiguration` — the OTel-agent feature is **preview-only** in the ARM surface. Used `2024-10-02-preview` (the version Microsoft's ACA managed-OTel docs use); azapi schema-validates the body at plan, so a wrong version fails the `infra.yml` gate loudly. ADR-0016 §4 + a code comment record the revisit-on-GA.

## Tradeoffs (in ADR)

- **Traces + logs only, no metrics destination** — the managed agent never sends metrics to App Insights; platform metrics (sibling audit C3) + trace-reconstructed request metrics cover it. YAGNI on a metrics sink now.
- **Connection string wired directly** (via `sensitive_body`), not Key Vault — it's a telemetry ingestion key, not a KV-class credential (ADR-0013 scope); already a TF-native attribute in state.

## Acceptance criteria

- [x] `terraform fmt -check -recursive` + `terraform validate` clean (run locally on this worktree).
- [x] App code unchanged — diff is `iac/` + `docs/` only; the clean OTLP `Program.cs` pipeline is untouched.
- [x] `azapi` exactly pinned; everything `var.env_id`-parametrized; reuses the existing LAW.
- [x] ADR-0016 added + linked from the runbook.
- [x] Runbook notes where to view traces + the metrics caveat.
- [x] Lockfile updated with multi-platform azapi hashes.

Reviewed by the `code-reviewer` agent: **APPROVE**, no blocking findings (the one doc nit on brittle `Program.cs` line refs was fixed; two Notes are accepted, ADR-documented tradeoffs).

> Note: the real `terraform plan` against Azure runs in the `infra.yml` PR gate (needs OIDC + remote state); local validation was `fmt` + `validate` + offline azapi schema validation of the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
