### PR TITLE
SEC-01: enforce confirmed-email on interactive login (RequireConfirmedEmail bypass)

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -67,6 +67,7 @@ internal static class EventIds
     public const int LoginAccountLockedOut = 2621;
     public const int LoginWrongPassword = 2622;
     public const int LoginSuccessful = 2623;
+    public const int LoginEmailNotConfirmed = 2624;
     public const int PasswordResetCompletedViaUi = 2630;
     public const int RegisterCompletedViaUi = 2640;
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
@@ -84,6 +84,17 @@ internal sealed partial class LoginModel : PageModel
             return Page();
         }
 
+        if (!await _userManager.IsEmailConfirmedAsync(user))
+        {
+            LogEmailNotConfirmed(_logger, user.Id, HttpContext.Connection.RemoteIpAddress);
+            // Identity is configured with RequireConfirmedEmail, but the interactive login path uses
+            // CheckPasswordAsync, which does not run PreSignInCheck. Enforce confirmation explicitly.
+            // Same generic message as the other branches — never reveal that the account exists but is
+            // unconfirmed — and placed after the password hash above so there is no timing oracle.
+            ErrorMessage = "Nieprawidłowa nazwa użytkownika lub hasło.";
+            return Page();
+        }
+
         await _userManager.ResetAccessFailedCountAsync(user);
 
         List<Claim> claims =
@@ -131,6 +142,9 @@ internal sealed partial class LoginModel : PageModel
 
     [LoggerMessage(EventId = EventIds.LoginWrongPassword, Level = LogLevel.Warning, Message = "Failed login: wrong password. UserId: {UserId}, IP: {IP}")]
     private static partial void LogWrongPassword(ILogger logger, Guid userId, System.Net.IPAddress? ip);
+
+    [LoggerMessage(EventId = EventIds.LoginEmailNotConfirmed, Level = LogLevel.Warning, Message = "Failed login: email not confirmed. UserId: {UserId}, IP: {IP}")]
+    private static partial void LogEmailNotConfirmed(ILogger logger, Guid userId, System.Net.IPAddress? ip);
 
     [LoggerMessage(EventId = EventIds.LoginSuccessful, Level = LogLevel.Information, Message = "User {UserId} logged in successfully")]
     private static partial void LogUserLoggedIn(ILogger logger, Guid userId);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AuthorizationCodeFlowTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AuthorizationCodeFlowTests.cs
@@ -265,6 +265,55 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
     }
 
     [Fact]
+    public async Task Login_ShouldNotAuthenticate_WhenEmailIsNotConfirmed()
+    {
+        // Arrange — a registered but UNCONFIRMED user, logging in with the CORRECT credentials.
+        // RequireConfirmedEmail is enabled, so the interactive login must reject this user.
+        const string password = "TestPass1!";
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserUnconfirmedAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
+
+        HttpResponseMessage loginPageResponse = await _noRedirectClient.GetAsync(
+            new Uri("/Account/Login", UriKind.Relative));
+        loginPageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string loginPageHtml = await loginPageResponse.Content.ReadAsStringAsync();
+        string? antiForgeryToken = ExtractAntiForgeryToken(loginPageHtml);
+
+        Dictionary<string, string> loginFormData = new()
+        {
+            ["Username"] = registerRequest.Username,
+            ["Password"] = password
+        };
+
+        if (antiForgeryToken is not null)
+        {
+            loginFormData["__RequestVerificationToken"] = antiForgeryToken;
+        }
+
+        using FormUrlEncodedContent content = new(loginFormData);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, "/Account/Login");
+        request.Content = content;
+
+        foreach (string cookie in loginPageResponse.Headers.GetValues("Set-Cookie"))
+        {
+            string cookiePair = cookie.Split(';')[0];
+            request.Headers.Add("Cookie", cookiePair);
+        }
+
+        // Act
+        HttpResponseMessage response = await _noRedirectClient.SendAsync(request);
+
+        // Assert — login is rejected: the page is re-rendered (200) with the generic error, NOT a
+        // redirect (302), which is what a successful sign-in would return.
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Nieprawidłowa nazwa użytkownika lub hasło");
+    }
+
+    [Fact]
     public async Task AuthorizationCodeExchange_ShouldFail_WhenCodeVerifierIsInvalid()
     {
         // Arrange: Get a valid authorization code through the full auth flow


### PR DESCRIPTION
Identity is configured with RequireConfirmedEmail = true, but the interactive
browser login (Pages/Account/Login.cshtml.cs) authenticated via
UserManager.CheckPasswordAsync, which does not run PreSignInCheck — so an
unconfirmed (e.g. email-squatted) account could log in and obtain real tokens.
This was the only production login path; the password grant is Testing-only and
already enforces confirmation via CheckPasswordSignInAsync.

Add an explicit IsEmailConfirmedAsync gate after the password check (the password
hash always runs first, so there is no timing/enumeration oracle), returning the
same generic error as the other failure branches, with a dedicated log event.

Integration test: an unconfirmed user with correct credentials is not
authenticated through the browser login flow (stays on the login page, HTTP 200,
generic error — no 302 redirect / cookie).

Closes #278

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
