### PR TITLE
PERF-04: Debounced background artifact rebuild — approve/upsert/import off the hot path

### DIFF
--- a/docs/adr/0007-read-projections-are-not-aggregates.md
+++ b/docs/adr/0007-read-projections-are-not-aggregates.md
@@ -1,9 +1,12 @@
 # ADR-0007: Read projections are not aggregates — the PrecomputedTranslationFile projection
 
-**Status:** Accepted
+**Status:** Accepted — amended 2026-07-02 by ADR-0021 (PERF-04): the projection refresh is no
+longer awaited before the response; writes schedule a debounced background rebuild, the store
+refresh is a set-based `ExecuteUpdate`, and `PrecomputedTranslationFile` is immutable
+(`Refresh(...)` deleted).
 **Date:** 2026-06-14
 **Decision-makers:** Solo maintainer
-**Related:** spec 0001 (translation-file distribution), ADR-0002 (TMS pivot + CQRS read/write split), branch `refactor/precomputed-translation-file-projection`
+**Related:** spec 0001 (translation-file distribution), ADR-0002 (TMS pivot + CQRS read/write split), branch `refactor/precomputed-translation-file-projection`, ADR-0021 (amendment)
 
 ## Context
 

--- a/docs/adr/0021-debounced-background-artifact-rebuild.md
+++ b/docs/adr/0021-debounced-background-artifact-rebuild.md
@@ -1,0 +1,182 @@
+# ADR-0021: Debounced background artifact rebuild — writes schedule, a worker projects
+
+**Status:** Accepted
+**Date:** 2026-07-02
+**Decision-makers:** Solo maintainer
+**Related:** TranslationSystem.API (TranslationFiles/Translations/Import slices), Persistence store, ticket #289 (PERF-04), performance audit 2026-07-02 finding P1-2, ADR-0007 (amended by this ADR), spec 0001
+
+## Context
+
+Spec 0001 distributes the Polish translation file as a precomputed row (`TranslationArtifacts`):
+`GET /translation-files/{lang}` streams stored content + hash-ETag and never builds per-request
+(ADR-0007). The write side kept that row fresh **inline**: `ApproveTranslation.Handler` (always),
+`UpsertTranslation.Handler` (when editing an Approved row) and `ImportExportedTexts.Handler`
+(always) awaited `IPrecomputedTranslationFileProjector.RebuildAsync(...)` right after
+`SaveChangesAsync`, passing the **request** `CancellationToken`.
+
+Code facts that make that a problem (audit finding P1-2):
+
+- A rebuild is O(N) in the catalog: scan the whole Approved set, serialize a multi-MB `||`
+  string, SHA-256 it, and UPDATE a multi-MB row — on every single approve click.
+- `PrecomputedTranslationFileProjector` serializes rebuilds behind a process-wide
+  `SemaphoreSlim(1,1)`. A reviewer burst of k approves paid k serialized rebuilds — the k-th
+  response waited k × rebuild — plus k rounds of MVCC/TOAST/WAL churn on the same row.
+- The awaited rebuild ran on the request token: a client disconnect after the domain commit but
+  before the rebuild finished cancelled the projection and left the artifact **silently stale**
+  until some later write. A rebuild failure after a successful commit also surfaced as a 5xx for
+  a write that had, in fact, committed.
+- `PrecomputedTranslationFileStore.GetByLanguageAsync` materialized the entire existing row —
+  including the previous multi-MB `Content` — only for `Refresh(...)` to overwrite every field.
+- ADR-0007 recorded the old contract explicitly: "refreshed in a separate transaction …
+  **awaited before the response (so no client-visible staleness)**". This ADR amends that
+  consequence.
+
+The artifact is a derived, regenerable projection — never a source of truth — and its consumers
+are the CLI/player download (ETag revalidation loop), the Frontend Import/Export page's export
+download (M3-07, `ImportExportLoader` — a user-clicked re-serve of the same endpoint) and the
+future WPF auto-download. None reads it synchronously after a write: the editor UI reads the read
+models, and an export click follows the triggering write by far more than the debounce window.
+
+## Decision
+
+### 1. Write handlers signal; they never await the rebuild
+
+Approve/upsert-of-approved/import call `ITranslationFileRebuildScheduler.Schedule(language)`
+**after** `SaveChangesAsync` instead of awaiting `RebuildAsync`. `Schedule` is synchronous and
+non-blocking (an unbounded-channel `TryWrite`), so the response returns at commit cost and — with
+no await between commit and signal — a client disconnect can no longer strand a committed write
+without its rebuild.
+
+### 2. A debounced BackgroundService performs the rebuilds on the host lifetime
+
+`TranslationFileRebuildWorker : BackgroundService` waits for the first dirty signal, sleeps one
+`TranslationFileRebuildSettings.DebounceWindow` (default 2 s; config
+`TranslationFileRebuild:DebounceWindow`, set short in test environments), drains everything queued
+meanwhile, and runs **one** rebuild per distinct language through the existing projector — with
+the worker's stopping token, i.e. the application lifetime, never a request token. A reviewer
+burst therefore collapses from k × O(N) to ~O(N). A failed rebuild is logged and re-scheduled, so
+the artifact converges even across transient DB faults, paced by the debounce window.
+
+### 3. Fixed coalescing window, not a sliding debounce
+
+The window starts at the first signal and is never extended by later ones: a sustained write
+stream cannot starve the rebuild, and artifact staleness is bounded by
+`DebounceWindow + one rebuild`. Signals arriving during a rebuild simply start the next cycle —
+rebuilds read a full snapshot, so a redundant cycle is idempotent (same content ⇒ same ETag).
+
+### 4. The store refresh is a set-based UPDATE
+
+`IPrecomputedTranslationFileStore.GetByLanguageAsync` + entity `Refresh(...)` are replaced by
+`TryRefreshAsync(language, content, contentHash, generatedAt)` — a single `ExecuteUpdateAsync`
+returning whether a row was hit; the projector inserts (change tracker + save) only when it
+returns false, i.e. the first build per language. The previous multi-MB content is never loaded
+again, and `PrecomputedTranslationFile` becomes immutable (create-only; EF maps its now get-only
+properties explicitly — no model/schema change).
+
+### 5. The single-replica assumption is explicit, and stays
+
+The dirty-signal channel is in-process and the projector's single-flight gate is per-process —
+both assume **one API replica**, which the infrastructure already pins
+(`iac/azure-container-apps.tf`: `max_replicas = 1`; `iac/vars.tf` validation says as much). The
+brief two-revision overlap during a rolling deploy stays safe: each process rebuilds from a full
+DB snapshot on its own writes. What is *not* safe is steady-state N > 1 — two replicas' rebuilds
+can finish out of order and the last committer may have started from the older snapshot, parking
+the artifact stale until the next write. Raising `max_replicas` above 1 therefore requires
+re-opening this decision (durable/db-backed scheduling — see Alternatives B) in a new ADR.
+Staging additionally runs `min_replicas = 0` (ADR-0018): its scale-to-zero shutdown is exactly the
+dropped-pending-signals trade-off recorded below, accepted there for the same regenerable-artifact
+reasons.
+
+### 6. Bootstrap keeps its synchronous rebuild
+
+`TranslationsBootstrapExtensions` still awaits the projector inline after the polish seed: it runs
+before the app serves traffic, where "respond fast" is meaningless and "artifact ready at first
+request" is the point.
+
+### 7. The consistency contract is now convergence, not read-your-write
+
+The distribution endpoint may briefly serve the previous artifact after a commit. Integration
+tests assert convergence by polling the download with a timeout instead of downloading once right
+after the write; the suite quiesces on the scheduler's pending-signal count before truncating
+tables between test classes.
+
+## Consequences
+
+### Positive
+
+- Approve/upsert/import respond at commit cost; the O(N) scan + multi-MB serialize/hash/UPDATE
+  leave the request path entirely.
+- Reviewer bursts coalesce: k clicks ⇒ one rebuild (was k serialized rebuilds behind the gate),
+  cutting MVCC/TOAST/WAL churn on the artifact row by the same factor.
+- A disconnect or post-commit failure can no longer leave the artifact silently stale — the
+  worker owns the rebuild on the host lifetime and retries failures until it converges.
+- A rebuild failure no longer turns a committed write into a 5xx response.
+- Each refresh is one UPDATE; the old read-modify-write (fetch multi-MB TOASTed content, then
+  overwrite it) is gone.
+
+### Negative / Accepted Trade-offs
+
+- Eventual consistency for the artifact: a download immediately after an approve can be one
+  debounce window behind. Acceptable — the CLI's ETag loop re-fetches on its next check, and the
+  editor UI never reads the artifact.
+- Signals pending at process shutdown are dropped; the artifact stays stale until the next write
+  (or bootstrap). Accepted for a regenerable projection on a single always-on replica.
+- The in-process queue hard-codes the single-replica topology (previously implicit in the gate);
+  scaling out now has a named blocker with a defined re-opening path (§5).
+- Tests trade "download right after write" for poll-with-timeout, and the integration suite needs
+  a quiesce point between classes — more moving parts in test infrastructure.
+
+## Alternatives Considered
+
+### A. Fire-and-forget `Task.Run(RebuildAsync)` per write
+
+Removes the wait but keeps k rebuilds for k clicks, loses failure observability (unobserved
+exceptions), and still needs a lifetime token story. Rejected.
+
+### B. Transactional outbox / DB-backed job queue
+
+Durable across restarts and multi-replica-safe — the correct shape once `max_replicas > 1` or an
+event-driven read store appears. Rejected **for now**: infrastructure weight (table, poller,
+dedupe) against a regenerable artifact on an infra-pinned single replica; named as the explicit
+re-opening path in §5.
+
+### C. Rebuild lazily on `GET` when stale
+
+Reintroduces the per-request build spec 0001 forbids, and moves the O(N) cost onto the CLI
+download path's tail latency. Rejected.
+
+### D. Sliding debounce (each signal restarts the window)
+
+Marginally better coalescing under sustained bursts, but a steady write stream can defer the
+rebuild indefinitely — unbounded staleness. Rejected for the fixed window (§3).
+
+### E. Quartz/Hangfire scheduler dependency
+
+A framework for one loop. The repo precedent (`OpenIddictPruneService`, PERF-02) is a plain
+`BackgroundService`; mirrored here. Rejected.
+
+## Implementation Notes
+
+- New: `TranslationSystem.API/Features/TranslationFiles/{ITranslationFileRebuildScheduler,
+  TranslationFileRebuildScheduler,TranslationFileRebuildWorker,TranslationFileRebuildSettings}.cs`
+- Changed: `ApproveTranslation`, `UpsertTranslation`, `ImportExportedTexts` (inject the scheduler,
+  signal after save), `PrecomputedTranslationFileProjector` (TryRefresh-else-Insert; doc),
+  `IPrecomputedTranslationFileStore` + `PrecomputedTranslationFileStore` (`TryRefreshAsync` via
+  `ExecuteUpdateAsync`), `PrecomputedTranslationFile` (immutable, `Refresh` deleted),
+  `PrecomputedTranslationFileConfiguration` (explicit get-only property mappings; no migration),
+  `ApiDependencyInjection` (options + scheduler + hosted worker), `EventIds` (1400/1401)
+- Tests: worker/scheduler unit tests; handler unit tests swap the projector fake for a scheduler
+  fake and pin the commit-then-signal ordering; integration tests poll the download for
+  convergence and reset shared DB state through the factory's fused quiesce-then-truncate
+  `ResetDatabaseAsync` (drains `TranslationFileRebuildScheduler.PendingCount` first); E2E fixtures
+  set a short debounce via env
+- ADR-0007's "awaited before the response" consequence is amended to point here
+
+## References
+
+- Ticket #289 (PERF-04) — performance audit 2026-07-02, finding P1-2
+- ADR-0007 — precomputed artifact modelling (projection, store, projector) — amended by this ADR
+- Spec 0001 — translation-file distribution (download never builds per-request; unchanged)
+- PERF-01 (#286/#294) — the read-side half: hash-only 304 revalidation
+- `OpenIddictPruneService` (PERF-02, #297) — the BackgroundService house pattern mirrored here
+- `iac/azure-container-apps.tf` / `iac/vars.tf` — `max_replicas = 1` (the single-replica pin)

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -68,8 +68,8 @@ table per service.
   (`compose.prod.yaml`) wires the very same keys with `*.lotro.test` hostnames.
 
 Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:AccessTokenLifetimeMinutes`
-= 60, `OpenIddict:RefreshTokenLifetimeDays` = 14, `Import:*`, `Email:TimeoutSeconds`/`MaxSendAttempts`,
-`AllowedHosts` = `*`).
+= 60, `OpenIddict:RefreshTokenLifetimeDays` = 14, `Import:*`, `TranslationFileRebuild:DebounceWindow`
+= 2 s (ADR-0021), `Email:TimeoutSeconds`/`MaxSendAttempts`, `AllowedHosts` = `*`).
 
 > ⚠️ **Live prod domain is `lotro-translator.pl`** — auth → `https://auth.lotro-translator.pl`,
 > tms → `https://tms.lotro-translator.pl`, frontend → `https://lotro-translator.pl`; live RG

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -121,6 +121,22 @@ internal static class ApiDependencyInjection
             // are singletons; the projector resolves scoped EF services through a fresh scope.
             services.AddSingleton<ITranslationFileSerializer, TranslationFileSerializer>();
             services.AddSingleton<IPrecomputedTranslationFileProjector, PrecomputedTranslationFileProjector>();
+
+            // Debounced background rebuild (PERF-04, ADR-0021): write handlers signal the scheduler;
+            // the worker coalesces the signals and drives the projector on the host lifetime. The
+            // worker needs the scheduler's channel reader, hence the concrete singleton + forward.
+            services.AddOptions<TranslationFileRebuildSettings>()
+                .BindConfiguration(TranslationFileRebuildSettings.ConfigurationSection)
+                .Validate(
+                    settings => settings.DebounceWindow >= TimeSpan.Zero
+                        && settings.DebounceWindow <= TranslationFileRebuildSettings.MaxDebounceWindow,
+                    $"{TranslationFileRebuildSettings.ConfigurationSection}:{nameof(TranslationFileRebuildSettings.DebounceWindow)} must be between 0 and {TranslationFileRebuildSettings.MaxDebounceWindow}.")
+                .ValidateOnStart();
+            services.AddSingleton<TranslationFileRebuildScheduler>();
+            services.AddSingleton<ITranslationFileRebuildScheduler>(serviceProvider =>
+                serviceProvider.GetRequiredService<TranslationFileRebuildScheduler>());
+            services.AddHostedService<TranslationFileRebuildWorker>();
+
             services.AddScoped<
                 IQueryHandler<GetTranslationFile.HashQuery, Result<string>>,
                 GetTranslationFile.HashHandler>();

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/EventIds.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/EventIds.cs
@@ -16,4 +16,8 @@ internal static class EventIds
     public const int UnauthorizedAccessAttempt = 1300;
     public const int ForbiddenAccessAttempt = 1301;
     public const int TranslatorProvisioningSkipped = 1302;
+
+    // Background workers (1400–1499)
+    public const int TranslationFileRebuildCompleted = 1400;
+    public const int TranslationFileRebuildFailed = 1401;
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Bootstrap/TranslationsBootstrapExtensions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Bootstrap/TranslationsBootstrapExtensions.cs
@@ -50,7 +50,9 @@ internal static class TranslationsBootstrapExtensions
         PolishSeedSummary? polish = await SeedPolishIfPresentAsync(services, settings, logger, cancellationToken);
 
         // The seed approves rows, so the pre-built distribution artifact must be regenerated to
-        // include them (spec 0001: regenerate on write; the download endpoint never builds per-request).
+        // include them (spec 0001: the download endpoint never builds per-request). Deliberately
+        // awaited inline — unlike the request handlers (PERF-04, ADR-0021), the bootstrap runs
+        // before the app serves traffic, so the artifact should be ready when it does.
         if (polish is { Approved: > 0 })
         {
             IPrecomputedTranslationFileProjector projector = services.GetRequiredService<IPrecomputedTranslationFileProjector>();

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
@@ -58,7 +58,7 @@ internal sealed class ImportExportedTexts : IEndpoint
         private readonly IUnitOfWork _unitOfWork;
         private readonly TimeProvider _timeProvider;
         private readonly ImportSettings _settings;
-        private readonly IPrecomputedTranslationFileProjector _projector;
+        private readonly ITranslationFileRebuildScheduler _rebuildScheduler;
 
         public Handler(
             IValidator<Command> validator,
@@ -69,7 +69,7 @@ internal sealed class ImportExportedTexts : IEndpoint
             IUnitOfWork unitOfWork,
             TimeProvider timeProvider,
             IOptions<ImportSettings> settings,
-            IPrecomputedTranslationFileProjector projector)
+            ITranslationFileRebuildScheduler rebuildScheduler)
         {
             _validator = validator;
             _parser = parser;
@@ -79,7 +79,7 @@ internal sealed class ImportExportedTexts : IEndpoint
             _unitOfWork = unitOfWork;
             _timeProvider = timeProvider;
             _settings = settings.Value;
-            _projector = projector;
+            _rebuildScheduler = rebuildScheduler;
         }
 
         public async ValueTask<Result<ImportSummary>> Handle(Command command, CancellationToken cancellationToken)
@@ -172,9 +172,10 @@ internal sealed class ImportExportedTexts : IEndpoint
                 cancellationToken);
 
             // Version processing changes the distributed set (removed rows drop out, re-added rows
-            // return), so regenerate the pre-built translation file after the import commits
-            // (spec 0001: regenerate on write — the download endpoint never builds per-request).
-            await _projector.RebuildAsync(SupportedLanguages.Polish, cancellationToken);
+            // return), so the pre-built translation file is regenerated after the import commits
+            // (spec 0001: the download endpoint never builds per-request). Scheduled, not awaited
+            // (PERF-04): the O(N) rebuild runs debounced in the background on the host lifetime.
+            _rebuildScheduler.Schedule(SupportedLanguages.Polish);
 
             return Result.Success(BuildSummary(plan));
         }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/GetTranslationFile.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/GetTranslationFile.cs
@@ -14,8 +14,9 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 /// <summary>
 /// Serves the pre-built translation file for a language (spec 0001): streams the stored artifact
 /// with its content hash as the <c>ETag</c> and honors <c>If-None-Match</c> with a 304. Anonymous
-/// (the CLI/player downloads it). Never builds per-request — the artifact is regenerated on write
-/// by <see cref="IPrecomputedTranslationFileProjector"/>. The 304 decision is driven by a
+/// (the CLI/player downloads it). Never builds per-request — after each relevant write the artifact
+/// is regenerated in the background, debounced, by <see cref="IPrecomputedTranslationFileProjector"/>
+/// (PERF-04, ADR-0021), so a download may briefly trail a commit. The 304 decision is driven by a
 /// hash-only lookup (PERF-01/#286): the multi-MB <c>Content</c> column is TOASTed by PostgreSQL,
 /// so a revalidation that never reads it stays O(1) regardless of artifact size — content is
 /// fetched only when the client's validator no longer matches.

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/IPrecomputedTranslationFileProjector.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/IPrecomputedTranslationFileProjector.cs
@@ -1,9 +1,11 @@
 namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 
 /// <summary>
-/// Regenerates the precomputed translation file for a language from the current Approved set. Called
-/// from writes (version processing, approve, upsert, bootstrap seed) so the distribution endpoint
-/// never builds per-request. See ADR-0007.
+/// Regenerates the precomputed translation file for a language from the current Approved set, so the
+/// distribution endpoint never builds per-request. Writes (version processing, approve, upsert) no
+/// longer call it directly — they signal <see cref="ITranslationFileRebuildScheduler"/> and the
+/// background worker invokes this with the host-lifetime token (PERF-04, ADR-0021); only the startup
+/// bootstrap seed still awaits it inline, before the app serves traffic. See ADR-0007.
 /// </summary>
 internal interface IPrecomputedTranslationFileProjector
 {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/ITranslationFileRebuildScheduler.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/ITranslationFileRebuildScheduler.cs
@@ -1,0 +1,16 @@
+namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+
+/// <summary>
+/// The write-path seam for artifact regeneration (PERF-04, ADR-0021): handlers that change the
+/// distributed set (import, approve, upsert of an Approved row) call <see cref="Schedule"/> after
+/// their commit instead of awaiting the O(N) rebuild inline, so the request responds immediately
+/// and a client disconnect can no longer strand a committed write with a stale artifact.
+/// </summary>
+internal interface ITranslationFileRebuildScheduler
+{
+    /// <summary>
+    /// Marks the language's precomputed translation file dirty. Non-blocking and synchronous — it
+    /// only enqueues a signal; the background worker debounces and performs the actual rebuild.
+    /// </summary>
+    void Schedule(string language);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/PrecomputedTranslationFileProjector.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/PrecomputedTranslationFileProjector.cs
@@ -1,6 +1,5 @@
 using System.Security.Cryptography;
 using System.Text;
-using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
@@ -12,11 +11,13 @@ using Microsoft.Extensions.DependencyInjection;
 namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 
 /// <summary>
-/// Projects the current Approved set into the precomputed translation file on write (spec 0001:
-/// regenerate on version processing, approve, and upsert affecting an Approved row), so the
-/// distribution endpoint serves a stored projection without ever building per-request. Single-flight:
-/// a process-wide gate serializes concurrent rebuilds, each producing a consistent snapshot of the
-/// Approved set. Registered as a singleton, so it resolves the scoped EF services through a fresh scope.
+/// Projects the current Approved set into the precomputed translation file (spec 0001: regenerate
+/// after version processing, approve, and upsert affecting an Approved row), so the distribution
+/// endpoint serves a stored projection without ever building per-request. Invoked by the debounced
+/// background worker (PERF-04, ADR-0021) and synchronously by the startup bootstrap seed.
+/// Single-flight: a process-wide gate serializes concurrent rebuilds, each producing a consistent
+/// snapshot of the Approved set — the gate (like the worker's queue) assumes a single API replica.
+/// Registered as a singleton, so it resolves the scoped EF services through a fresh scope.
 /// </summary>
 internal sealed class PrecomputedTranslationFileProjector : IPrecomputedTranslationFileProjector
 {
@@ -62,17 +63,14 @@ internal sealed class PrecomputedTranslationFileProjector : IPrecomputedTranslat
             string contentHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
             DateTimeOffset now = timeProvider.GetUtcNow();
 
-            Maybe<PrecomputedTranslationFile> existing = await fileStore.GetByLanguageAsync(language, cancellationToken);
-            if (existing.HasValue)
-            {
-                existing.Value.Refresh(content, contentHash, now);
-            }
-            else
+            // Set-based upsert (PERF-04): a single UPDATE refreshes the existing row without ever
+            // loading the previous multi-MB content; only the first build per language inserts.
+            bool refreshed = await fileStore.TryRefreshAsync(language, content, contentHash, now, cancellationToken);
+            if (!refreshed)
             {
                 fileStore.Insert(PrecomputedTranslationFile.Create(language, content, contentHash, now));
+                await unitOfWork.SaveChangesAsync(cancellationToken);
             }
-
-            await unitOfWork.SaveChangesAsync(cancellationToken);
         }
         finally
         {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/TranslationFileRebuildScheduler.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/TranslationFileRebuildScheduler.cs
@@ -1,0 +1,38 @@
+using System.Threading.Channels;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+
+/// <summary>
+/// In-process dirty-signal queue between the write handlers and the rebuild worker (PERF-04,
+/// ADR-0021). A singleton wrapping an unbounded channel: <see cref="Schedule"/> never blocks and
+/// never throws on a full queue, so the hot path pays only an enqueue. In-process is a deliberate
+/// single-replica assumption — with multiple API replicas each process would rebuild on its own
+/// writes only, missing the others' (see ADR-0021 for the scale-out trigger).
+/// </summary>
+internal sealed class TranslationFileRebuildScheduler : ITranslationFileRebuildScheduler
+{
+    private readonly Channel<string> _signals = Channel.CreateUnbounded<string>(
+        new UnboundedChannelOptions { SingleReader = true });
+
+    private int _pendingCount;
+
+    /// <summary>The worker's end of the queue; nothing else may read it.</summary>
+    public ChannelReader<string> Reader => _signals.Reader;
+
+    /// <summary>
+    /// Signals scheduled but not yet rebuilt. Zero means every scheduled rebuild has completed —
+    /// the quiesce point the integration suite waits for before truncating tables.
+    /// </summary>
+    public int PendingCount => Volatile.Read(ref _pendingCount);
+
+    public void Schedule(string language)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(language);
+
+        Interlocked.Increment(ref _pendingCount);
+        _signals.Writer.TryWrite(language);
+    }
+
+    /// <summary>Called by the worker once the rebuild covering the drained signals has finished.</summary>
+    public void MarkCompleted(int consumedSignalCount) => Interlocked.Add(ref _pendingCount, -consumedSignalCount);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/TranslationFileRebuildSettings.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/TranslationFileRebuildSettings.cs
@@ -1,0 +1,22 @@
+namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+
+/// <summary>
+/// Tuning knob for the debounced background artifact rebuild (PERF-04, ADR-0021). The worker waits
+/// this long after the first dirty signal before rebuilding, so a reviewer burst (k approves in a
+/// few seconds) collapses into one O(N) rebuild instead of k serialized ones. It is also the upper
+/// bound the artifact can lag a committed write by (plus one rebuild). Short in Testing so
+/// integration tests converge fast; zero is valid and disables the coalescing wait entirely.
+/// </summary>
+internal sealed class TranslationFileRebuildSettings
+{
+    public const string ConfigurationSection = "TranslationFileRebuild";
+
+    /// <summary>
+    /// Upper bound enforced at startup. The window is also the artifact's staleness bound, so
+    /// anything beyond minutes defeats the distribution loop — and an absurd value (~&gt; 49 days)
+    /// would overflow <see cref="Task.Delay(TimeSpan)"/> inside the worker and stop the host.
+    /// </summary>
+    public static readonly TimeSpan MaxDebounceWindow = TimeSpan.FromMinutes(5);
+
+    public TimeSpan DebounceWindow { get; init; } = TimeSpan.FromSeconds(2);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/TranslationFileRebuildWorker.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/TranslationFileRebuildWorker.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Options;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+
+/// <summary>
+/// Debounced background executor of the artifact rebuilds the write handlers schedule (PERF-04,
+/// ADR-0021). After the first dirty signal it waits one <see cref="TranslationFileRebuildSettings.DebounceWindow"/>,
+/// drains everything queued in the meantime, and runs one rebuild per distinct language — a fixed
+/// coalescing window rather than a sliding one, so a sustained write stream can never starve the
+/// rebuild. It calls the projector with the host's stopping token, never a request token: a client
+/// disconnect after commit cannot cancel the regeneration anymore. A failed rebuild is logged and
+/// re-scheduled, so the artifact still converges (paced by the debounce window). Two edges are
+/// accepted for this regenerable artifact: signals pending at process shutdown are dropped (the
+/// next write reschedules), and a second replica would not see this replica's signals — the whole
+/// pipeline is single-replica by design, like the projector's process-wide gate.
+/// </summary>
+internal sealed partial class TranslationFileRebuildWorker : BackgroundService
+{
+    private readonly TranslationFileRebuildScheduler _scheduler;
+    private readonly IPrecomputedTranslationFileProjector _projector;
+    private readonly TimeProvider _timeProvider;
+    private readonly TranslationFileRebuildSettings _settings;
+    private readonly ILogger<TranslationFileRebuildWorker> _logger;
+
+    public TranslationFileRebuildWorker(
+        TranslationFileRebuildScheduler scheduler,
+        IPrecomputedTranslationFileProjector projector,
+        TimeProvider timeProvider,
+        IOptions<TranslationFileRebuildSettings> settings,
+        ILogger<TranslationFileRebuildWorker> logger)
+    {
+        _scheduler = scheduler;
+        _projector = projector;
+        _timeProvider = timeProvider;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (await _scheduler.Reader.WaitToReadAsync(stoppingToken))
+        {
+            if (_settings.DebounceWindow > TimeSpan.Zero)
+            {
+                await Task.Delay(_settings.DebounceWindow, _timeProvider, stoppingToken);
+            }
+
+            Dictionary<string, int> signalCountsByLanguage = new(StringComparer.OrdinalIgnoreCase);
+            while (_scheduler.Reader.TryRead(out string? language))
+            {
+                signalCountsByLanguage[language] = signalCountsByLanguage.GetValueOrDefault(language) + 1;
+            }
+
+            foreach ((string language, int signalCount) in signalCountsByLanguage)
+            {
+                await RebuildAsync(language, signalCount, stoppingToken);
+            }
+        }
+    }
+
+    private async Task RebuildAsync(string language, int signalCount, CancellationToken stoppingToken)
+    {
+        try
+        {
+            await _projector.RebuildAsync(language, stoppingToken);
+            LogRebuildCompleted(_logger, language, signalCount);
+        }
+        catch (Exception exception)
+            when (exception is not OperationCanceledException || !stoppingToken.IsCancellationRequested)
+        {
+            // Swallowed deliberately: an exception escaping ExecuteAsync stops the whole host.
+            // Re-scheduling keeps the artifact converging; a shutdown cancellation propagates.
+            LogRebuildFailed(_logger, exception, language);
+            _scheduler.Schedule(language);
+        }
+        finally
+        {
+            _scheduler.MarkCompleted(signalCount);
+        }
+    }
+
+    [LoggerMessage(EventId = EventIds.TranslationFileRebuildCompleted, Level = LogLevel.Information, Message = "Precomputed translation file for '{Language}' rebuilt ({SignalCount} coalesced write signal(s))")]
+    private static partial void LogRebuildCompleted(ILogger logger, string language, int signalCount);
+
+    [LoggerMessage(EventId = EventIds.TranslationFileRebuildFailed, Level = LogLevel.Error, Message = "Precomputed translation file rebuild for '{Language}' failed; re-scheduled for the next debounce window")]
+    private static partial void LogRebuildFailed(ILogger logger, Exception exception, string language);
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ApproveTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ApproveTranslation.cs
@@ -21,9 +21,10 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
 /// <summary>
 /// Approves a translation for distribution (spec 0001, #101): a reviewer flips the row to Approved,
 /// which stamps the approving identity, clears any invalidation (<c>PreviousSourceText</c>) and pulls
-/// the row back into the distributed set — so the pre-built Polish artifact is regenerated after the
-/// change commits. Requires the admin (reviewer) policy. A row with no Polish or a soft-removed row
-/// cannot be approved (422); an unknown id is a 404.
+/// the row back into the distributed set — so a debounced background rebuild of the pre-built Polish
+/// artifact is scheduled after the change commits (PERF-04, ADR-0021); the response does not wait for
+/// it. Requires the admin (reviewer) policy. A row with no Polish or a soft-removed row cannot be
+/// approved (422); an unknown id is a 404.
 /// </summary>
 internal sealed class ApproveTranslation : IEndpoint
 {
@@ -46,7 +47,7 @@ internal sealed class ApproveTranslation : IEndpoint
         private readonly IUnitOfWork _unitOfWork;
         private readonly ITranslatorProvisioner _translatorProvisioner;
         private readonly TimeProvider _timeProvider;
-        private readonly IPrecomputedTranslationFileProjector _projector;
+        private readonly ITranslationFileRebuildScheduler _rebuildScheduler;
 
         public Handler(
             IValidator<Command> validator,
@@ -54,14 +55,14 @@ internal sealed class ApproveTranslation : IEndpoint
             IUnitOfWork unitOfWork,
             ITranslatorProvisioner translatorProvisioner,
             TimeProvider timeProvider,
-            IPrecomputedTranslationFileProjector projector)
+            ITranslationFileRebuildScheduler rebuildScheduler)
         {
             _validator = validator;
             _translationRepository = translationRepository;
             _unitOfWork = unitOfWork;
             _translatorProvisioner = translatorProvisioner;
             _timeProvider = timeProvider;
-            _projector = projector;
+            _rebuildScheduler = rebuildScheduler;
         }
 
         public async ValueTask<Result> Handle(Command command, CancellationToken cancellationToken)
@@ -98,7 +99,9 @@ internal sealed class ApproveTranslation : IEndpoint
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // The row has (re)entered the distributed set, so the pre-built Polish artifact is stale.
-            await _projector.RebuildAsync(SupportedLanguages.Polish, cancellationToken);
+            // Scheduled, not awaited (PERF-04): the rebuild runs debounced in the background on the
+            // host lifetime, so the response returns now and a disconnect cannot strand the commit.
+            _rebuildScheduler.Schedule(SupportedLanguages.Polish);
 
             return Result.Success();
         }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/UpsertTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/UpsertTranslation.cs
@@ -27,7 +27,8 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
 /// is born from import (English source only), this slice attaches the translator's Polish. Any prior
 /// status moves to <see cref="TranslationStatus.Draft"/> and the submitting translator is stamped
 /// from the authenticated identity. Editing an <see cref="TranslationStatus.Approved"/> row pulls it
-/// out of the distributed set, so the pre-built artifact is regenerated after the change commits;
+/// out of the distributed set, so a debounced background rebuild of the pre-built artifact is
+/// scheduled after the change commits (PERF-04, ADR-0021);
 /// re-translating a <see cref="TranslationStatus.NeedsReview"/> row keeps its
 /// <c>PreviousSourceText</c> until approve. Placeholders are stored verbatim — the
 /// count-mismatch warning UX is M3.
@@ -60,7 +61,7 @@ internal sealed class UpsertTranslation : IEndpoint
         private readonly ITranslatorProvisioner _translatorProvisioner;
         private readonly IApplicationReadDbContext _readDbContext;
         private readonly TimeProvider _timeProvider;
-        private readonly IPrecomputedTranslationFileProjector _projector;
+        private readonly ITranslationFileRebuildScheduler _rebuildScheduler;
 
         public Handler(
             IValidator<Command> validator,
@@ -69,7 +70,7 @@ internal sealed class UpsertTranslation : IEndpoint
             ITranslatorProvisioner translatorProvisioner,
             IApplicationReadDbContext readDbContext,
             TimeProvider timeProvider,
-            IPrecomputedTranslationFileProjector projector)
+            ITranslationFileRebuildScheduler rebuildScheduler)
         {
             _validator = validator;
             _translationRepository = translationRepository;
@@ -77,7 +78,7 @@ internal sealed class UpsertTranslation : IEndpoint
             _translatorProvisioner = translatorProvisioner;
             _readDbContext = readDbContext;
             _timeProvider = timeProvider;
-            _projector = projector;
+            _rebuildScheduler = rebuildScheduler;
         }
 
         public async ValueTask<Result<TranslationDetailResponse>> Handle(Command command, CancellationToken cancellationToken)
@@ -128,7 +129,10 @@ internal sealed class UpsertTranslation : IEndpoint
 
             if (wasApproved)
             {
-                await _projector.RebuildAsync(SupportedLanguages.Polish, cancellationToken);
+                // Scheduled, not awaited (PERF-04): the rebuild runs debounced in the background on
+                // the host lifetime, so the response returns now and a disconnect cannot strand the
+                // commit.
+                _rebuildScheduler.Schedule(SupportedLanguages.Polish);
             }
 
             // Re-read the committed row through the read model so the response carries the joined

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/PrecomputedTranslationFileConfiguration.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/PrecomputedTranslationFileConfiguration.cs
@@ -15,14 +15,19 @@ internal sealed class PrecomputedTranslationFileConfiguration : IEntityTypeConfi
         builder.Property(precomputedTranslationFile => precomputedTranslationFile.Id)
             .ValueGeneratedNever();
 
-        // Get-only property — EF Core convention skips it without an explicit mapping.
+        // Get-only properties — EF Core convention skips them without an explicit mapping (the
+        // type is immutable; refreshes are set-based updates through the store, PERF-04).
         builder.Property(precomputedTranslationFile => precomputedTranslationFile.Language)
             .HasMaxLength(PrecomputedTranslationFile.LanguageMaxLength);
 
         builder.HasIndex(precomputedTranslationFile => precomputedTranslationFile.Language)
             .IsUnique();
 
+        builder.Property(precomputedTranslationFile => precomputedTranslationFile.Content);
+
         builder.Property(precomputedTranslationFile => precomputedTranslationFile.ContentHash)
             .HasMaxLength(PrecomputedTranslationFile.ContentHashLength);
+
+        builder.Property(precomputedTranslationFile => precomputedTranslationFile.GeneratedAt);
     }
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Projections/PrecomputedTranslationFileStore.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Projections/PrecomputedTranslationFileStore.cs
@@ -1,4 +1,3 @@
-using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Projections;
 using Microsoft.EntityFrameworkCore;
@@ -14,14 +13,27 @@ internal sealed class PrecomputedTranslationFileStore : IPrecomputedTranslationF
         _dbContext = dbContext;
     }
 
-    public async Task<Maybe<PrecomputedTranslationFile>> GetByLanguageAsync(string language, CancellationToken cancellationToken)
+    public async Task<bool> TryRefreshAsync(
+        string language,
+        string content,
+        string contentHash,
+        DateTimeOffset generatedAt,
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(language);
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentHash);
 
-        PrecomputedTranslationFile? file = await _dbContext.PrecomputedTranslationFiles
-            .FirstOrDefaultAsync(precomputedTranslationFile => precomputedTranslationFile.Language == language, cancellationToken);
+        int updatedRowCount = await _dbContext.PrecomputedTranslationFiles
+            .Where(precomputedTranslationFile => precomputedTranslationFile.Language == language)
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(precomputedTranslationFile => precomputedTranslationFile.Content, content)
+                    .SetProperty(precomputedTranslationFile => precomputedTranslationFile.ContentHash, contentHash)
+                    .SetProperty(precomputedTranslationFile => precomputedTranslationFile.GeneratedAt, generatedAt),
+                cancellationToken);
 
-        return Maybe<PrecomputedTranslationFile>.From(file);
+        return updatedRowCount > 0;
     }
 
     public void Insert(PrecomputedTranslationFile file)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Projections/IPrecomputedTranslationFileStore.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Projections/IPrecomputedTranslationFileStore.cs
@@ -1,5 +1,3 @@
-using LotroKoniecDev.SharedKernel.Monads;
-
 namespace LotroKoniecDev.TranslationSystem.Projections;
 
 /// <summary>
@@ -9,8 +7,18 @@ namespace LotroKoniecDev.TranslationSystem.Projections;
 /// </summary>
 public interface IPrecomputedTranslationFileStore
 {
-    /// <summary>The projection is upserted by its natural key — one row per language.</summary>
-    Task<Maybe<PrecomputedTranslationFile>> GetByLanguageAsync(string language, CancellationToken cancellationToken);
+    /// <summary>
+    /// Set-based, in-place refresh of the language's projection row (PERF-04): a single
+    /// <c>UPDATE</c> that never loads the previous multi-MB content just to overwrite it. Executes
+    /// immediately — no unit-of-work save is involved. Returns <see langword="false"/> when no row
+    /// exists yet, in which case the caller inserts via <see cref="Insert"/>.
+    /// </summary>
+    Task<bool> TryRefreshAsync(
+        string language,
+        string content,
+        string contentHash,
+        DateTimeOffset generatedAt,
+        CancellationToken cancellationToken);
 
     void Insert(PrecomputedTranslationFile file);
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Projections/PrecomputedTranslationFile.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Projections/PrecomputedTranslationFile.cs
@@ -7,11 +7,14 @@ namespace LotroKoniecDev.TranslationSystem.Projections;
 /// <summary>
 /// The precomputed translation file for one language (spec 0001): the serialized <c>||</c> content
 /// plus its content hash (the HTTP <c>ETag</c>), stored ready-to-serve so the distribution endpoint
-/// never rebuilds per request. An app-maintained, derived read projection — refreshed on every write
-/// that changes the distributed set (see <c>IPrecomputedTranslationFileProjector</c>) and never a
-/// source of truth. It is deliberately a plain <see cref="Entity{TId}"/>, not an
+/// never rebuilds per request. An app-maintained, derived read projection — refreshed after every
+/// write that changes the distributed set (see <c>IPrecomputedTranslationFileProjector</c>) and never
+/// a source of truth. It is deliberately a plain <see cref="Entity{TId}"/>, not an
 /// <see cref="AggregateRoot{TId}"/>: it guards no business invariant and is only ever blind-upserted
-/// by its natural key (one row per language). See ADR-0007.
+/// by its natural key (one row per language). The type is immutable — it exists to insert the first
+/// row per language; every subsequent refresh is a set-based update through
+/// <see cref="IPrecomputedTranslationFileStore"/>, which never materializes the previous multi-MB
+/// content (PERF-04). See ADR-0007.
 /// </summary>
 public sealed class PrecomputedTranslationFile : Entity<PrecomputedTranslationFileId>
 {
@@ -19,23 +22,9 @@ public sealed class PrecomputedTranslationFile : Entity<PrecomputedTranslationFi
     public const int ContentHashLength = 64;
 
     public string Language { get; }
-    public string Content { get; private set; }
-    public string ContentHash { get; private set; }
-    public DateTimeOffset GeneratedAt { get; private set; }
-
-    /// <summary>
-    /// Regenerate-on-write: replaces the serialized content and its hash in place.
-    /// </summary>
-    public void Refresh(string content, string contentHash, DateTimeOffset now)
-    {
-        ArgumentNullException.ThrowIfNull(content);
-        ArgumentException.ThrowIfNullOrWhiteSpace(contentHash);
-        Ensure.NotEmpty(now);
-
-        Content = content;
-        ContentHash = contentHash;
-        GeneratedAt = now;
-    }
+    public string Content { get; }
+    public string ContentHash { get; }
+    public DateTimeOffset GeneratedAt { get; }
 
     public static PrecomputedTranslationFile Create(string language, string content, string contentHash, DateTimeOffset now)
     {

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/SqlCommandRecorder.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/SqlCommandRecorder.cs
@@ -5,9 +5,11 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration;
 
 /// <summary>
-/// Records the SQL text of every query the intercepted context executes, so a test can pin
+/// Records the SQL text of every command the intercepted context executes — reader commands
+/// (queries, SaveChanges batches) and non-queries (<c>ExecuteUpdate</c>) alike — so a test can pin
 /// properties that are invisible in the HTTP response — e.g. that the translation-file 304 path
-/// never reads the multi-MB <c>Content</c> column (PERF-01/#286). The DB command stream is the
+/// never reads the multi-MB <c>Content</c> column (PERF-01/#286), or that a projection refresh
+/// updates in place without re-fetching it (PERF-04/#289). The DB command stream is the
 /// only observable seam for "this column was not fetched": the repo's <c>.Received()</c> policy
 /// (side effects invisible in the return value) sanctions asserting on it.
 /// </summary>
@@ -36,5 +38,24 @@ public sealed class SqlCommandRecorder : DbCommandInterceptor
     {
         _commands.Enqueue(command.CommandText);
         return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+    }
+
+    public override InterceptionResult<int> NonQueryExecuting(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<int> result)
+    {
+        _commands.Enqueue(command.CommandText);
+        return base.NonQueryExecuting(command, eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        _commands.Enqueue(command.CommandText);
+        return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Bootstrap/BootstrapSeedTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Bootstrap/BootstrapSeedTests.cs
@@ -28,9 +28,7 @@ public sealed class BootstrapSeedTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using IServiceScope scope = _factory.Services.CreateScope();
-        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
+        await _factory.ResetDatabaseAsync(
             "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Concurrency/ConcurrencyEndpointsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Concurrency/ConcurrencyEndpointsTests.cs
@@ -21,8 +21,9 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Concurren
 /// Concurrency guards at the HTTP seam (mirrors the AuthSystem ConcurrencyEndpointsTests). Two write
 /// paths are stressed under a parallel fan-out of identical requests sharing one authenticated
 /// identity: parallel upsert of the same fragment, and double-approve of the same row. Both exercise
-/// the lazy-provisioning first-write race (ADR-0004), and approve additionally exercises the
-/// single-flight artifact rebuild — none of which may surface a 500.
+/// the lazy-provisioning first-write race (ADR-0004), and approve additionally floods the artifact
+/// rebuild scheduler (PERF-04: the burst coalesces into a debounced background rebuild) — none of
+/// which may surface a 500.
 /// </summary>
 [Collection("TranslationApi")]
 public sealed class ConcurrencyEndpointsTests : IAsyncLifetime
@@ -42,10 +43,11 @@ public sealed class ConcurrencyEndpointsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
         dbContext.GameVersions.Add(gameVersion);
@@ -94,9 +96,10 @@ public sealed class ConcurrencyEndpointsTests : IAsyncLifetime
             .ToArray();
         HttpResponseMessage[] responses = await Task.WhenAll(tasks);
 
-        // Assert — approve is idempotent (no "already approved" guard) and the artifact rebuild is
-        // single-flight, so every concurrent approve publishes; the row settles Approved and the admin
-        // approver is provisioned once (the seeded submitter is the only other Translator).
+        // Assert — approve is idempotent (no "already approved" guard) and the artifact rebuilds are
+        // scheduled, debounced signals (PERF-04), so every concurrent approve publishes; the row
+        // settles Approved and the admin approver is provisioned once (the seeded submitter is the
+        // only other Translator).
         foreach (HttpResponseMessage response in responses)
         {
             ((int)response.StatusCode).ShouldBeLessThan(500, $"Unexpected server error: {response.StatusCode}");

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/CoreLoop/CoreLoopTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/CoreLoop/CoreLoopTests.cs
@@ -8,10 +8,7 @@ using LotroKoniecDev.TranslationSystem.Contracts.Common;
 using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
 using LotroKoniecDev.TranslationSystem.Contracts.Import;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
-using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.CoreLoop;
 
@@ -40,9 +37,7 @@ public sealed class CoreLoopTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using IServiceScope scope = _factory.Services.CreateScope();
-        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
+        await _factory.ResetDatabaseAsync(
             "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
     }
 
@@ -73,9 +68,13 @@ public sealed class CoreLoopTests : IAsyncLifetime
         HttpResponseMessage approve = await admin.PostAsync(ApproveRoute(edited.Id.Value), null);
         approve.StatusCode.ShouldBe(HttpStatusCode.NoContent);
 
-        // Download the distributed file (anonymous): the approved row is in, the untranslated one is out.
-        HttpResponseMessage download = await _factory.CreateClient().GetAsync(FileRoute);
-        string file = await download.Content.ReadAsStringAsync();
+        // Download the distributed file (anonymous): the approved row is in, the untranslated one is
+        // out. The artifact is rebuilt in the background, debounced (PERF-04) — poll until the
+        // approve's rebuild has converged.
+        (HttpResponseMessage download, string file) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            FileRoute,
+            (candidate, content) => candidate.IsSuccessStatusCode && content.Contains($"{FileId}||1||Polski jeden||NULL||NULL||1"));
         download.StatusCode.ShouldBe(HttpStatusCode.OK);
         download.Headers.ETag.ShouldNotBeNull();
         EntityTagHeaderValue etag = download.Headers.ETag!;
@@ -113,14 +112,18 @@ public sealed class CoreLoopTests : IAsyncLifetime
         using HttpClient admin = AdminClient();
         using HttpClient translator = TranslatorClient();
 
-        // Baseline: import, translate + approve row 1, so it is in the distributed file.
+        // Baseline: import, translate + approve row 1, so it is in the distributed file (the approve's
+        // background rebuild is polled to convergence, PERF-04).
         Guid firstVersion = await RegisterVersionAsync(admin, "48.0");
         await ImportAsync(admin, firstVersion, Line(1, "English one"), Line(2, "English two"));
         TranslationDetailResponse edited = await UpsertAsync(translator, gossipId: 1, polish: "Polski jeden");
         await admin.PostAsync(ApproveRoute(edited.Id.Value), null);
 
-        HttpResponseMessage firstDownload = await _factory.CreateClient().GetAsync(FileRoute);
-        (await firstDownload.Content.ReadAsStringAsync()).ShouldContain($"{FileId}||1||Polski jeden||NULL||NULL||1");
+        (HttpResponseMessage firstDownload, string firstFile) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            FileRoute,
+            (candidate, content) => candidate.IsSuccessStatusCode && content.Contains($"{FileId}||1||Polski jeden||NULL||NULL||1"));
+        firstFile.ShouldContain($"{FileId}||1||Polski jeden||NULL||NULL||1");
         firstDownload.Headers.ETag.ShouldNotBeNull();
         EntityTagHeaderValue firstEtag = firstDownload.Headers.ETag!;
 
@@ -138,10 +141,14 @@ public sealed class CoreLoopTests : IAsyncLifetime
         row1.Status.ShouldBe(TranslationStatus.NeedsReview);
         row1.PreviousSourceText.ShouldBe("English one");
 
-        // The invalidated row drops out of the freshly regenerated distributed file (new ETag).
-        HttpResponseMessage secondDownload = await _factory.CreateClient().GetAsync(FileRoute);
+        // The invalidated row drops out of the regenerated distributed file (new ETag) once the
+        // import's background rebuild converges.
+        (HttpResponseMessage secondDownload, string secondFile) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            FileRoute,
+            (candidate, content) => candidate.IsSuccessStatusCode && !content.Contains($"{FileId}||1||"));
         secondDownload.Headers.ETag.ShouldNotBe(firstEtag);
-        (await secondDownload.Content.ReadAsStringAsync()).ShouldNotContain($"{FileId}||1||");
+        secondFile.ShouldNotContain($"{FileId}||1||");
     }
 
     private static string ApproveRoute(Guid translationId) => $"{TranslationsRoute}/{translationId}/approve";

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ErrorContract/ProblemDetailsContractTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ErrorContract/ProblemDetailsContractTests.cs
@@ -3,9 +3,6 @@ using System.Text.Json;
 using LotroKoniecDev.SharedKernel.Authorization;
 using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
-using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.ErrorContract;
 
@@ -31,9 +28,7 @@ public sealed class ProblemDetailsContractTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using IServiceScope scope = _factory.Services.CreateScope();
-        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
+        await _factory.ResetDatabaseAsync(
             "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTests.cs
@@ -10,7 +10,6 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Va
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.ForwardedHeaders;
@@ -42,9 +41,7 @@ public sealed class ForwardedHeadersTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using IServiceScope scope = _factory.Services.CreateScope();
-        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
+        await _factory.ResetDatabaseAsync(
             "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/DeleteGameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/DeleteGameVersionTests.cs
@@ -11,7 +11,6 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Va
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.GameVersions;
@@ -33,9 +32,7 @@ public sealed class DeleteGameVersionTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using IServiceScope scope = _factory.Services.CreateScope();
-        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
+        await _factory.ResetDatabaseAsync(
             "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/ListGameVersionsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/ListGameVersionsTests.cs
@@ -8,7 +8,6 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.En
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.GameVersions;
@@ -30,9 +29,7 @@ public sealed class ListGameVersionsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using IServiceScope scope = _factory.Services.CreateScope();
-        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
+        await _factory.ResetDatabaseAsync(
             "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/RegisterGameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/RegisterGameVersionTests.cs
@@ -4,10 +4,7 @@ using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.Authorization;
 using LotroKoniecDev.TranslationSystem.Contracts.Common;
 using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
-using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.GameVersions;
 
@@ -27,9 +24,7 @@ public sealed class RegisterGameVersionTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using IServiceScope scope = _factory.Services.CreateScope();
-        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
+        await _factory.ResetDatabaseAsync(
             "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/GameVersionAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/GameVersionAggregateHateoasTests.cs
@@ -10,7 +10,6 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.En
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Hateoas;
@@ -38,9 +37,7 @@ public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using IServiceScope scope = _factory.Services.CreateScope();
-        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
+        await _factory.ResetDatabaseAsync(
             "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/TranslationAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/TranslationAggregateHateoasTests.cs
@@ -17,7 +17,6 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Hateoas;
@@ -47,10 +46,11 @@ public sealed class TranslationAggregateHateoasTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
+
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
         dbContext.GameVersions.Add(gameVersion);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
@@ -43,9 +43,7 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using IServiceScope scope = _factory.Services.CreateScope();
-        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
+        await _factory.ResetDatabaseAsync(
             "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
@@ -36,10 +36,11 @@ public sealed class GetTranslationFileTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
         dbContext.GameVersions.Add(gameVersion);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/PrecomputedTranslationFileProjectorTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/PrecomputedTranslationFileProjectorTests.cs
@@ -1,0 +1,128 @@
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.TranslationFiles;
+
+/// <summary>
+/// Pins the projector's write shape against real PostgreSQL (PERF-04/#289): the first build per
+/// language inserts the artifact row; every later rebuild refreshes it with one set-based UPDATE
+/// and never re-fetches the previous multi-MB content. The DB command stream is the only
+/// observable seam for "the old content was not loaded", mirroring the PERF-01 idiom.
+/// </summary>
+[Collection("TranslationApi")]
+public sealed class PrecomputedTranslationFileProjectorTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+    private const string Route = "/api/v1/translation-files/pl";
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+    private TranslatorId _submitterId;
+
+    public PrecomputedTranslationFileProjectorTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+
+        Translator submitter = Translator.Create(
+            IdentityId.Create(), DisplayName.Create("Seed Author").Value, email: null, Now).Value;
+        dbContext.Translators.Add(submitter);
+
+        await dbContext.SaveChangesAsync();
+        _versionId = gameVersion.Id;
+        _submitterId = submitter.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Rebuild_OnFirstBuild_ShouldInsertTheArtifactRow()
+    {
+        // Arrange
+        await SeedApprovedAsync(gossipId: 1, polish: "Alfa");
+        _factory.WriteContextSqlRecorder.Clear();
+
+        // Act
+        await RebuildAsync();
+
+        // Assert — no row existed, so the set-based refresh missed and the first build inserted.
+        HttpResponseMessage download = await _factory.CreateClient().GetAsync(Route);
+        download.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await download.Content.ReadAsStringAsync()).ShouldContain($"{FileId}||1||Alfa||NULL||NULL||1");
+        _factory.WriteContextSqlRecorder.Commands
+            .ShouldContain(command => command.Contains("INSERT INTO translation.\"TranslationArtifacts\""));
+    }
+
+    [Fact]
+    public async Task Rebuild_WhenArtifactExists_ShouldRefreshInPlaceWithoutFetchingPreviousContent()
+    {
+        // Arrange — the artifact already exists from a first build.
+        await SeedApprovedAsync(gossipId: 1, polish: "Alfa");
+        await RebuildAsync();
+        await SeedApprovedAsync(gossipId: 2, polish: "Beta");
+        _factory.WriteContextSqlRecorder.Clear();
+
+        // Act
+        await RebuildAsync();
+
+        // Assert — one set-based UPDATE refreshed the row (PERF-04); nothing on the write context
+        // SELECTed the artifact table, so the previous multi-MB Content was never materialized
+        // just to be overwritten.
+        HttpResponseMessage download = await _factory.CreateClient().GetAsync(Route);
+        string body = await download.Content.ReadAsStringAsync();
+        body.ShouldContain($"{FileId}||1||Alfa||NULL||NULL||1");
+        body.ShouldContain($"{FileId}||2||Beta||NULL||NULL||1");
+
+        IReadOnlyList<string> commands = _factory.WriteContextSqlRecorder.Commands;
+        commands.ShouldContain(command => command.Contains("UPDATE translation.\"TranslationArtifacts\""));
+        commands.ShouldAllBe(command =>
+            !(command.Contains("SELECT") && command.Contains("\"TranslationArtifacts\"")));
+        commands.ShouldAllBe(command => !command.Contains("INSERT INTO translation.\"TranslationArtifacts\""));
+    }
+
+    private async Task SeedApprovedAsync(int gossipId, string polish)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create("English", null, null).Value,
+            _versionId,
+            Now).Value;
+        row.ProvideTranslation(polish, _submitterId, Now);
+        row.Approve(_submitterId, Now);
+
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task RebuildAsync()
+    {
+        IPrecomputedTranslationFileProjector projector =
+            _factory.Services.GetRequiredService<IPrecomputedTranslationFileProjector>();
+        await projector.RebuildAsync("pl", CancellationToken.None);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ApproveTranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ApproveTranslationTests.cs
@@ -14,7 +14,6 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
@@ -39,10 +38,11 @@ public sealed class ApproveTranslationTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
         dbContext.GameVersions.Add(gameVersion);
@@ -72,7 +72,13 @@ public sealed class ApproveTranslationTests : IAsyncLifetime
 
         TranslationDetailResponse? body = await (await client.GetAsync($"/api/v1/translations/{id}"))
             .Content.ReadFromJsonAsync<TranslationDetailResponse>(JsonOptions);
-        string file = await (await _factory.CreateClient().GetAsync(FileRoute)).Content.ReadAsStringAsync();
+
+        // The artifact is rebuilt in the background, debounced (PERF-04): the approve responded
+        // already; poll the download until the rebuild converges on the published row.
+        (_, string file) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            FileRoute,
+            (download, content) => download.IsSuccessStatusCode && content.Contains($"{FileId}||1||Witaj||NULL||NULL||1"));
 
         // Assert — the approver is the lazily provisioned Translator, carrying the JWT display name.
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
@@ -96,7 +102,10 @@ public sealed class ApproveTranslationTests : IAsyncLifetime
 
         TranslationDetailResponse? body = await (await client.GetAsync($"/api/v1/translations/{id}"))
             .Content.ReadFromJsonAsync<TranslationDetailResponse>(JsonOptions);
-        string file = await (await _factory.CreateClient().GetAsync(FileRoute)).Content.ReadAsStringAsync();
+        (_, string file) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            FileRoute,
+            (download, content) => download.IsSuccessStatusCode && content.Contains($"{FileId}||2||Stary polski||NULL||NULL||1"));
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationStatsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationStatsTests.cs
@@ -14,7 +14,6 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
@@ -39,10 +38,11 @@ public sealed class GetTranslationStatsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
+
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
         dbContext.GameVersions.Add(gameVersion);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationTests.cs
@@ -15,7 +15,6 @@ using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregat
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
@@ -40,10 +39,11 @@ public sealed class GetTranslationTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
+
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
         dbContext.GameVersions.Add(gameVersion);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
@@ -15,7 +15,6 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
@@ -40,10 +39,11 @@ public sealed class ListTranslationsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
+
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
         dbContext.GameVersions.Add(gameVersion);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/TranslatorProvisioningTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/TranslatorProvisioningTests.cs
@@ -41,10 +41,11 @@ public sealed class TranslatorProvisioningTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
         dbContext.GameVersions.Add(gameVersion);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/UpsertTranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/UpsertTranslationTests.cs
@@ -16,7 +16,6 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
@@ -42,10 +41,11 @@ public sealed class UpsertTranslationTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
         dbContext.GameVersions.Add(gameVersion);
@@ -98,8 +98,12 @@ public sealed class UpsertTranslationTests : IAsyncLifetime
             Route, new UpsertTranslationRequest(FileId, 1, "Alfa nowa"));
         TranslationDetailResponse? body = await response.Content.ReadFromJsonAsync<TranslationDetailResponse>(JsonOptions);
 
-        HttpResponseMessage download = await _factory.CreateClient().GetAsync(FileRoute);
-        string file = await download.Content.ReadAsStringAsync();
+        // The artifact is rebuilt in the background, debounced (PERF-04): the upsert responded
+        // already; poll the download until the edited row has dropped out of the file.
+        (HttpResponseMessage download, string file) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            FileRoute,
+            (candidate, content) => candidate.IsSuccessStatusCode && !content.Contains($"{FileId}||1||"));
 
         // Assert — the edited row is now a draft and gone from the freshly rebuilt file; row 2 stays.
         response.StatusCode.ShouldBe(HttpStatusCode.OK);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationFileDownloadPolling.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationFileDownloadPolling.cs
@@ -1,0 +1,35 @@
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration;
+
+/// <summary>
+/// Polls the anonymous translation-file download until the debounced background rebuild
+/// (PERF-04, ADR-0021) has converged on the caller's condition. On timeout the last snapshot is
+/// returned anyway, so the caller's regular assertions fail with the actually observed response
+/// instead of a bare timeout exception.
+/// </summary>
+internal static class TranslationFileDownloadPolling
+{
+    private static readonly TimeSpan ConvergenceTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(50);
+
+    public static async Task<(HttpResponseMessage Response, string Content)> DownloadWhenConvergedAsync(
+        HttpClient client,
+        string route,
+        Func<HttpResponseMessage, string, bool> hasConverged)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + ConvergenceTimeout;
+
+        while (true)
+        {
+            HttpResponseMessage response = await client.GetAsync(route);
+            string content = await response.Content.ReadAsStringAsync();
+
+            if (hasConverged(response, content) || DateTimeOffset.UtcNow >= deadline)
+            {
+                return (response, content);
+            }
+
+            response.Dispose();
+            await Task.Delay(PollInterval);
+        }
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
@@ -10,6 +10,7 @@ using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Testcontainers.PostgreSql;
 using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 
@@ -42,6 +43,12 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
     /// </summary>
     public SqlCommandRecorder ReadContextSqlRecorder { get; } = new();
 
+    /// <summary>
+    /// Same seam for the write context, so tests can pin the projection refresh's write shape —
+    /// an in-place UPDATE that never re-fetches the previous multi-MB content (PERF-04/#289).
+    /// </summary>
+    public SqlCommandRecorder WriteContextSqlRecorder { get; } = new();
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
@@ -53,6 +60,9 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
                 { "ConnectionStrings:TranslationDatabase", _connectionString },
                 { "Auth:Issuer", TestIssuer },
                 { "Auth:Audience", TestAudience },
+                // Short debounce so the background artifact rebuild (PERF-04) converges fast; the
+                // polling assertions stay meaningful while the suite stays quick.
+                { "TranslationFileRebuild:DebounceWindow", "00:00:00.050" },
             });
         });
 
@@ -66,16 +76,52 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
                 options.TokenValidationParameters.IssuerSigningKey = TestSigningKey;
             });
 
-            // AddDbContext calls compose (EF Core 9+): this appends the recording interceptor to the
-            // production registration of the read context instead of replacing it.
+            // AddDbContext calls compose (EF Core 9+): this appends the recording interceptors to
+            // the production registrations of the two contexts instead of replacing them.
             services.AddDbContext<ApplicationReadDbContext>(options =>
                 options.AddInterceptors(ReadContextSqlRecorder));
+            services.AddDbContext<ApplicationWriteDbContext>(options =>
+                options.AddInterceptors(WriteContextSqlRecorder));
         });
 
         builder.ConfigureLogging(logging =>
         {
             logging.SetMinimumLevel(LogLevel.Warning);
         });
+    }
+
+    /// <summary>
+    /// Resets shared database state between test classes: quiesces the background artifact rebuild
+    /// (PERF-04, ADR-0021), then truncates the given tables. The quiesce is fused into the reset —
+    /// never an opt-in pairing — because a rebuild still in flight from the previous class's writes
+    /// would re-materialize an artifact row right after the TRUNCATE and poison assertions such as
+    /// the "no artifact yet" 404.
+    /// </summary>
+    public async Task ResetDatabaseAsync(string truncateSql)
+    {
+        await WaitForArtifactRebuildQuiesceAsync();
+
+        using IServiceScope scope = Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        await dbContext.Database.ExecuteSqlRawAsync(truncateSql);
+    }
+
+    private async Task WaitForArtifactRebuildQuiesceAsync()
+    {
+        TranslationFileRebuildScheduler scheduler =
+            Services.GetRequiredService<TranslationFileRebuildScheduler>();
+
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(15);
+        while (scheduler.PendingCount > 0)
+        {
+            if (DateTimeOffset.UtcNow >= deadline)
+            {
+                throw new TimeoutException(
+                    $"Background artifact rebuild did not quiesce within 15 s; {scheduler.PendingCount} signal(s) still pending.");
+            }
+
+            await Task.Delay(10);
+        }
     }
 
     public static string CreateAccessToken(

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
@@ -50,14 +50,16 @@ public sealed class ImportExportedTextsHandlerTests
             _unitOfWork,
             TimeProvider.System,
             Microsoft.Extensions.Options.Options.Create(new ImportSettings { MaxRemovedFractionWithoutOverride = maxRemovedFraction }),
-            new NoOpProjector());
+            new NoOpScheduler());
 
-    // The projector is an internal interface (NSubstitute/Castle can't proxy it without a
+    // The scheduler is an internal interface (NSubstitute/Castle can't proxy it without a
     // DynamicProxyGenAssembly2 hook); a hand-written no-op keeps the import handler tests focused
     // on the diff, not on file regeneration (covered by the distribution integration tests).
-    private sealed class NoOpProjector : IPrecomputedTranslationFileProjector
+    private sealed class NoOpScheduler : ITranslationFileRebuildScheduler
     {
-        public Task RebuildAsync(string language, CancellationToken cancellationToken) => Task.CompletedTask;
+        public void Schedule(string language)
+        {
+        }
     }
 
     private static ImportExportedTexts.Command Command(GameVersionId versionId, string export, bool allowMassRemoval = false)

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/TranslationFiles/TranslationFileRebuildSchedulerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/TranslationFiles/TranslationFileRebuildSchedulerTests.cs
@@ -1,0 +1,51 @@
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.TranslationFiles;
+
+public sealed class TranslationFileRebuildSchedulerTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Schedule_WithBlankLanguage_ShouldThrow(string? language)
+    {
+        // Arrange
+        TranslationFileRebuildScheduler scheduler = new();
+
+        // Act & Assert — a blank language is a programmer error, not a business failure.
+        Should.Throw<ArgumentException>(() => scheduler.Schedule(language!));
+        scheduler.PendingCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Schedule_ShouldEnqueueSignalAndTrackItAsPending()
+    {
+        // Arrange
+        TranslationFileRebuildScheduler scheduler = new();
+
+        // Act
+        scheduler.Schedule("pl");
+
+        // Assert
+        scheduler.PendingCount.ShouldBe(1);
+        scheduler.Reader.TryRead(out string? language).ShouldBeTrue();
+        language.ShouldBe("pl");
+    }
+
+    [Fact]
+    public void MarkCompleted_AfterAllSignalsRebuilt_ShouldReturnToIdle()
+    {
+        // Arrange — a burst of signals the worker later drains as one batch.
+        TranslationFileRebuildScheduler scheduler = new();
+        scheduler.Schedule("pl");
+        scheduler.Schedule("pl");
+        scheduler.Schedule("pl");
+
+        // Act
+        scheduler.MarkCompleted(3);
+
+        // Assert — idle means every scheduled rebuild has completed (the tests' quiesce point).
+        scheduler.PendingCount.ShouldBe(0);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/TranslationFiles/TranslationFileRebuildWorkerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/TranslationFiles/TranslationFileRebuildWorkerTests.cs
@@ -1,0 +1,200 @@
+using System.Collections.Concurrent;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.TranslationFiles;
+
+public sealed class TranslationFileRebuildWorkerTests
+{
+    private static readonly TimeSpan ConvergenceTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly TranslationFileRebuildScheduler _scheduler = new();
+
+    private TranslationFileRebuildWorker CreateWorker(
+        IPrecomputedTranslationFileProjector projector,
+        TimeSpan? debounceWindow = null)
+        => new(
+            _scheduler,
+            projector,
+            TimeProvider.System,
+            Microsoft.Extensions.Options.Options.Create(new TranslationFileRebuildSettings
+            {
+                DebounceWindow = debounceWindow ?? TimeSpan.FromMilliseconds(50),
+            }),
+            NullLogger<TranslationFileRebuildWorker>.Instance);
+
+    private async Task WaitUntilIdleAsync()
+    {
+        using CancellationTokenSource timeout = new(ConvergenceTimeout);
+        while (_scheduler.PendingCount > 0)
+        {
+            await Task.Delay(10, timeout.Token);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BurstOfSignals_ShouldCoalesceIntoOneRebuild()
+    {
+        // Arrange — five approves land within one debounce window.
+        RecordingProjector projector = new();
+        using TranslationFileRebuildWorker worker = CreateWorker(projector);
+        for (int signal = 0; signal < 5; signal++)
+        {
+            _scheduler.Schedule("pl");
+        }
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await projector.FirstCompletedRebuild.WaitAsync(ConvergenceTimeout);
+        await WaitUntilIdleAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        // Assert — the queue was fully drained by a single O(N) rebuild, not five serialized ones.
+        projector.CallCount.ShouldBe(1);
+        projector.Languages.ShouldBe(["pl"]);
+        _scheduler.PendingCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SignalsForDistinctLanguages_ShouldRebuildEachOnce()
+    {
+        // Arrange — dirty signals for two languages inside one window.
+        RecordingProjector projector = new();
+        using TranslationFileRebuildWorker worker = CreateWorker(projector);
+        _scheduler.Schedule("pl");
+        _scheduler.Schedule("en");
+        _scheduler.Schedule("pl");
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await projector.FirstCompletedRebuild.WaitAsync(ConvergenceTimeout);
+        await WaitUntilIdleAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        // Assert
+        projector.CallCount.ShouldBe(2);
+        projector.Languages.Order().ShouldBe(["en", "pl"]);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRebuildFails_ShouldRescheduleUntilTheArtifactConverges()
+    {
+        // Arrange — the first rebuild attempt hits a transient fault.
+        RecordingProjector projector = new(failuresBeforeSuccess: 1);
+        using TranslationFileRebuildWorker worker = CreateWorker(projector);
+        _scheduler.Schedule("pl");
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await projector.FirstCompletedRebuild.WaitAsync(ConvergenceTimeout);
+        await WaitUntilIdleAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        // Assert — the failed pass was retried on the next debounce window; the signal is only
+        // considered done once a rebuild actually succeeded.
+        projector.CallCount.ShouldBe(2);
+        _scheduler.PendingCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRebuildThrowsCancellationWhileHostIsRunning_ShouldRescheduleInsteadOfStopping()
+    {
+        // Arrange — a transient fault surfacing as OCE (e.g. a cancelled DB command) while the host
+        // is NOT shutting down; only a shutdown cancellation may escape the worker loop.
+        RecordingProjector projector = new(
+            failuresBeforeSuccess: 1,
+            faultFactory: () => new OperationCanceledException("Transient command cancellation."));
+        using TranslationFileRebuildWorker worker = CreateWorker(projector);
+        _scheduler.Schedule("pl");
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await projector.FirstCompletedRebuild.WaitAsync(ConvergenceTimeout);
+        await WaitUntilIdleAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        // Assert — the loop survived the rogue OCE and retried to convergence.
+        projector.CallCount.ShouldBe(2);
+        _scheduler.PendingCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithZeroDebounceWindow_ShouldStillRebuild()
+    {
+        // Arrange — zero is a valid setting that disables the coalescing wait entirely.
+        RecordingProjector projector = new();
+        using TranslationFileRebuildWorker worker = CreateWorker(projector, TimeSpan.Zero);
+        _scheduler.Schedule("pl");
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await projector.FirstCompletedRebuild.WaitAsync(ConvergenceTimeout);
+        await WaitUntilIdleAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        // Assert
+        projector.CallCount.ShouldBe(1);
+        _scheduler.PendingCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldRebuildOnTheWorkerLifetimeToken()
+    {
+        // Arrange
+        RecordingProjector projector = new();
+        using TranslationFileRebuildWorker worker = CreateWorker(projector);
+        _scheduler.Schedule("pl");
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await projector.FirstCompletedRebuild.WaitAsync(ConvergenceTimeout);
+        bool cancelledWhileRunning = projector.LastToken.IsCancellationRequested;
+        await worker.StopAsync(CancellationToken.None);
+
+        // Assert — the projector ran on the host stopping token (live while the app runs, cancelled
+        // only at shutdown), so an aborted HTTP request can never cancel a scheduled rebuild.
+        cancelledWhileRunning.ShouldBeFalse();
+        projector.LastToken.IsCancellationRequested.ShouldBeTrue();
+    }
+
+    private sealed class RecordingProjector : IPrecomputedTranslationFileProjector
+    {
+        private readonly int _failuresBeforeSuccess;
+        private readonly Func<Exception> _faultFactory;
+        private readonly ConcurrentQueue<string> _languages = new();
+        private readonly TaskCompletionSource _firstCompletedRebuild =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private int _callCount;
+
+        public RecordingProjector(int failuresBeforeSuccess = 0, Func<Exception>? faultFactory = null)
+        {
+            _failuresBeforeSuccess = failuresBeforeSuccess;
+            _faultFactory = faultFactory ?? (() => new InvalidOperationException("Transient rebuild failure."));
+        }
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public IReadOnlyList<string> Languages => [.. _languages];
+
+        public CancellationToken LastToken { get; private set; }
+
+        /// <summary>Completes on the first rebuild that succeeds (failed attempts don't count).</summary>
+        public Task FirstCompletedRebuild => _firstCompletedRebuild.Task;
+
+        public Task RebuildAsync(string language, CancellationToken cancellationToken)
+        {
+            int call = Interlocked.Increment(ref _callCount);
+            _languages.Enqueue(language);
+            LastToken = cancellationToken;
+
+            if (call <= _failuresBeforeSuccess)
+            {
+                throw _faultFactory();
+            }
+
+            _firstCompletedRebuild.TrySetResult();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/ApproveTranslationHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/ApproveTranslationHandlerTests.cs
@@ -25,13 +25,21 @@ public sealed class ApproveTranslationHandlerTests
     private static readonly TranslatorId Approver = TranslatorId.Create();
 
     // ITranslationRepository / IUnitOfWork are genuine public boundaries (stubbed); the provisioner +
-    // artifact builder are internal interfaces NSubstitute can't proxy, so each gets a hand-written
+    // rebuild scheduler are internal interfaces NSubstitute can't proxy, so each gets a hand-written
     // double.
     private readonly ITranslationRepository _translationRepository = Substitute.For<ITranslationRepository>();
     private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
-    private readonly RecordingProjector _projector = new();
+    private readonly List<string> _callOrder = [];
+    private readonly RecordingScheduler _rebuildScheduler;
 
     private StubTranslatorProvisioner _provisioner = new(Result.Success(Approver));
+
+    public ApproveTranslationHandlerTests()
+    {
+        _rebuildScheduler = new RecordingScheduler(_callOrder);
+        _unitOfWork.When(unitOfWork => unitOfWork.SaveChangesAsync(Arg.Any<CancellationToken>()))
+            .Do(_ => _callOrder.Add(nameof(IUnitOfWork.SaveChangesAsync)));
+    }
 
     private ApproveTranslation.Handler CreateHandler()
         => new(
@@ -40,7 +48,7 @@ public sealed class ApproveTranslationHandlerTests
             _unitOfWork,
             _provisioner,
             TimeProvider.System,
-            _projector);
+            _rebuildScheduler);
 
     private static Translation Untranslated(int gossipId = 1, string source = "English")
         => Translation.CreateUntranslated(
@@ -63,7 +71,7 @@ public sealed class ApproveTranslationHandlerTests
         result.IsFailure.ShouldBeTrue();
         result.Error.Code.ShouldBe("Translations.Validation");
         await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
-        _projector.RebuildCount.ShouldBe(0);
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
     }
 
     [Fact]
@@ -85,7 +93,7 @@ public sealed class ApproveTranslationHandlerTests
         result.Error.Code.ShouldBe("Translators.Unauthenticated");
         row.Status.ShouldBe(TranslationStatus.Draft);
         await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
-        _projector.RebuildCount.ShouldBe(0);
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
     }
 
     [Fact]
@@ -102,7 +110,7 @@ public sealed class ApproveTranslationHandlerTests
         result.IsFailure.ShouldBeTrue();
         result.Error.Code.ShouldBe("TranslationEntity.NotFound");
         await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
-        _projector.RebuildCount.ShouldBe(0);
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
     }
 
     [Fact]
@@ -119,7 +127,7 @@ public sealed class ApproveTranslationHandlerTests
         result.IsFailure.ShouldBeTrue();
         result.Error.Code.ShouldBe("TranslationEntity.CannotApproveWithoutTranslation");
         await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
-        _projector.RebuildCount.ShouldBe(0);
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
     }
 
     [Fact]
@@ -138,7 +146,7 @@ public sealed class ApproveTranslationHandlerTests
         result.IsFailure.ShouldBeTrue();
         result.Error.Code.ShouldBe("TranslationEntity.CannotApproveRemoved");
         await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
-        _projector.RebuildCount.ShouldBe(0);
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
     }
 
     [Fact]
@@ -157,8 +165,26 @@ public sealed class ApproveTranslationHandlerTests
         row.Status.ShouldBe(TranslationStatus.Approved);
         row.ApprovedById.ShouldBe(Approver);
         await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
-        // The row enters the distributed set, so the artifact is always rebuilt on a successful approve.
-        _projector.RebuildCount.ShouldBe(1);
+        // The row enters the distributed set, so a rebuild is always scheduled on a successful approve.
+        _rebuildScheduler.ScheduleCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Handle_OnSuccess_ShouldScheduleTheRebuildAfterTheCommit()
+    {
+        // Arrange — ADR-0021 §1: the dirty signal must follow SaveChanges; signalled before the
+        // commit, a zero-debounce rebuild could publish a snapshot missing its own trigger and park
+        // the artifact stale. Ordering is invisible in the return value, hence the call log.
+        Translation row = Untranslated();
+        row.ProvideTranslation("Witaj", Submitter, Now);
+        GivenStoredRow(row);
+
+        // Act
+        Result result = await CreateHandler().Handle(new ApproveTranslation.Command(row.Id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        _callOrder.ShouldBe([nameof(IUnitOfWork.SaveChangesAsync), nameof(ITranslationFileRebuildScheduler.Schedule)]);
     }
 
     [Fact]
@@ -178,17 +204,24 @@ public sealed class ApproveTranslationHandlerTests
         result.IsSuccess.ShouldBeTrue();
         row.Status.ShouldBe(TranslationStatus.Approved);
         row.PreviousSourceText.ShouldBeNull();
-        _projector.RebuildCount.ShouldBe(1);
+        _rebuildScheduler.ScheduleCount.ShouldBe(1);
     }
 
-    private sealed class RecordingProjector : IPrecomputedTranslationFileProjector
+    private sealed class RecordingScheduler : ITranslationFileRebuildScheduler
     {
-        public int RebuildCount { get; private set; }
+        private readonly List<string> _callOrder;
 
-        public Task RebuildAsync(string language, CancellationToken cancellationToken)
+        public RecordingScheduler(List<string> callOrder)
         {
-            RebuildCount++;
-            return Task.CompletedTask;
+            _callOrder = callOrder;
+        }
+
+        public int ScheduleCount { get; private set; }
+
+        public void Schedule(string language)
+        {
+            ScheduleCount++;
+            _callOrder.Add(nameof(ITranslationFileRebuildScheduler.Schedule));
         }
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/UpsertTranslationHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/UpsertTranslationHandlerTests.cs
@@ -30,15 +30,23 @@ public sealed class UpsertTranslationHandlerTests
     private static readonly TranslatorId CurrentTranslator = TranslatorId.Create();
 
     // ITranslationRepository / IUnitOfWork are genuine public boundaries (stubbed); the read context
-    // is a pure in-memory double serving the response read-back, and the provisioner + artifact
-    // builder are internal interfaces NSubstitute can't proxy, so each gets a hand-written double.
+    // is a pure in-memory double serving the response read-back, and the provisioner + rebuild
+    // scheduler are internal interfaces NSubstitute can't proxy, so each gets a hand-written double.
     private readonly ITranslationRepository _translationRepository = Substitute.For<ITranslationRepository>();
     private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
     private readonly List<TranslationReadModel> _readModels = [];
+    private readonly List<string> _callOrder = [];
 
-    private readonly RecordingProjector _projector = new();
+    private readonly RecordingScheduler _rebuildScheduler;
 
     private StubTranslatorProvisioner _provisioner = new(Result.Success(CurrentTranslator));
+
+    public UpsertTranslationHandlerTests()
+    {
+        _rebuildScheduler = new RecordingScheduler(_callOrder);
+        _unitOfWork.When(unitOfWork => unitOfWork.SaveChangesAsync(Arg.Any<CancellationToken>()))
+            .Do(_ => _callOrder.Add(nameof(IUnitOfWork.SaveChangesAsync)));
+    }
 
     private UpsertTranslation.Handler CreateHandler(IApplicationReadDbContext? readDbContext = null)
         => new(
@@ -48,7 +56,7 @@ public sealed class UpsertTranslationHandlerTests
             _provisioner,
             readDbContext ?? new FakeReadDbContext(_readModels),
             TimeProvider.System,
-            _projector);
+            _rebuildScheduler);
 
     private static UpsertTranslation.Command Command(int gossipId, string text)
         => new(FileId, gossipId, text);
@@ -176,7 +184,7 @@ public sealed class UpsertTranslationHandlerTests
         row.SubmittedById.ShouldBe(CurrentTranslator);
         await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
         // Editing a non-Approved row does not change the distributed set, so no artifact rebuild.
-        _projector.RebuildCount.ShouldBe(0);
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
     }
 
     [Fact]
@@ -195,7 +203,27 @@ public sealed class UpsertTranslationHandlerTests
         // Assert
         result.IsSuccess.ShouldBeTrue();
         result.Value.Status.ShouldBe(TranslationStatus.Draft);
-        _projector.RebuildCount.ShouldBe(1);
+        _rebuildScheduler.ScheduleCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Handle_OnApprovedRow_ShouldScheduleTheRebuildAfterTheCommit()
+    {
+        // Arrange — ADR-0021 §1: the dirty signal must follow SaveChanges; signalled before the
+        // commit, a zero-debounce rebuild could publish a snapshot missing its own trigger and park
+        // the artifact stale. Ordering is invisible in the return value, hence the call log.
+        Translation approved = Untranslated();
+        approved.ProvideTranslation("Stary polski", CurrentTranslator, Now);
+        approved.Approve(CurrentTranslator, Now);
+        GivenStoredRow(approved);
+        GivenReadBack(approved, "Nowy polski");
+
+        // Act
+        Result<TranslationDetailResponse> result = await CreateHandler().Handle(Command(1, "Nowy polski"), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        _callOrder.ShouldBe([nameof(IUnitOfWork.SaveChangesAsync), nameof(ITranslationFileRebuildScheduler.Schedule)]);
     }
 
     [Fact]
@@ -216,17 +244,24 @@ public sealed class UpsertTranslationHandlerTests
         result.Value.Status.ShouldBe(TranslationStatus.Draft);
         result.Value.PreviousSourceText.ShouldBe("Old English");
         result.Value.TranslatedText.ShouldBe("Nowy polski");
-        _projector.RebuildCount.ShouldBe(0);
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
     }
 
-    private sealed class RecordingProjector : IPrecomputedTranslationFileProjector
+    private sealed class RecordingScheduler : ITranslationFileRebuildScheduler
     {
-        public int RebuildCount { get; private set; }
+        private readonly List<string> _callOrder;
 
-        public Task RebuildAsync(string language, CancellationToken cancellationToken)
+        public RecordingScheduler(List<string> callOrder)
         {
-            RebuildCount++;
-            return Task.CompletedTask;
+            _callOrder = callOrder;
+        }
+
+        public int ScheduleCount { get; private set; }
+
+        public void Schedule(string language)
+        {
+            ScheduleCount++;
+            _callOrder.Add(nameof(ITranslationFileRebuildScheduler.Schedule));
         }
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
@@ -185,6 +185,9 @@ public sealed class E2ETestFixture : IAsyncLifetime
             .WithEnvironment("Auth__Authority", "http://auth-api:8080")
             .WithEnvironment("Auth__Audience", Audience)
             .WithEnvironment("Bootstrap__Enabled", "false")
+            // Short debounce so the background artifact rebuild (PERF-04) converges fast; the
+            // download polls stay meaningful while the suite stays quick.
+            .WithEnvironment("TranslationFileRebuild__DebounceWindow", "00:00:00.100")
             .WithWaitStrategy(Wait.ForUnixContainer()
                 .UntilHttpRequestIsSucceeded(request => request.ForPath("/health/live").ForPort(8080)))
             .Build();

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/CoreLoopE2ETests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/CoreLoopE2ETests.cs
@@ -56,13 +56,17 @@ public sealed class CoreLoopE2ETests : E2ETestBase
             HttpResponseMessage approve = await admin.ApproveRawAsync(edited.Id.Value);
             approve.StatusCode.ShouldBe(HttpStatusCode.NoContent);
 
-            // Download the distributed file (anonymous): the approved row is in, the untranslated one is out.
-            HttpResponseMessage download = await anonymous.DownloadFileRawAsync(Language);
+            // Download the distributed file (anonymous): the approved row is in, the untranslated one
+            // is out. The artifact is rebuilt in the background, debounced (PERF-04) — poll until the
+            // approve's rebuild has converged.
+            (HttpResponseMessage download, string file) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+                anonymous,
+                Language,
+                (candidate, content) => candidate.IsSuccessStatusCode && content.Contains($"{FileId}||1||Polski jeden||NULL||NULL||1"));
             download.StatusCode.ShouldBe(HttpStatusCode.OK);
             download.Headers.ETag.ShouldNotBeNull();
             EntityTagHeaderValue etag = download.Headers.ETag!;
 
-            string file = await download.Content.ReadAsStringAsync();
             file.ShouldContain($"{FileId}||1||Polski jeden||NULL||NULL||1");
             file.ShouldNotContain($"{FileId}||2||");
 

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/UpdateCycleE2ETests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/UpdateCycleE2ETests.cs
@@ -41,8 +41,12 @@ public sealed class UpdateCycleE2ETests : E2ETestBase
             TranslationDetailResponse edited = await admin.UpsertAsync(FileId, gossipId: 1, translatedText: "Polski jeden");
             await admin.ApproveRawAsync(edited.Id.Value);
 
-            HttpResponseMessage firstDownload = await anonymous.DownloadFileRawAsync(Language);
-            (await firstDownload.Content.ReadAsStringAsync()).ShouldContain($"{FileId}||1||Polski jeden||NULL||NULL||1");
+            // The approve's artifact rebuild is debounced and backgrounded (PERF-04) — poll to convergence.
+            (HttpResponseMessage firstDownload, string firstFile) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+                anonymous,
+                Language,
+                (candidate, content) => candidate.IsSuccessStatusCode && content.Contains($"{FileId}||1||Polski jeden||NULL||NULL||1"));
+            firstFile.ShouldContain($"{FileId}||1||Polski jeden||NULL||NULL||1");
             firstDownload.Headers.ETag.ShouldNotBeNull();
             EntityTagHeaderValue firstEtag = firstDownload.Headers.ETag!;
 
@@ -59,10 +63,14 @@ public sealed class UpdateCycleE2ETests : E2ETestBase
             row1.Status.ShouldBe(TranslationStatus.NeedsReview);
             row1.PreviousSourceText.ShouldBe("English one");
 
-            // The invalidated row drops out of the freshly regenerated distributed file (new ETag).
-            HttpResponseMessage secondDownload = await anonymous.DownloadFileRawAsync(Language);
+            // The invalidated row drops out of the regenerated distributed file (new ETag) once the
+            // import's background rebuild converges.
+            (HttpResponseMessage secondDownload, string secondFile) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+                anonymous,
+                Language,
+                (candidate, content) => candidate.IsSuccessStatusCode && !content.Contains($"{FileId}||1||"));
             secondDownload.Headers.ETag.ShouldNotBe(firstEtag);
-            (await secondDownload.Content.ReadAsStringAsync()).ShouldNotContain($"{FileId}||1||");
+            secondFile.ShouldNotContain($"{FileId}||1||");
         }
         catch (Exception)
         {

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/TranslationFileDownloadPolling.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/TranslationFileDownloadPolling.cs
@@ -1,0 +1,37 @@
+using LotroKoniecDev.TranslationSystem.E2E.Tests.Clients;
+
+namespace LotroKoniecDev.TranslationSystem.E2E.Tests;
+
+/// <summary>
+/// Polls the anonymous translation-file download until the containerised tms-api's debounced
+/// background rebuild (PERF-04, ADR-0021) has converged on the caller's condition. On timeout the
+/// last snapshot is returned anyway, so the caller's regular assertions fail with the actually
+/// observed response instead of a bare timeout exception.
+/// </summary>
+internal static class TranslationFileDownloadPolling
+{
+    private static readonly TimeSpan ConvergenceTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
+
+    public static async Task<(HttpResponseMessage Response, string Content)> DownloadWhenConvergedAsync(
+        TranslationSystemApiClient client,
+        string language,
+        Func<HttpResponseMessage, string, bool> hasConverged)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + ConvergenceTimeout;
+
+        while (true)
+        {
+            HttpResponseMessage response = await client.DownloadFileRawAsync(language);
+            string content = await response.Content.ReadAsStringAsync();
+
+            if (hasConverged(response, content) || DateTimeOffset.UtcNow >= deadline)
+            {
+                return (response, content);
+            }
+
+            response.Dispose();
+            await Task.Delay(PollInterval);
+        }
+    }
+}


### PR DESCRIPTION
Write handlers no longer await the O(N) artifact rebuild inline: they signal a
singleton scheduler after SaveChanges and a debounced BackgroundService worker
(fixed coalescing window, host-lifetime token, log-and-reschedule on failure)
drives the existing projector — a reviewer burst collapses to one rebuild and a
client disconnect can no longer strand a committed write with a stale artifact.
The store refresh becomes a single set-based ExecuteUpdate that never reloads
the previous multi-MB content (PrecomputedTranslationFile is now immutable),
DebounceWindow is validated at startup (0..5 min), and the single-replica
assumption is documented in ADR-0021 (ADR-0007 amended). Integration/E2E tests
poll the download to convergence; shared DB resets go through the factory's
fused quiesce-then-truncate ResetDatabaseAsync.

Ticket #289 (performance audit 2026-07-02, finding P1-2).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
