### PR TITLE
obs: symptom-based availability SLO — external synthetic probe replaces log-based auth check (ADR-0019)

### DIFF
--- a/docs/adr/0019-symptom-based-external-slo-probe.md
+++ b/docs/adr/0019-symptom-based-external-slo-probe.md
@@ -1,0 +1,167 @@
+# ADR-0019: Symptom-based alerting — external synthetic SLO probe replaces the log-based auth check
+
+**Status:** Accepted
+**Date:** 2026-07-01
+**Decision-makers:** Solo maintainer
+**Related:** audit 0001 §C3 (zero alerting — the log-based check was its explicit *interim*), §M14 (Key
+Vault not in readiness), §M9 (LAW cap blind-spot); ADR-0016 (App Insights via the ACA managed OTel
+agent — now already provisioned), ADR-0017 (per-env IaC parametrization — made the public origin a
+single `local.*` var), ADR-0012 (health-gated rollout — the source of the false-positive), ADR-0018
+(shared-environment mode — every monitoring resource is `create_env`-guarded)
+
+## Context
+
+`iac/monitoring.tf`'s `auth_availability` rule (the platform's first SLO, Sev0) fires on **every
+deploy** while the platform is fully healthy. Root cause, confirmed in code:
+
+- The scheduled query matches `ContainerAppSystemLogs_CL` filtered **only by
+  `ContainerAppName_s`** (`monitoring.tf:369-377`) — it cannot tell the production revision from a
+  candidate.
+- The health-gated rollout (ADR-0012, `deploy.yml`) creates each release as a **candidate revision
+  at 0% traffic**, smokes it on a private label FQDN, then shifts traffic. A freshly-started
+  candidate fails `/health/ready` for a few probes until its Npgsql pool connects (readiness =
+  `AddNpgSql`, tagged `ready`; `Program.cs`), and ACA logs each miss as *"readiness probe failed /
+  Unhealthy"* under the app name.
+- The alert threshold is `Count > 0` over one 5-minute window, one failing period — **zero
+  tolerance**. A single transient candidate-startup log = Sev0, even though users are served by the
+  previous, healthy revision the whole time.
+
+This is textbook **cause-based alerting** (an internal probe log) standing in for a **symptom**
+(users cannot get a token). It manufactures alert fatigue: after N deploy-time Sev0s, a *real*
+auth outage gets dismissed as "probably a deploy". The audit anticipated exactly this — §C3 shipped
+the log query as *"the 'at least a basic' one"* and named a **true synthetic external probe (an
+Application Insights availability test)** as the correct instrument, deferred only because it "needs
+an App Insights resource + the public hostname extracted to a variable". **Both blockers are now
+gone:** ADR-0016 provisioned workspace-based App Insights (`observability.tf`), and ADR-0017 made
+`https://auth.<domain>` a single-source `local.auth_origin`.
+
+Adjacent gaps the same audit flagged and this ADR closes opportunistically: **no Key Vault
+availability alert** (§M14 — KV is the secret-resolution SPOF), **no latency signal**, and the
+platform's SPOFs (auth, KV) having no leading indicator before a hard outage.
+
+## Decision
+
+### 1. The SLO is measured by an external synthetic probe of the public origin, not by logs
+
+Replace `scheduled_query_rules_alert_v2.auth_availability` with an
+`azurerm_application_insights_standard_web_test` per user-facing app, hitting the **public HTTPS
+origin** (the revision serving 100% of traffic), plus an `azurerm_monitor_metric_alert` using the
+`application_insights_web_test_location_availability_criteria` block:
+
+| Web test | Target (`local.*`) | Expects | Severity |
+|---|---|---|---|
+| auth | `${auth_origin}/health/ready` | 200 | **0 — token-issuance SPOF** |
+| tms | `${tms_origin}/health/ready` | 200 | 1 |
+| frontend | `${apex_origin}/` | 200–399 (Static-SSR home) | 1 |
+
+**This is what makes the fix architectural, not a threshold tweak:** a candidate revision is
+reachable *only* through its private `<app>---cd-candidate.<domain>` label FQDN and takes **0%**
+public traffic during smoke, so an external probe of the public origin **cannot observe it**. The
+false-positive class is eliminated by construction — no exclusion filter, no debouncing that could
+also mask a real outage.
+
+### 2. Durability is geographic, not temporal
+
+The web tests run from **three EU-centric locations** (West Europe, North Europe, France Central)
+every 300 s. The alert fires only when **≥2 of 3 locations** fail
+(`failed_location_count = 2`). This rejects a single-location network blip *without* delaying a real
+outage the way "wait N consecutive windows" would — the right trade-off for a Sev0 availability SLO.
+
+### 3. Certificate expiry rides on the same web test
+
+Each standard web test enables SSL validation with a **7-day** remaining-lifetime threshold. The ACA
+managed custom-domain cert auto-renews well before that, so the gate never trips in a healthy cycle;
+if it does, auto-renew has failed and a real outage is imminent — correctly escalated with
+availability. No separate resource, no steady-state noise.
+
+### 4. Cover the SPOFs with leading indicators
+
+- **Key Vault availability (§M14):** `azurerm_monitor_metric_alert` scoped to
+  `data.azurerm_key_vault.secrets.id`, `Microsoft.KeyVault/vaults` → `Availability` < 100% over
+  5 min, **Sev1**. KV resolves every app secret at revision start; its loss is a platform outage.
+- **Auth latency:** `azurerm_monitor_metric_alert` on App Insights `requests/duration` (the OTel
+  agent reconstructs request metrics from traces, `observability.tf`) filtered to the auth role,
+  above a sustained threshold over 15 min, **Sev2** — a leading indicator before latency becomes a
+  probe failure. Auth-only by intent (§7 YAGNI); a `for_each` extends it later.
+
+### 5. Delivery stays email-only, one action group
+
+Deliberate (maintainer decision, pre-release, zero users): the existing single
+`azurerm_monitor_action_group` (email to `var.admin_email`) serves every severity. Severity is used
+for **triage discipline** (Sev0 = platform outage, Sev1 = degraded, Sev2 = leading indicator), not
+routing. Revisit when a second channel earns its keep.
+
+### 6. Explicit YAGNI
+
+Not built, and why: **multi-window multi-burn-rate error-budget SLO** (no traffic/SLA to spend a
+budget against yet); **a second alert channel / escalation** (§5); **automated deploy-window
+suppression** (the external probe is deploy-safe by construction, and the remaining log/metric
+alerts get a documented manual suppression procedure in the runbook, not an automation). Each is a
+one-change addition when a real need appears.
+
+### 7. Shared-environment compliance
+
+Every new resource is `create_env`-guarded exactly like the rest of `monitoring.tf` (ADR-0018):
+the web tests + their alerts + the KV/latency alerts are `count`/`for_each`-gated on
+`local.create_env`, so **staging inherits prod's monitoring and creates none of its own**, and the
+prod plan for existing resources stays a no-op.
+
+## Consequences
+
+### Positive
+
+- **Zero deploy-time false-positives** on the availability SLO — measured, not asserted: the probe
+  physically cannot see a 0%-traffic candidate.
+- The SLO now means what its name says — **user-facing availability of the serving revision**,
+  from outside the cluster, across regions.
+- Both platform SPOFs (auth, Key Vault) gain coverage; latency gives a leading indicator; cert
+  expiry is covered for free.
+- Reuses infra that already exists (App Insights, `local.auth_origin`) — no new App Insights, no new
+  variable.
+
+### Negative / Accepted Trade-offs
+
+- **Availability signal now depends on App Insights ingestion** rather than the raw LAW log table.
+  Acceptable: App Insights is already the telemetry sink (ADR-0016) and web tests are a first-class,
+  supported availability instrument.
+- **Standard web tests bill per execution** (3 tests × 3 locations × every 5 min). At this cadence
+  the ingestion/cost is negligible against the LAW `daily_quota_gb`; noted rather than a concern.
+- **Email remains a single delivery path** (§5) — a missed email misses a Sev0. Accepted for
+  pre-release; §6 revisit.
+- Removing the log-based rule is a **destroy + create** in state (pre-release, breaking changes are
+  free — CLAUDE.md).
+
+## Alternatives Considered
+
+- **Tune the log rule's threshold / add consecutive-window debounce** — rejected: still cause-based
+  (an internal probe log), still filtered by app name, and a debounce long enough to survive a
+  candidate's startup also delays a real Sev0. Treats the symptom of the symptom.
+- **Exclude candidate revisions in KQL** (`RevisionName_s !contains "cd-candidate"`) — rejected as
+  brittle: depends on undocumented `ContainerAppSystemLogs_CL` fields and re-breaks if the rollout's
+  revision-suffix scheme changes.
+- **Full burn-rate error-budget SLO** — deferred (§6): correct at scale, YAGNI at zero traffic.
+- **Application Insights *classic* ping test** — rejected: Microsoft-retired; the standard web test
+  is its supported successor (adds SSL validation, used in §3).
+
+## Implementation Notes
+
+- **New:** this ADR; in `iac/monitoring.tf` — three `azurerm_application_insights_standard_web_test`
+  + three webtest-location-availability `azurerm_monitor_metric_alert` (auth Sev0 / tms,frontend
+  Sev1), a Key Vault `Availability` metric alert (Sev1), an auth `requests/duration` metric alert
+  (Sev2). All `create_env`-guarded; web tests + availability alerts fan out via a single `for_each`
+  map carrying per-app origin + severity + expected-status.
+- **Changed:** `iac/monitoring.tf` — remove `scheduled_query_rules_alert_v2.auth_availability` and
+  its `moved {}`; `docs/deployment/runbook.md` — Monitoring & alerting table refreshed, per-alert
+  response steps + a manual suppression procedure for planned work.
+- **Unchanged (deliberately):** the metric alerts on ACA platform signals (`replica_restart`,
+  `http_5xx`, `cpu`, `memory`) and `law_daily_cap` — well-formed, kept green with assertions
+  untouched; the action group (§5); the health-gated rollout.
+- **Supersession:** closes audit 0001 §C3's interim availability check with its named target
+  instrument, and §M14; retires the deploy-time false-positive.
+
+## References
+
+- `docs/audits/0001-infrastructure-audit.md` — §C3 (interim log check + the deferred synthetic
+  probe), §M14 (KV readiness), §M9 (LAW cap)
+- ADR-0016 / ADR-0017 — App Insights + the single-source public origin that unblocked this
+- ADR-0012 / ADR-0018 — the health-gated rollout (false-positive source) + shared-env `count` guard

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -776,39 +776,73 @@ the traces**. Adding a metrics destination is deferred until there is a real nee
 
 ## Monitoring & alerting
 
-Defined as code in [`iac/monitoring.tf`](../../iac/monitoring.tf) (audit 0001 §C3). Every alert
+Defined as code in [`iac/monitoring.tf`](../../iac/monitoring.tf) (audit 0001 §C3; the availability
+SLO reworked in [ADR-0019](../adr/0019-symptom-based-external-slo-probe.md)). Every alert
 **fires by email** to `var.admin_email` through a single Azure Monitor action group
-(`lotrotmsag<env_id>`) — **email only, no SMS**. The alerts stand on signals that already exist (ACA
-platform metrics + the Log Analytics workspace the apps stream console logs to), so they need no
-OTLP / cloud-telemetry wiring. Everything is parametrized by `var.env_id`, so a future staging
+(`lotrotmsag<env_id>`) — **email only, no SMS**. Most alerts stand on signals that already exist (ACA
+platform metrics + the Log Analytics workspace the apps stream console logs to); the availability SLO
+and the auth latency alert additionally read **Application Insights** (synthetic web tests + the
+OTel-reconstructed request metrics). Everything is parametrized by `var.env_id`, so a future staging
 inherits the same alerting.
 
 | Alert | Source | Fires when | Severity |
 |---|---|---|---|
-| **Auth availability (SLO)** | LAW `ContainerAppSystemLogs_CL` | the auth app's `/health/ready` readiness probe fails / the app reports unhealthy — auth is the token-issuance SPOF, so this is the platform's first SLO | 0 Critical |
+| **Availability SLO — auth** | AI standard web test (public origin) | `https://auth.<domain>/health/ready` is unreachable from **≥2 of 3 regions** — auth is the token-issuance SPOF, so this is the platform's SLO | 0 Critical |
+| **Availability — tms / frontend** | AI standard web tests | `tms/health/ready` or the frontend home is unreachable from **≥2 of 3 regions** | 1 Error |
 | **Replica restart** | metric `RestartCount` | any of the three apps restarts a replica (crash-loop signal: OOM, failed readiness, unhandled crash). Sensitive by design (`> 0`); stays active for the affected revision and auto-mitigates on a clean revision | 1 Error |
 | **HTTP 5xx spike** | metric `Requests` (`statusCodeCategory = 5xx`) | an app returns more than 5 server errors in 5 minutes. 4xx is intentionally not alerted (auth 401/400 are normal control flow) | 1 Error |
+| **Key Vault availability** | metric `Microsoft.KeyVault/vaults` `Availability` | the vault's availability drops below 99% over 15 minutes — KV is the secret-resolution SPOF (every revision resolves its secrets at start) | 1 Error |
 | **Log error spike** | LAW `ContainerAppConsoleLogs_CL` | an app logs more than 10 Serilog `Error`/`Fatal` entries in 5 minutes — catches logged failures that never surface as a 5xx or restart | 2 Warning |
 | **Memory saturation** | metric `WorkingSetBytes` | an app sustains >80% of its 0.5 GiB limit for 15 minutes (OOM precursor) | 2 Warning |
+| **Auth latency** | AI `requests/duration` (auth role) | auth server response time averages **>2 s over 15 minutes** — a leading indicator before readiness fails | 2 Warning |
 | **LAW daily cap reached** | LAW `Operation` table | the workspace's daily ingestion cap (`daily_quota_gb` in `azure-law.tf`) is hit and **log collection has stopped** — a blind spot exactly during an error storm | 2 Warning |
 | **CPU saturation** | metric `UsageNanoCores` | an app sustains >80% of its 0.25 vCPU limit for 15 minutes (capacity signal; no horizontal headroom at min=max=1 replica) | 3 Informational |
 
 Notes for the operator:
 
+- **The availability SLO is deploy-safe by construction.** The standard web tests probe each app's
+  **public origin** — which only ever resolves to the revision serving 100% of traffic. A health-gated
+  rollout's candidate revision takes 0% traffic and is reachable only via its private
+  `<app>---cd-candidate` label FQDN, so **a deploy cannot trip these**. This is the fix for the old
+  log-based `auth_availability`, which paged Sev0 on every release (it matched the app name, not the
+  serving revision). Durability is geographic — **≥2 of 3 locations** (West Europe, North Europe,
+  France Central) must fail — so a single-region blip is rejected without delaying a real outage.
 - The metric alerts are fanned out **per app** (a `for_each` over auth-api / tms-api / frontend),
   one single-scope rule each — the universally-supported shape (Azure does not allow multi-resource
   metric alerts for Container Apps). The alert name carries the app key, e.g.
   `lotrotms-alert-replica-restart-auth-api-<env_id>`.
-- The three log (scheduled-query) alerts set `skip_query_validation = true`, because the
+- The two log (scheduled-query) alerts set `skip_query_validation = true`, because the
   `*_CL` tables only exist once the apps have emitted those records — a fresh environment can
   provision the alerts before any logs flow.
-- The auth-availability query matches ACA system-log vocabulary that cannot be verified from a
-  `terraform plan` sandbox — **confirm/tune the matched tokens against real
-  `ContainerAppSystemLogs_CL` after the first apply.**
-- A true synthetic external probe of `/health/ready` (an Application Insights availability test) is
-  deliberately deferred: it needs an App Insights resource and the public hostname extracted to a
-  variable (the H2/H3 follow-ups). The log-based availability check above is the "at least a basic
-  one" the audit calls for, with no new dependencies.
+- **Confirm-at-apply, not at plan.** The web-test geo codes, the auth alert's `cloud/roleName`
+  (= the app's OTel `service.name` = its entry-assembly name `LotroKoniecDev.AuthSystem.API`), and
+  the App Insights / KV metric names are only validated server-side. If an availability or latency
+  alert shows **no data**, verify those against live App Insights after the first apply.
+
+**Responding to an alert:**
+
+| Alert | First moves |
+|---|---|
+| Availability SLO (auth/tms/frontend) | Hit the public origin yourself: `curl -sS -o /dev/null -w '%{http_code}' https://auth.<domain>/health/ready`. If it's down, check ACA revision health + the traffic split (`az containerapp ingress traffic show`) — a bad revision live means the rollout's auto-rollback (`deploy.yml`) did not fire; steer traffic back with `az containerapp ingress traffic set --revision-weight <prev>=100`. If the origin is up, suspect DNS/cert/regional network. |
+| Key Vault availability | Portal → the vault → check for throttling / an Azure KV incident; confirm the `lotrotms-aca-<env_id>` identity still has *Key Vault Secrets User*; new revisions cannot boot without secret resolution. |
+| Auth latency | App Insights → Performance for the auth role; check the DB (Neon) latency and the sibling CPU/memory saturation alerts. Leading indicator — investigate before it becomes a 5xx / readiness failure. |
+| Replica restart / 5xx / log error spike | App Insights logs + `az containerapp logs show` for the named app; correlate with a recent deploy. |
+| CPU / memory saturation | Capacity signal at min=max=1 replica: inspect the workload, then raise the request or replica ceiling in `azure-container-apps.tf`. |
+
+**Silencing during planned disruptive work.** Routine deploys need **no** suppression (the availability
+SLO is deploy-safe by construction). For genuinely disruptive planned work (e.g. a migration with
+downtime), add a temporary **alert processing rule** rather than editing Terraform — scope it to the
+resource group for the maintenance window, then delete it:
+
+```bash
+az monitor alert-processing-rule create \
+  --name lotrotms-maint-suppress --resource-group rg-lotrotms-prod-polc-001 \
+  --scopes "$(az group show -n rg-lotrotms-prod-polc-001 --query id -o tsv)" \
+  --rule-type RemoveAllActionGroups --enabled true \
+  --description "Planned maintenance — suppress alert emails"
+# … do the work, then:
+az monitor alert-processing-rule delete --name lotrotms-maint-suppress -g rg-lotrotms-prod-polc-001
+```
 
 ## See also
 

--- a/iac/monitoring.tf
+++ b/iac/monitoring.tf
@@ -2,19 +2,21 @@
 # resources existed, so a crash-loop, an error storm, a stopped log pipeline, or an auth outage
 # (token issuance is the platform SPOF) surfaced only when the owner or a user noticed.
 #
-# These alerts deliberately stand on signals that ALREADY exist — ACA platform metrics
-# (Microsoft.App/containerApps) and the Log Analytics workspace the apps already stream console
-# logs to — so they carry NO dependency on the cloud-telemetry / OTLP work (audit H3). Everything
-# is parametrized by var.env_id so a future staging inherits alerting for free.
+# Most alerts deliberately stand on signals that ALREADY exist — ACA platform metrics
+# (Microsoft.App/containerApps) and the Log Analytics workspace the apps already stream console logs
+# to. The availability SLO + auth latency added in ADR-0019 additionally read Application Insights
+# (the synthetic web tests + the OTel-reconstructed request metrics, observability.tf). Everything is
+# parametrized by var.env_id so a future staging inherits alerting for free.
 #
 # Delivery is EMAIL ONLY (owner decision): one action group with a single email receiver
 # (var.admin_email). No SMS, no webhook. Every alert below references that action group.
 #
-# Plan-on-PR caveat: Terraform `plan` does not validate metric names, log-table schemas, or KQL
-# against the live Azure metric/log catalog — those are checked server-side at `apply`. The metric
-# names used here (RestartCount / Requests / UsageNanoCores / WorkingSetBytes) and the log tables
-# (ContainerAppConsoleLogs_CL / ContainerAppSystemLogs_CL / Operation) are the documented
-# Container Apps + LAW signals.
+# Plan-on-PR caveat: Terraform `plan` does not validate metric names, log-table schemas, KQL, the
+# web-test geo codes, or the auth cloud_RoleName against the live Azure catalog — those are checked
+# server-side at `apply` (or observed only once telemetry flows). The metric names used here
+# (RestartCount / Requests / UsageNanoCores / WorkingSetBytes / KeyVault Availability / requests-
+# duration) and the log tables (ContainerAppConsoleLogs_CL / Operation) are the documented
+# Container Apps + Key Vault + App Insights + LAW signals.
 
 locals {
   # All three container apps share one resource type, region and sizing (0.25 vCPU / 0.5 GiB,
@@ -332,63 +334,172 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "law_daily_cap" {
   }
 }
 
-# Auth availability — the platform's first SLO. Auth issues every token, so an unhealthy auth app
-# is a total-platform outage (front-channel login AND tms back-channel validation both fail). This
-# is the external availability check of /health/ready: the ACA readiness probe hits /health/ready,
-# and when it fails the platform records it in ContainerAppSystemLogs_CL. The query watches the
-# auth app for genuine health failures only and fires at the highest severity. (A true synthetic
-# external probe — Application Insights availability test — is the richer option, but it needs an
-# App Insights resource + the public hostname extracted to a variable; that is deferred to the
-# H2/H3 work. This log-based check uses signals that exist today, per the ticket's
-# "scheduled-query / availability test — at least a basic one".)
+# ---------------------------------------------------------------------------------------------------
+# External synthetic availability — the platform's real SLO (ADR-0019). This REPLACES the former
+# log-based auth_availability, which fired on EVERY deploy: that rule matched ContainerAppSystemLogs_CL
+# by app NAME (not revision), so a health-gated candidate revision (0% traffic, still starting → a few
+# transient /health/ready misses until its Npgsql pool connects) tripped a Sev0 while users were served
+# the whole time by the previous, healthy revision.
 #
-# Token discipline (this is severity 0, so a false positive is expensive): the match is deliberately
-# scoped to unhealthy / probe-failure signals and EXCLUDES routine lifecycle events — every deploy
-# deactivates the superseded revision (azure-container-apps.tf, Multiple revision_mode +
-# health-gated rollout), which would otherwise trip a Terminated/Killing match and page Critical on
-# every release. Multi-word phrases use `contains` (term operators like `has` would not match them).
-# The exact ACA system-log vocabulary cannot be queried from the plan sandbox — confirm/tune the
-# token set against real ContainerAppSystemLogs_CL on first apply.
-resource "azurerm_monitor_scheduled_query_rules_alert_v2" "auth_availability" {
-  count               = local.create_env ? 1 : 0
-  name                = "lotrotms-slo-auth-availability-${var.env_id}"
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  description         = "SLO: auth /health/ready failing (token-issuance SPOF unavailable). Fires by email."
-  severity            = 0 # Critical — platform-wide outage
+# A standard web test probes each app's PUBLIC origin from multiple regions. The public origin only
+# ever resolves to the revision serving 100% of traffic — a 0%-traffic candidate is reachable solely via
+# its private <app>---cd-candidate label FQDN — so a deploy CANNOT trip these. The false-positive class
+# is eliminated by construction, not by threshold tuning. This is exactly the synthetic probe audit 0001
+# §C3 named as the correct instrument, deferred only for want of an App Insights resource + a public-
+# origin variable; both now exist (ADR-0016 / ADR-0017).
+locals {
+  # cloud_RoleName as the apps tag it via OTel (service.name = IHostEnvironment.ApplicationName = the
+  # entry-assembly name; each Program.cs ConfigureResource). Scopes the auth latency alert below.
+  # Confirm against live App Insights on first apply (managed OTel agent → AI role-name mapping).
+  auth_role_name = "LotroKoniecDev.AuthSystem.API"
 
-  evaluation_frequency = "PT5M"
-  window_duration      = "PT5M"
-  scopes               = [azurerm_log_analytics_workspace.law[0].id]
-  # The *_CL custom-log tables only materialise once the apps have emitted those records, which lags
-  # a fresh environment's first apply. Skip create-time KQL schema validation so the alert can be
-  # provisioned before any logs flow — letting a future staging inherit alerting without a
-  # chicken-and-egg apply failure.
-  skip_query_validation = true
+  # Probe locations (Azure Monitor availability population tags): West Europe (Amsterdam), North Europe
+  # (Dublin), France Central (Paris) — EU-centric, closest to the Poland Central deployment.
+  availability_test_geo_locations = ["emea-nl-ams-azr", "emea-gb-db3-azr", "emea-fr-pra-edge"]
+
+  # One entry per user-facing app: its public origin, the status it must return, and the alert severity.
+  # auth is Sev0 (token-issuance SPOF = platform outage); tms + frontend are Sev1 (degraded, not a total
+  # outage). expected_status_code 0 = "any code < 400" — the Static-SSR frontend has no /health endpoint,
+  # so a 2xx/3xx on '/' is its liveness.
+  availability_web_tests = {
+    "auth"     = { url = "${local.auth_origin}/health/ready", expected_status_code = 200, severity = 0 }
+    "tms"      = { url = "${local.tms_origin}/health/ready", expected_status_code = 200, severity = 1 }
+    "frontend" = { url = "${local.apex_origin}/", expected_status_code = 0, severity = 1 }
+  }
+}
+
+# The web tests. Standard tests (classic ping tests are Microsoft-retired) run from the geo locations
+# above every 5 minutes, validating the status code + the SSL certificate's remaining lifetime. The
+# 7-day SSL threshold is a free, low-noise cert-expiry guard: the ACA managed cert auto-renews well
+# before 7 days, so a trip means auto-renew has failed — a real imminent outage, correctly escalated.
+resource "azurerm_application_insights_standard_web_test" "availability" {
+  for_each                = local.create_env ? local.availability_web_tests : {}
+  name                    = "lotrotms-webtest-${each.key}-${var.env_id}"
+  resource_group_name     = azurerm_resource_group.main.name
+  location                = azurerm_resource_group.main.location
+  application_insights_id = azurerm_application_insights.app_insights[0].id
+  geo_locations           = local.availability_test_geo_locations
+  frequency               = 300
+  timeout                 = 30
+  enabled                 = true
+  retry_enabled           = true
+  description             = "External synthetic availability probe of ${each.key} at its public origin (ADR-0019)."
+
+  request {
+    url                      = each.value.url
+    follow_redirects_enabled = true
+  }
+
+  validation_rules {
+    expected_status_code        = each.value.expected_status_code
+    ssl_check_enabled           = true
+    ssl_cert_remaining_lifetime = 7
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Availability alert per web test. Durability is GEOGRAPHIC, not temporal: the alert fires only when at
+# least 2 of the 3 locations fail in the window — rejecting a single-location network blip WITHOUT the
+# detection delay a "wait N consecutive windows" debounce would add to a real Sev0. A
+# location-availability criterion needs BOTH the web test id and the App Insights component id in scopes.
+resource "azurerm_monitor_metric_alert" "availability" {
+  for_each            = local.create_env ? local.availability_web_tests : {}
+  name                = "lotrotms-slo-availability-${each.key}-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes = [
+    azurerm_application_insights_standard_web_test.availability[each.key].id,
+    azurerm_application_insights.app_insights[0].id,
+  ]
+  description = "SLO: ${each.key} unreachable at its public origin from multiple regions. Fires by email."
+  severity    = each.value.severity
+  frequency   = "PT1M"
+  window_size = "PT5M"
+
+  application_insights_web_test_location_availability_criteria {
+    web_test_id           = azurerm_application_insights_standard_web_test.availability[each.key].id
+    component_id          = azurerm_application_insights.app_insights[0].id
+    failed_location_count = 2
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Key Vault availability (audit 0001 §M14). KV is the secret-resolution SPOF — every app + the migrator
+# resolve their connection strings / OpenIddict keys from it at revision start (ADR-0013), so a KV outage
+# is a platform outage that today surfaces only as a hard boot failure. The vault publishes an
+# Availability percentage; alert when it drops below 99% (a small buffer over a single transient throttle).
+resource "azurerm_monitor_metric_alert" "key_vault_availability" {
+  count               = local.create_env ? 1 : 0
+  name                = "lotrotms-alert-keyvault-availability-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [data.azurerm_key_vault.secrets.id]
+  description         = "Key Vault availability dropped below 99% (secret-resolution SPOF). Fires by email."
+  severity            = 1 # Error
+  frequency           = "PT5M"
+  window_size         = "PT15M"
 
   criteria {
-    query                   = <<-KQL
-      ContainerAppSystemLogs_CL
-      | where ContainerAppName_s == "${azurerm_container_app.auth_api.name}"
-      | where Reason_s has_any ("Unhealthy", "ProbeFailed")
-          or Log_s contains "readiness probe failed"
-          or Log_s contains "liveness probe failed"
-          or Log_s contains "unhealthy"
-    KQL
-    time_aggregation_method = "Count"
-    threshold               = 0
-    operator                = "GreaterThan"
+    metric_namespace = "Microsoft.KeyVault/vaults"
+    metric_name      = "Availability"
+    aggregation      = "Average"
+    operator         = "LessThan"
+    threshold        = 99
+  }
 
-    failing_periods {
-      minimum_failing_periods_to_trigger_alert = 1
-      number_of_evaluation_periods             = 1
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Auth latency — a LEADING indicator (Sev2), not an outage. Sustained high server response time on the
+# token-issuance SPOF precedes readiness failures and user-visible slowness. Reads App Insights request
+# duration (the managed OTel agent reconstructs request metrics from traces, observability.tf) scoped to
+# the auth role. Auth-only by intent (ADR-0019 §4); a for_each extends it to tms/frontend if a need appears.
+resource "azurerm_monitor_metric_alert" "auth_latency" {
+  count               = local.create_env ? 1 : 0
+  name                = "lotrotms-alert-auth-latency-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [azurerm_application_insights.app_insights[0].id]
+  description         = "Auth-api server response time sustained above 2s (degradation leading indicator). Fires by email."
+  severity            = 2 # Warning (leading indicator)
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "microsoft.insights/components"
+    metric_name      = "requests/duration"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 2000 # milliseconds
+
+    dimension {
+      name     = "cloud/roleName"
+      operator = "Include"
+      values   = [local.auth_role_name]
     }
   }
 
-  auto_mitigation_enabled = true
-
   action {
-    action_groups = [azurerm_monitor_action_group.alerts[0].id]
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
   }
 
   tags = {
@@ -410,9 +521,4 @@ moved {
 moved {
   from = azurerm_monitor_scheduled_query_rules_alert_v2.law_daily_cap
   to   = azurerm_monitor_scheduled_query_rules_alert_v2.law_daily_cap[0]
-}
-
-moved {
-  from = azurerm_monitor_scheduled_query_rules_alert_v2.auth_availability
-  to   = azurerm_monitor_scheduled_query_rules_alert_v2.auth_availability[0]
 }


### PR DESCRIPTION
## Why

Prod emits a **Sev0 email on every deploy** — `lotrotms-slo-auth-availability-prod` fires, then auto-resolves ~15 min later. It is **not** a real outage: blue-green works. The log-based `auth_availability` rule matched `ContainerAppSystemLogs_CL` by **app name, not revision**, so a health-gated **candidate revision at 0% traffic** (transient `/health/ready` misses while its Npgsql pool connects) tripped a platform-outage alert while users were served the whole time by the previous, healthy revision. A zero-tolerance threshold (`Count > 0`, one 5-min window) made a single transient log page Critical.

This is exactly the false-positive class audit 0001 §C3 anticipated — it shipped the log query as *"the 'at least a basic' one"* and named a **true synthetic external probe** as the correct instrument, deferred only for want of App Insights + a public-origin variable. **Both now exist** (ADR-0016 / ADR-0017).

## What (ADR-0019)

- **Availability SLO = App Insights standard web tests** on each app's **public origin** (auth Sev0; tms/frontend Sev1). Deploy-safe *by construction*: a 0%-traffic candidate is reachable only via its private `<app>---cd-candidate` label FQDN, so a deploy cannot trip them. Durability is **geographic** — ≥2 of 3 EU regions (West/North Europe, France Central) must fail.
- **Removed** the log-based `auth_availability` (+ its `moved`).
- **Key Vault availability** alert (audit §M14 — secret-resolution SPOF), Sev1.
- **Auth latency** leading indicator (App Insights `requests/duration`, auth role), Sev2.
- **Cert-expiry** covered free via each web test's 7-day SSL validation.
- Everything `create_env`-guarded → staging inherits (ADR-0018). Runbook: refreshed alert table + per-alert response steps + a planned-maintenance suppression procedure.

Deliberately **not** built (YAGNI, right-sized for pre-release / zero users): multi-burn-rate error-budget SLO, a second alert channel, automated deploy-window suppression.

## Verification

- `terraform fmt` + `validate`: **passing**.
- Live `plan`/`apply` runs through `infra.yml` behind the gate — this PR's plan should show the **destroy** of the log rule + **create** of the three web tests, three availability alerts, the KV alert and the latency alert.
- **Confirm-at-apply (server-side only):** the web-test geo codes, the auth `cloud/roleName` (= OTel `service.name` = `LotroKoniecDev.AuthSystem.API`), and the AI/KV metric names — flagged in code + runbook. If an availability/latency alert shows no data after first apply, verify these against live App Insights.

No separate ticket (surfaced from a prod alert email); genesis captured in ADR-0019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
