### PR TITLE
PERF-01: Translation-file 304 revalidation must not fetch artifact content

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -122,6 +122,9 @@ internal static class ApiDependencyInjection
             services.AddSingleton<ITranslationFileSerializer, TranslationFileSerializer>();
             services.AddSingleton<IPrecomputedTranslationFileProjector, PrecomputedTranslationFileProjector>();
             services.AddScoped<
+                IQueryHandler<GetTranslationFile.HashQuery, Result<string>>,
+                GetTranslationFile.HashHandler>();
+            services.AddScoped<
                 IQueryHandler<GetTranslationFile.Query, Result<GetTranslationFile.TranslationFileResult>>,
                 GetTranslationFile.Handler>();
         }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/GetTranslationFile.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/GetTranslationFile.cs
@@ -15,15 +15,47 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 /// Serves the pre-built translation file for a language (spec 0001): streams the stored artifact
 /// with its content hash as the <c>ETag</c> and honors <c>If-None-Match</c> with a 304. Anonymous
 /// (the CLI/player downloads it). Never builds per-request — the artifact is regenerated on write
-/// by <see cref="IPrecomputedTranslationFileProjector"/>.
+/// by <see cref="IPrecomputedTranslationFileProjector"/>. The 304 decision is driven by a
+/// hash-only lookup (PERF-01/#286): the multi-MB <c>Content</c> column is TOASTed by PostgreSQL,
+/// so a revalidation that never reads it stays O(1) regardless of artifact size — content is
+/// fetched only when the client's validator no longer matches.
 /// </summary>
 internal sealed class GetTranslationFile : IEndpoint
 {
     private const string SupportedLanguage = SupportedLanguages.Polish;
 
+    internal sealed record HashQuery(string Lang) : IQuery<Result<string>>;
+
     internal sealed record Query(string Lang) : IQuery<Result<TranslationFileResult>>;
 
     internal sealed record TranslationFileResult(string Content, string ETag);
+
+    internal sealed class HashHandler : IQueryHandler<HashQuery, Result<string>>
+    {
+        private readonly IApplicationReadDbContext _readDbContext;
+
+        public HashHandler(IApplicationReadDbContext readDbContext)
+        {
+            _readDbContext = readDbContext;
+        }
+
+        public async ValueTask<Result<string>> Handle(HashQuery query, CancellationToken cancellationToken)
+        {
+            if (ValidateLanguage(query.Lang) is { } validationError)
+            {
+                return Result.Failure<string>(validationError);
+            }
+
+            string? contentHash = await _readDbContext.PrecomputedTranslationFiles
+                .Where(file => file.Language == SupportedLanguage)
+                .Select(file => file.ContentHash)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            return contentHash is null
+                ? Result.Failure<string>(NotFound())
+                : Result.Success(contentHash);
+        }
+    }
 
     internal sealed class Handler : IQueryHandler<Query, Result<TranslationFileResult>>
     {
@@ -36,12 +68,9 @@ internal sealed class GetTranslationFile : IEndpoint
 
         public async ValueTask<Result<TranslationFileResult>> Handle(Query query, CancellationToken cancellationToken)
         {
-            if (!string.Equals(query.Lang, SupportedLanguage, StringComparison.OrdinalIgnoreCase))
+            if (ValidateLanguage(query.Lang) is { } validationError)
             {
-                return Result.Failure<TranslationFileResult>(new Error(
-                    "TranslationFiles.UnsupportedLanguage",
-                    $"Language '{query.Lang}' is not supported; only '{SupportedLanguage}' exists today.",
-                    TypeOfError.Validation));
+                return Result.Failure<TranslationFileResult>(validationError);
             }
 
             TranslationFileResult? result = await _readDbContext.PrecomputedTranslationFiles
@@ -50,10 +79,7 @@ internal sealed class GetTranslationFile : IEndpoint
                 .FirstOrDefaultAsync(cancellationToken);
 
             return result is null
-                ? Result.Failure<TranslationFileResult>(new Error(
-                    "TranslationFiles.NotFound",
-                    $"No translation file has been built for '{SupportedLanguage}' yet.",
-                    TypeOfError.NotFound))
+                ? Result.Failure<TranslationFileResult>(NotFound())
                 : Result.Success(result);
         }
     }
@@ -62,23 +88,19 @@ internal sealed class GetTranslationFile : IEndpoint
     {
         endpointRouteBuilder.MapGet("/api/v1/translation-files/{lang}", async (
                 string lang,
+                IQueryHandler<HashQuery, Result<string>> hashHandler,
                 IQueryHandler<Query, Result<TranslationFileResult>> handler,
                 HttpContext httpContext,
                 CancellationToken cancellationToken) =>
             {
-                Result<TranslationFileResult> result = await handler.Handle(new Query(lang), cancellationToken);
+                Result<string> hashResult = await hashHandler.Handle(new HashQuery(lang), cancellationToken);
 
-                if (result.IsFailure)
+                if (hashResult.IsFailure)
                 {
-                    return Results.Problem(result.Error.ToProblemDetails());
+                    return Results.Problem(hashResult.Error.ToProblemDetails());
                 }
 
-                EntityTagHeaderValue entityTag = new($"\"{result.Value.ETag}\"");
-
-                // Revalidation model: clients keep the cached file and re-check via If-None-Match.
-                // Setting Cache-Control explicitly stops GlobalNoCacheMiddleware from stamping no-store.
-                httpContext.Response.Headers.CacheControl = "private, no-cache";
-                httpContext.Response.GetTypedHeaders().ETag = entityTag;
+                EntityTagHeaderValue entityTag = new($"\"{hashResult.Value}\"");
 
                 // If-None-Match is a comma-separated list and may be "*" (RFC 9110 §13.1.2):
                 // 304 when any supplied validator matches the current strong tag.
@@ -86,9 +108,23 @@ internal sealed class GetTranslationFile : IEndpoint
                     .Any(candidate => candidate.Equals(EntityTagHeaderValue.Any)
                                       || candidate.Compare(entityTag, useStrongComparison: true));
 
-                return notModified
-                    ? Results.StatusCode(StatusCodes.Status304NotModified)
-                    : Results.Text(result.Value.Content, "text/plain", Encoding.UTF8);
+                if (notModified)
+                {
+                    SetRevalidationHeaders(httpContext, entityTag);
+                    return Results.StatusCode(StatusCodes.Status304NotModified);
+                }
+
+                Result<TranslationFileResult> result = await handler.Handle(new Query(lang), cancellationToken);
+
+                if (result.IsFailure)
+                {
+                    return Results.Problem(result.Error.ToProblemDetails());
+                }
+
+                // The ETag ships from the same row read as the content: were a rebuild to land between
+                // the hash lookup and this fetch, the client still receives a matching (tag, body) pair.
+                SetRevalidationHeaders(httpContext, new EntityTagHeaderValue($"\"{result.Value.ETag}\""));
+                return Results.Text(result.Value.Content, "text/plain", Encoding.UTF8);
             })
             .WithName(nameof(GetTranslationFile))
             .WithTags("TranslationFiles")
@@ -97,4 +133,28 @@ internal sealed class GetTranslationFile : IEndpoint
             .Produces(StatusCodes.Status304NotModified)
             .ProducesProblem(StatusCodes.Status404NotFound);
     }
+
+    /// <summary>
+    /// Revalidation model: clients keep the cached file and re-check via <c>If-None-Match</c>.
+    /// Setting Cache-Control explicitly stops GlobalNoCacheMiddleware from stamping no-store.
+    /// </summary>
+    private static void SetRevalidationHeaders(HttpContext httpContext, EntityTagHeaderValue entityTag)
+    {
+        httpContext.Response.Headers.CacheControl = "private, no-cache";
+        httpContext.Response.GetTypedHeaders().ETag = entityTag;
+    }
+
+    private static Error? ValidateLanguage(string lang)
+        => string.Equals(lang, SupportedLanguage, StringComparison.OrdinalIgnoreCase)
+            ? null
+            : new Error(
+                "TranslationFiles.UnsupportedLanguage",
+                $"Language '{lang}' is not supported; only '{SupportedLanguage}' exists today.",
+                TypeOfError.Validation);
+
+    private static Error NotFound()
+        => new(
+            "TranslationFiles.NotFound",
+            $"No translation file has been built for '{SupportedLanguage}' yet.",
+            TypeOfError.NotFound);
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/SqlCommandRecorder.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/SqlCommandRecorder.cs
@@ -1,0 +1,40 @@
+using System.Collections.Concurrent;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration;
+
+/// <summary>
+/// Records the SQL text of every query the intercepted context executes, so a test can pin
+/// properties that are invisible in the HTTP response — e.g. that the translation-file 304 path
+/// never reads the multi-MB <c>Content</c> column (PERF-01/#286). The DB command stream is the
+/// only observable seam for "this column was not fetched": the repo's <c>.Received()</c> policy
+/// (side effects invisible in the return value) sanctions asserting on it.
+/// </summary>
+public sealed class SqlCommandRecorder : DbCommandInterceptor
+{
+    private readonly ConcurrentQueue<string> _commands = new();
+
+    public IReadOnlyList<string> Commands => [.. _commands];
+
+    public void Clear() => _commands.Clear();
+
+    public override InterceptionResult<DbDataReader> ReaderExecuting(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result)
+    {
+        _commands.Enqueue(command.CommandText);
+        return base.ReaderExecuting(command, eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result,
+        CancellationToken cancellationToken = default)
+    {
+        _commands.Enqueue(command.CommandText);
+        return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
@@ -69,9 +69,14 @@ public sealed class GetTranslationFileTests : IAsyncLifetime
         HttpResponseMessage response = await _factory.CreateClient().GetAsync(Route);
         string body = await response.Content.ReadAsStringAsync();
 
-        // Assert
+        // Assert — Cache-Control must be the endpoint's revalidation pair, not the no-store
+        // stamp GlobalNoCacheMiddleware applies when an endpoint sets nothing.
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Headers.ETag.ShouldNotBeNull();
+        response.Headers.CacheControl.ShouldNotBeNull();
+        response.Headers.CacheControl.Private.ShouldBeTrue();
+        response.Headers.CacheControl.NoCache.ShouldBeTrue();
+        response.Headers.CacheControl.NoStore.ShouldBeFalse();
         body.ShouldContain($"{FileId}||1||Alfa||NULL||NULL||1");
         body.ShouldNotContain($"{FileId}||2||");
         body.ShouldNotContain($"{FileId}||3||");
@@ -92,9 +97,15 @@ public sealed class GetTranslationFileTests : IAsyncLifetime
         client.DefaultRequestHeaders.IfNoneMatch.Add(etag);
         HttpResponseMessage second = await client.GetAsync(Route);
 
-        // Assert
+        // Assert — a 304 must re-state the current validator (RFC 9110 §15.4.5) and the
+        // revalidation Cache-Control, or intermediaries would evict the cached artifact.
         second.StatusCode.ShouldBe(HttpStatusCode.NotModified);
         (await second.Content.ReadAsStringAsync()).ShouldBeEmpty();
+        second.Headers.ETag.ShouldBe(etag);
+        second.Headers.CacheControl.ShouldNotBeNull();
+        second.Headers.CacheControl.Private.ShouldBeTrue();
+        second.Headers.CacheControl.NoCache.ShouldBeTrue();
+        second.Headers.CacheControl.NoStore.ShouldBeFalse();
     }
 
     [Fact]
@@ -113,6 +124,67 @@ public sealed class GetTranslationFileTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+    }
+
+    [Fact]
+    public async Task Get_WithStaleIfNoneMatch_ShouldReturn200WithCurrentContentAndETag()
+    {
+        // Arrange
+        await SeedAsync(gossipId: 1, polish: "Alfa", status: SeedStatus.Approved);
+        await RebuildAsync();
+        EntityTagHeaderValue currentEtag = (await _factory.CreateClient().GetAsync(Route)).Headers.ETag!;
+
+        // Act — the canonical CLI update download: the held validator no longer matches.
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.IfNoneMatch.Add(new EntityTagHeaderValue("\"stale-tag\""));
+        HttpResponseMessage response = await client.GetAsync(Route);
+        string body = await response.Content.ReadAsStringAsync();
+
+        // Assert — full body plus the current validator, so the client re-syncs in one round-trip.
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldBe(currentEtag);
+        body.ShouldContain($"{FileId}||1||Alfa||NULL||NULL||1");
+    }
+
+    [Fact]
+    public async Task Get_WithWildcardIfNoneMatch_ShouldReturn304()
+    {
+        // Arrange
+        await SeedAsync(gossipId: 1, polish: "Alfa", status: SeedStatus.Approved);
+        await RebuildAsync();
+
+        // Act — "*" matches any current representation (RFC 9110 §13.1.2).
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.IfNoneMatch.Add(EntityTagHeaderValue.Any);
+        HttpResponseMessage response = await client.GetAsync(Route);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+    }
+
+    [Fact]
+    public async Task Get_WithMatchingIfNoneMatch_ShouldNotQueryContentColumn()
+    {
+        // Arrange
+        await SeedAsync(gossipId: 1, polish: "Alfa", status: SeedStatus.Approved);
+        await RebuildAsync();
+        EntityTagHeaderValue etag = (await _factory.CreateClient().GetAsync(Route)).Headers.ETag!;
+
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.IfNoneMatch.Add(etag);
+        _factory.ReadContextSqlRecorder.Clear();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(Route);
+
+        // Assert — the revalidation's cost model (PERF-01/#286): the hash column is read, the
+        // multi-MB Content column is not. The quoted-identifier match is exact on purpose:
+        // "ContentHash" contains the bare substring, so only "Content" with its closing quote
+        // proves the column itself was fetched.
+        response.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        IReadOnlyList<string> commands = _factory.ReadContextSqlRecorder.Commands;
+        commands.ShouldContain(command => command.Contains("\"ContentHash\""));
+        commands.ShouldAllBe(command => !command.Contains("\"Content\""));
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
@@ -10,6 +10,7 @@ using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Testcontainers.PostgreSql;
 using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration;
@@ -34,6 +35,13 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
 
     private string _connectionString = string.Empty;
 
+    /// <summary>
+    /// Records the read context's SQL so tests can pin column-level fetch behavior the HTTP
+    /// response cannot reveal (PERF-01/#286). Shared per factory; tests <see cref="SqlCommandRecorder.Clear"/>
+    /// before the request under observation (the collection runs sequentially, so nothing interleaves).
+    /// </summary>
+    public SqlCommandRecorder ReadContextSqlRecorder { get; } = new();
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
@@ -57,6 +65,11 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
                 options.ConfigurationManager = null;
                 options.TokenValidationParameters.IssuerSigningKey = TestSigningKey;
             });
+
+            // AddDbContext calls compose (EF Core 9+): this appends the recording interceptor to the
+            // production registration of the read context instead of replacing it.
+            services.AddDbContext<ApplicationReadDbContext>(options =>
+                options.AddInterceptors(ReadContextSqlRecorder));
         });
 
         builder.ConfigureLogging(logging =>


### PR DESCRIPTION
## Summary
Performance audit finding P1-1. `GET /api/v1/translation-files/{lang}` — the public hot path every player launch revalidates — always projected the multi-MB, TOASTed `Content` column before the endpoint compared `If-None-Match`, so a 304 paid the full de-TOAST + transfer + LOH allocation just to discard it.

The slice now has a hash-only `HashQuery` driving the 304 decision (single indexed row lookup — O(1) regardless of artifact size); `Content` is fetched only on an ETag miss, together with its hash from the same row read, so the response `(tag, body)` pair cannot be stale under a concurrent rebuild.

## Tests
- New `SqlCommandRecorder` (`DbCommandInterceptor`) in the integration factory pins the core property: the 304 request's SQL references `"ContentHash"` and never the `"Content"` column
- 304 asserts the re-stated `ETag` (RFC 9110 §15.4.5) + `Cache-Control: private, no-cache` (would otherwise regress to GlobalNoCacheMiddleware's `no-store`); 200 asserts the same pair
- New stale-tag→200 (current body + current ETag) and wildcard `*`→304 coverage
- Full TMS suites green: 149/149 integration, 140/140 unit; build zero warnings

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)