### PR TITLE
M6-22: shared-environment mode — staging apps run in the prod ACA environment (subscription 1-env cap)

### DIFF
--- a/iac/azure-container-apps.tf
+++ b/iac/azure-container-apps.tf
@@ -1,6 +1,6 @@
 resource "azurerm_container_app" "auth_api" {
   name                         = "lotrotms-auth-api-${var.env_id}"
-  container_app_environment_id = azurerm_container_app_environment.app_env.id
+  container_app_environment_id = local.app_env_id
   resource_group_name          = azurerm_resource_group.main.name
   revision_mode                = "Multiple"
 
@@ -227,7 +227,7 @@ resource "azurerm_container_app" "auth_api" {
 
 resource "azurerm_container_app" "tms_api" {
   name                         = "lotrotms-tms-api-${var.env_id}"
-  container_app_environment_id = azurerm_container_app_environment.app_env.id
+  container_app_environment_id = local.app_env_id
   resource_group_name          = azurerm_resource_group.main.name
   revision_mode                = "Multiple"
 
@@ -360,7 +360,7 @@ resource "azurerm_container_app" "tms_api" {
 
 resource "azurerm_container_app" "frontend" {
   name                         = "lotrotms-frontend-${var.env_id}"
-  container_app_environment_id = azurerm_container_app_environment.app_env.id
+  container_app_environment_id = local.app_env_id
   resource_group_name          = azurerm_resource_group.main.name
   revision_mode                = "Multiple"
 

--- a/iac/azure-law.tf
+++ b/iac/azure-law.tf
@@ -1,4 +1,5 @@
 resource "azurerm_log_analytics_workspace" "law" {
+  count               = local.create_env ? 1 : 0
   location            = azurerm_resource_group.main.location
   name                = "lotrotmslaw${var.env_id}"
   resource_group_name = azurerm_resource_group.main.name
@@ -17,4 +18,12 @@ resource "azurerm_log_analytics_workspace" "law" {
     src         = var.src_key
     project     = "lotrotms"
   }
+}
+
+# M6-22: law gained a count for shared-environment mode (staging reuses prod's workspace), shifting
+# its address to [0]. For prod (create_env = true) the workspace is otherwise unchanged, so this is a
+# pure state-address move — never a destroy/recreate.
+moved {
+  from = azurerm_log_analytics_workspace.law
+  to   = azurerm_log_analytics_workspace.law[0]
 }

--- a/iac/azure_container_app_env.tf
+++ b/iac/azure_container_app_env.tf
@@ -1,12 +1,31 @@
 resource "azurerm_container_app_environment" "app_env" {
+  count                      = local.create_env ? 1 : 0
   location                   = azurerm_resource_group.main.location
   name                       = "lotrotmsenv${var.env_id}"
   resource_group_name        = azurerm_resource_group.main.name
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.law[0].id
 
   tags = {
     environment = var.env_id
     src         = var.src_key
     project     = "lotrotms"
   }
+}
+
+# Shared-environment mode (M6-22): when var.aca_environment_name is set, this env deploys its apps
+# into that EXISTING managed environment (the subscription caps Container App Environments at one,
+# held by prod) instead of creating its own above. Read-only; surfaced to every app/job/storage via
+# local.app_env_id.
+data "azurerm_container_app_environment" "shared" {
+  count               = local.create_env ? 0 : 1
+  name                = var.aca_environment_name
+  resource_group_name = var.aca_environment_resource_group
+}
+
+# M6-22: app_env gained a count for shared-environment mode, shifting its address to [0]. For prod
+# (create_env = true) the resource is otherwise unchanged, so this is a pure state-address move
+# (terraform plan shows a `moved`, never a destroy/recreate) — same pattern as resource-group.tf.
+moved {
+  from = azurerm_container_app_environment.app_env
+  to   = azurerm_container_app_environment.app_env[0]
 }

--- a/iac/env/staging.tfvars
+++ b/iac/env/staging.tfvars
@@ -11,3 +11,9 @@ env_id             = "staging"
 public_base_domain = "staging.lotro-translator.pl"
 key_vault_name     = "lotrotms-kv-staging"
 aca_identity_name  = "lotrotms-aca-staging"
+
+# Shared-environment mode (M6-22): the subscription allows only ONE Container App Environment total,
+# held by prod, so staging deploys its apps INTO prod's managed environment instead of creating its
+# own. These point at prod's environment (name + resource group); see iac/locals.tf (create_env).
+aca_environment_name           = "lotrotmsenvprod"
+aca_environment_resource_group = "rg-lotrotms-prod-polc-001"

--- a/iac/locals.tf
+++ b/iac/locals.tf
@@ -11,3 +11,15 @@ locals {
   tms_origin   = "https://tms.${var.public_base_domain}"
   callback_url = "${local.apex_origin}/callback"
 }
+
+locals {
+  # Shared-environment mode (M6-22). The Azure subscription allows only ONE Container App Environment
+  # total, and prod holds it. When var.aca_environment_name is set this env (staging) deploys its apps
+  # INTO that existing managed environment instead of creating its own: create_env is false, so the
+  # managed-environment + its workspace / app-insights / OTel-agent / monitoring singletons are skipped
+  # and the shared environment is data-read instead. For prod the vars are empty -> create_env = true
+  # -> every singleton is created exactly as before (byte-identical plan). app_env_id is the single
+  # knob every container app, the migrator job, and the keyring storage point at.
+  create_env = var.aca_environment_name == ""
+  app_env_id = local.create_env ? azurerm_container_app_environment.app_env[0].id : data.azurerm_container_app_environment.shared[0].id
+}

--- a/iac/migrator-job.tf
+++ b/iac/migrator-job.tf
@@ -2,7 +2,7 @@ resource "azurerm_container_app_job" "migrator" {
   name                         = "lotrotms-migrator-${var.env_id}"
   location                     = azurerm_resource_group.main.location
   resource_group_name          = azurerm_resource_group.main.name
-  container_app_environment_id = azurerm_container_app_environment.app_env.id
+  container_app_environment_id = local.app_env_id
 
   replica_timeout_in_seconds = 1800
   replica_retry_limit        = 1

--- a/iac/monitoring.tf
+++ b/iac/monitoring.tf
@@ -46,6 +46,7 @@ locals {
 # Action group — the single delivery channel for every alert. Email only (owner decision); no SMS.
 # ---------------------------------------------------------------------------------------------------
 resource "azurerm_monitor_action_group" "alerts" {
+  count               = local.create_env ? 1 : 0
   name                = "lotrotmsag${var.env_id}"
   resource_group_name = azurerm_resource_group.main.name
   # short_name shows up in the notification subject and is capped by Azure at 12 characters, so it
@@ -66,6 +67,15 @@ resource "azurerm_monitor_action_group" "alerts" {
   }
 }
 
+# M6-22: the action group gained a count for shared-environment mode — alerting belongs to the env
+# that owns the workspace, so staging (which reuses prod's environment + workspace) inherits prod's
+# alerts and creates none of its own. This shifts the address to [0]. For prod (create_env = true)
+# the resource is otherwise unchanged, so this is a pure state-address move.
+moved {
+  from = azurerm_monitor_action_group.alerts
+  to   = azurerm_monitor_action_group.alerts[0]
+}
+
 # ---------------------------------------------------------------------------------------------------
 # Metric alerts — ACA platform metrics (Microsoft.App/containerApps). Each metric is one rule fanned
 # out per app (for_each over local.monitored_container_apps), single-scope — see the local for why.
@@ -77,7 +87,7 @@ resource "azurerm_monitor_action_group" "alerts" {
 # revision resets the metric and auto-mitigates it) — read it as "this revision restarted,
 # investigate", not "restarting right now".
 resource "azurerm_monitor_metric_alert" "replica_restart" {
-  for_each            = local.monitored_container_apps
+  for_each            = local.create_env ? local.monitored_container_apps : {}
   name                = "lotrotms-alert-replica-restart-${each.key}-${var.env_id}"
   resource_group_name = azurerm_resource_group.main.name
   scopes              = [each.value]
@@ -95,7 +105,7 @@ resource "azurerm_monitor_metric_alert" "replica_restart" {
   }
 
   action {
-    action_group_id = azurerm_monitor_action_group.alerts.id
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
   }
 
   tags = {
@@ -109,7 +119,7 @@ resource "azurerm_monitor_metric_alert" "replica_restart" {
 # flow (bad credentials, expired tokens) and would only create noise. 5xx is the app failing to serve
 # — the user-visible signal worth waking up for.
 resource "azurerm_monitor_metric_alert" "http_server_errors" {
-  for_each            = local.monitored_container_apps
+  for_each            = local.create_env ? local.monitored_container_apps : {}
   name                = "lotrotms-alert-http-5xx-${each.key}-${var.env_id}"
   resource_group_name = azurerm_resource_group.main.name
   scopes              = [each.value]
@@ -133,7 +143,7 @@ resource "azurerm_monitor_metric_alert" "http_server_errors" {
   }
 
   action {
-    action_group_id = azurerm_monitor_action_group.alerts.id
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
   }
 
   tags = {
@@ -147,7 +157,7 @@ resource "azurerm_monitor_metric_alert" "http_server_errors" {
 # min=max=1 replica there is no horizontal headroom, so this is a capacity signal — investigate or
 # raise the CPU request before it throttles.
 resource "azurerm_monitor_metric_alert" "cpu_saturation" {
-  for_each            = local.monitored_container_apps
+  for_each            = local.create_env ? local.monitored_container_apps : {}
   name                = "lotrotms-alert-cpu-high-${each.key}-${var.env_id}"
   resource_group_name = azurerm_resource_group.main.name
   scopes              = [each.value]
@@ -165,7 +175,7 @@ resource "azurerm_monitor_metric_alert" "cpu_saturation" {
   }
 
   action {
-    action_group_id = azurerm_monitor_action_group.alerts.id
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
   }
 
   tags = {
@@ -179,7 +189,7 @@ resource "azurerm_monitor_metric_alert" "cpu_saturation" {
 # informational: hitting the memory limit triggers an OOM kill and a replica restart, so this is the
 # usual leading indicator of the crash-loop alert above.
 resource "azurerm_monitor_metric_alert" "memory_saturation" {
-  for_each            = local.monitored_container_apps
+  for_each            = local.create_env ? local.monitored_container_apps : {}
   name                = "lotrotms-alert-memory-high-${each.key}-${var.env_id}"
   resource_group_name = azurerm_resource_group.main.name
   scopes              = [each.value]
@@ -197,7 +207,7 @@ resource "azurerm_monitor_metric_alert" "memory_saturation" {
   }
 
   action {
-    action_group_id = azurerm_monitor_action_group.alerts.id
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
   }
 
   tags = {
@@ -218,6 +228,7 @@ resource "azurerm_monitor_metric_alert" "memory_saturation" {
 # app whose count crosses the spike threshold. This complements the metric alerts by catching
 # logged failures that never become a 5xx or a restart (e.g. a background job throwing).
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_error_spike" {
+  count               = local.create_env ? 1 : 0
   name                = "lotrotms-alert-log-error-spike-${var.env_id}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -226,7 +237,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_error_spike" {
 
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
-  scopes               = [azurerm_log_analytics_workspace.law.id]
+  scopes               = [azurerm_log_analytics_workspace.law[0].id]
   # The *_CL custom-log tables only materialise once the apps have emitted those records, which lags
   # a fresh environment's first apply. Skip create-time KQL schema validation so the alert can be
   # provisioned before any logs flow — letting a future staging inherit alerting without a
@@ -260,7 +271,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_error_spike" {
   auto_mitigation_enabled = true
 
   action {
-    action_groups = [azurerm_monitor_action_group.alerts.id]
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
   }
 
   tags = {
@@ -276,6 +287,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_error_spike" {
 # in the Operation table ("Data collection stopped due to daily limit reached" / OverQuota), so this
 # rule turns a silent blind-spot into an email. Checked hourly because the cap is a daily event.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "law_daily_cap" {
+  count               = local.create_env ? 1 : 0
   name                = "lotrotms-alert-law-daily-cap-${var.env_id}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -284,7 +296,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "law_daily_cap" {
 
   evaluation_frequency = "PT1H"
   window_duration      = "PT1H"
-  scopes               = [azurerm_log_analytics_workspace.law.id]
+  scopes               = [azurerm_log_analytics_workspace.law[0].id]
   # The *_CL custom-log tables only materialise once the apps have emitted those records, which lags
   # a fresh environment's first apply. Skip create-time KQL schema validation so the alert can be
   # provisioned before any logs flow — letting a future staging inherit alerting without a
@@ -310,7 +322,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "law_daily_cap" {
   auto_mitigation_enabled = true
 
   action {
-    action_groups = [azurerm_monitor_action_group.alerts.id]
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
   }
 
   tags = {
@@ -338,6 +350,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "law_daily_cap" {
 # The exact ACA system-log vocabulary cannot be queried from the plan sandbox — confirm/tune the
 # token set against real ContainerAppSystemLogs_CL on first apply.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "auth_availability" {
+  count               = local.create_env ? 1 : 0
   name                = "lotrotms-slo-auth-availability-${var.env_id}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
@@ -346,7 +359,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "auth_availability" {
 
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
-  scopes               = [azurerm_log_analytics_workspace.law.id]
+  scopes               = [azurerm_log_analytics_workspace.law[0].id]
   # The *_CL custom-log tables only materialise once the apps have emitted those records, which lags
   # a fresh environment's first apply. Skip create-time KQL schema validation so the alert can be
   # provisioned before any logs flow — letting a future staging inherit alerting without a
@@ -375,7 +388,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "auth_availability" {
   auto_mitigation_enabled = true
 
   action {
-    action_groups = [azurerm_monitor_action_group.alerts.id]
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
   }
 
   tags = {
@@ -383,4 +396,23 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "auth_availability" {
     src         = var.src_key
     project     = "lotrotms"
   }
+}
+
+# M6-22: the three log alerts gained a count for shared-environment mode — they query the workspace,
+# which staging reuses from prod, so staging inherits prod's log alerts and creates none of its own.
+# Each address shifts to [0]; for prod (create_env = true) the rules are otherwise unchanged, so these
+# are pure state-address moves.
+moved {
+  from = azurerm_monitor_scheduled_query_rules_alert_v2.log_error_spike
+  to   = azurerm_monitor_scheduled_query_rules_alert_v2.log_error_spike[0]
+}
+
+moved {
+  from = azurerm_monitor_scheduled_query_rules_alert_v2.law_daily_cap
+  to   = azurerm_monitor_scheduled_query_rules_alert_v2.law_daily_cap[0]
+}
+
+moved {
+  from = azurerm_monitor_scheduled_query_rules_alert_v2.auth_availability
+  to   = azurerm_monitor_scheduled_query_rules_alert_v2.auth_availability[0]
 }

--- a/iac/observability.tf
+++ b/iac/observability.tf
@@ -11,10 +11,11 @@
 # H3 — reuse the LAW, never create a second workspace). Classic (non-workspace) AI is retired by
 # Azure, so workspace_id is mandatory.
 resource "azurerm_application_insights" "app_insights" {
+  count               = local.create_env ? 1 : 0
   name                = "lotrotmsappinsights${var.env_id}"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
-  workspace_id        = azurerm_log_analytics_workspace.law.id
+  workspace_id        = azurerm_log_analytics_workspace.law[0].id
   application_type    = "web"
 
   tags = {
@@ -22,6 +23,14 @@ resource "azurerm_application_insights" "app_insights" {
     src         = var.src_key
     project     = "lotrotms"
   }
+}
+
+# M6-22: app_insights gained a count for shared-environment mode (it backs the OTel agent on the
+# environment we create, which staging skips), shifting its address to [0]. For prod (create_env =
+# true) the resource is otherwise unchanged, so this is a pure state-address move.
+moved {
+  from = azurerm_application_insights.app_insights
+  to   = azurerm_application_insights.app_insights[0]
 }
 
 # Enable the Container Apps managed OpenTelemetry agent on the managed environment. azurerm 4.7.0 has
@@ -47,8 +56,9 @@ resource "azurerm_application_insights" "app_insights" {
 # stable version once Azure GAs the agent (azapi schema-validates the body at plan, so a wrong version
 # fails the infra.yml gate loudly rather than drifting).
 resource "azapi_update_resource" "app_env_otel" {
+  count       = local.create_env ? 1 : 0
   type        = "Microsoft.App/managedEnvironments@2024-10-02-preview"
-  resource_id = azurerm_container_app_environment.app_env.id
+  resource_id = azurerm_container_app_environment.app_env[0].id
 
   body = {
     properties = {
@@ -66,8 +76,17 @@ resource "azapi_update_resource" "app_env_otel" {
   sensitive_body = {
     properties = {
       appInsightsConfiguration = {
-        connectionString = azurerm_application_insights.app_insights.connection_string
+        connectionString = azurerm_application_insights.app_insights[0].connection_string
       }
     }
   }
+}
+
+# M6-22: app_env_otel gained a count for shared-environment mode — we patch the OTel agent only onto
+# the environment we create (staging never reconfigures prod's shared environment), shifting its
+# address to [0]. For prod (create_env = true) the patch is otherwise unchanged, so this is a pure
+# state-address move.
+moved {
+  from = azapi_update_resource.app_env_otel
+  to   = azapi_update_resource.app_env_otel[0]
 }

--- a/iac/storage.tf
+++ b/iac/storage.tf
@@ -31,9 +31,15 @@ resource "azurerm_storage_share" "frontend_keys" {
   quota                = 5
 }
 
+# Both envs create their own DP-keyring storage account + shares (above, unchanged), but the
+# environment-storage link is attached to the (possibly shared) managed environment via
+# local.app_env_id. On the shared env the link name must be env-unique so staging's mount doesn't
+# collide with prod's — hence the env_id suffix when create_env is false. For prod (create_env = true)
+# the name stays "auth-keys"/"frontend-keys" and the env id is identical, so neither attribute changes
+# (no moved block needed).
 resource "azurerm_container_app_environment_storage" "auth_keys" {
-  name                         = "auth-keys"
-  container_app_environment_id = azurerm_container_app_environment.app_env.id
+  name                         = local.create_env ? "auth-keys" : "auth-keys-${var.env_id}"
+  container_app_environment_id = local.app_env_id
   account_name                 = azurerm_storage_account.keys.name
   share_name                   = azurerm_storage_share.auth_keys.name
   access_key                   = azurerm_storage_account.keys.primary_access_key
@@ -41,8 +47,8 @@ resource "azurerm_container_app_environment_storage" "auth_keys" {
 }
 
 resource "azurerm_container_app_environment_storage" "frontend_keys" {
-  name                         = "frontend-keys"
-  container_app_environment_id = azurerm_container_app_environment.app_env.id
+  name                         = local.create_env ? "frontend-keys" : "frontend-keys-${var.env_id}"
+  container_app_environment_id = local.app_env_id
   account_name                 = azurerm_storage_account.keys.name
   share_name                   = azurerm_storage_share.frontend_keys.name
   access_key                   = azurerm_storage_account.keys.primary_access_key

--- a/iac/vars.tf
+++ b/iac/vars.tf
@@ -53,3 +53,15 @@ variable "admin_email" {
   type        = string
   description = "Seeded admin email"
 }
+
+variable "aca_environment_name" {
+  type        = string
+  description = "Name of an EXISTING managed Container Apps environment to deploy this env's apps into (shared-environment mode, M6-22). Empty = create our own. Set because the Azure subscription allows only ONE Container App Environment total, held by prod — staging runs its apps inside the prod environment."
+  default     = ""
+}
+
+variable "aca_environment_resource_group" {
+  type        = string
+  description = "Resource group of the existing managed environment named by var.aca_environment_name. Empty = our own resource group."
+  default     = ""
+}


### PR DESCRIPTION
Part of #249.

## Why
The Azure subscription allows only **one** Container App Environment total, and **prod holds it**. A second environment (staging) therefore cannot create its own managed environment — it must deploy its apps **into the existing prod one**.

## What
Introduces a **shared-environment mode** to the `iac/` root, toggled by two new string vars (both `default = ""`):

- `aca_environment_name` — name of an EXISTING managed environment to deploy into (empty = create our own).
- `aca_environment_resource_group` — resource group of that environment (empty = our own RG).

`local.create_env = var.aca_environment_name == ""` drives everything; `local.app_env_id` is the single knob every container app, the migrator job, and the keyring storage point at — it resolves to the created env (`app_env[0].id`) or the data-read shared env (`data.azurerm_container_app_environment.shared[0].id`).

When `create_env` is false (staging), the managed-environment + everything that belongs to *owning* a workspace is **skipped** and the shared env is data-read instead:
- count-guarded singletons: `azurerm_container_app_environment.app_env`, `azurerm_log_analytics_workspace.law`, `azurerm_application_insights.app_insights`, `azapi_update_resource.app_env_otel`, `azurerm_monitor_action_group.alerts`, and the 3 scheduled-query log alerts (`log_error_spike`, `law_daily_cap`, `auth_availability`).
- the 4 metric alerts use `for_each` gated by `create_env` (same addresses → no `moved` needed).

The apps/job/storage are **not** guarded (staging DOES create its own apps + its own DP-keyring storage account/shares); only the two `azurerm_container_app_environment_storage` links retarget to `local.app_env_id` and take env-unique names (`auth-keys-<env>` / `frontend-keys-<env>`) so staging's mounts don't collide with prod's on the shared env.

`env/staging.tfvars` points staging at prod's `lotrotmsenvprod` / `rg-lotrotms-prod-polc-001`.

## Prod stays byte-identical
With the new vars empty, `create_env = true`: every singleton is created at index `[0]`, and a `moved { from = X to = X[0] }` block accompanies **each** count-guarded singleton (the exact pattern already used for the RG rename in `resource-group.tf`). `terraform plan` for prod therefore shows **pure state-address moves, never destroy/recreate** — and the storage link names + env id are unchanged, so those need no move. Moved-block count: **8** new (one per count-guarded singleton) + the pre-existing RG move.

## Verification
`terraform fmt -check` clean, `terraform init -backend=false` + `terraform validate` → **"Success! The configuration is valid."** (no `plan`/`apply` — no backend/state access; CI verifies the prod plan.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)