### PR TITLE
audit 0001 H2/H5/H11 (ADR-0017): per-environment IaC parametrization — RG + URLs from one var, per-env state blob, prevent_destroy guards

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -81,7 +81,7 @@ jobs:
         run: terraform fmt -check -recursive
 
       - name: terraform init
-        run: terraform init -input=false
+        run: terraform init -input=false -reconfigure -backend-config=backend-config/prod.hcl
 
       - name: terraform validate
         run: terraform validate -no-color
@@ -132,7 +132,7 @@ jobs:
           terraform_version: 1.15.7
 
       - name: terraform init
-        run: terraform init -input=false
+        run: terraform init -input=false -reconfigure -backend-config=backend-config/prod.hcl
 
       - name: terraform apply
         run: terraform apply -input=false -auto-approve -lock-timeout=300s

--- a/.gitignore
+++ b/.gitignore
@@ -520,6 +520,10 @@ crash.*.log
 
 *.tfvars
 *.tfvars.json
+# Exception: per-environment NON-secret override files under iac/env/ are tracked (ADR-0017) — they
+# carry only env_id / public_base_domain / Key Vault + identity NAMES. Real secrets come from Key
+# Vault (ADR-0013) + TF_VAR_*, never from a tfvars; gitleaks + GitGuardian still gate any slip.
+!iac/env/*.tfvars
 
 # Terraform plan output (may embed secrets in plaintext)
 *.tfplan

--- a/docs/adr/0017-per-environment-iac-parametrization.md
+++ b/docs/adr/0017-per-environment-iac-parametrization.md
@@ -1,0 +1,195 @@
+# ADR-0017: Per-environment IaC parametrization (Rank 2 — parametrized flat root + per-env state key)
+
+**Status:** Accepted
+**Date:** 2026-06-30
+**Decision-makers:** Solo maintainer
+**Related:** IaC (`iac/`); audit 0001 §H2 (RG + URL literals), §H5 (flat root + monolithic state
+key), §H11 (`prevent_destroy`), §C5 (staging-blocker), §6 (approach ranking + staging blueprint),
+§M4 (ADR conflict); ADR-0008 (env strategy — staging + production), ADR-0012 (CD — "prod is
+de-facto staging" interim), ADR-0013 (Key Vault per-env secrets), ADR-0016 (env_id-parametrized
+telemetry — the precedent this generalizes)
+
+## Context
+
+Audit 0001 (§6, §H2/H5/H11) found the Terraform is **single-environment** despite ADR-0008 §1
+committing to "two environments — staging + production". The gaps, verified against the tree:
+
+- **RG name hardcoded.** `resource-group.tf:1,3` — both the resource symbol
+  `azurerm_resource_group.rg-lotrotms-prod-polc-001` and its `name` are the literal
+  `"rg-lotrotms-prod-polc-001"`; the symbol is referenced **28× across 9 `.tf` files**.
+- **10 URL literals.** `azure-container-apps.tf` bakes `lotro-translator.pl` in 10 places
+  (`:125/141/145/149/321/325/333/438/442/450`): OpenIddict `Issuer`, web-client redirect /
+  post-logout, both APIs' CORS, tms `Auth__Issuer`/`Auth__Authority`, frontend
+  `AuthSystem__Authority`/`__BaseUrl`, `TranslationSystem__BaseUrl`. Two carry a **trailing slash**
+  (`:442`, `:450`) — byte-identity matters (the OIDC `iss`, audit G15).
+- **Monolithic state key.** `setup.tf:25` `key = "prod.terraform.tfstate"` — a backend block cannot
+  take a variable, so a second env cannot get its own state file without intervention.
+- **No destroy guard** on the two stateful, TF-owned resources: the Data Protection keyring
+  `azurerm_storage_account.keys` (`storage.tf`) and `azurerm_log_analytics_workspace.law`
+  (`azure-law.tf`).
+
+The floor is already high: storage/LAW/App-Insights/app names are **already** `${var.env_id}`-derived
+(`lotrotmskeys${var.env_id}`, `lotrotmslaw${var.env_id}`, `lotrotms-*-${var.env_id}`),
+`monitoring.tf:53` even comments the `prod -> "lotrotmsprod" / staging -> "lotrotmsstag"` shape, and
+the apps are **env-name-agnostic** (audit G13 — guards key off `IsDevelopment()/IsTesting()`, not
+`=="Production"`). So the residual gap is narrow: RG name, the 10 URLs, the state key, destroy guards.
+
+Two hard constraints shape the change:
+
+- **Prod must stay byte-for-byte untouched.** The issuer/redirect/CORS strings feed the token `iss`
+  and OIDC redirects; the RG name and state blob must not change. The only acceptable prod `plan`
+  delta is a **state-address move** plus state-only `prevent_destroy` metas — zero infrastructure
+  change.
+- **`prevent_destroy` and the RG rename interact** (audit §6 "Sekwencja"): the symbol rename must go
+  through `moved {}` / `state mv`, **never** destroy + recreate.
+
+This also settles audit §M4: ADR-0008 §1 says "staging + production"; ADR-0012 took the interim
+"prod is de-facto staging (YAGNI)". This ADR resolves the contradiction in favor of 0008's two-env
+model and makes staging genuinely instantiable.
+
+## Decision
+
+### 1. Rank 2, not Rank 1 — parametrize the flat root; do not extract a module yet
+
+A single root module stays; each environment is selected by a **var-file** plus a **backend state
+key**. The audit's Rank 1 (`modules/environment/`, root = `module "prod"`/`module "staging"`) is
+**deferred**: at two environments of identical sizing a module abstraction is YAGNI
+(`CLAUDE.md` — right-size, no abstraction without a present need), and it would force a `moved {}` for
+**every** resource (all addresses become `module.X.*`) — far larger surgery on the live prod state —
+for a DRY win that only pays off at 3+ envs or diverging shapes. Rank 2 is a **strict subset** of
+Rank 1, so wrapping the parametrized root in `modules/environment/` later is a clean follow-up at no
+rework cost. **Revisit trigger:** a third environment, or env shapes that genuinely diverge.
+
+### 2. One variable drives every public origin
+
+New `var.public_base_domain` (default `"lotro-translator.pl"`) + a new `iac/locals.tf` deriving
+`apex_origin = "https://${var.public_base_domain}"`, `auth_origin = "https://auth.…"`,
+`tms_origin = "https://tms.…"`, `callback_url = "${local.apex_origin}/callback"`. The 10 literals
+become local references; the two trailing-slash values stay `"${local.auth_origin}/"` /
+`"${local.tms_origin}/"`. For prod the default reproduces **every former string byte-for-byte**.
+Staging sets `public_base_domain = "staging.lotro-translator.pl"`, yielding
+`auth.staging…/tms.staging…/staging…` — exactly the origins audit §6 prescribes for staging.
+
+### 3. RG name derives from `env_id`, renamed via `moved {}`
+
+Symbol `rg-lotrotms-prod-polc-001` → `main`; `name = "rg-lotrotms-${var.env_id}-polc-001"` (which
+evaluates **identically** for `env_id = "prod"`). A single `moved {}` block migrates the state
+address — no destroy/recreate. All 28 references repoint to `azurerm_resource_group.main`.
+
+### 4. Per-environment state key via a partial backend
+
+Drop the inline `key` from the `azurerm` backend (`setup.tf`); supply it at init via
+`-backend-config=backend-config/<env>.hcl` (`prod.hcl` → `prod.terraform.tfstate`, `staging.hcl` →
+`staging.terraform.tfstate`). Same storage account + container, **separate blobs** — a botched
+staging apply can never corrupt prod state (the core §C5/§H5 safety property). `infra.yml`'s two
+`terraform init` steps pass `prod.hcl` (with `-reconfigure`, idempotent on the fresh CI runner).
+
+### 5. `prevent_destroy` on the stateful resources
+
+`lifecycle { prevent_destroy = true }` on `azurerm_storage_account.keys` (losing the DP keyring logs
+everyone out) and `azurerm_log_analytics_workspace.law` (log history). A meta-argument — state-only,
+**no plan diff** — that blocks a stray rename / `-target` slip during multi-env work (audit §H11).
+
+### 6. Prod runs on defaults; only staging carries a tfvars
+
+`vars.tf` defaults are already prod-correct (`env_id=prod`, `public_base_domain=lotro-translator.pl`,
+`key_vault_name=lotrotms-kv-prod`, `aca_identity_name=lotrotms-aca-prod`), so prod apply needs **no**
+var-file and CI keeps passing only the required secret-free `TF_VAR_*` inputs. Only
+`iac/env/staging.tfvars` overrides `env_id`/`public_base_domain`/`key_vault_name`/`aca_identity_name`.
+Nothing is named `*.auto.tfvars`, so a prod apply can never load staging values.
+
+### 7. Out-of-band staging prerequisites are named, not Terraform-managed here
+
+Before the first staging apply, seed out-of-band (they are **data sources**, ADR-0013): a separate
+`lotrotms-kv-staging` Key Vault with **freshly generated** secrets (never the prod vault — §C5) and a
+`lotrotms-aca-staging` identity, plus a Neon `staging` branch (audit §H13). A staging CI job /
+promotion model (audit §H10) is a **separate** change; this ADR only makes staging instantiable —
+today via a manual `terraform apply -var-file=env/staging.tfvars`.
+
+## Consequences
+
+### Positive
+
+- **Staging is instantiable with zero app/code change** (app already env-name-agnostic, G13) — only a
+  var-file, a backend key, and the out-of-band KV/identity/Neon-branch from §7.
+- **Prod is provably untouched:** identical issuer/redirect/CORS, identical RG name, same state blob.
+  The only prod `plan` delta is the RG state-address move + two `prevent_destroy` metas — no
+  infrastructure change.
+- **Single source of truth** for the public domain (one var → 10 URLs) and the env name
+  (`env_id` → RG/storage/LAW/AI/apps).
+- **Real blast-radius isolation:** separate state blobs + destroy guards close §H2/§H5/§H11 and
+  defuse the §C5 "staging on prod secrets/state" trap (with the separate KV from ADR-0013 seeding).
+
+### Negative / Accepted Trade-offs
+
+- The flat root is kept; the `modules/` DRY win is deferred (Decision §1) — accepted YAGNI, with a
+  documented revisit trigger.
+- `terraform init` now needs `-backend-config=backend-config/<env>.hcl`; a local dev with a
+  pre-existing `.terraform` needs `-reconfigure` once. Documented in the runbook.
+- Per-env required inputs (`subscription_id`, `smtp_sender_email`, `admin_*`) still arrive as
+  `TF_VAR_*`, not tfvars, so no env-specific value or secret is committed — staging wiring of those is
+  manual until the promotion model (§H10) lands.
+- The subdomain scheme is fixed to `auth.<domain>` / `tms.<domain>` / `<domain>`; a differently-shaped
+  env would need a small `locals.tf` tweak. Both prod and the §6 staging shape fit it.
+
+## Alternatives Considered
+
+### A. Rank 2 — parametrized flat root + per-env state key + tfvars (this ADR)
+
+Chosen. Strongest state isolation (separate blobs) for the lowest-risk change on the live prod state
+(one `moved {}`), fully parametrizes the residual gap, and is a strict subset of Rank 1 so nothing is
+foreclosed.
+
+### B. Rank 1 — extract `modules/environment/`, root = `module "prod"` / `module "staging"`
+
+Rejected for now. Cleanest DRY structure and the audit's nominal #1, but requires a `moved {}` for
+**every** resource (all addresses move under `module.X.*`) — far larger surgery on live prod state —
+for a benefit that pays off only at 3+ envs / diverging shapes; it also trends toward one shared
+root+state unless split further, which is **weaker** isolation than Rank 2's separate blobs. Strict
+superset of this work, deferrable at no rework cost.
+
+### C. Terraform workspaces (`terraform.workspace`-keyed state)
+
+Rejected. Co-located state is weaker isolation, carries the classic "applied to the wrong workspace"
+footgun, and still needs all the same parametrization — lower safety for the same effort (audit §6
+Rank 3).
+
+### D. Copy `iac/` to `iac-staging/`
+
+Rejected. Immediate drift; every change made twice by hand (audit §6 Rank 4).
+
+### E. Keep "prod is de-facto staging" (ADR-0012 interim — no second env)
+
+Rejected. The right pre-cloud call, but it is exactly the §C5 risk once a second person (QA) touches
+the system — rollout/migration/smoke happen first-and-only on live prod. ADR-0008's two-env intent
+supersedes it; this ADR makes the second env real.
+
+## Implementation Notes
+
+- **New:** `iac/locals.tf` (public-origin derivation); `iac/backend-config/prod.hcl` +
+  `backend-config/staging.hcl`; `iac/env/staging.tfvars`; this ADR.
+- **Changed:** `iac/vars.tf` (+ `public_base_domain`); `iac/resource-group.tf` (symbol → `main`,
+  `env_id`-derived `name`, `moved {}`); `iac/azure-container-apps.tf` (10 literals → locals);
+  `iac/storage.tf` + `iac/azure-law.tf` (`prevent_destroy`); `iac/setup.tf` (partial backend — drop
+  inline `key`); the RG-symbol reference in `azure_container_app_env.tf`, `keyvault.tf`,
+  `migrator-job.tf`, `observability.tf`, `monitoring.tf` (→ `.main`); `.github/workflows/infra.yml`
+  (both `terraform init` → `-reconfigure -backend-config=backend-config/prod.hcl`);
+  `docs/deployment/runbook.md` (per-env init + staging bring-up).
+- **Unchanged (deliberately):** the three `Program.cs` (env-name-agnostic, G13); every existing
+  `${var.env_id}`-derived name (storage/LAW/AI/app); the KV data-source wiring (ADR-0013) — staging
+  just points `key_vault_name` at a separate vault.
+- **Supersession (audit §M4):** ADR-0012's "prod is de-facto staging" is now an **interim**,
+  superseded by this ADR for the environment-topology question; ADR-0008's two-env model stands.
+
+## References
+
+- `docs/audits/0001-infrastructure-audit.md` — §H2, §H5, §H11, §C5, §M4, and §6 (approach ranking +
+  staging blueprint)
+- ADR-0008 — cloud-agnostic deployment & environment strategy (staging + production); this ADR
+  delivers its two-env intent in IaC
+- ADR-0012 — continuous deployment pipeline; its "prod = de-facto staging" interim is superseded here
+  for env topology
+- ADR-0013 — Key Vault single source of truth for prod secrets (the separate staging vault is the
+  seeding boundary, §C5)
+- ADR-0016 — env_id-parametrized App Insights ("a future staging environment inherits it for free" —
+  the precedent this generalizes to RG name + URLs + state key)

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -332,6 +332,34 @@ the provider-specific walkthrough is deferred until the provider is chosen):
 > The **manual** sequence above is the provider-neutral fallback / first bring-up. **Ongoing deploys
 > to the live Azure environment are automated** — see [Continuous deployment (CI/CD)](#continuous-deployment-cicd).
 
+### Per-environment Terraform (state key + staging)
+
+The `iac/` root is a single parametrized module; an environment is **one var-file + one state blob**
+(ADR-0017). The `azurerm` backend is **partial** — the state key is chosen at `init`, and prod runs
+purely on the `vars.tf` defaults:
+
+```bash
+cd iac
+# prod (default — no var-file; vars.tf defaults are already prod-correct):
+terraform init -reconfigure -backend-config=backend-config/prod.hcl
+terraform apply                                    # CI does this behind the production gate
+
+# staging (separate state blob, separate Key Vault + Neon branch — see prerequisites):
+terraform init -reconfigure -backend-config=backend-config/staging.hcl
+terraform apply -var-file=env/staging.tfvars
+```
+
+`prod.terraform.tfstate` and `staging.terraform.tfstate` are separate blobs in the one backend
+container, so a botched staging apply can never corrupt prod state. `var.public_base_domain` derives
+every OIDC issuer / redirect / CORS / base URL (`iac/locals.tf`) and `var.env_id` derives the resource
+group and every resource name — so the only env-specific edits live in `env/staging.tfvars`.
+
+**Before the first staging apply** (out-of-band — they are Terraform *data sources*, ADR-0017 §7):
+seed a **separate** `lotrotms-kv-staging` Key Vault with freshly generated secrets (never the prod
+vault — audit §C5), a `lotrotms-aca-staging` identity, and a Neon `staging` branch (audit §H13); the
+secret-free required inputs (`subscription_id`, `smtp_sender_email`, `admin_username`, `admin_email`)
+arrive as `TF_VAR_*`. A staging CI job / promotion model (audit §H10) is separate, future work.
+
 ## Continuous deployment (CI/CD)
 
 Ongoing delivery to the live Azure environment is automated (ADR-0012). Three workflows:

--- a/iac/azure-container-apps.tf
+++ b/iac/azure-container-apps.tf
@@ -1,7 +1,7 @@
 resource "azurerm_container_app" "auth_api" {
   name                         = "lotrotms-auth-api-${var.env_id}"
   container_app_environment_id = azurerm_container_app_environment.app_env.id
-  resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name          = azurerm_resource_group.main.name
   revision_mode                = "Multiple"
 
   identity {
@@ -122,7 +122,7 @@ resource "azurerm_container_app" "auth_api" {
       }
       env {
         name  = "OpenIddict__Issuer"
-        value = "https://auth.lotro-translator.pl"
+        value = local.auth_origin
       }
       env {
         name        = "OpenIddict__SigningKey__RsaPrivateKeyXml"
@@ -138,15 +138,15 @@ resource "azurerm_container_app" "auth_api" {
       }
       env {
         name  = "OpenIddict__WebClient__RedirectUris__0"
-        value = "https://lotro-translator.pl/callback"
+        value = local.callback_url
       }
       env {
         name  = "OpenIddict__WebClient__PostLogoutRedirectUris__0"
-        value = "https://lotro-translator.pl"
+        value = local.apex_origin
       }
       env {
         name  = "Cors__AllowedOrigins__0"
-        value = "https://lotro-translator.pl"
+        value = local.apex_origin
       }
       env {
         name  = "DataProtection__KeyRingPath"
@@ -228,7 +228,7 @@ resource "azurerm_container_app" "auth_api" {
 resource "azurerm_container_app" "tms_api" {
   name                         = "lotrotms-tms-api-${var.env_id}"
   container_app_environment_id = azurerm_container_app_environment.app_env.id
-  resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name          = azurerm_resource_group.main.name
   revision_mode                = "Multiple"
 
   identity {
@@ -318,11 +318,11 @@ resource "azurerm_container_app" "tms_api" {
       }
       env {
         name  = "Auth__Issuer"
-        value = "https://auth.lotro-translator.pl"
+        value = local.auth_origin
       }
       env {
         name  = "Auth__Authority"
-        value = "https://auth.lotro-translator.pl"
+        value = local.auth_origin
       }
       env {
         name  = "Auth__Audience"
@@ -330,7 +330,7 @@ resource "azurerm_container_app" "tms_api" {
       }
       env {
         name  = "Cors__AllowedOrigins__0"
-        value = "https://lotro-translator.pl"
+        value = local.apex_origin
       }
       env {
         name  = "Bootstrap__Enabled"
@@ -361,7 +361,7 @@ resource "azurerm_container_app" "tms_api" {
 resource "azurerm_container_app" "frontend" {
   name                         = "lotrotms-frontend-${var.env_id}"
   container_app_environment_id = azurerm_container_app_environment.app_env.id
-  resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name          = azurerm_resource_group.main.name
   revision_mode                = "Multiple"
 
   # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
@@ -435,11 +435,11 @@ resource "azurerm_container_app" "frontend" {
       }
       env {
         name  = "AuthSystem__Authority"
-        value = "https://auth.lotro-translator.pl"
+        value = local.auth_origin
       }
       env {
         name  = "AuthSystem__BaseUrl"
-        value = "https://auth.lotro-translator.pl/"
+        value = "${local.auth_origin}/"
       }
       env {
         name  = "AuthSystem__ClientId"
@@ -447,7 +447,7 @@ resource "azurerm_container_app" "frontend" {
       }
       env {
         name  = "TranslationSystem__BaseUrl"
-        value = "https://tms.lotro-translator.pl/"
+        value = "${local.tms_origin}/"
       }
       env {
         name  = "DataProtection__KeyRingPath"

--- a/iac/azure-law.tf
+++ b/iac/azure-law.tf
@@ -1,10 +1,16 @@
 resource "azurerm_log_analytics_workspace" "law" {
-  location            = azurerm_resource_group.rg-lotrotms-prod-polc-001.location
+  location            = azurerm_resource_group.main.location
   name                = "lotrotmslaw${var.env_id}"
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name = azurerm_resource_group.main.name
   sku                 = "PerGB2018"
   retention_in_days   = 30
   daily_quota_gb      = 0.16
+
+  lifecycle {
+    # Audit 0001 / H11 (ADR-0017): losing this workspace drops all log history. Guard against a stray
+    # rename / -target slip during multi-env work.
+    prevent_destroy = true
+  }
 
   tags = {
     environment = var.env_id

--- a/iac/azure_container_app_env.tf
+++ b/iac/azure_container_app_env.tf
@@ -1,7 +1,7 @@
 resource "azurerm_container_app_environment" "app_env" {
-  location                   = azurerm_resource_group.rg-lotrotms-prod-polc-001.location
+  location                   = azurerm_resource_group.main.location
   name                       = "lotrotmsenv${var.env_id}"
-  resource_group_name        = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name        = azurerm_resource_group.main.name
   log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
 
   tags = {

--- a/iac/backend-config/prod.hcl
+++ b/iac/backend-config/prod.hcl
@@ -1,0 +1,4 @@
+# Prod Terraform state blob (audit 0001 / H5, ADR-0017). The azurerm backend in setup.tf is partial;
+# select this key at init:
+#   terraform init -reconfigure -backend-config=backend-config/prod.hcl
+key = "prod.terraform.tfstate"

--- a/iac/backend-config/staging.hcl
+++ b/iac/backend-config/staging.hcl
@@ -1,0 +1,4 @@
+# Staging Terraform state blob (audit 0001 / H5, ADR-0017) — a separate blob from prod in the same
+# backend container, so a botched staging apply can never corrupt prod state. Select this key at init:
+#   terraform init -reconfigure -backend-config=backend-config/staging.hcl
+key = "staging.terraform.tfstate"

--- a/iac/env/staging.tfvars
+++ b/iac/env/staging.tfvars
@@ -1,0 +1,12 @@
+# Staging environment overrides (audit 0001 / H2+H5, ADR-0017). Apply with:
+#   terraform init -reconfigure -backend-config=backend-config/staging.hcl
+#   terraform apply -var-file=env/staging.tfvars
+#
+# Prerequisites (out-of-band, ADR-0017 §7): a SEPARATE lotrotms-kv-staging Key Vault with freshly
+# generated secrets (never the prod vault — audit §C5), a lotrotms-aca-staging identity, and a Neon
+# `staging` branch (audit §H13). The required secret-free inputs (subscription_id, smtp_sender_email,
+# admin_username, admin_email) still arrive as TF_VAR_*, not from this file.
+env_id             = "staging"
+public_base_domain = "staging.lotro-translator.pl"
+key_vault_name     = "lotrotms-kv-staging"
+aca_identity_name  = "lotrotms-aca-staging"

--- a/iac/keyvault.tf
+++ b/iac/keyvault.tf
@@ -8,12 +8,12 @@
 
 data "azurerm_key_vault" "secrets" {
   name                = var.key_vault_name
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 data "azurerm_user_assigned_identity" "aca" {
   name                = var.aca_identity_name
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 locals {

--- a/iac/locals.tf
+++ b/iac/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  # Single source of truth for the platform's public origins (audit 0001 / H2, ADR-0017). Every OIDC
+  # issuer, redirect, CORS allow-list and base URL in azure-container-apps.tf derives from
+  # var.public_base_domain, so a new environment is one variable away. For prod
+  # (var.public_base_domain = "lotro-translator.pl") each value below is byte-identical to the literal
+  # it replaced — the OIDC `iss` and redirect_uri must match exactly (audit G15). Staging sets
+  # public_base_domain = "staging.lotro-translator.pl", yielding auth.staging.… / tms.staging.… /
+  # staging.… (the origins audit §6 prescribes).
+  apex_origin  = "https://${var.public_base_domain}"
+  auth_origin  = "https://auth.${var.public_base_domain}"
+  tms_origin   = "https://tms.${var.public_base_domain}"
+  callback_url = "${local.apex_origin}/callback"
+}

--- a/iac/migrator-job.tf
+++ b/iac/migrator-job.tf
@@ -1,7 +1,7 @@
 resource "azurerm_container_app_job" "migrator" {
   name                         = "lotrotms-migrator-${var.env_id}"
-  location                     = azurerm_resource_group.rg-lotrotms-prod-polc-001.location
-  resource_group_name          = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  location                     = azurerm_resource_group.main.location
+  resource_group_name          = azurerm_resource_group.main.name
   container_app_environment_id = azurerm_container_app_environment.app_env.id
 
   replica_timeout_in_seconds = 1800

--- a/iac/monitoring.tf
+++ b/iac/monitoring.tf
@@ -47,7 +47,7 @@ locals {
 # ---------------------------------------------------------------------------------------------------
 resource "azurerm_monitor_action_group" "alerts" {
   name                = "lotrotmsag${var.env_id}"
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name = azurerm_resource_group.main.name
   # short_name shows up in the notification subject and is capped by Azure at 12 characters, so it
   # cannot simply carry the full env-qualified name — substr keeps it env-aware within the cap
   # (e.g. prod -> "lotrotmsprod", staging -> "lotrotmsstag").
@@ -79,7 +79,7 @@ resource "azurerm_monitor_action_group" "alerts" {
 resource "azurerm_monitor_metric_alert" "replica_restart" {
   for_each            = local.monitored_container_apps
   name                = "lotrotms-alert-replica-restart-${each.key}-${var.env_id}"
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name = azurerm_resource_group.main.name
   scopes              = [each.value]
   description         = "Container app ${each.key} restarted a replica (crash-loop signal). Fires by email."
   severity            = 1 # Error
@@ -111,7 +111,7 @@ resource "azurerm_monitor_metric_alert" "replica_restart" {
 resource "azurerm_monitor_metric_alert" "http_server_errors" {
   for_each            = local.monitored_container_apps
   name                = "lotrotms-alert-http-5xx-${each.key}-${var.env_id}"
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name = azurerm_resource_group.main.name
   scopes              = [each.value]
   description         = "Spike of HTTP 5xx responses from container app ${each.key}. Fires by email."
   severity            = 1 # Error
@@ -149,7 +149,7 @@ resource "azurerm_monitor_metric_alert" "http_server_errors" {
 resource "azurerm_monitor_metric_alert" "cpu_saturation" {
   for_each            = local.monitored_container_apps
   name                = "lotrotms-alert-cpu-high-${each.key}-${var.env_id}"
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name = azurerm_resource_group.main.name
   scopes              = [each.value]
   description         = "Container app ${each.key} CPU sustained above 80% of its limit. Fires by email."
   severity            = 3 # Informational (capacity signal)
@@ -181,7 +181,7 @@ resource "azurerm_monitor_metric_alert" "cpu_saturation" {
 resource "azurerm_monitor_metric_alert" "memory_saturation" {
   for_each            = local.monitored_container_apps
   name                = "lotrotms-alert-memory-high-${each.key}-${var.env_id}"
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  resource_group_name = azurerm_resource_group.main.name
   scopes              = [each.value]
   description         = "Container app ${each.key} memory sustained above 80% of its limit (OOM precursor). Fires by email."
   severity            = 2 # Warning
@@ -219,8 +219,8 @@ resource "azurerm_monitor_metric_alert" "memory_saturation" {
 # logged failures that never become a 5xx or a restart (e.g. a background job throwing).
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_error_spike" {
   name                = "lotrotms-alert-log-error-spike-${var.env_id}"
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
-  location            = azurerm_resource_group.rg-lotrotms-prod-polc-001.location
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
   description         = "Spike of Error/Fatal Serilog entries in a container app's console logs. Fires by email."
   severity            = 2 # Warning
 
@@ -277,8 +277,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_error_spike" {
 # rule turns a silent blind-spot into an email. Checked hourly because the cap is a daily event.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "law_daily_cap" {
   name                = "lotrotms-alert-law-daily-cap-${var.env_id}"
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
-  location            = azurerm_resource_group.rg-lotrotms-prod-polc-001.location
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
   description         = "Log Analytics daily ingestion cap reached — log collection has stopped. Fires by email."
   severity            = 2 # Warning
 
@@ -339,8 +339,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "law_daily_cap" {
 # token set against real ContainerAppSystemLogs_CL on first apply.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "auth_availability" {
   name                = "lotrotms-slo-auth-availability-${var.env_id}"
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
-  location            = azurerm_resource_group.rg-lotrotms-prod-polc-001.location
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
   description         = "SLO: auth /health/ready failing (token-issuance SPOF unavailable). Fires by email."
   severity            = 0 # Critical — platform-wide outage
 

--- a/iac/observability.tf
+++ b/iac/observability.tf
@@ -12,8 +12,8 @@
 # Azure, so workspace_id is mandatory.
 resource "azurerm_application_insights" "app_insights" {
   name                = "lotrotmsappinsights${var.env_id}"
-  location            = azurerm_resource_group.rg-lotrotms-prod-polc-001.location
-  resource_group_name = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
   workspace_id        = azurerm_log_analytics_workspace.law.id
   application_type    = "web"
 

--- a/iac/resource-group.tf
+++ b/iac/resource-group.tf
@@ -1,10 +1,18 @@
-resource "azurerm_resource_group" "rg-lotrotms-prod-polc-001" {
+resource "azurerm_resource_group" "main" {
   location = "polandcentral"
-  name     = "rg-lotrotms-prod-polc-001"
+  name     = "rg-lotrotms-${var.env_id}-polc-001"
 
   tags = {
     environment = var.env_id
     src         = var.src_key
     project     = "lotrotms"
   }
+}
+
+# Audit 0001 / H2 (ADR-0017): the symbol was renamed rg-lotrotms-prod-polc-001 -> main and the name is
+# now env_id-derived. For env_id = "prod" the name is unchanged, so this is a pure state-address move
+# (terraform plan shows a `moved`, never a destroy/recreate).
+moved {
+  from = azurerm_resource_group.rg-lotrotms-prod-polc-001
+  to   = azurerm_resource_group.main
 }

--- a/iac/setup.tf
+++ b/iac/setup.tf
@@ -22,7 +22,10 @@ terraform {
     resource_group_name  = "rg-lotrotms-tfstate"
     storage_account_name = "sttflotrotms23957"
     container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    # Per-environment state key (audit 0001 / H5, ADR-0017): partial backend — the key is supplied at
+    # init via `-backend-config=backend-config/<env>.hcl` (prod.hcl / staging.hcl), so prod and staging
+    # live in separate blobs in this one container and a botched staging apply can never touch prod
+    # state. CI passes prod.hcl; see .github/workflows/infra.yml and docs/deployment/runbook.md.
   }
 }
 

--- a/iac/storage.tf
+++ b/iac/storage.tf
@@ -1,10 +1,16 @@
 resource "azurerm_storage_account" "keys" {
   name                     = "lotrotmskeys${var.env_id}"
-  resource_group_name      = azurerm_resource_group.rg-lotrotms-prod-polc-001.name
-  location                 = azurerm_resource_group.rg-lotrotms-prod-polc-001.location
+  resource_group_name      = azurerm_resource_group.main.name
+  location                 = azurerm_resource_group.main.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
   min_tls_version          = "TLS1_2"
+
+  lifecycle {
+    # Audit 0001 / H11 (ADR-0017): the Data Protection keyring lives in this account — destroying it
+    # logs every user out. Guard against a stray rename / -target slip during multi-env work.
+    prevent_destroy = true
+  }
 
   tags = {
     environment = var.env_id

--- a/iac/vars.tf
+++ b/iac/vars.tf
@@ -4,6 +4,12 @@ variable "env_id" {
   default     = "prod"
 }
 
+variable "public_base_domain" {
+  type        = string
+  description = "Public apex domain for this environment. Every OIDC issuer/redirect/CORS/base URL derives from it via iac/locals.tf (audit 0001 / H2). The default keeps prod byte-identical; staging sets \"staging.lotro-translator.pl\"."
+  default     = "lotro-translator.pl"
+}
+
 variable "src_key" {
   type        = string
   description = "The infrastructure source"


### PR DESCRIPTION
## What

Parametrizes the single Terraform root (`iac/`) so a **second environment (staging)** is instantiable, closing audit 0001 §H2 / §H5 / §H11 and defusing the §C5 "staging on prod state/secrets" trap. Implements **ADR-0017** (Accepted) — Rank 2 (parametrize the flat root in place), not Rank 1 (extract `modules/environment/`, deferred as YAGNI at two same-sized envs). Settles §M4 in favour of ADR-0008's two-env model; supersedes ADR-0012's "prod is de-facto staging" interim for env topology.

## Prod is provably untouched

The only prod `plan` delta is a **state-address move** + two state-only metas — **zero infrastructure change**:
- RG symbol `rg-lotrotms-prod-polc-001` → `main` migrates via a `moved {}` block; `name = "rg-lotrotms-${var.env_id}-polc-001"` evaluates **identically** for `env_id = "prod"`.
- `var.public_base_domain` default reproduces every OIDC issuer / redirect / CORS / base-URL literal **byte-for-byte** (the `iss` + `redirect_uri` must match exactly).
- `prevent_destroy` on the DP keyring storage account + the LAW workspace are state-only (no plan diff).
- The backend `key` moves from inline to `-backend-config=backend-config/prod.hcl` (same blob name `prod.terraform.tfstate`).

## Logical commits

1. **ADR-0017** — the decision record.
2. **Public origins → one var** — `var.public_base_domain` + `iac/locals.tf` deriving apex/auth/tms origins + callback (defined).
3. **Apply across the resource graph + guard state** — RG name from `env_id` (`moved {}`, 28 refs → `.main`), 10 URL literals → `local.*`, `prevent_destroy` on the two stateful resources.
4. **Per-env state via a partial backend** — drop the inline `key`; `backend-config/{prod,staging}.hcl` select it at init → separate state blobs in one container; CI inits with `-reconfigure -backend-config=backend-config/prod.hcl`.
5. **Make staging instantiable + document** — `iac/env/staging.tfvars` (names only, no secrets), `.gitignore` negation to track `iac/env/*.tfvars`, runbook per-env flow + out-of-band prerequisites.

## Staging, after this

One var-file + one state blob: `terraform init -reconfigure -backend-config=backend-config/staging.hcl && terraform apply -var-file=env/staging.tfvars`. Out-of-band prereqs (ADR-0017 §7, all data sources): a **separate** `lotrotms-kv-staging` vault with freshly-generated secrets (never the prod vault), a `lotrotms-aca-staging` identity, and a Neon `staging` branch. A staging CI job / promotion model (§H10) is separate, future work.

## Verification (local, Terraform 1.15.7 — the CI version)

- `terraform fmt -check -recursive` ✅
- `terraform init -backend=false` ✅
- `terraform validate` → **Success! The configuration is valid.** ✅

No application code touched — Terraform / CI / docs only; the three `Program.cs` stay env-name-agnostic (audit G13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
