### PR TITLE
PERF-03: Search and status indexes for Translations (pg_trgm GIN + partial status index)

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
@@ -30,23 +30,38 @@ internal sealed class TranslationConfiguration : IEntityTypeConfiguration<Transl
                 .IsUnique();
         });
 
-        // The English source is a pure value compared as one unit by the diff — ComplexProperty,
-        // no index needed.
-        builder.ComplexProperty(translation => translation.Source, complexBuilder =>
+        // SourceText carries the trigram search index below, so the VO is mapped with OwnsOne
+        // (ComplexProperty cannot be indexed in EF Core 10).
+        builder.OwnsOne(translation => translation.Source, ownedBuilder =>
         {
-            complexBuilder.Property(source => source.Text)
+            ownedBuilder.Property(source => source.Text)
                 .HasColumnName(nameof(Translation.Source) + nameof(TranslationSource.Text));
 
-            complexBuilder.Property(source => source.ArgsOrder)
+            ownedBuilder.Property(source => source.ArgsOrder)
                 .HasColumnName(nameof(TranslationSource.ArgsOrder));
 
-            complexBuilder.Property(source => source.ArgsId)
+            ownedBuilder.Property(source => source.ArgsId)
                 .HasColumnName(nameof(TranslationSource.ArgsId));
+
+            // Trigram GIN serves ListTranslations' ILIKE '%term%' search over the English source.
+            ownedBuilder.HasIndex(source => source.Text)
+                .HasMethod("gin")
+                .HasOperators("gin_trgm_ops");
         });
+
+        // Trigram GIN serves ListTranslations' ILIKE '%term%' search over the Polish text.
+        builder.HasIndex(translation => translation.TranslatedText)
+            .HasMethod("gin")
+            .HasOperators("gin_trgm_ops");
 
         builder.Property(translation => translation.Status)
             .HasConversion<string>()
             .HasMaxLength(EnumConsts.MaxLength);
+
+        // Partial index over the live rows: the status-filtered list, the stats GROUP BY and the
+        // artifact projector's Approved scan all filter on RemovedInVersion IS NULL first.
+        builder.HasIndex(translation => translation.Status)
+            .HasFilter($"\"{nameof(Translation.RemovedInVersion)}\" IS NULL");
 
         // Submitter / approver are local FKs to Translators (ADR-0004), not the bare Auth IdentityId.
         // The write aggregate references the Translator by id only (DDD — no navigation across

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/WriteDbContexts/ApplicationWriteDbContext.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DbContexts/WriteDbContexts/ApplicationWriteDbContext.cs
@@ -64,6 +64,10 @@ internal sealed class ApplicationWriteDbContext : DbContext, IUnitOfWork
     {
         modelBuilder.HasDefaultSchema(DatabaseSchemas.Translation);
 
+        // The trigram GIN indexes on Translations (TranslationConfiguration) need pg_trgm; the
+        // migration emits CREATE EXTENSION IF NOT EXISTS, so the migrator role must be allowed to.
+        modelBuilder.HasPostgresExtension("pg_trgm");
+
         modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
 
         base.OnModelCreating(modelBuilder);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260702031513_AddTranslationSearchAndStatusIndexes.Designer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260702031513_AddTranslationSearchAndStatusIndexes.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationWriteDbContext))]
-    partial class ApplicationWriteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702031513_AddTranslationSearchAndStatusIndexes")]
+    partial class AddTranslationSearchAndStatusIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260702031513_AddTranslationSearchAndStatusIndexes.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260702031513_AddTranslationSearchAndStatusIndexes.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTranslationSearchAndStatusIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:pg_trgm", ",,");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Translations_SourceText",
+                schema: "translation",
+                table: "Translations",
+                column: "SourceText")
+                .Annotation("Npgsql:IndexMethod", "gin")
+                .Annotation("Npgsql:IndexOperators", new[] { "gin_trgm_ops" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Translations_Status",
+                schema: "translation",
+                table: "Translations",
+                column: "Status",
+                filter: "\"RemovedInVersion\" IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Translations_TranslatedText",
+                schema: "translation",
+                table: "Translations",
+                column: "TranslatedText")
+                .Annotation("Npgsql:IndexMethod", "gin")
+                .Annotation("Npgsql:IndexOperators", new[] { "gin_trgm_ops" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Translations_SourceText",
+                schema: "translation",
+                table: "Translations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Translations_Status",
+                schema: "translation",
+                table: "Translations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Translations_TranslatedText",
+                schema: "translation",
+                table: "Translations");
+
+            migrationBuilder.AlterDatabase()
+                .OldAnnotation("Npgsql:PostgresExtension:pg_trgm", ",,");
+        }
+    }
+}


### PR DESCRIPTION
Closes #288

## What

- `Translation.Source` VO mapping: `ComplexProperty` → `OwnsOne` (house rule: OwnsOne when an index is needed — ComplexProperty cannot be indexed in EF Core 10). Column names `SourceText`/`ArgsOrder`/`ArgsId` preserved, so there is zero data movement.
- `modelBuilder.HasPostgresExtension("pg_trgm")` on the write model.
- Trigram GIN indexes (`gin_trgm_ops`) on `SourceText` (inside the owned builder) and `TranslatedText` — serve `ListTranslations`' `ILIKE '%term%'` search (audit P2-a: 2× seq scan of ~780k rows per search — COUNT + page).
- Partial index on `Status` with `HasFilter` on `"RemovedInVersion" IS NULL` (nameof-parametrized) — serves the status-filtered list, `GetTranslationStats` GROUP BY and the artifact projector's Approved scan (audit P2-b).
- New migration `AddTranslationSearchAndStatusIndexes`: **only** the extension op + 3 `CreateIndex` — no `AlterColumn`, no table rebuild; scaffold-diff empty (`dotnet ef migrations has-pending-model-changes`: none).

## Deployment note (ticket AC)

**Prod DB (Neon/Supabase) must allow `CREATE EXTENSION pg_trgm` for the migrator role** — the migration emits `CREATE EXTENSION IF NOT EXISTS pg_trgm`. Both providers ship `pg_trgm` on their extension allowlists.

## Verification

- `dotnet build LotroKoniecDev.slnx` — 0 warnings, 0 errors (TreatWarningsAsErrors).
- Full `dotnet test` — all 11 test projects green, incl. 149 TranslationSystem integration tests that `MigrateAsync` this migration against real PostgreSQL (exercises `CREATE EXTENSION pg_trgm` + all three indexes) and the import-diff path that replaces the now-owned `Source` instance on a tracked aggregate.
- Emitted SQL inspected: `CREATE EXTENSION IF NOT EXISTS pg_trgm;` + 2× `CREATE INDEX ... USING gin (... gin_trgm_ops)` + 1× partial `CREATE INDEX ... WHERE "RemovedInVersion" IS NULL`.
- code-reviewer: **APPROVE**. Informational notes: non-`CONCURRENTLY` GIN build is fine pre-release; `Down()` deliberately keeps the extension installed; an `EXPLAIN ANALYZE` sanity pass on staging post-merge is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)