### PR TITLE
M6-23: shared-env doc/ADR sync + OTel apply fix (#246 LogAnalyticsConfiguration)

### DIFF
--- a/docs/adr/0018-staging-environment-and-two-stage-promotion.md
+++ b/docs/adr/0018-staging-environment-and-two-stage-promotion.md
@@ -1,0 +1,138 @@
+# ADR-0018: Staging environment & two-stage promotion (staging auto → prod gated)
+
+**Status:** Accepted
+**Date:** 2026-06-30 (amended 2026-07-01 — shared-environment reality)
+**Decision-makers:** Solo maintainer
+**Related:** audit 0001 §H10 (staging CI / promotion model — was future work), §C5 (isolation);
+ADR-0017 (per-env IaC parametrization — made staging *instantiable*), ADR-0012 (CD — single
+`production` gate), ADR-0008 (cloud-agnostic deployment + the two-environment intent), ADR-0013 (Key
+Vault per-env secrets), ADR-0016 (env_id-parametrized telemetry / the OTel agent)
+
+## Context
+
+ADR-0008 §1 committed to **two environments — staging + production**. ADR-0017 closed the IaC half
+(parametrized root, per-env state blob, `env/staging.tfvars`) but deferred the **CI / promotion model**
+(§H10). This ADR delivers it: a real **staging** environment fed by CI/CD with a **promotion** boundary
+to production.
+
+A hard external constraint, discovered while building it, shapes the topology: the **"Azure for
+Students" subscription permits exactly ONE Container Apps Environment in the whole subscription** — not
+one *per region*. Both `MaxNumberOfRegionalEnvironmentsInSubExceeded` (a second env in Poland Central)
+**and** `MaxNumberOfGlobalEnvironmentsInSubExceeded` (a second env in Germany West Central) were hit, so
+a region change does not help. Prod holds the one environment (`lotrotmsenvprod`, Poland Central).
+A *separate* staging environment is therefore impossible on this subscription.
+
+Other constraints: prod must stay behavior-identical; secrets stay per-env in Key Vault (ADR-0013); the
+staging DB is a separate Neon project (full DB isolation).
+
+## Decision
+
+### 1. Build-once, promote-the-artifact
+
+`cd.yml` builds the four images **once** (`build-and-push`, unchanged), then:
+
+```
+deploy-staging   env: staging      AUTO   (no protection rule)         needs: build-and-push
+deploy-prod      env: production    GATED  (required reviewer)          needs: deploy-staging
+```
+
+The **`production` approval gate IS the staging→prod promotion**: the exact `sha-<short>` that passed
+the staging rollout + smoke is what a human promotes. There is no separate prod build.
+
+### 2. Staging shares the production ACA environment (forced by the 1-env cap)
+
+Staging is **not** a separate Container Apps Environment. Its apps
+(`lotrotms-{auth-api,tms-api,frontend}-staging`) + `lotrotms-migrator-staging` run **inside**
+`lotrotmsenvprod`, referenced by id. What stays **separate and isolated** for staging: the three apps
+(own revisions/scaling/ingress), the **separate Neon project** (`lotro_translation` + `lotro_auth`),
+`lotrotms-kv-staging` + `lotrotms-aca-staging` identity + its 8 secrets, the custom domains
+`*.staging.lotro-translator.pl`, and the Data-Protection keyring (own storage account + env-storage
+links named `auth-keys-staging` / `frontend-keys-staging` on the shared env). What is **shared** with
+prod: the ACA environment itself, its Log Analytics workspace, and the managed OTel agent → prod's
+Application Insights (telemetry co-mingled, distinguishable by app name). The resource group, Key Vault
+and identity stay in Poland Central.
+
+This is weaker than a fully separate environment (shared env infra + telemetry sink), but the isolation
+that matters for a QA tier — data, secrets, images, domains — is preserved; an app in `staging` cannot
+reach prod's database or secrets.
+
+### 3. IaC: a "shared-environment" mode in the flat root (no module, no copy)
+
+New `var.aca_environment_name` / `var.aca_environment_resource_group` (default `""` = create our own).
+`local.create_env = var.aca_environment_name == ""`; `local.app_env_id` resolves to either the created
+env or a `data.azurerm_container_app_environment` of the shared one. The environment, Log Analytics,
+App Insights, the OTel agent and all of `monitoring.tf` are **`count`-guarded on `create_env`**, each
+with a `moved {}` block (the ADR-0017 RG-rename pattern) so the **prod plan shows state moves only —
+zero infrastructure change**. The apps + migrator + the env-storage links point at `local.app_env_id`;
+the env-storage names carry the `env_id` suffix only for the shared case so they never collide with
+prod's on the same environment. (ADR-0017's Rank-1 module extraction is still deferred — this is the
+minimal conditional that the 1-env cap forced.)
+
+### 4. `infra.yml` mirrors the same promotion; `STAGING_ENABLED` makes it safe
+
+`plan` runs a prod+staging matrix on PRs; on push to main `apply-staging` (auto) → `apply-prod` (gated),
+on separate state blobs. A repo variable **`STAGING_ENABLED`** (default false) gates the staging legs
+alongside `CD_ENABLED`; while false, staging is skipped and prod deploys/applies **exactly as before**
+(`deploy-prod`/`apply-prod` use `always()` + a `(success||skipped)` guard tolerating a skipped staging).
+Flipping it to true turns on staging-auto and makes prod a true gated promotion.
+
+### 5. Out-of-band prerequisites (separate from prod, §C5)
+
+A separate `lotrotms-kv-staging` + `lotrotms-aca-staging` (seeded by `scripts/seed-keyvault.sh` with
+`KV_*` overrides), a separate **Neon project** (two DBs), a `gh-env-staging` federated credential +
+`Contributor` on `rg-lotrotms-staging-polc-001`, the `staging` GitHub environment + env-scoped `vars`,
+and the custom-domain bindings (asuid TXT + CNAME/A → the shared env's IP/FQDNs). The staging RG was
+pre-created and imported into the staging state.
+
+## Consequences
+
+### Positive
+
+- A real two-environment promotion within a free subscription: every green-CI commit auto-validates on
+  a prod-adjacent staging tier, and prod releases are a one-click promotion of an already-verified
+  artifact. Verified end-to-end: a green `deploy-staging` left `deploy-prod` `waiting` for approval, and
+  a red staging smoke left `deploy-prod` `skipped`.
+- Strong isolation where it matters (separate Neon project, KV, identity, apps, domains, state blob).
+- Prod is provably untouched at merge time (the `STAGING_ENABLED`-false path) and one source of truth
+  for the rollout (`deploy.yml`).
+
+### Negative / Accepted Trade-offs
+
+- **Shared ACA environment + Log Analytics + telemetry** with prod — staging logs/traces co-mingle in
+  prod's App Insights (filter by app name). Forced by the 1-env cap, not chosen. Revisit if a second
+  subscription (or a paid plan lifting the cap) becomes available — `create_env` makes a true split a
+  var-file change.
+- The flat-root conditionals (`count` + `moved` across env/LAW/AI/OTel/monitoring) add surgery to the
+  prod state addresses; accepted via the proven ADR-0017 `moved {}` pattern (prod plan: 0 change).
+- A separate Neon project does not share prod data — intentional.
+
+## Alternatives Considered
+
+- **Separate ACA environment for staging** (the original intent) — *impossible* on this subscription
+  (1-env global cap; a region change to Germany West Central also failed). Would need a second
+  subscription (real cost) — rejected for now.
+- **A separate subscription** for staging — full isolation but real monthly cost; deferred.
+- **Local-only staging** (`compose.prod.yaml` parity) — loses the deployed-staging + auto-CD the goal
+  requires; rejected.
+- **Independent (non-promotion) gates / Neon branch / workspaces / `iac-staging` copy** — rejected as in
+  ADR-0017 (weaker isolation / drift / loses the build-once guarantee).
+
+## Implementation Notes
+
+- **New:** `.github/workflows/deploy.yml` (reusable rollout, `environment` input); this ADR.
+- **Changed:** `cd.yml` (env-scoped vars/secrets; `deploy-staging` + `deploy-prod` callers);
+  `infra.yml` (plan matrix + `apply-staging`→`apply-prod`); `iac/` shared-env mode
+  (`var.aca_environment_*`, `local.create_env`/`app_env_id`, `count`+`moved` on
+  env/LAW/AI/OTel/monitoring, env-storage suffix, apps/migrator → `local.app_env_id`);
+  `iac/observability.tf` OTel azapi patch re-supplies `appLogsConfiguration` (the #246 prod-apply fix);
+  `docs/deployment/runbook.md`.
+- **Unchanged (deliberately):** `gate` + `build-and-push`; the health-gated rollout steps (verbatim in
+  `deploy.yml`); the ADR-0013 KV model; the three `Program.cs` (env-name-agnostic).
+- **Supersession:** ADR-0012's single-gate model is generalized to the two-stage promotion; ADR-0008's
+  two-env intent is now real end-to-end; ADR-0017 §H10 is closed.
+
+## References
+
+- `docs/audits/0001-infrastructure-audit.md` — §H10, §C5
+- ADR-0017 — per-environment IaC parametrization (the foundation this builds on)
+- ADR-0012 / ADR-0008 / ADR-0013 / ADR-0016 — CD pipeline / env strategy / KV secrets / OTel agent

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -364,6 +364,15 @@ arrive as `TF_VAR_*`. See [Staging bring-up](#staging-bring-up) for the full ord
 
 First-time sequence for the `staging` environment. Prerequisite: complete the [one-time operator setup](#one-time-operator-setup) steps 1–7 (federated credential `gh-env-staging`, `Contributor` on `rg-lotrotms-staging-polc-001`, GitHub `staging` environment with env-scoped variables).
 
+> ⚠️ **Staging shares the production ACA Environment** (ADR-0018). The "Azure for Students" subscription
+> permits only **one Container Apps Environment in the whole subscription**, so `env/staging.tfvars` sets
+> `aca_environment_name = "lotrotmsenvprod"` / `aca_environment_resource_group = "rg-lotrotms-prod-polc-001"`
+> and the staging apply creates **only** the staging apps + migrator + DP-keyring storage + env-storage
+> links **inside the prod environment** — it does NOT create an environment, Log Analytics, App Insights,
+> the OTel agent or alerts (those are `count = 0` for the shared case). Everything else stays separate
+> (apps, the Neon project, KV + identity, custom domains). The shared env's default domain and
+> `customDomainVerificationId` are the **prod** ones (the same token for all three subdomains).
+
 **1 — Seed the staging Key Vault** (a *separate* vault from prod — audit §C5):
 
 ```bash
@@ -413,13 +422,21 @@ az containerapp hostname bind \
 
 The `bind` command outputs the **domain validation token** needed for the TXT record in step 4. Collect all three tokens before adding DNS records.
 
-**4 — Add DNS records at the registrar.** For each app add a CNAME and a matching TXT verification record (exact ACA default domain and validation tokens come from step 3):
+**4 — Add DNS records at the registrar.** The two subdomains are CNAMEs to their app FQDN; the apex-of-the-tier
+`staging.lotro-translator.pl` is an **A record to the environment's static IP** (it has children
+`auth.staging` / `tms.staging`, so it cannot be a CNAME), exactly like the prod apex. The `asuid` TXT is the
+env's `customDomainVerificationId` — **one value, the same for all three** (shared env). The app FQDN is
+`<app>.<prod-env-default-domain>` (the shared prod env), the env IP is its `staticIp`
+(`az containerapp env show -n lotrotmsenvprod -g rg-lotrotms-prod-polc-001 --query "{ip:properties.staticIp,domain:properties.defaultDomain}"`):
 
-| App | CNAME record | TXT verification record |
+| Host | Record | Value |
 |---|---|---|
-| auth-api (`lotrotms-auth-api-staging`) | `auth.staging.lotro-translator.pl → <app>.<aca-env-default-domain>` | `asuid.auth.staging.lotro-translator.pl = <validation-token>` |
-| tms-api (`lotrotms-tms-api-staging`) | `tms.staging.lotro-translator.pl → <app>.<aca-env-default-domain>` | `asuid.tms.staging.lotro-translator.pl = <validation-token>` |
-| frontend (`lotrotms-frontend-staging`) | `staging.lotro-translator.pl → <app>.<aca-env-default-domain>` | `asuid.staging.lotro-translator.pl = <validation-token>` |
+| `auth.staging.lotro-translator.pl` | CNAME | `lotrotms-auth-api-staging.<prod-env-default-domain>` |
+| `tms.staging.lotro-translator.pl` | CNAME | `lotrotms-tms-api-staging.<prod-env-default-domain>` |
+| `staging.lotro-translator.pl` | A | `<env staticIp>` |
+| `asuid.{,auth.,tms.}staging.lotro-translator.pl` | TXT (×3) | `<customDomainVerificationId>` |
+
+Bind the apex with `--validation-method HTTP` (A record), the two subdomains with `--validation-method CNAME`.
 
 **5 — Verify staging** with the smoke test:
 

--- a/iac/observability.tf
+++ b/iac/observability.tf
@@ -75,6 +75,19 @@ resource "azapi_update_resource" "app_env_otel" {
 
   sensitive_body = {
     properties = {
+      # #246 fix (M6-23): the 2024-10-02-preview managedEnvironments PATCH re-validates the WHOLE
+      # resource, and the environment's existing appLogsConfiguration round-trips without the
+      # write-only logAnalyticsConfiguration.sharedKey — so a body that omits it fails apply with
+      # `400 LogAnalyticsConfiguration is invalid. Must provide a valid LogAnalyticsConfiguration`.
+      # Re-supply the SAME workspace (customerId + sharedKey) so the existing log-analytics destination
+      # stays valid while the OTel agent is added; this changes no destination, only re-asserts it.
+      appLogsConfiguration = {
+        destination = "log-analytics"
+        logAnalyticsConfiguration = {
+          customerId = azurerm_log_analytics_workspace.law[0].workspace_id
+          sharedKey  = azurerm_log_analytics_workspace.law[0].primary_shared_key
+        }
+      }
       appInsightsConfiguration = {
         connectionString = azurerm_application_insights.app_insights[0].connection_string
       }


### PR DESCRIPTION
Part of #249 (epic). Closes the shared-environment doc gap + fixes the OTel prod-apply failure found while checking the pipelines.

**ADR-0018** (added here, corrected from the #256 draft): records the real topology — the "Azure for Students" subscription caps at **ONE Container Apps Environment globally** (both regional + global 409s hit), so staging apps run **inside** `lotrotmsenvprod`. Separate: apps, Neon project, KV+identity, domains; shared: env + LAW + telemetry. Documents `create_env`/`app_env_id` + the `moved {}` pattern + the region-pivot history.

**runbook** — staging bring-up corrected: shared-env callout, apex `staging` as an **A record** to the env static IP (subdomains stay CNAME), one `customDomainVerificationId` for all three.

**`iac/observability.tf` — OTel apply fix (#246).** The `2024-10-02-preview` `managedEnvironments` PATCH re-validates the whole resource; the env's `appLogsConfiguration` round-trips without the write-only `logAnalyticsConfiguration.sharedKey`, so the OTel patch failed with `400 LogAnalyticsConfiguration is invalid` (this is why `apply-prod` went red — prod never had OTel since #246). Re-supply the same LAW (customerId + sharedKey) so the existing log destination stays valid while the agent is added. **No destination change** — only re-asserts the current workspace. Validated on the next **gated** prod apply (your approval is the checkpoint).

`terraform fmt -check` + `validate` pass. Closes #256 (its ADR draft is superseded here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)