### PR TITLE
ci(cd): GHA cache export non-fatal (ignore-error) + docs: README platform overview

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -253,8 +253,14 @@ jobs:
             BUILD_CONFIGURATION=Release
           # Per-image GHA layer cache so unchanged layers (restore/build) are reused across runs,
           # keeping rebuilds fast. Scoped per image so the four builds don't clobber each other.
+          # ignore-error=true: the cache EXPORT is a build-speed optimization, not a correctness step —
+          # by the time layers export, the image is already built AND pushed to GHCR. The GHA cache
+          # backend intermittently 404s a single large-layer blob under API throttling (moby/buildkit
+          # #2408/#2276/#2804); that blip must not fail the job and block the deploy. It did once — run
+          # 28515436800, tms-api leg only, while the three sibling legs exported the same cache fine at
+          # the same moment. A flake now degrades to a warning and the next run re-exports the cache.
           cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }},ignore-error=true
           # Attach build attestations to the image in GHCR (audit 0001 H9): SLSA provenance (build
           # inputs/invocation) + an SPDX SBOM (package inventory for CVE triage). These ride along as
           # OCI referrer manifests, so the push is an image INDEX — the linux/amd64 runtime manifest

--- a/README.md
+++ b/README.md
@@ -1,233 +1,229 @@
-# LOTRO Polish Patcher
+# LOTRO Polish Translation Platform
 
-Narzedzie do wstrzykiwania polskich tlumaczen do plikow DAT gry Lord of the Rings Online.
+> An end-to-end platform that lets a community translate **The Lord of the Rings Online** into
+> Polish: a web-based **Translation Management System** for the editorial workflow, plus a
+> game-patching **CLI** that injects the approved translation back into the game.
 
-**Status:** CLI (`export` / `patch` / `launch`) dziala i jest przetestowane na zywych
-aktualizacjach gry. W budowie: webowa platforma do zarzadzania tlumaczeniami
-(Web API + Blazor SSR + PostgreSQL + OpenIddict).
+![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
+![C# 13](https://img.shields.io/badge/C%23-13-239120?logo=csharp&logoColor=white)
+![Blazor SSR](https://img.shields.io/badge/Blazor-Static%20SSR-5C2D91?logo=blazor&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-EF%20Core-4169E1?logo=postgresql&logoColor=white)
+![OpenIddict](https://img.shields.io/badge/Auth-OpenIddict%20OIDC-FF6F00)
+![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)
+![Terraform](https://img.shields.io/badge/IaC-Terraform-7B42BC?logo=terraform&logoColor=white)
+![Azure](https://img.shields.io/badge/Cloud-Azure%20Container%20Apps-0078D4?logo=microsoftazure&logoColor=white)
 
-## Wymagania
+**🔗 Live:** https://lotro-translator.pl &nbsp;·&nbsp; **Staging:** https://staging.lotro-translator.pl
 
-- Windows (x86/x64)
-- [.NET 10 Runtime x86](https://dotnet.microsoft.com/download/dotnet/10.0) (sam runtime, nie SDK)
-- Zainstalowane LOTRO
+---
 
-## Szybki start
+## Overview
 
-### Dla deweloperow (z kodem zrodlowym)
+The Lord of the Rings Online has no official Polish localization. Historically, the only way to play
+in Polish was to hand-edit the game's **binary `DAT` files** — fragile, solitary work that is easy to
+corrupt and breaks on every game patch. This project turns that into a proper, collaborative pipeline.
 
-1. Zainstaluj [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
-2. Umiesc plik tlumaczen w `translations/` (np. `translations/polish.txt`)
-3. Odpal:
+It is built as **two cooperating products** that share a single versioned file contract — not code:
 
-```
-patch.bat polish
-```
+1. **Translation Management System (TMS)** — a web platform where translators import the game's
+   English texts, translate them with a review/approval workflow, and the system publishes a
+   ready-to-apply translation file. *(Sections below, top.)*
+2. **Patcher** — a command-line tool that exports the English texts from the game, downloads the
+   approved Polish file from the TMS, injects it back into the `DAT`, and launches the game.
+   *(Section at the bottom.)*
 
-Patcher automatycznie znajdzie instalacje LOTRO i spatchuje plik DAT.
+> **For reviewers:** this is a from-scratch, production-deployed **.NET 10** system used to
+> demonstrate Domain-Driven Design, Vertical Slice Architecture, CQRS, a Result-monad error model,
+> a self-hosted OAuth2/OIDC server, Blazor static SSR, reverse-engineered binary-format handling,
+> and full Infrastructure-as-Code + CI/CD on Azure. Architecture notes are in each section and in
+> [`docs/`](docs/).
 
-### Dla uzytkownikow (samo exe)
+### How it works — the core loop
 
-1. Zainstaluj [.NET 10 Runtime x86](https://dotnet.microsoft.com/download/dotnet/10.0)
-2. Pobierz cala zawartosc katalogu `bin/Debug/net10.0-windows/` (exe + wszystkie DLL)
-3. Umiesc plik tlumaczen w katalogu `translations/`
-4. Odpal z konsoli:
+```mermaid
+flowchart LR
+    DAT[("LOTRO<br/>DAT files")]
+    CLI["Patcher CLI<br/>(export · patch · launch)"]
+    TMS["TMS Web API<br/>+ PostgreSQL"]
+    PORTAL["Blazor SSR<br/>translator portal"]
 
-```
-LotroKoniecDev.exe patch polish
-```
-
-## Komendy
-
-### Patchowanie (wstrzykiwanie tlumaczen)
-
-```
-patch.bat <nazwa>
-```
-
-`<nazwa>` to nazwa pliku w `translations/` bez rozszerzenia `.txt`:
-
-```
-patch.bat example_polish    ->  translations/example_polish.txt
-patch.bat polish            ->  translations/polish.txt
-```
-
-Mozna tez podac pelna sciezke do tlumaczenia i/lub do pliku DAT:
-
-```
-patch.bat polish C:\sciezka\do\client_local_English.dat
-patch.bat C:\moje_tlumaczenia\quest1.txt
+    DAT -- "1 · export English texts" --> CLI
+    CLI -- "2 · exported.txt → import" --> TMS
+    TMS --- PORTAL
+    PORTAL -- "3 · translate · review · approve" --> TMS
+    TMS -- "4 · publish polish.txt" --> CLI
+    CLI -- "5 · inject Polish + launch game" --> DAT
 ```
 
-### Auto-discovery instalacji LOTRO
+When the game updates, the new English export is re-imported: texts whose English source changed are
+automatically **invalidated** (flagged *needs review*) and **excluded** from the published file until
+a translator re-approves them — so the game never shows a stale Polish line for changed content.
 
-Jesli nie podasz sciezki do pliku DAT, patcher automatycznie szuka instalacji LOTRO:
+---
 
-1. Domyslna sciezka SSG: `C:\Program Files (x86)\StandingStoneGames\The Lord of the Rings Online\`
-2. Steam: `C:\Program Files (x86)\Steam\steamapps\common\The Lord of the Rings Online\`
-3. Rejestr Windows (klucze StandingStoneGames / Turbine)
-4. Full scan dyskow (jesli nic nie znaleziono wyzej)
-5. Lokalne `data/client_local_English.dat` (fallback)
+## Translation Management System (TMS)
 
-Jesli znajdzie wiele instalacji (np. Live + Bullroarer), zapyta ktora wybrac.
+The web application at the heart of the project — where the human translation work happens.
 
-### Pre-flight checks
+### What a translator can do
 
-Przed patchowaniem automatycznie:
-- Sprawdza czy LOTRO jest uruchomione (plik DAT moze byc zablokowany)
-- Sprawdza uprawnienia do zapisu (Program Files wymaga admina)
-- Tworzy backup pliku DAT (`.backup`)
+- **Import** a version-bound game export (`exported.txt`). The import runs a **diff** against the
+  existing catalog and reports exactly what changed: *added / English-changed / invalidated /
+  removed / unchanged*.
+- **Browse, search and filter** the whole catalog — by English or Polish text, and by status
+  (*untranslated · draft · approved · needs review*) — with pagination.
+- **Translate** in a **side-by-side editor**: read-only English on the left, the Polish translation
+  on the right, with live validation of the `<--DO_NOT_TOUCH!-->` argument placeholders (so dynamic
+  values like player names or item counts are never broken).
+- **Review & approve**: approving a translation publishes it into the distributed file; changed
+  English re-opens a row for review.
+- **Track game versions**: the catalog is bound to a LOTRO version; admins register versions
+  manually *(automatic detection from the official forum is on the roadmap)*.
+- **Export / download** the approved `polish.txt` in one click — the same artifact the Patcher CLI
+  pulls automatically (served with `ETag`/`304` caching).
+- See a **progress dashboard**, behind **authentication with roles** (translator / admin).
 
-### Eksport tekstow z gry
+### Architecture & engineering
 
-```
-export.bat
-```
+| Area | Choice |
+|---|---|
+| **Language / runtime** | .NET 10, C# 13, ASP.NET Core Minimal APIs |
+| **Application architecture** | **Vertical Slice Architecture** — one feature = endpoint + command/query + handler; **no MediatR** (a small in-house messaging abstraction instead — [ADR-0001](docs/adr)) |
+| **Domain** | **DDD** aggregates + value objects (no primitive obsession); business failures are **values, not exceptions** (a `Result`/`Error` monad) |
+| **Persistence** | **PostgreSQL** + EF Core (Fluent API only); **CQRS** read/write split — queries read POCO read-models, commands mutate aggregates via repositories + unit of work |
+| **Authentication** | self-hosted **OpenIddict** authorization server (OAuth2 / OIDC, authorization-code + PKCE, refresh tokens, JWKS); the API is a JWT-bearer resource server; translators are provisioned lazily on first authenticated request |
+| **Frontend** | **Blazor static SSR** (no WebAssembly, no SignalR circuit) as an **OIDC relying party** with silent token refresh; a **HATEOAS**-driven UI where the server's link relations decide which actions a user sees |
+| **Bounded contexts** | TMS and Patcher integrate **only** through the versioned `\|\|` translation-file contract — round-trip-tested against golden fixtures on both sides, so the format can never drift unnoticed |
+| **Observability & ops** | Serilog + OpenTelemetry; **Docker**; **Terraform** IaC; **GitHub Actions** CI/CD to **Azure Container Apps** with a gated **staging → production** promotion |
+| **Quality gates** | zero-warning builds (`TreatWarningsAsErrors`), ADR-driven decisions, spec-first features, secret scanning (pre-commit gitleaks + CI + GitGuardian), and a layered test suite (unit · integration on real PostgreSQL · Playwright browser E2E) |
 
-Eksportuje wszystkie teksty z pliku DAT do `data/exported.txt`. Przydatne jako baza do tlumaczenia.
-
-### Launch (patch + uruchomienie gry)
-
-```
-LotroKoniecDev.exe launch polish
-```
-
-Sprawdza hash pliku tlumaczen, patchuje tylko jesli tlumaczenia sie zmienily, po czym uruchamia
-launcher LOTRO. Testy na zywo wykazaly, ze tlumaczenia przezywaja aktualizacje gry — to zalecany
-sposob codziennego grania.
-
-### lotro.bat (alternatywa manualna)
-
-```
-lotro.bat
-```
-
-Starszy helper: ustawia plik DAT na read-only, uruchamia launcher LOTRO, a po zamknieciu gry
-przywraca zapis. Ochrona read-only okazala sie w testach zbedna (tlumaczenia przezywaja
-aktualizacje bez niej) — preferuj komende `launch`.
-
-Mozna podac sciezke do instalacji: `lotro.bat "D:\Games\LOTRO"`
-
-## Format pliku tlumaczen
-
-Pliki `.txt` w katalogu `translations/`. Kazda linia to jedno tlumaczenie:
+### Repository layout
 
 ```
-file_id||gossip_id||przetlumaczony_tekst||args_order||args_id||approved
+src/
+  TranslationSystem/   TMS — Primitives · Domain · ReadModels · Persistence · Contracts · API
+  AuthSystem/          self-hosted OpenIddict + ASP.NET Identity authorization server
+  Frontend/            Blazor static-SSR translator portal (OIDC relying party)
+  SharedKernel/        Result/Maybe monads, building blocks, in-house messaging abstraction
+  Patcher/             game-side CLI — Cli · Application · Domain · Infrastructure · Primitives
+  Utilities/           small shared helpers
+tests/                 Unit · Integration (real PostgreSQL) · E2E (CLI + Playwright browser)
+docs/                  API · domain · invariants · ADRs · specs · deployment runbook · knowledge base
 ```
 
-Przyklady:
+### Run the TMS locally (dev)
+
+The dev loop is **infrastructure in Docker + the three apps on the host** (fast hot-reload, no image
+rebuilds):
+
+```bash
+scripts/up.sh                     # boots Postgres + migrator + Mailpit + Aspire dashboard
+                                  #   (Windows: scripts/up.ps1)
+dotnet dev-certs https --trust    # one-time, so the host serves trusted HTTPS
+
+# then start the three apps (Rider compound ".run/TMS dev (all hosts)", or individually):
+dotnet run --project src/AuthSystem/LotroKoniecDev.AuthSystem.API                # https://localhost:5003
+dotnet run --project src/TranslationSystem/LotroKoniecDev.TranslationSystem.API  # https://localhost:5002
+dotnet run --project src/Frontend/LotroKoniecDev.Frontend                        # https://localhost:7017
+```
+
+```bash
+dotnet build LotroKoniecDev.slnx   # zero-warning build gate
+dotnet test                        # everything runnable on this OS
+```
+
+Full operator procedure (environment-variable matrix, secret generation, bring-up sequence, DB
+migrations) lives in [`docs/deployment/runbook.md`](docs/deployment/runbook.md). A separate
+production-parity stack runs via `scripts/up-prod.sh` (`compose.prod.yaml`).
+
+### Documentation
+
+Generated **from the code** (the code is the source of truth):
+
+- [`docs/API.md`](docs/API.md) — full HTTP API reference: every `/api/v1/...` endpoint, authorization
+  policies, request/response shapes, status codes + `ProblemDetails`, and the translation-file
+  distribution endpoint (`ETag`/`304`).
+- [`docs/DOMAIN.md`](docs/DOMAIN.md) — a tour of the domain model: aggregates (`Translation`,
+  `GameVersion`, `Translator`), value objects, the update/invalidation lifecycle, and the CQRS split.
+- [`docs/INVARIANTS.md`](docs/INVARIANTS.md) — catalogue of enforced business rules, each tagged
+  *domain* / *application* with a `file:line` anchor.
+- [`docs/auth-tutorial.md`](docs/auth-tutorial.md) — authentication end-to-end (OpenIddict server,
+  JWT-bearer resource server, JWKS, lazy translator provisioning, roles & policies).
+- [`docs/adr/`](docs/adr) — architecture decision records · [`docs/specs/`](docs/specs) — feature
+  specs · [`docs/knowledge-base/`](docs/knowledge-base) — empirical findings about the DAT format and
+  how translations survive game updates.
+
+---
+
+## The Patcher (game-side CLI)
+
+A shipped, empirically-proven command-line tool that reads and writes LOTRO's binary `DAT` files. It
+is the bridge between the game on a player's machine and the translation file the TMS produces.
+
+### What it does
+
+- **`export`** — pulls every English text out of the game's `DAT` file into `data/exported.txt`
+  (the starting point for translation; this is what gets imported into the TMS).
+- **`patch`** — injects a Polish translation file back into the `DAT`.
+- **`launch`** — hashes the translation file, re-patches **only if it changed**, then starts the
+  game. Live testing across real game updates (including a major 47.2 → 48.0 patch) proved that
+  translations survive updates, so this is the recommended day-to-day command.
+- The CLI can **auto-download** the latest approved file from the TMS (`ETag`-cached), so players
+  always get the current translation without manual steps.
+
+It also **auto-discovers** the LOTRO install (default Standing Stone Games path, Steam, the Windows
+registry, then a disk scan), runs **pre-flight checks** (game not running, write permissions,
+automatic `.backup` of the `DAT`), and maps failures to clear exit codes.
+
+### Requirements & usage
+
+- **Windows** (x86/x64), [.NET 10 Runtime x86](https://dotnet.microsoft.com/download/dotnet/10.0),
+  and an installed copy of LOTRO. Writing into `Program Files` needs administrator rights.
+
+```bash
+export.bat                 # game DAT  → data/exported.txt
+patch.bat polish           # translations/polish.txt → game DAT
+LotroKoniecDev.exe launch polish   # hash-check → patch if changed → launch the game
+```
+
+`patch.bat <name>` resolves `translations/<name>.txt`; you can also pass an explicit translation
+path and/or an explicit `DAT` path. A `.backup` of the `DAT` is written next to the original — to
+revert, copy it back over `client_local_English.dat`.
+
+### Translation file format (the inter-context contract)
+
+Each line is one translation; `#` starts a comment:
 
 ```
-# Prosty tekst (bez argumentow):
-620756992||1001||Witaj w Srodziemiu!||NULL||NULL||1
+file_id||gossip_id||translated_text||args_order||args_id||approved
+```
 
-# Tekst z argumentem (np. imie gracza):
+```
+# Simple text:
+620756992||1001||Witaj w Śródziemiu!||NULL||NULL||1
+
+# Text with a dynamic argument (e.g. a player name):
 620756992||1002||Witaj, <--DO_NOT_TOUCH!-->!||1||1||1
 
-# Tekst z wieloma argumentami:
-620756992||1003||Masz <--DO_NOT_TOUCH!--> zlota i <--DO_NOT_TOUCH!--> srebra.||1-2||1-2||1
-
-# Zmieniona kolejnosc argumentow (oryg: "Level {0}: {1}" -> "Poziom {1}: {0}"):
+# Reordered arguments ("Level {0}: {1}" → "Poziom {1}: {0}"):
 620756992||1004||Poziom <--DO_NOT_TOUCH!-->: <--DO_NOT_TOUCH!-->||2-1||1-2||1
 ```
 
-Zasady:
-- Linie zaczynajace sie od `#` sa ignorowane (komentarze)
-- Puste linie sa ignorowane
-- `<--DO_NOT_TOUCH!-->` to placeholdery na argumenty gry - nie zmieniaj ich
-- `args_order` - kolejnosc argumentow w tlumaczeniu (np. `2-1` zamienia kolejnosc)
-- `args_id` - ID argumentow z oryginalu
-- `approved` - `1` = zatwierdzone
+`<--DO_NOT_TOUCH!-->` marks a game-supplied argument and must be kept verbatim; `args_order`
+reorders arguments (`NULL` or e.g. `2-1`); `approved` is `1` when the line is approved. Changing this
+format requires an ADR and updated golden fixtures in **both** the Patcher and the TMS.
 
-## Struktura projektu
+---
 
-```
-LotroKoniecDev/
-  translations/                    # Pliki tlumaczen
-    example_polish.txt             # Przyklad
-  data/                            # Lokalna kopia DAT (fallback)
-  src/
-    Patcher/                       # Patcher (CLI) - warstwy Clean Architecture
-      LotroKoniecDev.Cli/            # CLI (punkt wejscia)
-      LotroKoniecDev.Application/    # Use case'y (slim handlery)
-      LotroKoniecDev.Domain/         # Model domenowy, Result
-      LotroKoniecDev.Infrastructure/ # Obsluga plikow DAT (natywne DLL)
-      LotroKoniecDev.Primitives/     # Stale i enumy
-    SharedKernel/ TranslationSystem/ AuthSystem/ Frontend/ Utilities/   # TMS (M2+)
-  tests/                           # Unit / Infrastructure / E2E
-  patch.bat / export.bat / lotro.bat
-```
+## Project status & roadmap
 
-## Przywracanie oryginalu
+Pre-release, actively developed. The Patcher (**M1**) is shipped and proven on live game updates. The
+TMS backend (**M2**) and the Blazor frontend (**M3**) are built and **deployed** (see the live link
+above). A native **WPF desktop player** (M4) — a GUI over the same patcher engine and TMS download —
+is planned. Backlog and milestones: GitHub issues (`M{milestone}-{nn}` titles).
 
-Backup pliku DAT jest tworzony automatycznie z rozszerzeniem `.backup` obok oryginalu. Aby przywrocic oryginal, skopiuj backup z powrotem na `client_local_English.dat`.
+## License & disclaimer
 
-## Lokalne uruchomienie backendu TMS (dev)
-
-Petla deweloperska TMS to **infra w Dockerze + trzy aplikacje na hoscie** (ADR-0006, zmieniony przez
-#190 / M6-14). `compose.yaml` uruchamia wylacznie infrastrukture: postgres + migrator + mailpit +
-aspire-dashboard. Aplikacje (auth-api, tms-api, frontend) odpalasz na hoscie — szybki hot reload,
-breakpointy, bez przebudowy obrazow.
-
-```bash
-scripts/up.sh                       # PowerShell: scripts/up.ps1 — startuje infrastrukture + migrator
-dotnet dev-certs https --trust      # jednorazowo, aby host serwowal zaufane HTTPS
-
-# trzy hosty naraz: kompound Rider "TMS dev (all hosts)", albo kazdy osobno:
-dotnet run --project src/AuthSystem/LotroKoniecDev.AuthSystem.API                 # https://localhost:5003
-dotnet run --project src/TranslationSystem/LotroKoniecDev.TranslationSystem.API   # https://localhost:5002
-dotnet run --project src/Frontend/LotroKoniecDev.Frontend                         # https://localhost:7017
-```
-
-Pelna procedura, macierz zmiennych srodowiskowych i sekwencja bring-up:
-[`docs/deployment/runbook.md`](docs/deployment/runbook.md). `compose.prod.yaml` to osobny stack
-parytetu produkcyjnego (`scripts/up-prod.sh`).
-
-## Dokumentacja (TMS)
-
-Cztery dokumenty referencyjne dla backendu TMS — wygenerowane **z kodu** (kod jest źródłem prawdy):
-
-- [`docs/API.md`](docs/API.md) — pełna referencja HTTP API: każdy endpoint (`/api/v1/...`), polityki
-  autoryzacji, kształty request/response, kody statusu + `ProblemDetails`, endpointy tokenowe Auth i
-  dystrybucja pliku tłumaczeń (ETag/304).
-- [`docs/DOMAIN.md`](docs/DOMAIN.md) — spacer po modelu domenowym: agregaty (`Translation`,
-  `GameVersion`, `Translator`), value objecty, cykl aktualizacji / unieważnienia (spec 0001) i podział
-  CQRS read/write.
-- [`docs/INVARIANTS.md`](docs/INVARIANTS.md) (+ [`INVARIANTS.slim.md`](docs/INVARIANTS.slim.md)) —
-  katalog egzekwowanych reguł z Domain + walidatorów, każda z tagiem 🟢 Domena / 🔵 Aplikacja i kotwicą
-  `plik:linia`.
-- [`docs/auth-tutorial.md`](docs/auth-tutorial.md) — auth end-to-end: serwer autoryzacji OpenIddict
-  (AuthSystem), resource server JwtBearer (tms-api), JWKS, leniwe prowizjonowanie tłumacza (ADR-0004),
-  role/policies.
-
-Wdrożenie i operacje: [`docs/deployment/runbook.md`](docs/deployment/runbook.md) — runbook operatora:
-macierz zmiennych środowiskowych (usługa × środowisko), generowanie sekretów, reguły spójności
-(issuer / redirect / authority / CORS), sekwencja uruchomienia i migracje bazy.
-
-Głębiej: `docs/specs/` (spec 0001 — cykl aktualizacji; spec 0002 — HATEOAS), `docs/adr/` (decyzje
-architektoniczne), `docs/knowledge-base/` (empiryczne ustalenia o DAT/aktualizacjach).
-
-## Bezpieczenstwo i sekrety (backend / TMS)
-
-Repo bedzie publiczne — **realne sekrety nigdy nie trafiaja do historii gita**. Trzy warstwy ochrony:
-
-1. **pre-commit (gitleaks)** — blokuje commit z sekretem lokalnie. Setup raz na klon:
-   ```
-   pip install pre-commit      # lub: brew install pre-commit
-   pre-commit install
-   ```
-   Od teraz `git commit` skanuje staged changes (gitleaks). Konfiguracja: `.pre-commit-config.yaml` + `.gitleaks.toml`.
-2. **CI** (`.github/workflows/gitleaks.yml`) — skanuje kazdy PR i push do `main`; PR z sekretem nie przejdzie.
-3. **GitGuardian app** — serwerowy skan PR (warstwa dodatkowa).
-
-**Sekrety w dev:** uzywaj `dotnet user-secrets` (per-projekt) albo `.env` (git-ignored, bootstrapowany przez
-`scripts/up.sh` z `.env.example`). W `.gitignore` sa `*.env` / `.env.*` (poza `.env.example`),
-`appsettings.*.local.json` i `**/secrets.json`. `appsettings.Development.json` trzyma **wylacznie** wartosci dev,
-nigdy realne sekrety.
-
-Przyklad ustawienia sekretu w dev przez user-secrets:
-```
-dotnet user-secrets set "OpenIddict:ApiClientSecret" "<twoj-sekret>" \
-  --project src/AuthSystem/LotroKoniecDev.AuthSystem.API
-```
+Personal portfolio project © Artur Koniec. *The Lord of the Rings Online* and all related names and
+content are trademarks of **Standing Stone Games**; this is an unofficial, non-commercial fan tool,
+not affiliated with or endorsed by SSG or Middle-earth Enterprises.


### PR DESCRIPTION
## Why

CD run 28515436800 failed the whole `build-and-push` job on the **tms-api** leg with
`error writing layer blob: not_found` during `exporting to GitHub Actions Cache`. The image
was already built and **pushed to GHCR** — only the GHA cache *export* (a build-speed
optimization) flaked on one large layer. The three sibling legs exported the same cache fine at
the same moment, and the 11 prior CD runs were green: this is a known transient GHA
cache-backend failure under API throttling (moby/buildkit#2408 / #2276 / #2804), not our bug. A
non-essential optimization step must not fail CD and block the deploy.

## What

- **`.github/workflows/cd.yml`** — add `ignore-error=true` to `cache-to: type=gha`. A cache-export
  flake now degrades to a warning; the image still builds → pushes → scans → signs → deploys, and
  the next run re-exports the cache. `mode=max` is kept (it caches the multi-stage restore/build
  layers that make the cache worthwhile).
- **`README.md`** — platform overview rewrite, bundled in. A docs-only PR would deadlock on the
  strict-required `Pull Request Verification` check (it `paths-ignore`s `**/*.md`); bundling with the
  workflow change makes that check run.

## Verification

- `cd.yml` parses cleanly as YAML.
- `ignore-error=true` is the documented Docker option for exactly this (default `false`) —
  https://docs.docker.com/build/cache/backends/gha/
- No code change, so the build + unit + integration suite in `Pull Request Verification` is unaffected.

Merging this triggers a fresh CI → CD on main with the fix active, which also deploys the current
tip (origin/main was still parked on the flaked commit `2f8d738`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
