### PR TITLE
Bug: White flash after login — unstyled OIDC form_post interstitial before the redirect home

### DIFF
--- a/docs/adr/0009-browser-e2e-playwright-via-testcontainers.md
+++ b/docs/adr/0009-browser-e2e-playwright-via-testcontainers.md
@@ -28,9 +28,9 @@ Code facts that constrain the design:
   (`OpenIddictExtensions.cs`). ADR-0006 secured this in dev by running everything on the host
   (`localhost:5003` resolves identically for browser and host RP). A browser E2E needs the same
   property in an automatable, headless-CI-friendly substrate.
-- **HTTPS is mandatory.** The OIDC code flow uses `response_mode=form_post`; the correlation/nonce
-  cookies are `SameSite=None`, which a browser only sends when `Secure`. Plain HTTP breaks the
-  callback. So the stack must serve HTTPS, which means a cert the FE/tms back-channels **trust** —
+- **HTTPS is mandatory.** The OIDC handler's correlation/nonce cookies are `SameSite=None`
+  regardless of the authorize `response_mode` (`form_post` originally; `query` since #306), and a
+  browser only sends `SameSite=None` cookies when `Secure`. Plain HTTP breaks the callback. So the stack must serve HTTPS, which means a cert the FE/tms back-channels **trust** —
   and .NET validates against the **OS trust store** (it ignores `SSL_CERT_FILE`; see
   `.docker/trust-ca-entrypoint.sh`).
 - **We already orchestrate the full stack from C# with Testcontainers.**

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthenticationDependencyInjectionExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthenticationDependencyInjectionExtensions.cs
@@ -103,6 +103,11 @@ internal static class AuthenticationDependencyInjectionExtensions
             "http://", StringComparison.OrdinalIgnoreCase);
 
         options.ResponseType = OpenIdConnectResponseType.Code;
+        // Not the handler's form_post default: form_post makes the authorize endpoint render
+        // OpenIddict's bare white interstitial (visible flash before a dark app repaints), while query
+        // keeps the whole login return a 302 chain the browser never paints. Code-in-URL is the
+        // RFC 9700 baseline shape — PKCE below is the mitigation that makes an intercepted code useless.
+        options.ResponseMode = OpenIdConnectResponseMode.Query;
         options.UsePkce = true;
         options.SaveTokens = true;
         options.GetClaimsFromUserInfoEndpoint = true;

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/AuthenticationDependencyInjectionExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/AuthenticationDependencyInjectionExtensionsTests.cs
@@ -1,0 +1,50 @@
+using LotroKoniecDev.Frontend.Infrastructure.Auth;
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Auth;
+
+public sealed class AuthenticationDependencyInjectionExtensionsTests
+{
+    [Fact]
+    public void AddFrontendAuthentication_OpenIdConnectOptions_UsesQueryResponseMode()
+    {
+        OpenIdConnectOptions options = ResolveConfiguredOidcOptions();
+
+        options.ResponseMode.ShouldBe(OpenIdConnectResponseMode.Query);
+    }
+
+    [Fact]
+    public void AddFrontendAuthentication_OpenIdConnectOptions_UsesPkce()
+    {
+        OpenIdConnectOptions options = ResolveConfiguredOidcOptions();
+
+        options.UsePkce.ShouldBeTrue();
+    }
+
+    private static OpenIdConnectOptions ResolveConfiguredOidcOptions()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddSingleton<IDataProtectionProvider>(new EphemeralDataProtectionProvider());
+        services.AddSingleton<IOptions<AuthSystemSettings>>(Microsoft.Extensions.Options.Options.Create(new AuthSystemSettings
+        {
+            BaseUrl = "https://localhost:5003",
+            Authority = "https://localhost:5003",
+            ClientId = "lotrokoniecdev-web",
+            CallbackPath = "/callback",
+            SignedOutCallbackPath = "/signout-callback-oidc",
+            Scopes = ["openid", "email", "profile"],
+        }));
+        services.AddFrontendAuthentication();
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        return provider
+            .GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>()
+            .Get(OpenIdConnectDefaults.AuthenticationScheme);
+    }
+}


### PR DESCRIPTION
Closes #306

## What & why

After successful login the browser painted a **white page for ~0.4 s** (longer on cold cache) before the dark home page: `GET /connect/authorize` returned OpenIddict's built-in `response_mode=form_post` interstitial — a bare, unstyled auto-submit `<form>` document — which stayed painted through the JS submit → callback POST (back-channel code exchange) → `302 /`. The ASP.NET Core OIDC handler defaults to `form_post`; our config never overrode it.

**Fix:** `options.ResponseMode = OpenIdConnectResponseMode.Query` in the Frontend RP. The whole post-login return becomes a pure 302 chain, so the browser keeps the previous (dark) page painted until the home page renders — the interstitial (and the flash) ceases to exist. No auth-server changes: query is the OAuth default response mode for `code`, and the handler even omits `response_mode` from the authorize request (spec-recommended).

## Security assessment (reviewed, not a violation)

Code-in-query is the RFC 9700 (OAuth Security BCP) baseline flow. Verified in-repo: OpenIddict **enforces PKCE server-side** (`RequireProofKeyForCodeExchange`), codes are single-use and short-lived, `Referrer-Policy: no-referrer` is app-wide, the callback answers an immediate 302 (no rendered document), the FE request log **redacts `code`** (`SensitiveDataRedactor`, test-pinned) and OTel redacts `url.query` by default. Dedicated security review of the diff: **no HIGH/MEDIUM findings**. `UsePkce` — the invariant the rationale leans on — is now pinned by a unit test. Rejected alternative (documented in #306): keep `form_post` and hand-maintain a branded dark interstitial.

## Changes

- `AuthenticationDependencyInjectionExtensions.cs` — the one-line fix + why-comment
- `AuthenticationDependencyInjectionExtensionsTests.cs` — new: pins `ResponseMode == Query` (TDD, watched it fail on `form_post`) and `UsePkce == true` on the resolved named options
- `docs/adr/0009` — amends the stale premise "code flow uses form_post"; HTTPS stays mandatory because correlation/nonce cookies are `SameSite=None` regardless of response mode

## Verification

- Full solution build: **0 warnings**; Frontend unit suite: **240/240**
- Browser E2E (`LotroKoniecDev.Frontend.E2E.Tests`, Testcontainers + Playwright): **8/8 green** on images rebuilt from this working tree — register → e-mail confirm → **OIDC login over the new query-mode GET callback** → logout
- `code-reviewer` agent: APPROVE (both minor recommendations applied in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)