### PR TITLE
infra: staging-only tms-api scale to 2 vCPU / 4Gi (per-env sizing) — import OOM bridge until #290

### DIFF
--- a/iac/azure-container-apps.tf
+++ b/iac/azure-container-apps.tf
@@ -271,15 +271,15 @@ resource "azurerm_container_app" "tms_api" {
     max_replicas = 1
 
     container {
-      name   = "tms-api"
-      image  = "ghcr.io/koniecdev/lotrokoniecdev-tms-api:${var.image_tag}"
-      # Import of the full exported.txt (~79 MB, ~792k rows) retains ~1.2 GB managed at peak — the
-      # 0.5Gi size OOMs deterministically at its ~384 MB GC cap (75% of the cgroup limit), and 2Gi
-      # still OOMs on RE-import once the tracked full-catalog load lands on top (incident
-      # 2026-07-02). Max Consumption size until the streaming import (#290) lands; scale back
-      # with #290's DoD.
-      cpu    = 2
-      memory = "4Gi"
+      name  = "tms-api"
+      image = "ghcr.io/koniecdev/lotrokoniecdev-tms-api:${var.image_tag}"
+      # Sizing is per-env (vars.tf): the full exported.txt import (~79 MB, ~792k rows) retains
+      # ~1.2 GB managed at peak and OOMs the 0.5Gi size at its ~384 MB GC cap (75% of the cgroup
+      # limit; incident 2026-07-02), so STAGING overrides to the max Consumption size for QA while
+      # PROD deliberately stays small — the real fix is the #290 streaming import, and the staging
+      # override is removed with #290's DoD.
+      cpu    = var.tms_api_cpu
+      memory = var.tms_api_memory
 
       liveness_probe {
         transport = "HTTP"

--- a/iac/azure-container-apps.tf
+++ b/iac/azure-container-apps.tf
@@ -273,8 +273,13 @@ resource "azurerm_container_app" "tms_api" {
     container {
       name   = "tms-api"
       image  = "ghcr.io/koniecdev/lotrokoniecdev-tms-api:${var.image_tag}"
-      cpu    = 0.25
-      memory = "0.5Gi"
+      # Import of the full exported.txt (~79 MB, ~792k rows) retains ~1.2 GB managed at peak — the
+      # 0.5Gi size OOMs deterministically at its ~384 MB GC cap (75% of the cgroup limit), and 2Gi
+      # still OOMs on RE-import once the tracked full-catalog load lands on top (incident
+      # 2026-07-02). Max Consumption size until the streaming import (#290) lands; scale back
+      # with #290's DoD.
+      cpu    = 2
+      memory = "4Gi"
 
       liveness_probe {
         transport = "HTTP"

--- a/iac/env/staging.tfvars
+++ b/iac/env/staging.tfvars
@@ -23,3 +23,10 @@ aca_environment_resource_group = "rg-lotrotms-prod-polc-001"
 # 0.25 vCPU / 0.5 GiB replicas were pure idle spend (~$15-18/month). First request after idle pays a
 # cold start (~10-20 s incl. Neon wake); accepted for QA. Prod stays at 1 (ADR-0012 R8).
 app_min_replicas = 0
+
+# Import-OOM bridge (#300, incident 2026-07-02): a full exported.txt import retains ~1.2 GB managed
+# (a re-import ~2 GB with the tracked catalog on top), so QA imports need the max Consumption size
+# until the #290 streaming import brings the working set to O(batch). Removed with #290's DoD.
+# Nearly free here: with app_min_replicas = 0 the big size bills only while QA actually runs.
+tms_api_cpu    = 2
+tms_api_memory = "4Gi"

--- a/iac/vars.tf
+++ b/iac/vars.tf
@@ -76,3 +76,15 @@ variable "app_min_replicas" {
     error_message = "app_min_replicas must be 0 or 1 (max_replicas is fixed at 1)."
   }
 }
+
+variable "tms_api_cpu" {
+  type        = number
+  description = "vCPU for the tms-api container. Prod keeps the default 0.25 — the exported.txt import OOM (incident 2026-07-02) is fixed by the #290 streaming import, not by paying ~$40/mo for an always-on bigger box. Staging overrides to 2 (env/staging.tfvars) so QA can import the full file before #290 lands; that override is removed with #290's DoD."
+  default     = 0.25
+}
+
+variable "tms_api_memory" {
+  type        = string
+  description = "Memory for the tms-api container, paired with tms_api_cpu (ACA Consumption allows only fixed pairs: 0.25/0.5Gi, 0.5/1Gi, 1/2Gi, 1.5/3Gi, 2/4Gi). Prod keeps the default 0.5Gi; staging overrides to 4Gi — see tms_api_cpu."
+  default     = "0.5Gi"
+}


### PR DESCRIPTION
## Incident

Import of the full `exported.txt` (79 MB, **792,500 rows**) fails with `OutOfMemoryException` in `TranslationDiffService.ComputePlan` on **both staging and prod** (2026-07-02, ~14:25 / ~14:36 local; App Insights `lotrotmsappinsightsprod` — staging telemetry lands there too by design, shared env + LAW per ADR-0018). Prod failed with an **empty catalog**: `GetAllAsync` returned in 81 ms, so the OOM needs no existing data at all.

## Root cause (measured on the real file, not estimated)

Harness re-running the exact import pipeline stages (parse → `MapToIncoming` → `ComputePlan`) against the real 79 MB export:

| Stage | Managed memory |
|---|---|
| after parse (`List<ParsedExportRow>`) | ~530 MB |
| after `MapToIncoming` (per-row `FragmentKey`/`TranslationSource` class VOs) | ~1.1 GB |
| peak at `ComputePlan` (792k `Translation.CreateUntranslated`) | **~1.2 GB committed, 932 MB retained after full GC** |

All stages stay reachable **simultaneously** — they are hoisted locals of the async `Handle` state machine, alive until the handler returns. The container gives 0.25 vCPU / 0.5Gi; .NET caps the GC heap at 75% of the cgroup limit ≈ **384 MB**. Running the harness under `DOTNET_GCHeapHardLimit=0x18000000` (384 MB) reproduces the OOM deterministically, mid-parse.

## Fix here: STAGING-ONLY bump via per-env sizing vars — prod stays 0.25 vCPU / 0.5Gi

`tms_api_cpu` / `tms_api_memory` land in `vars.tf` with prod-shaped defaults (0.25 / `0.5Gi` — `infra.yml` applies prod with no var-file); `env/staging.tfvars` overrides to **2 vCPU / 4Gi**, the Consumption maximum. Why the split:

- **Staging is where the OOM actually blocks work**: the QA-FE batch (QA-FE-09 import flow) runs against staging. With `app_min_replicas = 0` the bigger size bills only while QA actually exercises it — ~free.
- **Prod at 2/4Gi is ~+$40/mo run-rate** (always-on per ADR-0012 R8) **for an operation that runs ~once per game update** — not worth it days before the real fix. Prod imports are owner-only and pre-release (zero users); they simply wait for #290.
- A middle 2Gi size still OOMs the flow QA exercises (import → tweak → re-import): a re-import additionally materializes the full catalog as ~792k *tracked* aggregates, conservatively ~1.8–2 GB peak. The only useful bump is the max — all the more reason to pay it only where it is ~free.

## The real fix is #290 (streaming import) — design doc in progress

#290 as currently scoped (projection instead of tracked load) would **not** have prevented this incident — prod OOM'd with an empty catalog. It is being extended into a two-pass streaming import (stream-parse + compact hash projections + chunked apply; working set O(batch), fits the 0.5Gi cap with headroom). Design doc lands under `docs/specs/`. **#290's DoD: remove the staging override from `env/staging.tfvars`** so tms-api folds back to the small default everywhere.

## Rollout (traffic does not follow a template change)

1. Merge → `infra.yml` auto-applies **staging** (resized template). **The prod plan is a no-op** (defaults unchanged) — approve the gated prod apply as an empty apply, or let it sit.
2. CD pins traffic by revision name, so staging needs one CD deploy for the new size to take effect: dispatch `cd.yml` after the staging apply (deploy-staging is gate-free; the run then pauses at the prod approval — leave it unapproved, prod has nothing to pick up).
3. Verify: re-run the staging import (QA-FE-09 flow) — expect 200 + diff summary instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
