### PR TITLE
SEC-02: revoke OpenIddict tokens on password reset/change (sessions survive credential change)

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -11,6 +11,7 @@ using LotroKoniecDev.AuthSystem.API.Features.Auth;
 using LotroKoniecDev.AuthSystem.API.Hateoas.AccountAggregateFactories;
 using LotroKoniecDev.AuthSystem.API.Hateoas.DiscoveryFactories;
 using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.Hateoas;
@@ -73,6 +74,8 @@ internal static class ApiDependencyInjection
             services.AddScoped<IPasswordResetLinkFactory, PasswordResetLinkFactory>();
             services.AddScoped<IPasswordResetEmailSender, PasswordResetEmailSender>();
             services.AddScoped<IAccountConfirmationEmailSender, AccountConfirmationEmailSender>();
+
+            services.AddScoped<IUserSessionRevoker, UserSessionRevoker>();
 
             // Fail-fast startup validation of the OpenIddict server config (ADR-0008 §3, M6-05): the
             // OpenIddictSettingsValidator enforces the production key material / issuer and names the

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -55,6 +55,8 @@ internal static class EventIds
 
     // Token Revocation (2300–2309)
     public const int TokenRevoked = 2300;
+    public const int UserSessionsRevoked = 2301;
+    public const int UserSessionsRevocationFailed = 2302;
 
     // Middleware (2400–2499)
     public const int UnauthorizedAccessAttempt = 2400;

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ChangePassword.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ChangePassword.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Identity;
 using LotroKoniecDev.AuthSystem.API.ApiErrors;
 using LotroKoniecDev.AuthSystem.API.Common;
 using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 
@@ -37,15 +38,18 @@ internal sealed partial class ChangePassword : IApiEndpoint
     internal sealed partial class Handler : ICommandHandler<Command, Result>
     {
         private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IUserSessionRevoker _sessionRevoker;
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
 
         public Handler(
             UserManager<ApplicationUser> userManager,
+            IUserSessionRevoker sessionRevoker,
             IValidator<Command> validator,
             ILogger<Handler> logger)
         {
             _userManager = userManager;
+            _sessionRevoker = sessionRevoker;
             _validator = validator;
             _logger = logger;
         }
@@ -77,6 +81,8 @@ internal sealed partial class ChangePassword : IApiEndpoint
                 {
                     LogSecurityStampUpdateFailed(_logger, user.Id);
                 }
+
+                await _sessionRevoker.RevokeAllAsync(user.Id.ToString(), cancellationToken);
 
                 return Result.Success();
             }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ResetPassword.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ResetPassword.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Identity;
 using LotroKoniecDev.AuthSystem.API.ApiErrors;
 using LotroKoniecDev.AuthSystem.API.Common;
 using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 
@@ -47,15 +48,18 @@ internal sealed partial class ResetPassword : IApiEndpoint
             new PasswordHasher<ApplicationUser>().HashPassword(new ApplicationUser(), "DummyP@ssw0rd!");
 
         private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IUserSessionRevoker _sessionRevoker;
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
 
         public Handler(
             UserManager<ApplicationUser> userManager,
+            IUserSessionRevoker sessionRevoker,
             IValidator<Command> validator,
             ILogger<Handler> logger)
         {
             _userManager = userManager;
+            _sessionRevoker = sessionRevoker;
             _validator = validator;
             _logger = logger;
         }
@@ -98,6 +102,8 @@ internal sealed partial class ResetPassword : IApiEndpoint
             {
                 LogSecurityStampUpdateFailed(_logger, user.Id);
             }
+
+            await _sessionRevoker.RevokeAllAsync(user.Id.ToString(), cancellationToken);
 
             return Result.Success();
         }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 
 namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
@@ -14,13 +15,16 @@ internal sealed partial class ResetPasswordModel : PageModel
         new PasswordHasher<ApplicationUser>().HashPassword(new ApplicationUser(), "DummyP@ssw0rd!");
 
     private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IUserSessionRevoker _sessionRevoker;
     private readonly ILogger<ResetPasswordModel> _logger;
 
     public ResetPasswordModel(
         UserManager<ApplicationUser> userManager,
+        IUserSessionRevoker sessionRevoker,
         ILogger<ResetPasswordModel> logger)
     {
         _userManager = userManager;
+        _sessionRevoker = sessionRevoker;
         _logger = logger;
     }
 
@@ -92,6 +96,7 @@ internal sealed partial class ResetPasswordModel : PageModel
         }
 
         await _userManager.UpdateSecurityStampAsync(user);
+        await _sessionRevoker.RevokeAllAsync(user.Id.ToString(), HttpContext.RequestAborted);
 
         LogPasswordResetCompleted(_logger, user.Id);
 
@@ -99,6 +104,6 @@ internal sealed partial class ResetPasswordModel : PageModel
         return Page();
     }
 
-    [LoggerMessage(EventId = EventIds.PasswordResetCompletedViaUi, Level = LogLevel.Information, Message = "Password reset completed via UI for user {UserId}. All sessions invalidated.")]
+    [LoggerMessage(EventId = EventIds.PasswordResetCompletedViaUi, Level = LogLevel.Information, Message = "Password reset completed via UI for user {UserId}. Tokens and authorizations revoked.")]
     private static partial void LogPasswordResetCompleted(ILogger logger, Guid userId);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Sessions/IUserSessionRevoker.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Sessions/IUserSessionRevoker.cs
@@ -1,0 +1,11 @@
+namespace LotroKoniecDev.AuthSystem.API.Services.Sessions;
+
+/// <summary>
+/// Revokes every OpenIddict token and authorization issued to a user, evicting all active sessions.
+/// Used when a credential change (password reset or change) must invalidate outstanding access/refresh
+/// tokens and consents.
+/// </summary>
+internal interface IUserSessionRevoker
+{
+    Task RevokeAllAsync(string userId, CancellationToken cancellationToken = default);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Sessions/UserSessionRevoker.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Sessions/UserSessionRevoker.cs
@@ -1,0 +1,60 @@
+using OpenIddict.Abstractions;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Sessions;
+
+/// <summary>
+/// Default <see cref="IUserSessionRevoker"/> backed by the OpenIddict token and authorization managers.
+/// Mirrors the revocation the DeleteAccount and Logout flows already perform, so every credential-change
+/// flow evicts sessions through one shared implementation.
+/// </summary>
+internal sealed partial class UserSessionRevoker : IUserSessionRevoker
+{
+    private readonly IOpenIddictTokenManager _tokenManager;
+    private readonly IOpenIddictAuthorizationManager _authorizationManager;
+    private readonly ILogger<UserSessionRevoker> _logger;
+
+    public UserSessionRevoker(
+        IOpenIddictTokenManager tokenManager,
+        IOpenIddictAuthorizationManager authorizationManager,
+        ILogger<UserSessionRevoker> logger)
+    {
+        _tokenManager = tokenManager;
+        _authorizationManager = authorizationManager;
+        _logger = logger;
+    }
+
+    public async Task RevokeAllAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        // Best-effort: the credential change and its security-stamp rotation have already succeeded, so a
+        // transient revocation failure must not fail the whole operation — it is logged and the surviving
+        // tokens expire at their (short) lifetimes. Same posture as DeleteAccount's artifact cleanup.
+        try
+        {
+            int revokedTokens = 0;
+            await foreach (object token in _tokenManager.FindBySubjectAsync(userId, cancellationToken))
+            {
+                await _tokenManager.TryRevokeAsync(token, cancellationToken);
+                revokedTokens++;
+            }
+
+            int revokedAuthorizations = 0;
+            await foreach (object authorization in _authorizationManager.FindBySubjectAsync(userId, cancellationToken))
+            {
+                await _authorizationManager.TryRevokeAsync(authorization, cancellationToken);
+                revokedAuthorizations++;
+            }
+
+            LogSessionsRevoked(_logger, userId, revokedTokens, revokedAuthorizations);
+        }
+        catch (Exception ex)
+        {
+            LogRevocationFailed(_logger, ex, userId);
+        }
+    }
+
+    [LoggerMessage(EventId = EventIds.UserSessionsRevoked, Level = LogLevel.Information, Message = "Revoked all sessions for user {UserId}: {TokenCount} token(s), {AuthorizationCount} authorization(s)")]
+    private static partial void LogSessionsRevoked(ILogger logger, string userId, int tokenCount, int authorizationCount);
+
+    [LoggerMessage(EventId = EventIds.UserSessionsRevocationFailed, Level = LogLevel.Error, Message = "Failed to revoke sessions for user {UserId}. Outstanding tokens will expire naturally.")]
+    private static partial void LogRevocationFailed(ILogger logger, Exception exception, string userId);
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ChangePasswordEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ChangePasswordEndpointTests.cs
@@ -71,6 +71,57 @@ public sealed class ChangePasswordEndpointTests : EndpointsTestBase
     }
 
     [Fact]
+    public async Task ChangePassword_ShouldRevokeExistingRefreshTokens_AfterChange()
+    {
+        // Arrange — a confirmed user with an active refresh token (offline_access)
+        const string currentPassword = "TestPass1!";
+        const string newPassword = "NewPass99!";
+
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, currentPassword);
+
+        using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = registerRequest.Username,
+            ["password"] = currentPassword,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api offline_access"
+        });
+
+        HttpResponseMessage loginResponse = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), loginRequest);
+        loginResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string loginContent = await loginResponse.Content.ReadAsStringAsync();
+        using JsonDocument loginJson = JsonDocument.Parse(loginContent);
+        string accessToken = loginJson.RootElement.GetProperty("access_token").GetString()!;
+        string refreshToken = loginJson.RootElement.GetProperty("refresh_token").GetString()!;
+
+        // Change the password (authenticated with the pre-change access token)
+        using HttpRequestMessage changeReq = new(HttpMethod.Post, "auth/change-password");
+        changeReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        changeReq.Content = JsonContent.Create(new ChangePasswordRequest(currentPassword, newPassword));
+
+        HttpResponseMessage changeResponse = await ApiClient.Http.SendAsync(changeReq);
+        changeResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Act — try to use the refresh token that was issued BEFORE the change
+        using FormUrlEncodedContent refreshRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+            ["client_id"] = "lotrokoniecdev-test"
+        });
+
+        HttpResponseMessage response = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), refreshRequest);
+
+        // Assert — the pre-change refresh token must be dead
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task ChangePassword_ShouldReturnBadRequest_WhenCurrentPasswordIsWrong()
     {
         // Arrange

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordEndpointTests.cs
@@ -115,6 +115,59 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
     }
 
     [Fact]
+    public async Task ResetPassword_ShouldRevokeExistingRefreshTokens_AfterReset()
+    {
+        // Arrange — a confirmed user with an active refresh token (offline_access)
+        const string originalPassword = "TestPass1!";
+        const string newPassword = "NewPass99!";
+
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, originalPassword);
+
+        using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = registerRequest.Username,
+            ["password"] = originalPassword,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api offline_access"
+        });
+
+        HttpResponseMessage loginResponse = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), loginRequest);
+        loginResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string loginContent = await loginResponse.Content.ReadAsStringAsync();
+        using JsonDocument loginJson = JsonDocument.Parse(loginContent);
+        string refreshToken = loginJson.RootElement.GetProperty("refresh_token").GetString()!;
+
+        // Reset the password
+        PasswordResetEmailSpy.Reset();
+        await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/forgot-password", UriKind.Relative),
+            new ForgotPasswordRequest(registerRequest.Email));
+
+        HttpResponseMessage resetResponse = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/reset-password", UriKind.Relative),
+            new ResetPasswordRequest(registerRequest.Email, PasswordResetEmailSpy.LastResetToken!, newPassword));
+        resetResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Act — try to use the refresh token that was issued BEFORE the reset
+        using FormUrlEncodedContent refreshRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+            ["client_id"] = "lotrokoniecdev-test"
+        });
+
+        HttpResponseMessage response = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), refreshRequest);
+
+        // Assert — the pre-reset refresh token must be dead
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task ResetPassword_ShouldReturnBadRequest_WhenTokenIsInvalid()
     {
         // Arrange

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordPageTests.cs
@@ -1,0 +1,111 @@
+using System.Text.RegularExpressions;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+public sealed partial class ResetPasswordPageTests : EndpointsTestBase
+{
+    public ResetPasswordPageTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public async Task ResetPasswordPage_ShouldRevokeExistingRefreshTokens_AfterReset()
+    {
+        // Arrange — a confirmed user with an active refresh token (offline_access)
+        const string originalPassword = "TestPass1!";
+        const string newPassword = "NewPass99!";
+
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, originalPassword);
+
+        using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = registerRequest.Username,
+            ["password"] = originalPassword,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api offline_access"
+        });
+
+        HttpResponseMessage loginResponse = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), loginRequest);
+        loginResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string loginContent = await loginResponse.Content.ReadAsStringAsync();
+        using JsonDocument loginJson = JsonDocument.Parse(loginContent);
+        string refreshToken = loginJson.RootElement.GetProperty("refresh_token").GetString()!;
+
+        // Obtain a reset token
+        PasswordResetEmailSpy.Reset();
+        await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/forgot-password", UriKind.Relative),
+            new ForgotPasswordRequest(registerRequest.Email));
+        string resetToken = PasswordResetEmailSpy.LastResetToken!;
+
+        // Complete the reset through the browser Razor page
+        HttpResponseMessage resetPageResponse = await PostToResetPasswordPageAsync(new Dictionary<string, string>
+        {
+            ["Email"] = registerRequest.Email,
+            ["Token"] = resetToken,
+            ["NewPassword"] = newPassword,
+            ["ConfirmPassword"] = newPassword
+        });
+        resetPageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string resetHtml = await resetPageResponse.Content.ReadAsStringAsync();
+        resetHtml.ShouldContain("Hasło zmienione"); // the IsCompleted success panel
+
+        // Act — try to use the refresh token that was issued BEFORE the reset
+        using FormUrlEncodedContent refreshRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+            ["client_id"] = "lotrokoniecdev-test"
+        });
+
+        HttpResponseMessage response = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), refreshRequest);
+
+        // Assert — the pre-reset refresh token must be dead
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    private async Task<HttpResponseMessage> PostToResetPasswordPageAsync(Dictionary<string, string> formFields)
+    {
+        HttpResponseMessage pageResponse = await ApiClient.Http.GetAsync(
+            new Uri("/Account/ResetPassword", UriKind.Relative));
+        pageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await pageResponse.Content.ReadAsStringAsync();
+        string? antiForgeryToken = ExtractAntiForgeryToken(html);
+        if (antiForgeryToken is not null)
+        {
+            formFields["__RequestVerificationToken"] = antiForgeryToken;
+        }
+
+        using FormUrlEncodedContent content = new(formFields);
+        using HttpRequestMessage request = new(HttpMethod.Post, "/Account/ResetPassword");
+        request.Content = content;
+
+        if (pageResponse.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
+        {
+            foreach (string cookie in cookies)
+            {
+                request.Headers.Add("Cookie", cookie.Split(';')[0]);
+            }
+        }
+
+        return await ApiClient.Http.SendAsync(request);
+    }
+
+    private static string? ExtractAntiForgeryToken(string html)
+    {
+        Match match = AntiForgeryTokenRegex().Match(html);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [GeneratedRegex("""name="__RequestVerificationToken".*?value="([^"]+)""")]
+    private static partial Regex AntiForgeryTokenRegex();
+}


### PR DESCRIPTION
ResetPassword, ChangePassword and the reset Razor page invalidated sessions only
via UpdateSecurityStampAsync, but nothing consumes the Identity stamp (the auth
cookie has no SecurityStampValidator and OpenIddict does not check it). With
reference refresh tokens (14-day lifetime) a refresh token issued before a
password reset/change kept minting fresh access tokens afterwards — so recovering
an account did not evict an attacker who had captured the tokens. DeleteAccount and
LogoutEndpoint already revoke tokens; the password-change flows skipped it.

Extract a single IUserSessionRevoker (revokes all OpenIddict tokens + authorizations
for a subject; mirrors the DeleteAccount/Logout revocation) and call it from both
handlers and the reset page after the security-stamp update. Correct the reset
page's misleading "All sessions invalidated" log to what actually happens.

Tests: a refresh token obtained before a password reset (API endpoint + Razor page)
and before a password change is rejected by the refresh grant afterwards.

Out of scope, tracked as follow-up SEC-03: the auth-server Identity cookie is not
evicted by a stamp change (no SecurityStampValidator wired), leaving a <=30-min
sliding-expiry residual window; closing it needs the stamp claim at login + a validator.

Closes #280

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
