### PR TITLE
PERF-02: Prune expired OpenIddict tokens and authorizations

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -11,6 +11,7 @@ using LotroKoniecDev.AuthSystem.API.Features.Auth;
 using LotroKoniecDev.AuthSystem.API.Hateoas.AccountAggregateFactories;
 using LotroKoniecDev.AuthSystem.API.Hateoas.DiscoveryFactories;
 using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Services.Maintenance;
 using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
@@ -76,6 +77,10 @@ internal static class ApiDependencyInjection
             services.AddScoped<IAccountConfirmationEmailSender, AccountConfirmationEmailSender>();
 
             services.AddScoped<IUserSessionRevoker, UserSessionRevoker>();
+
+            // PERF-02: reference refresh tokens accumulate one row per refresh and are never
+            // deleted otherwise; prune expired/invalid tokens and authorizations daily.
+            services.AddHostedService<OpenIddictPruneService>();
 
             // Fail-fast startup validation of the OpenIddict server config (ADR-0008 §3, M6-05): the
             // OpenIddictSettingsValidator enforces the production key material / issuer and names the

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -58,6 +58,10 @@ internal static class EventIds
     public const int UserSessionsRevoked = 2301;
     public const int UserSessionsRevocationFailed = 2302;
 
+    // Token Pruning (2310–2319)
+    public const int OpenIddictPruneCompleted = 2310;
+    public const int OpenIddictPruneFailed = 2311;
+
     // Middleware (2400–2499)
     public const int UnauthorizedAccessAttempt = 2400;
     public const int ForbiddenAccessAttempt = 2401;

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Maintenance/OpenIddictPruneService.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Maintenance/OpenIddictPruneService.cs
@@ -1,0 +1,87 @@
+using OpenIddict.Abstractions;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Maintenance;
+
+/// <summary>
+/// Daily background prune of stale OpenIddict tokens and authorizations (PERF-02). Rolling reference
+/// refresh tokens (<c>UseReferenceRefreshTokens()</c>) write a new token row on every refresh and
+/// nothing else ever deletes them, so without this pass the <c>OpenIddictTokens</c> and
+/// <c>OpenIddictAuthorizations</c> tables grow without bound and slow every token-endpoint lookup.
+/// </summary>
+internal sealed partial class OpenIddictPruneService : BackgroundService
+{
+    /// <summary>
+    /// Rows younger than this are never pruned, mirroring the default threshold of OpenIddict's own
+    /// Quartz integration; the prune only ever removes rows that are already expired or invalid.
+    /// </summary>
+    internal static readonly TimeSpan RetentionPeriod = TimeSpan.FromDays(14);
+
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromMinutes(1);
+
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
+
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<OpenIddictPruneService> _logger;
+
+    public OpenIddictPruneService(
+        IServiceScopeFactory serviceScopeFactory,
+        TimeProvider timeProvider,
+        ILogger<OpenIddictPruneService> logger)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(StartupDelay, _timeProvider, stoppingToken);
+        await PruneOnceAsync(stoppingToken);
+
+        using PeriodicTimer timer = new(Interval, _timeProvider);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await PruneOnceAsync(stoppingToken);
+        }
+    }
+
+    /// <summary>
+    /// Runs a single prune pass. Tokens are pruned before authorizations because OpenIddict never
+    /// deletes an authorization that still has tokens attached. The managers are scoped (they ride on
+    /// <c>AuthDbContext</c>), hence the explicit scope per pass. Every failure is logged and
+    /// swallowed — an exception escaping <see cref="ExecuteAsync"/> stops the whole host — except a
+    /// cancellation of <paramref name="cancellationToken"/> itself, which is a normal shutdown and
+    /// must propagate.
+    /// </summary>
+    internal async Task PruneOnceAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using AsyncServiceScope scope = _serviceScopeFactory.CreateAsyncScope();
+
+            IOpenIddictTokenManager tokenManager =
+                scope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+            IOpenIddictAuthorizationManager authorizationManager =
+                scope.ServiceProvider.GetRequiredService<IOpenIddictAuthorizationManager>();
+
+            DateTimeOffset threshold = _timeProvider.GetUtcNow() - RetentionPeriod;
+
+            long prunedTokens = await tokenManager.PruneAsync(threshold, cancellationToken);
+            long prunedAuthorizations = await authorizationManager.PruneAsync(threshold, cancellationToken);
+
+            LogPruneCompleted(_logger, prunedTokens, prunedAuthorizations, threshold);
+        }
+        catch (Exception exception)
+            when (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+        {
+            LogPruneFailed(_logger, exception);
+        }
+    }
+
+    [LoggerMessage(EventId = EventIds.OpenIddictPruneCompleted, Level = LogLevel.Information, Message = "OpenIddict prune removed {TokenCount} token(s) and {AuthorizationCount} authorization(s) created before {Threshold}")]
+    private static partial void LogPruneCompleted(ILogger logger, long tokenCount, long authorizationCount, DateTimeOffset threshold);
+
+    [LoggerMessage(EventId = EventIds.OpenIddictPruneFailed, Level = LogLevel.Error, Message = "OpenIddict prune pass failed. Stale tokens and authorizations will be retried on the next daily pass.")]
+    private static partial void LogPruneFailed(ILogger logger, Exception exception);
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj
@@ -15,6 +15,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
         <PackageReference Include="Testcontainers" />
         <PackageReference Include="Testcontainers.PostgreSql"/>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Maintenance/OpenIddictPruneServiceIntegrationTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Maintenance/OpenIddictPruneServiceIntegrationTests.cs
@@ -1,0 +1,146 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenIddict.Abstractions;
+using LotroKoniecDev.AuthSystem.API.Services.Maintenance;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Maintenance;
+
+/// <summary>
+/// Prune behavior against the real OpenIddict Entity Framework stores and PostgreSQL: rows past the
+/// 14-day retention that are expired or revoked disappear, while recent or still-valid rows survive.
+/// The 13/15-day-old rows bracket the retention threshold from both sides without clock faking —
+/// the descriptors carry explicit creation dates.
+/// </summary>
+[Collection("AuthApi")]
+public sealed class OpenIddictPruneServiceIntegrationTests
+{
+    private readonly AuthSystemApiFactory _factory;
+
+    public OpenIddictPruneServiceIntegrationTests(AuthSystemApiFactory appFactory)
+    {
+        _factory = appFactory;
+    }
+
+    [Fact]
+    public void AddAuthApi_RegistersPruneHostedService()
+    {
+        // Assert
+        _factory.Services.GetServices<IHostedService>()
+            .OfType<OpenIddictPruneService>()
+            .ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task PruneOnceAsync_ExpiredTokenPastRetention_IsPrunedWhileRecentAndValidTokensSurvive()
+    {
+        // Arrange
+        string prunedTokenId;
+        string recentExpiredTokenId;
+        string oldValidTokenId;
+        await using (AsyncServiceScope arrangeScope = _factory.Services.CreateAsyncScope())
+        {
+            IOpenIddictTokenManager tokenManager =
+                arrangeScope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+
+            prunedTokenId = await CreateTokenAsync(tokenManager, createdDaysAgo: 15, expired: true);
+            recentExpiredTokenId = await CreateTokenAsync(tokenManager, createdDaysAgo: 13, expired: true);
+            oldValidTokenId = await CreateTokenAsync(tokenManager, createdDaysAgo: 15, expired: false);
+        }
+
+        // Act
+        await ResolvePruneService().PruneOnceAsync(CancellationToken.None);
+
+        // Assert
+        await using AsyncServiceScope assertScope = _factory.Services.CreateAsyncScope();
+        IOpenIddictTokenManager assertTokenManager =
+            assertScope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+
+        (await assertTokenManager.FindByIdAsync(prunedTokenId)).ShouldBeNull();
+        (await assertTokenManager.FindByIdAsync(recentExpiredTokenId)).ShouldNotBeNull();
+        (await assertTokenManager.FindByIdAsync(oldValidTokenId)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task PruneOnceAsync_RevokedAuthorizationPastRetention_IsPrunedWhileRecentAndPermanentSurvive()
+    {
+        // Arrange
+        string prunedAuthorizationId;
+        string recentRevokedAuthorizationId;
+        string oldPermanentAuthorizationId;
+        await using (AsyncServiceScope arrangeScope = _factory.Services.CreateAsyncScope())
+        {
+            IOpenIddictAuthorizationManager authorizationManager =
+                arrangeScope.ServiceProvider.GetRequiredService<IOpenIddictAuthorizationManager>();
+
+            prunedAuthorizationId = await CreateAuthorizationAsync(
+                authorizationManager,
+                createdDaysAgo: 15,
+                status: OpenIddictConstants.Statuses.Revoked,
+                type: OpenIddictConstants.AuthorizationTypes.AdHoc);
+            recentRevokedAuthorizationId = await CreateAuthorizationAsync(
+                authorizationManager,
+                createdDaysAgo: 13,
+                status: OpenIddictConstants.Statuses.Revoked,
+                type: OpenIddictConstants.AuthorizationTypes.AdHoc);
+            oldPermanentAuthorizationId = await CreateAuthorizationAsync(
+                authorizationManager,
+                createdDaysAgo: 15,
+                status: OpenIddictConstants.Statuses.Valid,
+                type: OpenIddictConstants.AuthorizationTypes.Permanent);
+        }
+
+        // Act
+        await ResolvePruneService().PruneOnceAsync(CancellationToken.None);
+
+        // Assert — the permanent valid grant is a user's live consent and must never be pruned
+        await using AsyncServiceScope assertScope = _factory.Services.CreateAsyncScope();
+        IOpenIddictAuthorizationManager assertAuthorizationManager =
+            assertScope.ServiceProvider.GetRequiredService<IOpenIddictAuthorizationManager>();
+
+        (await assertAuthorizationManager.FindByIdAsync(prunedAuthorizationId)).ShouldBeNull();
+        (await assertAuthorizationManager.FindByIdAsync(recentRevokedAuthorizationId)).ShouldNotBeNull();
+        (await assertAuthorizationManager.FindByIdAsync(oldPermanentAuthorizationId)).ShouldNotBeNull();
+    }
+
+    private OpenIddictPruneService ResolvePruneService()
+        => _factory.Services.GetServices<IHostedService>()
+            .OfType<OpenIddictPruneService>()
+            .Single();
+
+    private static async Task<string> CreateTokenAsync(
+        IOpenIddictTokenManager tokenManager,
+        int createdDaysAgo,
+        bool expired)
+    {
+        DateTimeOffset utcNow = DateTimeOffset.UtcNow;
+        OpenIddictTokenDescriptor descriptor = new()
+        {
+            Subject = Guid.NewGuid().ToString(),
+            Type = OpenIddictConstants.TokenTypeHints.RefreshToken,
+            Status = OpenIddictConstants.Statuses.Valid,
+            CreationDate = utcNow.AddDays(-createdDaysAgo),
+            ExpirationDate = expired ? utcNow.AddDays(-1) : utcNow.AddDays(30)
+        };
+
+        object token = await tokenManager.CreateAsync(descriptor);
+        return (await tokenManager.GetIdAsync(token))!;
+    }
+
+    private static async Task<string> CreateAuthorizationAsync(
+        IOpenIddictAuthorizationManager authorizationManager,
+        int createdDaysAgo,
+        string status,
+        string type)
+    {
+        OpenIddictAuthorizationDescriptor descriptor = new()
+        {
+            Subject = Guid.NewGuid().ToString(),
+            Type = type,
+            Status = status,
+            CreationDate = DateTimeOffset.UtcNow.AddDays(-createdDaysAgo)
+        };
+
+        object authorization = await authorizationManager.CreateAsync(descriptor);
+        return (await authorizationManager.GetIdAsync(authorization))!;
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Maintenance/OpenIddictPruneServiceTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Maintenance/OpenIddictPruneServiceTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using LotroKoniecDev.AuthSystem.API.Services.Maintenance;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Maintenance;
+
+/// <summary>
+/// Behavior of a single prune pass against substituted OpenIddict managers: the 14-day threshold,
+/// the tokens-before-authorizations order OpenIddict requires, and the never-crash-the-host
+/// failure posture. Pure tests; they start no container.
+/// </summary>
+public sealed class OpenIddictPruneServiceTests
+{
+    private static readonly DateTimeOffset FixedUtcNow = new(2026, 7, 2, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IOpenIddictTokenManager _tokenManager =
+        Substitute.For<IOpenIddictTokenManager>();
+
+    private readonly IOpenIddictAuthorizationManager _authorizationManager =
+        Substitute.For<IOpenIddictAuthorizationManager>();
+
+    [Fact]
+    public async Task PruneOnceAsync_HealthyManagers_PrunesTokensBeforeAuthorizationsWithFourteenDayThreshold()
+    {
+        // Arrange
+        await using ServiceProvider serviceProvider = BuildServiceProvider();
+        using OpenIddictPruneService service = CreateService(serviceProvider);
+        DateTimeOffset expectedThreshold = FixedUtcNow - OpenIddictPruneService.RetentionPeriod;
+
+        // Act
+        await service.PruneOnceAsync(CancellationToken.None);
+
+        // Assert — pruning is invisible in any return value, so the manager calls are the observable
+        // side effect; tokens must go first because OpenIddict never deletes an authorization that
+        // still has tokens attached.
+        Received.InOrder(() =>
+        {
+            _tokenManager.PruneAsync(expectedThreshold, Arg.Any<CancellationToken>());
+            _authorizationManager.PruneAsync(expectedThreshold, Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Fact]
+    public async Task PruneOnceAsync_TokenManagerFails_DoesNotThrow()
+    {
+        // Arrange
+        _tokenManager.PruneAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<long>(new InvalidOperationException("database unavailable")));
+        await using ServiceProvider serviceProvider = BuildServiceProvider();
+        using OpenIddictPruneService service = CreateService(serviceProvider);
+
+        // Act & Assert
+        await Should.NotThrowAsync(() => service.PruneOnceAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PruneOnceAsync_AuthorizationManagerFails_DoesNotThrow()
+    {
+        // Arrange
+        _authorizationManager.PruneAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<long>(new InvalidOperationException("database unavailable")));
+        await using ServiceProvider serviceProvider = BuildServiceProvider();
+        using OpenIddictPruneService service = CreateService(serviceProvider);
+
+        // Act & Assert
+        await Should.NotThrowAsync(() => service.PruneOnceAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PruneOnceAsync_HostShutdownCancellation_PropagatesOperationCanceledException()
+    {
+        // Arrange
+        using CancellationTokenSource cancellationSource = new();
+        await cancellationSource.CancelAsync();
+        _tokenManager.PruneAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<long>(new OperationCanceledException(cancellationSource.Token)));
+        await using ServiceProvider serviceProvider = BuildServiceProvider();
+        using OpenIddictPruneService service = CreateService(serviceProvider);
+
+        // Act & Assert — a shutdown cancellation must not be swallowed and logged as a failure
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => service.PruneOnceAsync(cancellationSource.Token));
+    }
+
+    [Fact]
+    public async Task PruneOnceAsync_OperationCanceledWithoutShutdown_IsSwallowedLikeAnyFailure()
+    {
+        // Arrange — a rogue OperationCanceledException not caused by the host's own stopping token
+        _tokenManager.PruneAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<long>(new OperationCanceledException()));
+        await using ServiceProvider serviceProvider = BuildServiceProvider();
+        using OpenIddictPruneService service = CreateService(serviceProvider);
+
+        // Act & Assert
+        await Should.NotThrowAsync(() => service.PruneOnceAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task StartAsync_StoppedBeforeStartupDelayElapses_NeverPrunes()
+    {
+        // Arrange — real clock: the one-minute startup delay cannot elapse within this test
+        await using ServiceProvider serviceProvider = BuildServiceProvider();
+        using OpenIddictPruneService service = new(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            TimeProvider.System,
+            NullLogger<OpenIddictPruneService>.Instance);
+
+        // Act
+        await service.StartAsync(CancellationToken.None);
+        await service.StopAsync(CancellationToken.None);
+
+        // Assert
+        await _tokenManager.DidNotReceiveWithAnyArgs().PruneAsync(default, default);
+        await _authorizationManager.DidNotReceiveWithAnyArgs().PruneAsync(default, default);
+    }
+
+    private ServiceProvider BuildServiceProvider()
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => _tokenManager);
+        services.AddScoped(_ => _authorizationManager);
+        return services.BuildServiceProvider();
+    }
+
+    private static OpenIddictPruneService CreateService(ServiceProvider serviceProvider)
+    {
+        TimeProvider timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(FixedUtcNow);
+
+        return new OpenIddictPruneService(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            timeProvider,
+            NullLogger<OpenIddictPruneService>.Instance);
+    }
+}


### PR DESCRIPTION
Daily `BackgroundService` in AuthSystem.API pruning expired/invalid OpenIddict tokens and authorizations — perf-audit finding P1-3: `UseReferenceRefreshTokens()` + rolling refresh writes a token row per refresh and nothing ever deleted them.

- One pass ~1 minute after startup, then every 24h (`PeriodicTimer`); 14-day threshold (`TimeProvider`-derived); managers resolved via a per-pass `AsyncServiceScope`; tokens pruned before authorizations (OpenIddict never deletes an authorization with tokens still attached); every non-shutdown failure is logged (event ids 2310/2311) and swallowed so the host never crashes.
- Registered via `AddHostedService` in `ApiDependencyInjection`.
- Tests: substitute-based (threshold exactness, ordering, failure swallowing, shutdown-cancellation propagation, no premature prune) + real-PostgreSQL integration (hosted-service registration; 15-day-old expired/revoked rows pruned while 13-day-old and still-valid/permanent rows survive — brackets the threshold from both sides).
- Deferred (reviewer-optional): a FakeTimeProvider pinning test for the 24h cadence.

Code review: APPROVE. Security review: clean (pruning fails closed everywhere; no retention-vs-lifetime window; no token/PII in logs). Build zero warnings; AuthSystem integration suite 186/186 green.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)