### PR TITLE
chore: ignore appsettings.Local.json in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 ﻿**/.dockerignore
 **/.env
+**/appsettings.Local.json
 **/.git
 **/.gitignore
 **/.project


### PR DESCRIPTION
Straggler `.dockerignore` change from the `obs-01-external-slo-probe` branch that didn't make it into its PR — excludes `appsettings.Local.json` from the Docker build context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)