### PR TITLE
FE: design system lift from TheKittySaver — hobbit-gold OKLCH theme across Frontend + Auth pages

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmail.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmail.cshtml
@@ -15,21 +15,21 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
     <style>
         :root {
-            --bg:        oklch(0.16 0.013 165);
-            --bg-2:      oklch(0.20 0.015 165);
-            --surface:   oklch(0.23 0.016 165);
-            --surface-hi:oklch(0.28 0.018 165);
-            --border:    oklch(0.34 0.018 165);
-            --border-hi: oklch(0.44 0.022 165);
+            --bg:        oklch(0.16 0.011 80);
+            --bg-2:      oklch(0.20 0.013 80);
+            --surface:   oklch(0.23 0.014 80);
+            --surface-hi:oklch(0.28 0.016 80);
+            --border:    oklch(0.34 0.016 80);
+            --border-hi: oklch(0.44 0.020 80);
 
-            --text:      oklch(0.96 0.008 160);
-            --text-mute: oklch(0.80 0.012 160);
-            --text-dim:  oklch(0.68 0.014 160);
+            --text:      oklch(0.96 0.008 85);
+            --text-mute: oklch(0.80 0.012 85);
+            --text-dim:  oklch(0.68 0.014 85);
 
-            --accent:     oklch(0.80 0.17 168);
-            --accent-hi:  oklch(0.87 0.18 168);
-            --accent-dim: oklch(0.48 0.10 168);
-            --accent-soft:oklch(0.32 0.08 168);
+            --accent:     oklch(0.78 0.11 84);
+            --accent-hi:  oklch(0.85 0.12 84);
+            --accent-dim: oklch(0.48 0.07 84);
+            --accent-soft:oklch(0.32 0.05 84);
 
             --danger:      oklch(0.68 0.16 25);
             --danger-hi:   oklch(0.76 0.18 25);
@@ -38,7 +38,7 @@
 
             --radius: 14px;
             --radius-sm: 8px;
-            --shadow: 0 1px 0 oklch(0.38 0.014 165 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
+            --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
 
             --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
             --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -64,8 +64,8 @@
             display: flex;
             flex-direction: column;
             background:
-                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.06 168 / 0.35), transparent 60%),
-                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.03 165 / 0.5), transparent 60%);
+                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
         }
 
         .auth-top {
@@ -75,7 +75,7 @@
             gap: 16px;
             padding: 16px 28px;
             border-bottom: 1px solid var(--border);
-            background: oklch(0.15 0.012 165 / 0.7);
+            background: oklch(0.15 0.011 80 / 0.7);
             backdrop-filter: blur(10px);
         }
         .brand {
@@ -91,10 +91,10 @@
             width: 30px; height: 30px;
             border-radius: 8px;
             background: linear-gradient(160deg, var(--accent), var(--accent-dim));
-            color: oklch(0.16 0.012 165);
+            color: oklch(0.16 0.012 80);
             display: grid;
             place-items: center;
-            box-shadow: 0 0 0 1px oklch(0.60 0.08 168 / 0.5) inset;
+            box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
         }
         .brand-mark svg { width: 17px; height: 17px; }
         .brand-accent { color: var(--accent-hi); }
@@ -153,8 +153,8 @@
             padding: 18px 24px;
             border-bottom: 1px solid var(--border);
             background: linear-gradient(to bottom,
-                oklch(0.25 0.018 165 / 0.6),
-                oklch(0.22 0.016 165 / 0));
+                oklch(0.25 0.016 80 / 0.6),
+                oklch(0.22 0.014 80 / 0));
         }
         .auth-panel-head h2 {
             margin: 0;
@@ -218,12 +218,12 @@
             font-size: 12.5px;
         }
         .auth-alert.success {
-            background: oklch(0.28 0.06 165 / 0.42);
-            border-color: oklch(0.55 0.13 165 / 0.5);
-            color: oklch(0.94 0.04 165);
+            background: oklch(0.28 0.06 150 / 0.42);
+            border-color: oklch(0.55 0.13 150 / 0.5);
+            color: oklch(0.94 0.04 150);
         }
         .auth-alert.success > svg { color: var(--accent-hi); }
-        .auth-alert.success .s { color: oklch(0.84 0.05 165); }
+        .auth-alert.success .s { color: oklch(0.84 0.05 150); }
 
         .btn {
             display: inline-flex;
@@ -241,8 +241,8 @@
         .btn svg { width: 16px; height: 16px; flex: 0 0 16px; }
         .btn-primary {
             background: var(--accent);
-            color: oklch(0.15 0.014 165);
-            border-color: oklch(0.62 0.10 168);
+            color: oklch(0.16 0.012 80);
+            border-color: oklch(0.62 0.09 84);
         }
         .btn-primary:hover { background: var(--accent-hi); }
         .btn-ghost {
@@ -292,7 +292,7 @@
     <div class="app">
         <div class="auth-top">
             <a href="https://lotro-translator.pl" class="brand">
-                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
+                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="1.1" fill="currentColor"/></svg></span>
                 <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ForgotPassword.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ForgotPassword.cshtml
@@ -15,21 +15,21 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
     <style>
         :root {
-            --bg:        oklch(0.16 0.013 165);
-            --bg-2:      oklch(0.20 0.015 165);
-            --surface:   oklch(0.23 0.016 165);
-            --surface-hi:oklch(0.28 0.018 165);
-            --border:    oklch(0.34 0.018 165);
-            --border-hi: oklch(0.44 0.022 165);
+            --bg:        oklch(0.16 0.011 80);
+            --bg-2:      oklch(0.20 0.013 80);
+            --surface:   oklch(0.23 0.014 80);
+            --surface-hi:oklch(0.28 0.016 80);
+            --border:    oklch(0.34 0.016 80);
+            --border-hi: oklch(0.44 0.020 80);
 
-            --text:      oklch(0.96 0.008 160);
-            --text-mute: oklch(0.80 0.012 160);
-            --text-dim:  oklch(0.68 0.014 160);
+            --text:      oklch(0.96 0.008 85);
+            --text-mute: oklch(0.80 0.012 85);
+            --text-dim:  oklch(0.68 0.014 85);
 
-            --accent:     oklch(0.80 0.17 168);
-            --accent-hi:  oklch(0.87 0.18 168);
-            --accent-dim: oklch(0.48 0.10 168);
-            --accent-soft:oklch(0.32 0.08 168);
+            --accent:     oklch(0.78 0.11 84);
+            --accent-hi:  oklch(0.85 0.12 84);
+            --accent-dim: oklch(0.48 0.07 84);
+            --accent-soft:oklch(0.32 0.05 84);
 
             --danger:      oklch(0.68 0.16 25);
             --danger-hi:   oklch(0.76 0.18 25);
@@ -38,7 +38,7 @@
 
             --radius: 14px;
             --radius-sm: 8px;
-            --shadow: 0 1px 0 oklch(0.38 0.014 165 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
+            --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
 
             --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
             --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -64,8 +64,8 @@
             display: flex;
             flex-direction: column;
             background:
-                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.06 168 / 0.35), transparent 60%),
-                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.03 165 / 0.5), transparent 60%);
+                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
         }
 
         .auth-top {
@@ -75,7 +75,7 @@
             gap: 16px;
             padding: 16px 28px;
             border-bottom: 1px solid var(--border);
-            background: oklch(0.15 0.012 165 / 0.7);
+            background: oklch(0.15 0.011 80 / 0.7);
             backdrop-filter: blur(10px);
         }
         .brand {
@@ -91,10 +91,10 @@
             width: 30px; height: 30px;
             border-radius: 8px;
             background: linear-gradient(160deg, var(--accent), var(--accent-dim));
-            color: oklch(0.16 0.012 165);
+            color: oklch(0.16 0.012 80);
             display: grid;
             place-items: center;
-            box-shadow: 0 0 0 1px oklch(0.60 0.08 168 / 0.5) inset;
+            box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
         }
         .brand-mark svg { width: 17px; height: 17px; }
         .brand-accent { color: var(--accent-hi); }
@@ -153,8 +153,8 @@
             padding: 18px 24px;
             border-bottom: 1px solid var(--border);
             background: linear-gradient(to bottom,
-                oklch(0.25 0.018 165 / 0.6),
-                oklch(0.22 0.016 165 / 0));
+                oklch(0.25 0.016 80 / 0.6),
+                oklch(0.22 0.014 80 / 0));
         }
         .auth-panel-head h2 {
             margin: 0;
@@ -230,7 +230,7 @@
         .auth-input:focus {
             outline: none;
             border-color: var(--accent);
-            box-shadow: 0 0 0 3px oklch(0.80 0.17 168 / 0.18);
+            box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.18);
         }
         .auth-field-help {
             font-size: 12.5px;
@@ -259,12 +259,12 @@
             font-size: 12.5px;
         }
         .auth-alert.success {
-            background: oklch(0.28 0.06 165 / 0.42);
-            border-color: oklch(0.55 0.13 165 / 0.5);
-            color: oklch(0.94 0.04 165);
+            background: oklch(0.28 0.06 150 / 0.42);
+            border-color: oklch(0.55 0.13 150 / 0.5);
+            color: oklch(0.94 0.04 150);
         }
         .auth-alert.success > svg { color: var(--accent-hi); }
-        .auth-alert.success .s { color: oklch(0.84 0.05 165); }
+        .auth-alert.success .s { color: oklch(0.84 0.05 150); }
 
         .btn {
             display: inline-flex;
@@ -282,8 +282,8 @@
         .btn svg { width: 16px; height: 16px; flex: 0 0 16px; }
         .btn-primary {
             background: var(--accent);
-            color: oklch(0.15 0.014 165);
-            border-color: oklch(0.62 0.10 168);
+            color: oklch(0.16 0.012 80);
+            border-color: oklch(0.62 0.09 84);
         }
         .btn-primary:hover { background: var(--accent-hi); }
         .btn-ghost {
@@ -354,7 +354,7 @@
     <div class="app">
         <div class="auth-top">
             <a href="https://lotro-translator.pl" class="brand">
-                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
+                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="1.1" fill="currentColor"/></svg></span>
                 <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
@@ -416,7 +416,7 @@
                                 <label asp-for="Email">Adres e-mail</label>
                                 <div class="auth-input-wrap">
                                     <svg class="leading" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
-                                    <input asp-for="Email" type="email" class="auth-input" placeholder="ty@@example.com" autocomplete="email" required autofocus />
+                                    <input asp-for="Email" type="email" class="auth-input" placeholder="@("ty@example.com")" autocomplete="email" required autofocus />
                                 </div>
                                 <p class="auth-field-help">Ze względów bezpieczeństwa nie ujawniamy, czy konto o podanym adresie istnieje.</p>
                             </div>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
@@ -18,20 +18,20 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
     <style>
         :root {
-            --bg:        oklch(0.16 0.013 165);
-            --bg-2:      oklch(0.20 0.015 165);
-            --surface:   oklch(0.23 0.016 165);
-            --surface-hi:oklch(0.28 0.018 165);
-            --border:    oklch(0.34 0.018 165);
-            --border-hi: oklch(0.44 0.022 165);
+            --bg:        oklch(0.16 0.011 80);
+            --bg-2:      oklch(0.20 0.013 80);
+            --surface:   oklch(0.23 0.014 80);
+            --surface-hi:oklch(0.28 0.016 80);
+            --border:    oklch(0.34 0.016 80);
+            --border-hi: oklch(0.44 0.020 80);
 
-            --text:      oklch(0.96 0.008 160);
-            --text-mute: oklch(0.80 0.012 160);
-            --text-dim:  oklch(0.68 0.014 160);
+            --text:      oklch(0.96 0.008 85);
+            --text-mute: oklch(0.80 0.012 85);
+            --text-dim:  oklch(0.68 0.014 85);
 
-            --accent:     oklch(0.80 0.17 168);
-            --accent-hi:  oklch(0.87 0.18 168);
-            --accent-dim: oklch(0.48 0.10 168);
+            --accent:     oklch(0.78 0.11 84);
+            --accent-hi:  oklch(0.85 0.12 84);
+            --accent-dim: oklch(0.48 0.07 84);
 
             --danger:     oklch(0.65 0.20 25);
             --danger-hi:  oklch(0.76 0.18 25);
@@ -39,7 +39,7 @@
 
             --radius: 14px;
             --radius-sm: 8px;
-            --shadow: 0 1px 0 oklch(0.38 0.014 165 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
+            --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
 
             --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
             --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -67,8 +67,8 @@
 
         .app {
             background:
-                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.06 168 / 0.35), transparent 60%),
-                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.03 165 / 0.5), transparent 60%);
+                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
             min-height: 100vh;
             display: flex;
             flex-direction: column;
@@ -97,10 +97,10 @@
             width: 34px; height: 34px;
             border-radius: 9px;
             background: linear-gradient(160deg, var(--accent), var(--accent-dim));
-            color: oklch(0.16 0.012 165);
+            color: oklch(0.16 0.012 80);
             display: grid;
             place-items: center;
-            box-shadow: 0 0 0 1px oklch(0.60 0.08 168 / 0.5) inset;
+            box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
         }
         .brand-mark svg { width: 22px; height: 22px; }
         .brand-accent { color: var(--accent-hi); }
@@ -205,7 +205,7 @@
             gap: 12px;
             padding: 18px 24px;
             border-bottom: 1px solid var(--border);
-            background: linear-gradient(to bottom, oklch(0.25 0.018 165 / 0.6), oklch(0.22 0.016 165 / 0));
+            background: linear-gradient(to bottom, oklch(0.25 0.016 80 / 0.6), oklch(0.22 0.014 80 / 0));
         }
         .auth-panel-head h2 {
             font-size: 16px;
@@ -284,7 +284,7 @@
         .auth-input:focus {
             outline: none;
             border-color: var(--accent);
-            box-shadow: 0 0 0 3px oklch(0.80 0.17 168 / 0.18);
+            box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.18);
         }
         .auth-input.has-trailing { padding-right: 44px; }
 
@@ -334,7 +334,7 @@
         }
         .checkbox .box svg {
             width: 12px; height: 12px;
-            color: oklch(0.15 0.014 165);
+            color: oklch(0.16 0.012 80);
             opacity: 0;
             transform: scale(0.7);
             transition: opacity .12s, transform .12s;
@@ -345,7 +345,7 @@
         }
         .checkbox input:checked ~ .box svg { opacity: 1; transform: scale(1); }
         .checkbox input:focus-visible ~ .box {
-            box-shadow: 0 0 0 3px oklch(0.80 0.17 168 / 0.25);
+            box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.25);
         }
         .checkbox:hover .box { border-color: var(--text-mute); }
 
@@ -363,7 +363,7 @@
         }
         .btn-primary {
             background: var(--accent);
-            color: oklch(0.16 0.012 165);
+            color: oklch(0.16 0.012 80);
             border-color: var(--accent);
         }
         .btn-primary:hover:not([disabled]) { background: var(--accent-hi); border-color: var(--accent-hi); }
@@ -381,8 +381,8 @@
         .auth-submit .spinner-sm {
             width: 14px; height: 14px;
             border-radius: 50%;
-            border: 2px solid oklch(0.15 0.014 165 / 0.35);
-            border-top-color: oklch(0.15 0.014 165);
+            border: 2px solid oklch(0.16 0.012 80 / 0.35);
+            border-top-color: oklch(0.16 0.012 80);
             animation: spin 0.7s linear infinite;
             display: none;
         }
@@ -476,10 +476,8 @@
                 <a href="https://lotro-translator.pl" class="brand">
                     <span class="brand-mark" aria-hidden="true">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10" />
-                            <path d="M4 10 L12 4 L20 10" />
-                            <circle cx="9"  cy="17" r="0.6" fill="currentColor"/>
-                            <circle cx="11" cy="17" r="0.6" fill="currentColor"/>
+                            <circle cx="12" cy="12" r="8.5"/>
+                            <circle cx="12" cy="12" r="1.1" fill="currentColor"/>
                         </svg>
                     </span>
                     <span>lotro-<span class="brand-accent">translator</span>.pl</span>
@@ -499,29 +497,27 @@
                         <li>
                             <span class="ico">
                                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                    <circle cx="5.5"  cy="11" r="1.7"/>
-                                    <circle cx="18.5" cy="11" r="1.7"/>
-                                    <circle cx="9"    cy="6.5" r="1.7"/>
-                                    <circle cx="15"   cy="6.5" r="1.7"/>
-                                    <path d="M8.5 14.5C8 17 6 18.2 6 20a2.5 2.5 0 0 0 4.6 1.3c.5-.7 1.3-1 2.4-.6 1.1.4 2.3.6 3 .1A2.5 2.5 0 0 0 18 20c0-1.8-2-3-2.5-5.5-.4-1.7-2.2-2.5-3.5-2.5s-3.1.8-3.5 2.5z"/>
+                                    <path d="M12 20h9"/>
+                                    <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/>
                                 </svg>
                             </span>
                             <span class="copy">
-                                Publikuj ogłoszenia
-                                <span class="sub">Tłumacz teksty gry prosto w przeglądarce</span>
+                                Tłumacz teksty gry
+                                <span class="sub">Edytor z podglądem angielskiego oryginału</span>
                             </span>
                         </li>
                         <li>
                             <span class="ico">
                                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-                                    <rect x="9.5" y="10.5" width="5" height="4" rx="1"/>
-                                    <path d="M10.5 10.5V9.5a1.5 1.5 0 0 1 3 0v1"/>
+                                    <path d="M3 3v18h18"/>
+                                    <path d="M7 15v3"/>
+                                    <path d="M12 10v8"/>
+                                    <path d="M17 6v12"/>
                                 </svg>
                             </span>
                             <span class="copy">
                                 Śledź postęp tłumaczenia
-                                <span class="sub">Pełna lista, zdjęcia, statusy adopcji</span>
+                                <span class="sub">Filtry, statusy i obieg zatwierdzania</span>
                             </span>
                         </li>
                         <li>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
@@ -15,24 +15,24 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
     <style>
         :root {
-            --bg:        oklch(0.16 0.013 165);
-            --bg-2:      oklch(0.20 0.015 165);
-            --surface:   oklch(0.23 0.016 165);
-            --surface-hi:oklch(0.28 0.018 165);
-            --border:    oklch(0.34 0.018 165);
-            --border-hi: oklch(0.44 0.022 165);
+            --bg:        oklch(0.16 0.011 80);
+            --bg-2:      oklch(0.20 0.013 80);
+            --surface:   oklch(0.23 0.014 80);
+            --surface-hi:oklch(0.28 0.016 80);
+            --border:    oklch(0.34 0.016 80);
+            --border-hi: oklch(0.44 0.020 80);
 
-            --text:      oklch(0.96 0.008 160);
-            --text-mute: oklch(0.80 0.012 160);
-            --text-dim:  oklch(0.68 0.014 160);
+            --text:      oklch(0.96 0.008 85);
+            --text-mute: oklch(0.80 0.012 85);
+            --text-dim:  oklch(0.68 0.014 85);
 
-            --accent:     oklch(0.80 0.17 168);
-            --accent-hi:  oklch(0.87 0.18 168);
-            --accent-dim: oklch(0.48 0.10 168);
+            --accent:     oklch(0.78 0.11 84);
+            --accent-hi:  oklch(0.85 0.12 84);
+            --accent-dim: oklch(0.48 0.07 84);
 
             --radius: 14px;
             --radius-sm: 8px;
-            --shadow: 0 1px 0 oklch(0.38 0.014 165 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
+            --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
 
             --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
             --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -57,8 +57,8 @@
             display: flex;
             flex-direction: column;
             background:
-                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.06 168 / 0.35), transparent 60%),
-                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.03 165 / 0.5), transparent 60%);
+                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
         }
 
         .auth-top {
@@ -68,7 +68,7 @@
             gap: 16px;
             padding: 16px 28px;
             border-bottom: 1px solid var(--border);
-            background: oklch(0.15 0.012 165 / 0.7);
+            background: oklch(0.15 0.011 80 / 0.7);
             backdrop-filter: blur(10px);
         }
         .brand {
@@ -84,10 +84,10 @@
             width: 30px; height: 30px;
             border-radius: 8px;
             background: linear-gradient(160deg, var(--accent), var(--accent-dim));
-            color: oklch(0.16 0.012 165);
+            color: oklch(0.16 0.012 80);
             display: grid;
             place-items: center;
-            box-shadow: 0 0 0 1px oklch(0.60 0.08 168 / 0.5) inset;
+            box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
         }
         .brand-mark svg { width: 17px; height: 17px; }
         .brand-accent { color: var(--accent-hi); }
@@ -219,7 +219,7 @@
     <div class="app">
         <div class="auth-top">
             <a href="https://lotro-translator.pl" class="brand">
-                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
+                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="1.1" fill="currentColor"/></svg></span>
                 <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
@@ -244,7 +244,7 @@
             </ul>
 
             <h2><span class="sec-num">03</span> Cel i podstawa przetwarzania</h2>
-            <p>Dane przetwarzamy w celu prowadzenia konta i publikacji ogłoszeń (art. 6 ust. 1 lit. b RODO — wykonanie umowy), zapewnienia bezpieczeństwa serwisu (lit. f — prawnie uzasadniony interes) oraz — jeśli wyrazisz zgodę — kontaktu w sprawach związanych z adopcją (lit. a).</p>
+            <p>Dane przetwarzamy w celu prowadzenia konta i umożliwienia współtworzenia tłumaczenia — zapisywania i zatwierdzania wpisów przypisanych do Twojego konta (art. 6 ust. 1 lit. b RODO — wykonanie umowy), a także zapewnienia bezpieczeństwa serwisu (lit. f — prawnie uzasadniony interes).</p>
 
             <h2><span class="sec-num">04</span> Twoje prawa</h2>
             <p>W każdej chwili możesz skorzystać z przysługujących Ci praw:</p>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
@@ -18,21 +18,21 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
     <style>
         :root {
-            --bg:        oklch(0.16 0.013 165);
-            --bg-2:      oklch(0.20 0.015 165);
-            --surface:   oklch(0.23 0.016 165);
-            --surface-hi:oklch(0.28 0.018 165);
-            --border:    oklch(0.34 0.018 165);
-            --border-hi: oklch(0.44 0.022 165);
+            --bg:        oklch(0.16 0.011 80);
+            --bg-2:      oklch(0.20 0.013 80);
+            --surface:   oklch(0.23 0.014 80);
+            --surface-hi:oklch(0.28 0.016 80);
+            --border:    oklch(0.34 0.016 80);
+            --border-hi: oklch(0.44 0.020 80);
 
-            --text:      oklch(0.96 0.008 160);
-            --text-mute: oklch(0.80 0.012 160);
-            --text-dim:  oklch(0.68 0.014 160);
+            --text:      oklch(0.96 0.008 85);
+            --text-mute: oklch(0.80 0.012 85);
+            --text-dim:  oklch(0.68 0.014 85);
 
-            --accent:     oklch(0.80 0.17 168);
-            --accent-hi:  oklch(0.87 0.18 168);
-            --accent-dim: oklch(0.48 0.10 168);
-            --accent-soft:oklch(0.32 0.08 168);
+            --accent:     oklch(0.78 0.11 84);
+            --accent-hi:  oklch(0.85 0.12 84);
+            --accent-dim: oklch(0.48 0.07 84);
+            --accent-soft:oklch(0.32 0.05 84);
 
             --danger:      oklch(0.68 0.16 25);
             --danger-hi:   oklch(0.76 0.18 25);
@@ -41,7 +41,7 @@
 
             --radius: 14px;
             --radius-sm: 8px;
-            --shadow: 0 1px 0 oklch(0.38 0.014 165 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
+            --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
 
             --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
             --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -67,8 +67,8 @@
             display: flex;
             flex-direction: column;
             background:
-                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.06 168 / 0.35), transparent 60%),
-                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.03 165 / 0.5), transparent 60%);
+                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
         }
 
         .auth-top {
@@ -78,7 +78,7 @@
             gap: 16px;
             padding: 16px 28px;
             border-bottom: 1px solid var(--border);
-            background: oklch(0.15 0.012 165 / 0.7);
+            background: oklch(0.15 0.011 80 / 0.7);
             backdrop-filter: blur(10px);
         }
         .brand {
@@ -94,10 +94,10 @@
             width: 30px; height: 30px;
             border-radius: 8px;
             background: linear-gradient(160deg, var(--accent), var(--accent-dim));
-            color: oklch(0.16 0.012 165);
+            color: oklch(0.16 0.012 80);
             display: grid;
             place-items: center;
-            box-shadow: 0 0 0 1px oklch(0.60 0.08 168 / 0.5) inset;
+            box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
         }
         .brand-mark svg { width: 17px; height: 17px; }
         .brand-accent { color: var(--accent-hi); }
@@ -155,8 +155,8 @@
             padding: 18px 24px;
             border-bottom: 1px solid var(--border);
             background: linear-gradient(to bottom,
-                oklch(0.25 0.018 165 / 0.6),
-                oklch(0.22 0.016 165 / 0));
+                oklch(0.25 0.016 80 / 0.6),
+                oklch(0.22 0.014 80 / 0));
         }
         .auth-panel-head h2 {
             margin: 0;
@@ -232,7 +232,7 @@
         .auth-input:focus {
             outline: none;
             border-color: var(--accent);
-            box-shadow: 0 0 0 3px oklch(0.80 0.17 168 / 0.18);
+            box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.18);
         }
         .auth-field-help {
             font-size: 12.5px;
@@ -261,12 +261,12 @@
             font-size: 12.5px;
         }
         .auth-alert.success {
-            background: oklch(0.28 0.06 165 / 0.42);
-            border-color: oklch(0.55 0.13 165 / 0.5);
-            color: oklch(0.94 0.04 165);
+            background: oklch(0.28 0.06 150 / 0.42);
+            border-color: oklch(0.55 0.13 150 / 0.5);
+            color: oklch(0.94 0.04 150);
         }
         .auth-alert.success > svg { color: var(--accent-hi); }
-        .auth-alert.success .s { color: oklch(0.84 0.05 165); }
+        .auth-alert.success .s { color: oklch(0.84 0.05 150); }
 
         .pw-rules {
             display: grid;
@@ -296,7 +296,7 @@
         }
         .pw-rules li .dot svg {
             width: 9px; height: 9px;
-            color: oklch(0.15 0.014 165);
+            color: oklch(0.16 0.012 80);
             opacity: 0.55;
         }
 
@@ -333,7 +333,7 @@
         }
         .checkbox .box svg {
             width: 12px; height: 12px;
-            color: oklch(0.15 0.014 165);
+            color: oklch(0.16 0.012 80);
             opacity: 0;
             transform: scale(0.7);
             transition: opacity .12s, transform .12s;
@@ -344,7 +344,7 @@
         }
         .checkbox input:checked ~ .box svg { opacity: 1; transform: scale(1); }
         .checkbox input:focus-visible ~ .box {
-            box-shadow: 0 0 0 3px oklch(0.80 0.17 168 / 0.25);
+            box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.25);
         }
         .checkbox:hover .box { border-color: var(--text-mute); }
         .checkbox a { color: var(--accent-hi); font-weight: 600; }
@@ -366,8 +366,8 @@
         .btn svg { width: 16px; height: 16px; flex: 0 0 16px; }
         .btn-primary {
             background: var(--accent);
-            color: oklch(0.15 0.014 165);
-            border-color: oklch(0.62 0.10 168);
+            color: oklch(0.16 0.012 80);
+            border-color: oklch(0.62 0.09 84);
         }
         .btn-primary:hover { background: var(--accent-hi); }
         .btn-ghost {
@@ -439,7 +439,7 @@
     <div class="app">
         <div class="auth-top">
             <a href="https://lotro-translator.pl" class="brand">
-                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
+                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="1.1" fill="currentColor"/></svg></span>
                 <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="@loginUrl" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
@@ -511,7 +511,7 @@
                                 <label asp-for="Email">Adres e-mail</label>
                                 <div class="auth-input-wrap">
                                     <svg class="leading" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
-                                    <input asp-for="Email" type="email" class="auth-input" placeholder="ty@@example.com" autocomplete="email" required />
+                                    <input asp-for="Email" type="email" class="auth-input" placeholder="@("ty@example.com")" autocomplete="email" required />
                                 </div>
                             </div>
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml
@@ -15,21 +15,21 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
     <style>
         :root {
-            --bg:        oklch(0.16 0.013 165);
-            --bg-2:      oklch(0.20 0.015 165);
-            --surface:   oklch(0.23 0.016 165);
-            --surface-hi:oklch(0.28 0.018 165);
-            --border:    oklch(0.34 0.018 165);
-            --border-hi: oklch(0.44 0.022 165);
+            --bg:        oklch(0.16 0.011 80);
+            --bg-2:      oklch(0.20 0.013 80);
+            --surface:   oklch(0.23 0.014 80);
+            --surface-hi:oklch(0.28 0.016 80);
+            --border:    oklch(0.34 0.016 80);
+            --border-hi: oklch(0.44 0.020 80);
 
-            --text:      oklch(0.96 0.008 160);
-            --text-mute: oklch(0.80 0.012 160);
-            --text-dim:  oklch(0.68 0.014 160);
+            --text:      oklch(0.96 0.008 85);
+            --text-mute: oklch(0.80 0.012 85);
+            --text-dim:  oklch(0.68 0.014 85);
 
-            --accent:     oklch(0.80 0.17 168);
-            --accent-hi:  oklch(0.87 0.18 168);
-            --accent-dim: oklch(0.48 0.10 168);
-            --accent-soft:oklch(0.32 0.08 168);
+            --accent:     oklch(0.78 0.11 84);
+            --accent-hi:  oklch(0.85 0.12 84);
+            --accent-dim: oklch(0.48 0.07 84);
+            --accent-soft:oklch(0.32 0.05 84);
 
             --danger:      oklch(0.68 0.16 25);
             --danger-hi:   oklch(0.76 0.18 25);
@@ -38,7 +38,7 @@
 
             --radius: 14px;
             --radius-sm: 8px;
-            --shadow: 0 1px 0 oklch(0.38 0.014 165 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
+            --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
 
             --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
             --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -64,8 +64,8 @@
             display: flex;
             flex-direction: column;
             background:
-                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.06 168 / 0.35), transparent 60%),
-                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.03 165 / 0.5), transparent 60%);
+                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
         }
 
         .auth-top {
@@ -75,7 +75,7 @@
             gap: 16px;
             padding: 16px 28px;
             border-bottom: 1px solid var(--border);
-            background: oklch(0.15 0.012 165 / 0.7);
+            background: oklch(0.15 0.011 80 / 0.7);
             backdrop-filter: blur(10px);
         }
         .brand {
@@ -91,10 +91,10 @@
             width: 30px; height: 30px;
             border-radius: 8px;
             background: linear-gradient(160deg, var(--accent), var(--accent-dim));
-            color: oklch(0.16 0.012 165);
+            color: oklch(0.16 0.012 80);
             display: grid;
             place-items: center;
-            box-shadow: 0 0 0 1px oklch(0.60 0.08 168 / 0.5) inset;
+            box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
         }
         .brand-mark svg { width: 17px; height: 17px; }
         .brand-accent { color: var(--accent-hi); }
@@ -153,8 +153,8 @@
             padding: 18px 24px;
             border-bottom: 1px solid var(--border);
             background: linear-gradient(to bottom,
-                oklch(0.25 0.018 165 / 0.6),
-                oklch(0.22 0.016 165 / 0));
+                oklch(0.25 0.016 80 / 0.6),
+                oklch(0.22 0.014 80 / 0));
         }
         .auth-panel-head h2 {
             margin: 0;
@@ -230,7 +230,7 @@
         .auth-input:focus {
             outline: none;
             border-color: var(--accent);
-            box-shadow: 0 0 0 3px oklch(0.80 0.17 168 / 0.18);
+            box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.18);
         }
 
         .auth-alert {
@@ -254,12 +254,12 @@
             font-size: 12.5px;
         }
         .auth-alert.success {
-            background: oklch(0.28 0.06 165 / 0.42);
-            border-color: oklch(0.55 0.13 165 / 0.5);
-            color: oklch(0.94 0.04 165);
+            background: oklch(0.28 0.06 150 / 0.42);
+            border-color: oklch(0.55 0.13 150 / 0.5);
+            color: oklch(0.94 0.04 150);
         }
         .auth-alert.success > svg { color: var(--accent-hi); }
-        .auth-alert.success .s { color: oklch(0.84 0.05 165); }
+        .auth-alert.success .s { color: oklch(0.84 0.05 150); }
 
         .pw-rules {
             display: grid;
@@ -289,7 +289,7 @@
         }
         .pw-rules li .dot svg {
             width: 9px; height: 9px;
-            color: oklch(0.15 0.014 165);
+            color: oklch(0.16 0.012 80);
             opacity: 0;
             transform: scale(0.6);
         }
@@ -313,8 +313,8 @@
         .btn svg { width: 16px; height: 16px; flex: 0 0 16px; }
         .btn-primary {
             background: var(--accent);
-            color: oklch(0.15 0.014 165);
-            border-color: oklch(0.62 0.10 168);
+            color: oklch(0.16 0.012 80);
+            border-color: oklch(0.62 0.09 84);
         }
         .btn-primary:hover { background: var(--accent-hi); }
         .btn-ghost {
@@ -365,7 +365,7 @@
     <div class="app">
         <div class="auth-top">
             <a href="https://lotro-translator.pl" class="brand">
-                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10 L4 19 L10 19 L10 14 L14 14 L14 19 L20 19 L20 10"/><path d="M4 10 L12 4 L20 10"/></svg></span>
+                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="1.1" fill="currentColor"/></svg></span>
                 <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
             </a>
             <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
@@ -2,34 +2,38 @@
 @using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession
 @inject ISessionExpiryNotice SessionExpiryNotice
 
-<div class="app-shell">
+<div class="app">
     <NavMenu/>
 
-    <div class="app-main">
-        <main class="content">
-            @if (_showSessionExpiredNotice)
-            {
-                <div class="status-message status-warning" role="status">
-                    <p>Twoja sesja wygasła. Zaloguj się ponownie, aby kontynuować.</p>
-                </div>
-            }
+    @if (_showSessionExpiredNotice)
+    {
+        <div class="container" style="padding-top: 16px;">
+            <div class="status-message status-warning" role="status">
+                <p>Twoja sesja wygasła. Zaloguj się ponownie, aby kontynuować.</p>
+            </div>
+        </div>
+    }
 
-            <ErrorBoundary>
-                <ChildContent>
-                    @Body
-                </ChildContent>
-                <ErrorContent>
+    <main>
+        <ErrorBoundary>
+            <ChildContent>
+                @Body
+            </ChildContent>
+            <ErrorContent>
+                <div class="container" style="padding-top: 72px; padding-bottom: 72px;">
                     <div class="status-message status-error" role="alert">
                         <p>Wystąpił nieoczekiwany błąd. Odśwież stronę lub spróbuj ponownie później.</p>
                     </div>
-                </ErrorContent>
-            </ErrorBoundary>
-        </main>
+                </div>
+            </ErrorContent>
+        </ErrorBoundary>
+    </main>
 
-        <footer class="app-footer">
-            <span>© @DateTime.UtcNow.Year LotroKoniecDev — polskie tłumaczenie LOTRO</span>
-        </footer>
-    </div>
+    <footer class="foot">
+        <div class="container">
+            <p>© @DateTime.UtcNow.Year lotro-translator.pl — polskie tłumaczenie The Lord of the Rings Online</p>
+        </div>
+    </footer>
 </div>
 
 @code {

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
@@ -1,46 +1,36 @@
 @using LotroKoniecDev.Frontend.Infrastructure.Auth
 
-<aside class="sidebar">
-    <div class="sidebar-brand">
+<header class="nav">
+    <div class="container nav-inner">
         <a class="brand" href="/">
-            <span class="brand-mark">LK</span>
-            <span class="brand-text">LotroKoniec<span class="brand-accent">Dev</span></span>
+            <span class="brand-mark" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="8.5"/>
+                    <circle cx="12" cy="12" r="1.1" fill="currentColor"/>
+                </svg>
+            </span>
+            <span>lotro-<span class="brand-accent">translator</span>.pl</span>
         </a>
-        <p class="brand-sub">Tłumaczenie LOTRO</p>
-    </div>
 
-    <nav class="sidebar-nav" aria-label="Nawigacja główna">
-        <NavLink class="nav-link" href="/" Match="NavLinkMatch.All">
-            <span class="nav-text">Start</span>
-        </NavLink>
-        <NavLink class="nav-link" href="/translations">
-            <span class="nav-text">Tłumaczenia</span>
-        </NavLink>
-        <NavLink class="nav-link" href="/import-export">
-            <span class="nav-text">Import / Eksport</span>
-        </NavLink>
-        <NavLink class="nav-link" href="/game-versions">
-            <span class="nav-text">Wersje gry</span>
-        </NavLink>
-        <NavLink class="nav-link" href="/dashboard">
-            <span class="nav-text">Panel</span>
-        </NavLink>
-    </nav>
+        <nav class="nav-links" aria-label="Nawigacja główna">
+            <NavLink class="nav-link" href="/" Match="NavLinkMatch.All">Start</NavLink>
+            <NavLink class="nav-link" href="/translations">Tłumaczenia</NavLink>
+            <NavLink class="nav-link" href="/import-export">Import / Eksport</NavLink>
+            <NavLink class="nav-link" href="/game-versions">Wersje gry</NavLink>
+            <NavLink class="nav-link" href="/dashboard">Panel</NavLink>
 
-    <div class="sidebar-auth">
-        <AuthorizeView>
-            <Authorized>
-                <span class="auth-user">@(context.User.Identity?.Name)</span>
-                <form method="post" action="@AuthenticationDependencyInjectionExtensions.LogoutPath">
-                    <AntiforgeryToken/>
-                    <button type="submit" class="btn btn-ghost btn-block">Wyloguj</button>
-                </form>
-            </Authorized>
-            <NotAuthorized>
-                <a class="btn btn-primary btn-block" href="@AuthenticationDependencyInjectionExtensions.LoginPath">
-                    Zaloguj
-                </a>
-            </NotAuthorized>
-        </AuthorizeView>
+            <AuthorizeView>
+                <Authorized>
+                    <span class="nav-user">@(context.User.Identity?.Name)</span>
+                    <form class="nav-logout-form" method="post" action="@AuthenticationDependencyInjectionExtensions.LogoutPath">
+                        <AntiforgeryToken/>
+                        <button type="submit" class="nav-link nav-logout">Wyloguj</button>
+                    </form>
+                </Authorized>
+                <NotAuthorized>
+                    <a class="nav-link" href="@AuthenticationDependencyInjectionExtensions.LoginPath">Zaloguj</a>
+                </NotAuthorized>
+            </AuthorizeView>
+        </nav>
     </div>
-</aside>
+</header>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/AccessDenied.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/AccessDenied.razor
@@ -3,10 +3,16 @@
 @attribute [AllowAnonymous]
 @using Microsoft.AspNetCore.Authorization
 
-<PageTitle>Brak dostępu — LotroKoniecDev</PageTitle>
+<PageTitle>Brak dostępu — lotro-translator.pl</PageTitle>
 
 <div class="status-stage">
     <div class="status-card status-danger">
+        <div class="status-glyph" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="4" y="11" width="16" height="10" rx="2"/>
+                <path d="M8 11V8a4 4 0 0 1 8 0v3"/>
+            </svg>
+        </div>
         <div class="status-code">403</div>
         <h1>Brak dostępu</h1>
         <p class="status-desc">Nie masz uprawnień do wyświetlenia tej strony.</p>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/BadRequest.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/BadRequest.razor
@@ -3,10 +3,17 @@
 @attribute [AllowAnonymous]
 @using Microsoft.AspNetCore.Authorization
 
-<PageTitle>Nieprawidłowe żądanie — LotroKoniecDev</PageTitle>
+<PageTitle>Nieprawidłowe żądanie — lotro-translator.pl</PageTitle>
 
 <div class="status-stage">
     <div class="status-card status-warning">
+        <div class="status-glyph" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
+                <path d="M12 9v4"/>
+                <path d="M12 17h.01"/>
+            </svg>
+        </div>
         <div class="status-code">400</div>
         <h1>Nieprawidłowe żądanie</h1>
         <p class="status-desc">Serwer nie mógł przetworzyć żądania. Sprawdź wprowadzone dane i spróbuj ponownie.</p>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/Dashboard.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/Dashboard.razor
@@ -7,65 +7,77 @@
 @using LotroKoniecDev.TranslationSystem.Contracts.Translations
 @inject DashboardStatsLoader Loader
 
-<PageTitle>Panel — LotroKoniecDev</PageTitle>
+<PageTitle>Panel — lotro-translator.pl</PageTitle>
 
-<section class="page-head">
-    <h1>Panel</h1>
-    <p class="lede">Postęp tłumaczenia polskiej wersji LOTRO w skrócie.</p>
+<section class="container page-head">
+    <div>
+        <h1>Panel</h1>
+        <p class="lede">Postęp tłumaczenia polskiej wersji LOTRO w skrócie.</p>
+    </div>
 </section>
 
-@if (_result is null)
-{
-    <section class="results-meta">
+<section class="container content-wrap">
+    @if (_result is null)
+    {
         <div class="loading-indicator">
             <span class="li-spin"></span> Wczytywanie statystyk…
         </div>
-    </section>
-}
-else if (_result.IsFailure)
-{
-    <section class="panel">
-        <p class="status-line status-down" role="alert">
-            <span class="dot"></span>
-            @(_result.ProblemDetails?.Title ?? "Nie udało się wczytać statystyk.")
-        </p>
-    </section>
-}
-else
-{
-    DashboardView view = DashboardView.From(_result.Value);
-
-    <section class="stat-grid">
-        <article class="stat-card">
-            <span class="stat-label">Wszystkie</span>
-            <span class="stat-value mono">@view.Total</span>
-        </article>
-        <article class="stat-card">
-            <span class="stat-label">Przetłumaczone</span>
-            <span class="stat-value mono">@view.Translated</span>
-        </article>
-        <article class="stat-card">
-            <span class="stat-label">Zatwierdzone</span>
-            <span class="stat-value mono stat-value-ok">@view.Approved</span>
-        </article>
-        <article class="stat-card">
-            <span class="stat-label">Pozostałe</span>
-            <span class="stat-value mono">@view.Remaining</span>
-        </article>
-    </section>
-
-    <section class="panel">
-        <h2>Postęp zatwierdzania</h2>
-        <div class="progress" role="progressbar"
-             aria-valuenow="@view.ApprovedPercent" aria-valuemin="0" aria-valuemax="100"
-             aria-label="Zatwierdzone tłumaczenia">
-            <div class="progress-bar" style="width: @view.ApprovedPercent.ToString(CultureInfo.InvariantCulture)%;"></div>
+    }
+    else if (_result.IsFailure)
+    {
+        <div class="error-message" role="alert">
+            <span class="em-ico" aria-hidden="true">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
+                    <path d="M12 9v4"/><path d="M12 17h.01"/>
+                </svg>
+            </span>
+            <div class="em-body">
+                <span class="t">@(_result.ProblemDetails?.Title ?? "Nie udało się wczytać statystyk.")</span>
+            </div>
         </div>
-        <p class="progress-caption">
-            <strong>@view.ApprovedPercent%</strong> zatwierdzone (@view.Approved z @view.Total)
-        </p>
-    </section>
-}
+    }
+    else
+    {
+        DashboardView view = DashboardView.From(_result.Value);
+
+        <section class="stats-grid">
+            <article class="stat-tile">
+                <span class="num @(view.Total == 0 ? "zero" : null)">@view.Total</span>
+                <span class="lbl">Wszystkie</span>
+            </article>
+            <article class="stat-tile">
+                <span class="num @(view.Translated == 0 ? "zero" : null)">@view.Translated</span>
+                <span class="lbl">Przetłumaczone</span>
+            </article>
+            <article class="stat-tile">
+                <span class="num @(view.Approved == 0 ? "zero" : "ok")">@view.Approved</span>
+                <span class="lbl">Zatwierdzone</span>
+            </article>
+            <article class="stat-tile">
+                <span class="num @(view.Remaining == 0 ? "zero" : null)">@view.Remaining</span>
+                <span class="lbl">Pozostałe</span>
+            </article>
+        </section>
+
+        <section class="panel">
+            <header class="panel-head">
+                <h2>Postęp zatwierdzania</h2>
+                <span class="panel-aside">Zatwierdzone / wszystkie</span>
+            </header>
+            <div class="panel-body">
+                <div class="progress" role="progressbar"
+                     aria-valuenow="@view.ApprovedPercent" aria-valuemin="0" aria-valuemax="100"
+                     aria-label="Zatwierdzone tłumaczenia">
+                    <div class="progress-bar" style="width: @view.ApprovedPercent.ToString(CultureInfo.InvariantCulture)%;"></div>
+                </div>
+                <p class="progress-caption">
+                    <strong>@view.ApprovedPercent%</strong> zatwierdzone (@view.Approved z @view.Total)
+                </p>
+            </div>
+        </section>
+    }
+</section>
 
 @code
 {

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
@@ -11,169 +11,190 @@
 @using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate
 @inject TranslationEditorLoader Loader
 
-<PageTitle>Edytor tłumaczenia — LotroKoniecDev</PageTitle>
+<PageTitle>Edytor tłumaczenia — lotro-translator.pl</PageTitle>
 
-<section class="page-head">
-    <h1>Edytor tłumaczenia</h1>
-    <p class="lede">
-        Po lewej tekst angielski (do odczytu), po prawej Twoje tłumaczenie. Zachowaj znaczniki
-        <code class="ph-token">@PlaceholderAnalyzer.Placeholder</code> w niezmienionej postaci.
-    </p>
-    <a class="btn btn-ghost btn-sm" href="/translations">← Wróć do listy</a>
+<section class="container page-head">
+    <div>
+        <h1>Edytor tłumaczenia</h1>
+        <p class="lede">
+            Po lewej tekst angielski (do odczytu), po prawej Twoje tłumaczenie. Zachowaj znaczniki
+            <code class="ph-token">@PlaceholderAnalyzer.Placeholder</code> w niezmienionej postaci.
+        </p>
+    </div>
+    <div class="head-actions">
+        <a class="btn btn-ghost" href="/translations">← Wróć do listy</a>
+    </div>
 </section>
 
-@if (_detail is null)
-{
-    @if (_saveProblem is not null && _draftText is not null)
+<section class="container content-wrap">
+    @if (_detail is null)
     {
-        @* Recovery path: the row could not be reloaded AND the save failed in the same request.
-           Surface the error and keep the translator's typed text in a resubmittable form so it is
-           never silently lost (the hidden key fields survived the post). *@
-        <section class="panel">
-            <p class="status-line status-down" role="alert">
-                <span class="dot"></span>@(_saveProblem.Title ?? "Nie udało się zapisać tłumaczenia.")
-            </p>
-        </section>
-        <section class="panel editor-pane">
-            <h2 class="editor-pane-title">Tłumaczenie polskie</h2>
-            <form method="post" @formname="save-translation" @onsubmit="SaveAsync">
-                <AntiforgeryToken/>
-                <input type="hidden" name="FileIdField" value="@FileIdField"/>
-                <input type="hidden" name="GossipIdField" value="@GossipIdField"/>
-                <label class="visually-hidden" for="translated-recovery">Tłumaczenie polskie</label>
-                <textarea id="translated-recovery" name="DraftField" class="editor-textarea mono" rows="8"
-                          placeholder="Wpisz tłumaczenie…">@_draftText</textarea>
-                <div class="editor-actions">
-                    <button type="submit" class="btn btn-primary">Zapisz ponownie</button>
+        @if (_saveProblem is not null && _draftText is not null)
+        {
+            @* Recovery path: the row could not be reloaded AND the save failed in the same request.
+               Surface the error and keep the translator's typed text in a resubmittable form so it is
+               never silently lost (the hidden key fields survived the post). *@
+            <div class="error-message" role="alert">
+                <span class="em-ico" aria-hidden="true">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
+                        <path d="M12 9v4"/><path d="M12 17h.01"/>
+                    </svg>
+                </span>
+                <div class="em-body">
+                    <span class="t">@(_saveProblem.Title ?? "Nie udało się zapisać tłumaczenia.")</span>
                 </div>
-            </form>
-        </section>
-    }
-    else if (_loadProblem is not null)
-    {
-        <section class="panel">
-            <p class="status-line status-down" role="alert">
-                <span class="dot"></span>@(_loadProblem.Title ?? "Nie udało się wczytać tłumaczenia.")
-            </p>
-        </section>
-    }
-    else
-    {
-        <section class="results-meta">
+            </div>
+            <section class="panel">
+                <header class="panel-head">
+                    <h2>Tłumaczenie polskie</h2>
+                    <span class="panel-aside">Wersja robocza</span>
+                </header>
+                <div class="panel-body">
+                    <form method="post" @formname="save-translation" @onsubmit="SaveAsync">
+                        <AntiforgeryToken/>
+                        <input type="hidden" name="FileIdField" value="@FileIdField"/>
+                        <input type="hidden" name="GossipIdField" value="@GossipIdField"/>
+                        <label class="visually-hidden" for="translated-recovery">Tłumaczenie polskie</label>
+                        <textarea id="translated-recovery" name="DraftField" class="editor-textarea mono" rows="8"
+                                  placeholder="Wpisz tłumaczenie…">@_draftText</textarea>
+                        <div class="editor-actions" style="margin-top: 12px;">
+                            <button type="submit" class="btn btn-primary">Zapisz ponownie</button>
+                        </div>
+                    </form>
+                </div>
+            </section>
+        }
+        else if (_loadProblem is not null)
+        {
+            <div class="error-message" role="alert">
+                <span class="em-ico" aria-hidden="true">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
+                        <path d="M12 9v4"/><path d="M12 17h.01"/>
+                    </svg>
+                </span>
+                <div class="em-body">
+                    <span class="t">@(_loadProblem.Title ?? "Nie udało się wczytać tłumaczenia.")</span>
+                </div>
+            </div>
+        }
+        else
+        {
             <div class="loading-indicator">
                 <span class="li-spin"></span> Wczytywanie tłumaczenia…
             </div>
-        </section>
+        }
     }
-}
-else
-{
-    TranslationDetailResponse detail = _detail;
-    PlaceholderComparison comparison = PlaceholderAnalyzer.Compare(detail.SourceText, _draftText ?? detail.TranslatedText);
-
-    <section class="results-meta">
-        <span class="count">FileId <strong class="mono">@detail.FileId</strong></span>
-        <span class="count">GossipId <strong class="mono">@detail.GossipId</strong></span>
-        <span class="badge @TranslationStatusDisplay.BadgeClass(detail.Status)">
-            <span class="dot"></span>@TranslationStatusDisplay.Label(detail.Status)
-        </span>
-    </section>
-
-    @if (_saveProblem is not null)
+    else
     {
-        <section class="panel">
-            <p class="status-line status-down" role="alert">
-                <span class="dot"></span>@(_saveProblem.Title ?? "Nie udało się zapisać tłumaczenia.")
-            </p>
-        </section>
-    }
-    else if (_saved)
-    {
-        <section class="panel">
-            <p class="status-line status-ok" role="status">
-                <span class="dot"></span>Tłumaczenie zapisano.
-            </p>
-        </section>
-    }
+        TranslationDetailResponse detail = _detail;
+        PlaceholderComparison comparison = PlaceholderAnalyzer.Compare(detail.SourceText, _draftText ?? detail.TranslatedText);
 
-    @if (_approveProblem is not null)
-    {
-        <section class="panel">
-            <p class="status-line status-down" role="alert">
-                <span class="dot"></span>@(_approveProblem.Title ?? "Nie udało się zatwierdzić tłumaczenia.")
-            </p>
-        </section>
-    }
-    else if (_approved)
-    {
-        <section class="panel">
-            <p class="status-line status-ok" role="status">
-                <span class="dot"></span>Tłumaczenie zatwierdzono i dołączono do dystrybucji.
-            </p>
-        </section>
-    }
+        <div class="results-meta">
+            <span class="count">FileId <strong class="mono">@detail.FileId</strong></span>
+            <span class="count">GossipId <strong class="mono">@detail.GossipId</strong></span>
+            <span class="badge @TranslationStatusDisplay.BadgeClass(detail.Status)">
+                <span class="dot"></span>@TranslationStatusDisplay.Label(detail.Status)
+            </span>
+        </div>
 
-    @if (!comparison.IsMatch)
-    {
-        <section class="panel">
-            <p class="status-line status-warning" role="alert">
-                <span class="dot"></span>
-                Liczba znaczników się nie zgadza: w tekście angielskim @comparison.SourceCount,
-                w tłumaczeniu @comparison.TranslatedCount. Zachowaj każdy znacznik
-                <code class="ph-token">@PlaceholderAnalyzer.Placeholder</code>.
-            </p>
-        </section>
-    }
+        @if (_saveProblem is not null)
+        {
+            <div class="status-message status-error" role="alert">
+                <p>@(_saveProblem.Title ?? "Nie udało się zapisać tłumaczenia.")</p>
+            </div>
+        }
+        else if (_saved)
+        {
+            <div class="status-message status-success" role="status">
+                <p>Tłumaczenie zapisano.</p>
+            </div>
+        }
 
-    <div class="editor-grid">
-        <section class="panel editor-pane">
-            <h2 class="editor-pane-title">Tekst angielski</h2>
-            <div class="editor-source">@RenderHighlighted(detail.SourceText)</div>
+        @if (_approveProblem is not null)
+        {
+            <div class="status-message status-error" role="alert">
+                <p>@(_approveProblem.Title ?? "Nie udało się zatwierdzić tłumaczenia.")</p>
+            </div>
+        }
+        else if (_approved)
+        {
+            <div class="status-message status-success" role="status">
+                <p>Tłumaczenie zatwierdzono i dołączono do dystrybucji.</p>
+            </div>
+        }
 
-            @if (!string.IsNullOrEmpty(detail.PreviousSourceText))
-            {
-                <div class="editor-superseded">
-                    <h3 class="editor-pane-subtitle">Poprzednia wersja angielska (do porównania)</h3>
-                    <div class="editor-source is-superseded">@RenderHighlighted(detail.PreviousSourceText)</div>
+        @if (!comparison.IsMatch)
+        {
+            <div class="status-message status-warning" role="alert">
+                <p>
+                    Liczba znaczników się nie zgadza: w tekście angielskim @comparison.SourceCount,
+                    w tłumaczeniu @comparison.TranslatedCount. Zachowaj każdy znacznik
+                    <code class="ph-token">@PlaceholderAnalyzer.Placeholder</code>.
+                </p>
+            </div>
+        }
+
+        <div class="editor-grid">
+            <section class="panel">
+                <header class="panel-head">
+                    <h2>Tekst angielski</h2>
+                    <span class="panel-aside">Oryginał</span>
+                </header>
+                <div class="panel-body">
+                    <div class="editor-source">@RenderHighlighted(detail.SourceText)</div>
+
+                    @if (!string.IsNullOrEmpty(detail.PreviousSourceText))
+                    {
+                        <div class="editor-superseded">
+                            <h3 class="editor-pane-subtitle">Poprzednia wersja angielska (do porównania)</h3>
+                            <div class="editor-source is-superseded">@RenderHighlighted(detail.PreviousSourceText)</div>
+                        </div>
+                    }
                 </div>
-            }
-        </section>
+            </section>
 
-        <section class="panel editor-pane">
-            <h2 class="editor-pane-title">Tłumaczenie polskie</h2>
+            <section class="panel">
+                <header class="panel-head">
+                    <h2>Tłumaczenie polskie</h2>
+                    <span class="panel-aside">Edycja</span>
+                </header>
+                <div class="panel-body">
+                    @{
+                        LinkDto? upsertLink = detail.Links.FindLink(Rels.Upsert);
+                    }
+                    @if (upsertLink is not null)
+                    {
+                        <form method="post" @formname="save-translation" @onsubmit="SaveAsync">
+                            <AntiforgeryToken/>
+                            <input type="hidden" name="FileIdField" value="@detail.FileId"/>
+                            <input type="hidden" name="GossipIdField" value="@detail.GossipId"/>
+                            <label class="visually-hidden" for="translated">Tłumaczenie polskie</label>
+                            <textarea id="translated" name="DraftField" class="editor-textarea mono" rows="8"
+                                      placeholder="Wpisz tłumaczenie…">@(_draftText ?? detail.TranslatedText)</textarea>
+                            <div class="editor-actions" style="margin-top: 12px;">
+                                <button type="submit" class="btn btn-primary">Zapisz</button>
+                            </div>
+                        </form>
+                    }
+                    else
+                    {
+                        <p class="text-dim">Ten wiersz jest tylko do odczytu.</p>
+                    }
 
-            @{
-                LinkDto? upsertLink = detail.Links.FindLink(Rels.Upsert);
-            }
-            @if (upsertLink is not null)
-            {
-                <form method="post" @formname="save-translation" @onsubmit="SaveAsync">
-                    <AntiforgeryToken/>
-                    <input type="hidden" name="FileIdField" value="@detail.FileId"/>
-                    <input type="hidden" name="GossipIdField" value="@detail.GossipId"/>
-                    <label class="visually-hidden" for="translated">Tłumaczenie polskie</label>
-                    <textarea id="translated" name="DraftField" class="editor-textarea mono" rows="8"
-                              placeholder="Wpisz tłumaczenie…">@(_draftText ?? detail.TranslatedText)</textarea>
-                    <div class="editor-actions">
-                        <button type="submit" class="btn btn-primary">Zapisz</button>
-                    </div>
-                </form>
-            }
-            else
-            {
-                <p class="text-dim">Ten wiersz jest tylko do odczytu.</p>
-            }
-
-            @if (detail.Links.HasLink(Rels.Approve))
-            {
-                <form method="post" @formname="approve-translation" @onsubmit="ApproveAsync" class="editor-approve">
-                    <AntiforgeryToken/>
-                    <button type="submit" class="btn btn-ghost">Zatwierdź</button>
-                </form>
-            }
-        </section>
-    </div>
-}
+                    @if (detail.Links.HasLink(Rels.Approve))
+                    {
+                        <form method="post" @formname="approve-translation" @onsubmit="ApproveAsync" class="editor-approve">
+                            <AntiforgeryToken/>
+                            <button type="submit" class="btn btn-ghost">Zatwierdź</button>
+                        </form>
+                    }
+                </div>
+            </section>
+        </div>
+    }
+</section>
 
 @code
 {

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Error.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Error.razor
@@ -4,18 +4,25 @@
 @using System.Diagnostics
 @using Microsoft.AspNetCore.Authorization
 
-<PageTitle>Błąd — LotroKoniecDev</PageTitle>
+<PageTitle>Błąd — lotro-translator.pl</PageTitle>
 
 <div class="status-stage">
     <div class="status-card status-danger">
+        <div class="status-glyph" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/>
+            </svg>
+        </div>
         <div class="status-code">500</div>
         <h1>Coś poszło nie tak</h1>
         <p class="status-desc">Wystąpił nieoczekiwany błąd po stronie serwera. Spróbuj ponownie za chwilę.</p>
         @if (!string.IsNullOrEmpty(RequestId))
         {
             <div class="status-detail">
-                <span class="det-k">Identyfikator żądania</span>
-                <code>@RequestId</code>
+                <div class="det-row">
+                    <span class="det-k">Identyfikator żądania</span>
+                    <code>@RequestId</code>
+                </div>
             </div>
         }
         <div class="status-actions">

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
@@ -11,124 +11,138 @@
 @using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate
 @inject GameVersionsLoader Loader
 
-<PageTitle>Wersje gry — LotroKoniecDev</PageTitle>
+<PageTitle>Wersje gry — lotro-translator.pl</PageTitle>
 
-<section class="page-head">
-    <h1>Wersje gry</h1>
-    <p class="lede">
-        Przeglądaj wykryte wersje gry LOTRO i ich stan w cyklu aktualizacji. Administrator może ręcznie
-        zarejestrować wersję, gdy odczyt z forum jest niedostępny, oraz usunąć błędnie dodaną, jeszcze
-        nieprzetworzoną wersję.
-    </p>
+<section class="container page-head">
+    <div>
+        <h1>Wersje gry</h1>
+        <p class="lede">
+            Przeglądaj wykryte wersje gry LOTRO i ich stan w cyklu aktualizacji. Administrator może ręcznie
+            zarejestrować wersję, gdy odczyt z forum jest niedostępny, oraz usunąć błędnie dodaną, jeszcze
+            nieprzetworzoną wersję.
+        </p>
+    </div>
 </section>
 
-@if (_versionsProblem is not null)
-{
-    <section class="panel">
-        <p class="status-line status-down" role="alert">
-            <span class="dot"></span>@(_versionsProblem.Title ?? "Nie udało się wczytać listy wersji gry.")
-        </p>
-    </section>
-}
-
-@if (_actionProblem is not null)
-{
-    <section class="panel">
-        <p class="status-line status-down" role="alert">
-            <span class="dot"></span>@(_actionProblem.Detail ?? _actionProblem.Title ?? "Operacja nie powiodła się.")
-        </p>
-    </section>
-}
-else if (_actionMessage is not null)
-{
-    <section class="panel">
-        <p class="status-line status-ok" role="status">
-            <span class="dot"></span>@_actionMessage
-        </p>
-    </section>
-}
-
-@* The register affordance is the collection's admin-only `register` rel (#158) — not a local role check. *@
-@if (_canRegister)
-{
-    <section class="panel">
-        <h2>Zarejestruj wersję ręcznie</h2>
-        <p class="lede">
-            Podaj wersję w notacji LOTRO (np. <code class="mono">48.0</code>). Nowa wersja pojawi się jako
-            nieprzetworzona (operacja administratora).
-        </p>
-        <form method="post" @formname="register-version" @onsubmit="RegisterAsync" class="filter-form">
-            <AntiforgeryToken/>
-            <div class="filter-field filter-search">
-                <label for="new-version">Wersja</label>
-                <input id="new-version" name="RegisterInput.Version" type="text"
-                       maxlength="@MaxVersionLength" placeholder="np. 48.0"
-                       value="@(RegisterInput?.Version)" autocomplete="off"/>
+<section class="container content-wrap">
+    @if (_versionsProblem is not null)
+    {
+        <div class="error-message" role="alert">
+            <span class="em-ico" aria-hidden="true">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
+                    <path d="M12 9v4"/><path d="M12 17h.01"/>
+                </svg>
+            </span>
+            <div class="em-body">
+                <span class="t">@(_versionsProblem.Title ?? "Nie udało się wczytać listy wersji gry.")</span>
             </div>
-            <div class="filter-actions">
-                <button type="submit" class="btn btn-primary">Zarejestruj</button>
-            </div>
-        </form>
-    </section>
-}
+        </div>
+    }
 
-@if (_versions is null && _versionsProblem is null)
-{
-    <section class="results-meta">
+    @if (_actionProblem is not null)
+    {
+        <div class="status-message status-error" role="alert">
+            <p>@(_actionProblem.Detail ?? _actionProblem.Title ?? "Operacja nie powiodła się.")</p>
+        </div>
+    }
+    else if (_actionMessage is not null)
+    {
+        <div class="status-message status-success" role="status">
+            <p>@_actionMessage</p>
+        </div>
+    }
+
+    @* The register affordance is the collection's admin-only `register` rel (#158) — not a local role check. *@
+    @if (_canRegister)
+    {
+        <section class="panel">
+            <header class="panel-head">
+                <h2>Zarejestruj wersję ręcznie</h2>
+                <span class="panel-aside">Operacja administratora</span>
+            </header>
+            <div class="panel-body">
+                <p class="lede">
+                    Podaj wersję w notacji LOTRO (np. <code class="mono">48.0</code>). Nowa wersja pojawi się jako
+                    nieprzetworzona.
+                </p>
+                <form method="post" @formname="register-version" @onsubmit="RegisterAsync" class="form-row">
+                    <AntiforgeryToken/>
+                    <div class="field">
+                        <label for="new-version">Wersja</label>
+                        <input id="new-version" name="RegisterInput.Version" type="text"
+                               maxlength="@MaxVersionLength" placeholder="np. 48.0"
+                               value="@(RegisterInput?.Version)" autocomplete="off"/>
+                    </div>
+                    <div class="filter-actions">
+                        <button type="submit" class="btn btn-primary">Zarejestruj</button>
+                    </div>
+                </form>
+            </div>
+        </section>
+    }
+
+    @if (_versions is null && _versionsProblem is null)
+    {
         <div class="loading-indicator">
             <span class="li-spin"></span> Wczytywanie wersji gry…
         </div>
-    </section>
-}
-else if (_versions is { Count: 0 })
-{
-    <section class="panel">
+    }
+    else if (_versions is { Count: 0 })
+    {
         <div class="empty">
+            <span class="empty-glyph" aria-hidden="true">
+                <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M12 3v18"/>
+                    <path d="M5 8h14"/>
+                    <path d="M5 8a7 7 0 0 0 14 0"/>
+                </svg>
+            </span>
             <h2>Brak wersji gry</h2>
             <p>Nie wykryto jeszcze żadnej wersji gry.</p>
         </div>
-    </section>
-}
-else if (_versions is not null)
-{
-    <section class="table-wrap">
-        <table class="data-table">
-            <thead>
-                <tr>
-                    <th scope="col">Wersja</th>
-                    <th scope="col">Wykryto</th>
-                    <th scope="col" class="col-status">Status</th>
-                    <th scope="col" class="col-actions"><span class="visually-hidden">Akcje</span></th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (GameVersionResponse version in _versions)
-                {
+    }
+    else if (_versions is not null)
+    {
+        <div class="table-wrap">
+            <table class="data-table">
+                <thead>
                     <tr>
-                        <td class="mono">@version.Version</td>
-                        <td>@version.DetectedAt.ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture)</td>
-                        <td class="col-status">
-                            <span class="badge @GameVersionStatusDisplay.BadgeClass(version.Status)">
-                                <span class="dot"></span>@GameVersionStatusDisplay.Label(version.Status)
-                            </span>
-                        </td>
-                        <td class="col-actions">
-                            @* The `delete` rel is emitted only for an admin on an Unprocessed version (#158). *@
-                            @if (version.Links.HasLink(Rels.Delete))
-                            {
-                                <form method="post" @formname="@DeleteFormName(version.Id)"
-                                      @onsubmit="() => DeleteAsync(version.Id)">
-                                    <AntiforgeryToken/>
-                                    <button type="submit" class="btn btn-ghost btn-sm">Usuń</button>
-                                </form>
-                            }
-                        </td>
+                        <th scope="col">Wersja</th>
+                        <th scope="col">Wykryto</th>
+                        <th scope="col" class="col-status">Status</th>
+                        <th scope="col" class="col-actions"><span class="visually-hidden">Akcje</span></th>
                     </tr>
-                }
-            </tbody>
-        </table>
-    </section>
-}
+                </thead>
+                <tbody>
+                    @foreach (GameVersionResponse version in _versions)
+                    {
+                        <tr>
+                            <td class="mono">@version.Version</td>
+                            <td>@version.DetectedAt.ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture)</td>
+                            <td class="col-status">
+                                <span class="badge @GameVersionStatusDisplay.BadgeClass(version.Status)">
+                                    <span class="dot"></span>@GameVersionStatusDisplay.Label(version.Status)
+                                </span>
+                            </td>
+                            <td class="col-actions">
+                                @* The `delete` rel is emitted only for an admin on an Unprocessed version (#158). *@
+                                @if (version.Links.HasLink(Rels.Delete))
+                                {
+                                    <form method="post" @formname="@DeleteFormName(version.Id)"
+                                          @onsubmit="() => DeleteAsync(version.Id)">
+                                        <AntiforgeryToken/>
+                                        <button type="submit" class="btn btn-ghost btn-sm">Usuń</button>
+                                    </form>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</section>
 
 @code
 {

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home.razor
@@ -6,37 +6,47 @@
 @using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients
 @inject ITranslationSystemClient TranslationSystemClient
 
-<PageTitle>LotroKoniecDev — Tłumaczenie LOTRO</PageTitle>
+<PageTitle>lotro-translator.pl — polskie tłumaczenie LOTRO</PageTitle>
 
 <section class="hero">
-    <h1>System zarządzania tłumaczeniami</h1>
-    <p class="lede">
-        Panel tłumacza polskiej wersji The Lord of the Rings Online: import tekstów z gry,
-        edycja z obiegiem zatwierdzania i eksport pliku tłumaczenia do patchera.
-    </p>
+    <div class="container">
+        <p class="eyebrow">Polskie tłumaczenie LOTRO</p>
+        <h1>System zarządzania tłumaczeniami</h1>
+        <p class="lede">
+            Panel tłumacza polskiej wersji The Lord of the Rings Online: import tekstów z gry,
+            edycja z obiegiem zatwierdzania i eksport pliku tłumaczenia do patchera.
+        </p>
+    </div>
 </section>
 
-<section class="panel">
-    <h2>Połączenie z API</h2>
-    @if (_healthResult is null)
-    {
-        <p class="status-line status-pending">
-            <span class="dot"></span> Sprawdzanie dostępności API…
-        </p>
-    }
-    else if (_healthResult.IsSuccess)
-    {
-        <p class="status-line status-ok">
-            <span class="dot"></span> API odpowiada — stan: <strong>@_healthResult.Value.Status</strong>
-        </p>
-    }
-    else
-    {
-        <p class="status-line status-down" role="alert">
-            <span class="dot"></span>
-            @(_healthResult.ProblemDetails?.Title ?? "API jest nieosiągalne")
-        </p>
-    }
+<section class="container content-wrap">
+    <section class="panel">
+        <header class="panel-head">
+            <h2>Połączenie z API</h2>
+            <span class="panel-aside">tms-api</span>
+        </header>
+        <div class="panel-body">
+            @if (_healthResult is null)
+            {
+                <p class="status-line status-pending">
+                    <span class="dot"></span> Sprawdzanie dostępności API…
+                </p>
+            }
+            else if (_healthResult.IsSuccess)
+            {
+                <p class="status-line status-ok">
+                    <span class="dot"></span> API odpowiada — stan: <strong>@_healthResult.Value.Status</strong>
+                </p>
+            }
+            else
+            {
+                <p class="status-line status-down" role="alert">
+                    <span class="dot"></span>
+                    @(_healthResult.ProblemDetails?.Title ?? "API jest nieosiągalne")
+                </p>
+            }
+        </div>
+    </section>
 </section>
 
 @code

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
@@ -11,157 +11,189 @@
 @using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate
 @inject ImportExportLoader Loader
 
-<PageTitle>Import / Eksport — LotroKoniecDev</PageTitle>
+<PageTitle>Import / Eksport — lotro-translator.pl</PageTitle>
 
-<section class="page-head">
-    <h1>Import / Eksport</h1>
-    <p class="lede">
-        Wgraj świeży plik <code class="mono">exported.txt</code> z gry, aby zaktualizować katalog,
-        oraz pobierz gotowy plik <code class="mono">polish.txt</code> do nałożenia łatki.
-    </p>
-</section>
-
-<section class="panel">
-    <h2>Eksport tłumaczenia</h2>
-    <p class="lede">
-        Pobierz aktualny, zatwierdzony plik tłumaczenia. Zapisz go jako
-        <code class="mono">@ImportExportLoader.DownloadFileName</code> i użyj polecenia
-        <code class="mono">patch</code> patchera.
-    </p>
-    <div class="editor-actions">
-        <a class="btn btn-primary" href="@DownloadPath" download="@ImportExportLoader.DownloadFileName">
-            Pobierz @ImportExportLoader.DownloadFileName
-        </a>
+<section class="container page-head">
+    <div>
+        <h1>Import / Eksport</h1>
+        <p class="lede">
+            Wgraj świeży plik <code class="mono">exported.txt</code> z gry, aby zaktualizować katalog,
+            oraz pobierz gotowy plik <code class="mono">polish.txt</code> do nałożenia łatki.
+        </p>
     </div>
 </section>
 
-@* A failed game-versions fetch hides the import panel (its admin-only `register` rel can't be read),
-   so surface the error here — outside the gate — to give an admin feedback rather than silence (#158). *@
-@if (_versionsProblem is not null)
-{
+<section class="container content-wrap">
     <section class="panel">
-        <p class="status-line status-down" role="alert">
-            <span class="dot"></span>@(_versionsProblem.Title ?? "Nie udało się wczytać listy wersji gry.")
-        </p>
+        <header class="panel-head">
+            <h2>Eksport tłumaczenia</h2>
+            <span class="panel-aside">polish.txt</span>
+        </header>
+        <div class="panel-body">
+            <p class="lede">
+                Pobierz aktualny, zatwierdzony plik tłumaczenia. Zapisz go jako
+                <code class="mono">@ImportExportLoader.DownloadFileName</code> i użyj polecenia
+                <code class="mono">patch</code> patchera.
+            </p>
+            <div class="editor-actions">
+                <a class="btn btn-primary" href="@DownloadPath" download="@ImportExportLoader.DownloadFileName">
+                    Pobierz @ImportExportLoader.DownloadFileName
+                </a>
+            </div>
+        </div>
     </section>
-}
 
-@if (_canImport)
-{
-    <section class="panel">
-        <h2>Import eksportu z gry</h2>
-        <p class="lede">
-            Wybierz wersję gry, do której należy plik, a następnie wgraj
-            <code class="mono">exported.txt</code>. Import porówna plik z bieżącym stanem i zaktualizuje
-            teksty (operacja administratora).
-        </p>
-
-        @if (_importProblem is not null)
-        {
-            <p class="status-line status-down" role="alert">
-                <span class="dot"></span>@(_importProblem.Detail ?? _importProblem.Title ?? "Nie udało się zaimportować pliku.")
-            </p>
-        }
-        else if (_summary is not null)
-        {
-            <p class="status-line status-ok" role="status">
-                <span class="dot"></span>Import zakończony powodzeniem.
-            </p>
-        }
-
-        @if (_versions is null && _versionsProblem is null)
-        {
-            <div class="loading-indicator">
-                <span class="li-spin"></span> Wczytywanie wersji gry…
+    @* A failed game-versions fetch hides the import panel (its admin-only `register` rel can't be read),
+       so surface the error here — outside the gate — to give an admin feedback rather than silence (#158). *@
+    @if (_versionsProblem is not null)
+    {
+        <div class="error-message" role="alert">
+            <span class="em-ico" aria-hidden="true">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
+                    <path d="M12 9v4"/><path d="M12 17h.01"/>
+                </svg>
+            </span>
+            <div class="em-body">
+                <span class="t">@(_versionsProblem.Title ?? "Nie udało się wczytać listy wersji gry.")</span>
             </div>
-        }
-        else if (_versions is { Count: 0 })
-        {
-            <div class="empty">
-                <h2>Brak wersji gry</h2>
-                <p>Najpierw zarejestruj wersję gry, zanim zaimportujesz eksport.</p>
+        </div>
+    }
+
+    @if (_canImport)
+    {
+        <section class="panel">
+            <header class="panel-head">
+                <h2>Import eksportu z gry</h2>
+                <span class="panel-aside">Operacja administratora</span>
+            </header>
+            <div class="panel-body">
+                <p class="lede">
+                    Wybierz wersję gry, do której należy plik, a następnie wgraj
+                    <code class="mono">exported.txt</code>. Import porówna plik z bieżącym stanem i zaktualizuje
+                    teksty.
+                </p>
+
+                @if (_importProblem is not null)
+                {
+                    <p class="status-line status-down" role="alert">
+                        <span class="dot"></span>@(_importProblem.Detail ?? _importProblem.Title ?? "Nie udało się zaimportować pliku.")
+                    </p>
+                }
+                else if (_summary is not null)
+                {
+                    <p class="status-line status-ok" role="status">
+                        <span class="dot"></span>Import zakończony powodzeniem.
+                    </p>
+                }
+
+                @if (_versions is null && _versionsProblem is null)
+                {
+                    <div class="loading-indicator">
+                        <span class="li-spin"></span> Wczytywanie wersji gry…
+                    </div>
+                }
+                else if (_versions is { Count: 0 })
+                {
+                    <div class="empty">
+                        <h2>Brak wersji gry</h2>
+                        <p>Najpierw zarejestruj wersję gry, zanim zaimportujesz eksport.</p>
+                    </div>
+                }
+                else if (_versions is not null)
+                {
+                    @* EditForm in static SSR emits the antiforgery token itself; a manual <AntiforgeryToken/>
+                       here would render __RequestVerificationToken twice and the middleware reads the
+                       comma-joined pair as an invalid token. Plain <form> posts (Editor/NavMenu) still need it. *@
+                    <EditForm Model="ImportInput" OnValidSubmit="ImportAsync"
+                              FormName="import-export" method="post" enctype="multipart/form-data">
+                        <div class="form-row">
+                            <div class="field">
+                                <label for="game-version">Wersja gry</label>
+                                <div class="select-wrap">
+                                    <select id="game-version" name="ImportInput.GameVersionId">
+                                        @foreach (GameVersionResponse version in _versions)
+                                        {
+                                            <option value="@version.Id.Value" selected="@(version.Id.Value == ImportInput?.GameVersionId)">
+                                                @version.Version (@version.Status)
+                                            </option>
+                                        }
+                                    </select>
+                                    <span class="select-chev" aria-hidden="true">▾</span>
+                                </div>
+                            </div>
+                            <div class="field">
+                                <label for="export-file">Plik exported.txt</label>
+                                <input id="export-file" name="ImportInput.File" type="file" accept=".txt"/>
+                            </div>
+                            <div class="field-static">
+                                <label class="checkbox">
+                                    <input id="allow-mass-removal" name="ImportInput.AllowMassRemoval" type="checkbox" value="true"/>
+                                    <span class="box">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                            <path d="M20 6 9 17l-5-5"/>
+                                        </svg>
+                                    </span>
+                                    <span>Zezwól na masowe usuwanie</span>
+                                </label>
+                            </div>
+                            <div class="filter-actions">
+                                <button type="submit" class="btn btn-primary">Importuj</button>
+                            </div>
+                        </div>
+                    </EditForm>
+                }
             </div>
-        }
-        else if (_versions is not null)
-        {
-            @* EditForm in static SSR emits the antiforgery token itself; a manual <AntiforgeryToken/>
-               here would render __RequestVerificationToken twice and the middleware reads the
-               comma-joined pair as an invalid token. Plain <form> posts (Editor/NavMenu) still need it. *@
-            <EditForm Model="ImportInput" OnValidSubmit="ImportAsync"
-                      FormName="import-export" method="post" enctype="multipart/form-data">
-                <div class="filter-form">
-                    <div class="filter-field">
-                        <label for="game-version">Wersja gry</label>
-                        <select id="game-version" name="ImportInput.GameVersionId">
-                            @foreach (GameVersionResponse version in _versions)
-                            {
-                                <option value="@version.Id.Value" selected="@(version.Id.Value == ImportInput?.GameVersionId)">
-                                    @version.Version (@version.Status)
-                                </option>
-                            }
-                        </select>
-                    </div>
-                    <div class="filter-field filter-search">
-                        <label for="export-file">Plik exported.txt</label>
-                        <input id="export-file" name="ImportInput.File" type="file" accept=".txt"/>
-                    </div>
-                    <div class="filter-field">
-                        <label for="allow-mass-removal" class="checkbox-label">
-                            <input id="allow-mass-removal" name="ImportInput.AllowMassRemoval" type="checkbox" value="true"/>
-                            Zezwól na masowe usuwanie
-                        </label>
-                    </div>
-                    <div class="filter-actions">
-                        <button type="submit" class="btn btn-primary">Importuj</button>
-                    </div>
-                </div>
-            </EditForm>
-        }
+        </section>
 
         @if (_summary is not null)
         {
             ImportSummary summary = _summary;
 
-            <section class="stat-grid">
-                <article class="stat-card">
-                    <span class="stat-label">Dodane</span>
-                    <span class="stat-value mono">@summary.Added</span>
+            <section class="stats-grid">
+                <article class="stat-tile">
+                    <span class="num @(summary.Added == 0 ? "zero" : null)">@summary.Added</span>
+                    <span class="lbl">Dodane</span>
                 </article>
-                <article class="stat-card">
-                    <span class="stat-label">Zmieniony angielski</span>
-                    <span class="stat-value mono">@summary.SourceChanged</span>
+                <article class="stat-tile">
+                    <span class="num @(summary.SourceChanged == 0 ? "zero" : null)">@summary.SourceChanged</span>
+                    <span class="lbl">Zmieniony angielski</span>
                 </article>
-                <article class="stat-card">
-                    <span class="stat-label">Unieważnione</span>
-                    <span class="stat-value mono">@summary.Invalidated</span>
+                <article class="stat-tile">
+                    <span class="num @(summary.Invalidated == 0 ? "zero" : null)">@summary.Invalidated</span>
+                    <span class="lbl">Unieważnione</span>
                 </article>
-                <article class="stat-card">
-                    <span class="stat-label">Usunięte</span>
-                    <span class="stat-value mono">@summary.Removed</span>
+                <article class="stat-tile">
+                    <span class="num @(summary.Removed == 0 ? "zero" : null)">@summary.Removed</span>
+                    <span class="lbl">Usunięte</span>
                 </article>
-                <article class="stat-card">
-                    <span class="stat-label">Bez zmian</span>
-                    <span class="stat-value mono">@summary.Unchanged</span>
+                <article class="stat-tile">
+                    <span class="num @(summary.Unchanged == 0 ? "zero" : null)">@summary.Unchanged</span>
+                    <span class="lbl">Bez zmian</span>
                 </article>
             </section>
 
             @if (summary.Warnings.Count > 0)
             {
-                <div class="panel">
-                    <h2>Uwagi</h2>
-                    <ul class="notice-list">
-                        @foreach (string warning in summary.Warnings)
-                        {
-                            <li class="status-line status-warning">
-                                <span class="dot"></span>@warning
-                            </li>
-                        }
-                    </ul>
-                </div>
+                <section class="panel">
+                    <header class="panel-head">
+                        <h2>Uwagi</h2>
+                    </header>
+                    <div class="panel-body">
+                        <ul class="notice-list">
+                            @foreach (string warning in summary.Warnings)
+                            {
+                                <li class="status-line status-warning">
+                                    <span class="dot"></span>@warning
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                </section>
             }
         }
-    </section>
-}
+    }
+</section>
 
 @code
 {

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/NotFound.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/NotFound.razor
@@ -3,10 +3,16 @@
 @attribute [AllowAnonymous]
 @using Microsoft.AspNetCore.Authorization
 
-<PageTitle>Nie znaleziono — LotroKoniecDev</PageTitle>
+<PageTitle>Nie znaleziono — lotro-translator.pl</PageTitle>
 
 <div class="status-stage">
     <div class="status-card">
+        <div class="status-glyph" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="8"/>
+                <path d="m21 21-4.3-4.3"/>
+            </svg>
+        </div>
         <div class="status-code">404</div>
         <h1>Strony nie znaleziono</h1>
         <p class="status-desc">Strona, której szukasz, nie istnieje lub została przeniesiona.</p>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
@@ -10,171 +10,187 @@
 @using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums
 @inject TranslationListLoader Loader
 
-<PageTitle>Tłumaczenia — LotroKoniecDev</PageTitle>
+<PageTitle>Tłumaczenia — lotro-translator.pl</PageTitle>
 
-<section class="page-head">
-    <h1>Tłumaczenia</h1>
-    <p class="lede">Przeglądaj, wyszukuj i filtruj teksty zaimportowane z gry.</p>
+<section class="container page-head">
+    <div>
+        <h1>Tłumaczenia</h1>
+        <p class="lede">Przeglądaj, wyszukuj i filtruj teksty zaimportowane z gry.</p>
+    </div>
 </section>
 
-<section class="panel filters">
-    <form method="get" class="filter-form">
-        <div class="filter-field filter-search">
-            <label for="search">Wyszukaj</label>
-            <input id="search" name="search" type="search" value="@_query.Search"
-                   placeholder="Tekst angielski lub polski…" autocomplete="off"/>
-        </div>
-        <div class="filter-field">
-            <label for="status">Status</label>
-            <select id="status" name="status">
-                <option value="">Wszystkie</option>
-                @foreach (TranslationStatus status in TranslationStatusDisplay.FilterableStatuses)
-                {
-                    <option value="@status" selected="@(_query.Status == status)">
-                        @TranslationStatusDisplay.Label(status)
-                    </option>
-                }
-            </select>
-        </div>
-        <div class="filter-actions">
-            <button type="submit" class="btn btn-primary">Filtruj</button>
-            <a class="btn btn-ghost" href="/translations">Wyczyść</a>
-        </div>
-    </form>
+<section class="filter-wrap">
+    <div class="container">
+        <form class="filter" method="get">
+            <div class="field">
+                <label for="search">Wyszukaj</label>
+                <input id="search" name="search" type="search" value="@_query.Search"
+                       placeholder="Tekst angielski lub polski…" autocomplete="off"/>
+            </div>
+            <div class="field">
+                <label for="status">Status</label>
+                <div class="select-wrap">
+                    <select id="status" name="status">
+                        <option value="">Wszystkie</option>
+                        @foreach (TranslationStatus status in TranslationStatusDisplay.FilterableStatuses)
+                        {
+                            <option value="@status" selected="@(_query.Status == status)">
+                                @TranslationStatusDisplay.Label(status)
+                            </option>
+                        }
+                    </select>
+                    <span class="select-chev" aria-hidden="true">▾</span>
+                </div>
+            </div>
+            <div class="filter-actions">
+                <a class="btn btn-ghost" href="/translations">Wyczyść</a>
+                <button type="submit" class="btn btn-primary">Filtruj</button>
+            </div>
+        </form>
+    </div>
 </section>
 
-@if (_result is null)
-{
-    <section class="results-meta">
+<section class="container content-wrap">
+    @if (_result is null)
+    {
         <div class="loading-indicator">
             <span class="li-spin"></span> Wczytywanie tłumaczeń…
         </div>
-    </section>
-}
-else if (_result.IsFailure)
-{
-    <section class="panel">
-        <p class="status-line status-down" role="alert">
-            <span class="dot"></span>
-            @(_result.ProblemDetails?.Title ?? "Nie udało się wczytać tłumaczeń.")
-        </p>
-    </section>
-}
-else
-{
-    PaginationResponse<TranslationListItemResponse> pageData = _result.Value;
-
-    <section class="results-meta">
-        <span class="count">Znaleziono: <strong>@pageData.TotalCount</strong></span>
-        @if (pageData.TotalPages > 0)
-        {
-            <span class="count">Strona @pageData.Page z @pageData.TotalPages</span>
-        }
-    </section>
-
-    @if (pageData.Items.Count == 0)
+    }
+    else if (_result.IsFailure)
     {
-        <section class="panel">
-            <div class="empty">
-                <h2>Brak wyników</h2>
-                <p>Żadne tłumaczenie nie pasuje do wybranych kryteriów.</p>
+        <div class="error-message" role="alert">
+            <span class="em-ico" aria-hidden="true">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
+                    <path d="M12 9v4"/><path d="M12 17h.01"/>
+                </svg>
+            </span>
+            <div class="em-body">
+                <span class="t">@(_result.ProblemDetails?.Title ?? "Nie udało się wczytać tłumaczeń.")</span>
             </div>
-        </section>
+        </div>
     }
     else
     {
-        <section class="table-wrap">
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th scope="col" class="col-num">FileId</th>
-                        <th scope="col" class="col-num">GossipId</th>
-                        <th scope="col">Tekst angielski</th>
-                        <th scope="col">Tłumaczenie polskie</th>
-                        <th scope="col" class="col-status">Status</th>
-                        <th scope="col" class="col-actions"><span class="visually-hidden">Akcje</span></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach (TranslationListItemResponse item in pageData.Items)
-                    {
-                        <tr>
-                            <td class="col-num mono">@item.FileId</td>
-                            <td class="col-num mono">@item.GossipId</td>
-                            <td class="col-text">@item.SourceText</td>
-                            <td class="col-text">
-                                @if (string.IsNullOrWhiteSpace(item.TranslatedText))
-                                {
-                                    <span class="text-dim">—</span>
-                                }
-                                else
-                                {
-                                    @item.TranslatedText
-                                }
-                            </td>
-                            <td class="col-status">
-                                <span class="badge @TranslationStatusDisplay.BadgeClass(item.Status)">
-                                    <span class="dot"></span>@TranslationStatusDisplay.Label(item.Status)
-                                </span>
-                            </td>
-                            <td class="col-actions">
-                                @if (item.Links.HasLink(Rels.Upsert))
-                                {
-                                    <a class="btn btn-ghost btn-sm" href="@EditorHref(item)">Edytuj</a>
-                                }
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
-        </section>
+        PaginationResponse<TranslationListItemResponse> pageData = _result.Value;
 
-        @* The pager controls' availability is driven by the server's pagination link rels (#158); the
-           user-facing /translations?... URLs stay FE-built via ToPageRelativeUri so they remain clean. *@
-        @if (pageData.Links.HasLink(Rels.PreviousPage) || pageData.Links.HasLink(Rels.NextPage))
+        <div class="results-meta">
+            <span class="count">Znaleziono: <strong>@pageData.TotalCount</strong></span>
+            @if (pageData.TotalPages > 0)
+            {
+                <span class="count">Strona @pageData.Page z @pageData.TotalPages</span>
+            }
+        </div>
+
+        @if (pageData.Items.Count == 0)
         {
-            <nav class="pager" aria-label="Stronicowanie">
-                @if (pageData.Links.HasLink(Rels.FirstPage))
-                {
-                    <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(1)" rel="first">« Pierwsza</a>
-                }
-                else
-                {
-                    <span class="btn btn-ghost is-disabled" aria-disabled="true">« Pierwsza</span>
-                }
+            <div class="empty">
+                <span class="empty-glyph" aria-hidden="true">
+                    <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="11" cy="11" r="8"/>
+                        <path d="m21 21-4.3-4.3"/>
+                    </svg>
+                </span>
+                <h2>Brak wyników</h2>
+                <p>Żadne tłumaczenie nie pasuje do wybranych kryteriów.</p>
+            </div>
+        }
+        else
+        {
+            <div class="table-wrap">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="col-num">FileId</th>
+                            <th scope="col" class="col-num">GossipId</th>
+                            <th scope="col">Tekst angielski</th>
+                            <th scope="col">Tłumaczenie polskie</th>
+                            <th scope="col" class="col-status">Status</th>
+                            <th scope="col" class="col-actions"><span class="visually-hidden">Akcje</span></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (TranslationListItemResponse item in pageData.Items)
+                        {
+                            <tr>
+                                <td class="col-num mono">@item.FileId</td>
+                                <td class="col-num mono">@item.GossipId</td>
+                                <td class="col-text">@item.SourceText</td>
+                                <td class="col-text">
+                                    @if (string.IsNullOrWhiteSpace(item.TranslatedText))
+                                    {
+                                        <span class="text-dim">—</span>
+                                    }
+                                    else
+                                    {
+                                        @item.TranslatedText
+                                    }
+                                </td>
+                                <td class="col-status">
+                                    <span class="badge @TranslationStatusDisplay.BadgeClass(item.Status)">
+                                        <span class="dot"></span>@TranslationStatusDisplay.Label(item.Status)
+                                    </span>
+                                </td>
+                                <td class="col-actions">
+                                    @if (item.Links.HasLink(Rels.Upsert))
+                                    {
+                                        <a class="btn btn-ghost btn-sm" href="@EditorHref(item)">Edytuj</a>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
 
-                @if (pageData.Links.HasLink(Rels.PreviousPage))
-                {
-                    <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.Page - 1)" rel="prev">← Poprzednia</a>
-                }
-                else
-                {
-                    <span class="btn btn-ghost is-disabled" aria-disabled="true">← Poprzednia</span>
-                }
+            @* The pager controls' availability is driven by the server's pagination link rels (#158); the
+               user-facing /translations?... URLs stay FE-built via ToPageRelativeUri so they remain clean. *@
+            @if (pageData.Links.HasLink(Rels.PreviousPage) || pageData.Links.HasLink(Rels.NextPage))
+            {
+                <nav class="pager" aria-label="Stronicowanie">
+                    @if (pageData.Links.HasLink(Rels.FirstPage))
+                    {
+                        <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(1)" rel="first">« Pierwsza</a>
+                    }
+                    else
+                    {
+                        <span class="btn btn-ghost is-disabled" aria-disabled="true">« Pierwsza</span>
+                    }
 
-                <span class="pager-status">@pageData.Page / @pageData.TotalPages</span>
+                    @if (pageData.Links.HasLink(Rels.PreviousPage))
+                    {
+                        <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.Page - 1)" rel="prev">← Poprzednia</a>
+                    }
+                    else
+                    {
+                        <span class="btn btn-ghost is-disabled" aria-disabled="true">← Poprzednia</span>
+                    }
 
-                @if (pageData.Links.HasLink(Rels.NextPage))
-                {
-                    <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.Page + 1)" rel="next">Następna →</a>
-                }
-                else
-                {
-                    <span class="btn btn-ghost is-disabled" aria-disabled="true">Następna →</span>
-                }
+                    <span class="pager-status">@pageData.Page / @pageData.TotalPages</span>
 
-                @if (pageData.Links.HasLink(Rels.LastPage))
-                {
-                    <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.TotalPages)" rel="last">Ostatnia »</a>
-                }
-                else
-                {
-                    <span class="btn btn-ghost is-disabled" aria-disabled="true">Ostatnia »</span>
-                }
-            </nav>
+                    @if (pageData.Links.HasLink(Rels.NextPage))
+                    {
+                        <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.Page + 1)" rel="next">Następna →</a>
+                    }
+                    else
+                    {
+                        <span class="btn btn-ghost is-disabled" aria-disabled="true">Następna →</span>
+                    }
+
+                    @if (pageData.Links.HasLink(Rels.LastPage))
+                    {
+                        <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.TotalPages)" rel="last">Ostatnia »</a>
+                    }
+                    else
+                    {
+                        <span class="btn btn-ghost is-disabled" aria-disabled="true">Ostatnia »</span>
+                    }
+                </nav>
+            }
         }
     }
-}
+</section>
 
 @code
 {

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -1,19 +1,58 @@
+/* ═════════════════════════════════════════════════════════════════════
+   Design system lifted from TheKittySaver (wwwroot/layout.css), re-themed
+   to the hobbit-gold palette anchored to the previous accent #c8a45c /
+   #e0bd72 ≈ oklch hue 84. Hue map vs. the TKS original:
+     accent (mint 168)      → gold 84
+     neutral scaffolding 165 → warm 80
+     text 160               → warm 85
+     warning 85 (≈ gold)    → orange 60 (kept distinct from the accent)
+     success (mint = accent) → green 150 (decoupled: approved ≠ accent)
+     danger 25              → unchanged
+   Cat-only sections (photo slider, wizard, gallery, cookie bar, legacy
+   block) are deliberately not ported.
+   ═════════════════════════════════════════════════════════════════════ */
+
+/* ───────── Tokens ───────── */
 :root {
-    --bg: #0f1115;
-    --surface: #171a21;
-    --surface-2: #1e222b;
-    --border: #2a2f3a;
-    --text: #e6e8ec;
-    --text-dim: #9aa1ad;
-    --accent: #c8a45c;
-    --accent-strong: #e0bd72;
-    --ok: #4caf78;
-    --warn: #d9a441;
-    --danger: #d9534f;
-    --radius: 10px;
-    --sidebar-w: 248px;
-    --font-sans: "Manrope", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-    --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    --bg: oklch(0.16 0.011 80);
+    --bg-2: oklch(0.20 0.013 80);
+    --surface: oklch(0.23 0.014 80);
+    --surface-hi: oklch(0.28 0.016 80);
+    --border: oklch(0.34 0.016 80);
+    --border-hi: oklch(0.44 0.020 80);
+
+    --text: oklch(0.96 0.008 85);
+    --text-mute: oklch(0.80 0.012 85);
+    --text-dim: oklch(0.68 0.014 85);
+
+    --accent: oklch(0.78 0.11 84);
+    --accent-hi: oklch(0.85 0.12 84);
+    --accent-dim: oklch(0.48 0.07 84);
+    --accent-soft: oklch(0.32 0.05 84);
+    --accent-ink: oklch(0.16 0.012 80);
+
+    --danger: oklch(0.65 0.20 25);
+    --danger-hi: oklch(0.76 0.18 25);
+    --danger-dim: oklch(0.42 0.10 25);
+    --danger-soft: oklch(0.30 0.10 25);
+    --warning: oklch(0.78 0.14 60);
+    --warning-hi: oklch(0.86 0.14 60);
+    --warning-dim: oklch(0.50 0.09 60);
+    --warning-soft: oklch(0.32 0.07 60);
+    --success: oklch(0.78 0.14 150);
+    --success-hi: oklch(0.86 0.13 150);
+    --success-dim: oklch(0.46 0.08 150);
+    --success-soft: oklch(0.30 0.06 150);
+
+    --radius: 14px;
+    --radius-sm: 8px;
+    --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0, 0, 0, 0.55);
+
+    --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+    --container-max: 1400px;
+    --container-px: 32px;
 }
 
 * {
@@ -32,21 +71,36 @@ body {
     font-size: 15px;
     line-height: 1.55;
     -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
 }
 
-h1, h2, h3 {
-    font-weight: 700;
-    line-height: 1.2;
-    margin: 0 0 0.5em;
+button, input, select, textarea {
+    font-family: inherit;
+}
+
+button {
+    cursor: pointer;
 }
 
 a {
-    color: var(--accent-strong);
+    color: inherit;
     text-decoration: none;
 }
 
-a:hover {
-    text-decoration: underline;
+img {
+    max-width: 100%;
+    display: block;
+}
+
+h1, h2, h3, h4, h5, h6, p {
+    margin: 0;
+}
+
+/* FocusOnNavigate targets h1 after every enhanced navigation — keep the programmatic
+   focus for screen readers, drop the default ring it would paint on each page load. */
+h1:focus {
+    outline: none;
 }
 
 code {
@@ -54,197 +108,627 @@ code {
     font-size: 0.9em;
 }
 
-/* App shell — sidebar + content */
-.app-shell {
-    display: flex;
+.app {
+    background: radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+    radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
     min-height: 100vh;
-}
-
-.app-main {
-    flex: 1;
     display: flex;
     flex-direction: column;
-    min-width: 0;
 }
 
-.content {
-    flex: 1;
-    padding: 40px clamp(20px, 5vw, 56px);
-    max-width: 1100px;
+/* ───────── Container ───────── */
+.container {
     width: 100%;
+    max-width: var(--container-max);
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: var(--container-px);
+    padding-right: var(--container-px);
 }
 
-.app-footer {
-    padding: 18px clamp(20px, 5vw, 56px);
-    border-top: 1px solid var(--border);
-    color: var(--text-dim);
-    font-size: 13px;
+/* ───────── Navbar ───────── */
+.nav {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: oklch(0.15 0.011 80 / 0.85);
+    backdrop-filter: blur(14px) saturate(140%);
+    border-bottom: 1px solid var(--border);
 }
 
-/* Sidebar */
-.sidebar {
-    width: var(--sidebar-w);
-    flex-shrink: 0;
-    background: var(--surface);
-    border-right: 1px solid var(--border);
+.nav-inner {
+    padding-top: 14px;
+    padding-bottom: 14px;
     display: flex;
-    flex-direction: column;
-    padding: 24px 18px;
-    gap: 24px;
+    align-items: center;
+    gap: 28px;
 }
 
-.sidebar-brand .brand {
-    display: flex;
+.brand {
+    display: inline-flex;
     align-items: center;
     gap: 10px;
     color: var(--text);
-    font-weight: 800;
-    font-size: 18px;
-}
-
-.sidebar-brand .brand:hover {
-    text-decoration: none;
+    font-weight: 700;
+    font-size: 17px;
+    letter-spacing: -0.01em;
 }
 
 .brand-mark {
-    display: inline-grid;
-    place-items: center;
     width: 34px;
     height: 34px;
-    border-radius: 8px;
-    background: var(--accent);
-    color: #1a1300;
+    border-radius: 9px;
+    background: linear-gradient(160deg, var(--accent), var(--accent-dim));
+    color: var(--accent-ink);
+    display: grid;
+    place-items: center;
+    box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
     font-weight: 800;
-    letter-spacing: 0.5px;
+}
+
+.brand-mark svg {
+    width: 22px;
+    height: 22px;
 }
 
 .brand-accent {
-    color: var(--accent-strong);
+    color: var(--accent-hi);
 }
 
-.brand-sub {
-    margin: 8px 0 0 2px;
-    color: var(--text-dim);
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-}
-
-.sidebar-nav {
+.nav-links {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
-    flex: 1;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
 }
 
 .nav-link {
-    display: block;
-    padding: 10px 12px;
+    padding: 8px 14px;
+    color: var(--text-mute);
+    font-size: 14px;
+    font-weight: 500;
     border-radius: 8px;
-    color: var(--text-dim);
-    font-weight: 600;
-    transition: background 0.12s, color 0.12s;
+    transition: color .15s, background .15s;
+    position: relative;
+    background: transparent;
+    border: 0;
 }
 
 .nav-link:hover {
-    background: var(--surface-2);
     color: var(--text);
-    text-decoration: none;
+    background: var(--surface);
 }
 
 .nav-link.active {
-    background: var(--surface-2);
-    color: var(--accent-strong);
-    box-shadow: inset 2px 0 0 var(--accent);
+    color: var(--text);
 }
 
-.sidebar-auth {
-    border-top: 1px solid var(--border);
-    padding-top: 18px;
+.nav-link.active::after {
+    content: "";
+    position: absolute;
+    left: 14px;
+    right: 14px;
+    bottom: 2px;
+    height: 2px;
+    background: var(--accent);
+    border-radius: 2px;
+}
+
+.nav-user {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+    padding: 0 6px;
+}
+
+.nav-logout {
+    color: var(--text-dim);
+    margin-left: 6px;
+}
+
+.nav-logout:hover {
+    color: var(--text);
+}
+
+.nav-logout-form {
+    margin: 0;
+    padding: 0;
+}
+
+/* ───────── Hero ───────── */
+.hero {
+    padding-top: 72px;
+    padding-bottom: 16px;
+}
+
+.eyebrow {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    color: var(--accent);
+    margin: 0 0 14px;
+    text-transform: uppercase;
+}
+
+.hero h1 {
+    font-size: clamp(36px, 5vw, 56px);
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    font-weight: 700;
+    margin: 0 0 16px;
+    max-width: 18ch;
+    text-wrap: balance;
+}
+
+.lede {
+    font-size: 17px;
+    color: var(--text-mute);
+    max-width: 56ch;
+    margin: 0;
+}
+
+/* ───────── Page head (subpages) ───────── */
+.page-head {
+    padding-top: 56px;
+    padding-bottom: 28px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.page-head h1 {
+    font-size: clamp(32px, 4.2vw, 44px);
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    font-weight: 700;
+    margin: 0;
+}
+
+.page-head .lede {
+    font-size: 15.5px;
+    margin-top: 12px;
+}
+
+.page-head .head-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
+/* ───────── Filter ───────── */
+.filter-wrap {
+    padding-top: 16px;
+    padding-bottom: 8px;
+}
+
+.filter {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px;
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 14px;
+    align-items: end;
+    box-shadow: var(--shadow);
+}
+
+.field {
     display: flex;
     flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+}
+
+.field label {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-mute);
+}
+
+.field input[type="text"],
+.field input[type="email"],
+.field input[type="password"],
+.field input[type="number"],
+.field input[type="tel"],
+.field input[type="search"],
+.field input[type="file"],
+.field textarea,
+.select-wrap select {
+    appearance: none;
+    width: 100%;
+    padding: 12px 14px;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font: inherit;
+    transition: border-color .15s, box-shadow .15s;
+}
+
+.field input[type="file"] {
+    padding: 9px 14px;
+}
+
+.field input[type="file"]::file-selector-button {
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    background: var(--surface-hi);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 5px 12px;
+    margin-right: 12px;
+    cursor: pointer;
+}
+
+.select-wrap {
+    position: relative;
+}
+
+.select-wrap select {
+    padding: 12px 36px 12px 14px;
+}
+
+.field input:hover:not(:disabled),
+.field textarea:hover:not(:disabled),
+.select-wrap select:hover:not(:disabled) {
+    border-color: var(--border-hi);
+}
+
+.field input:focus,
+.field textarea:focus,
+.select-wrap select:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.18);
+}
+
+.field input:disabled,
+.select-wrap select:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.select-chev {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-mute);
+    pointer-events: none;
+    font-size: 12px;
+}
+
+.filter-actions {
+    display: flex;
     gap: 8px;
 }
 
-.auth-user {
-    color: var(--text-dim);
-    font-size: 13px;
-    padding-left: 2px;
+/* ───────── Inline form row (forms hosted inside a panel body) ───────── */
+.form-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 14px;
+    margin: 0;
 }
 
-/* Buttons */
+.form-row .field {
+    flex: 1 1 220px;
+}
+
+.form-row .field-static {
+    flex: 0 0 auto;
+}
+
+.form-row .checkbox {
+    padding: 12px 0;
+}
+
+/* ───────── Buttons ───────── */
 .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 8px;
-    padding: 9px 16px;
-    border-radius: 8px;
+    padding: 12px 20px;
+    border-radius: var(--radius-sm);
     border: 1px solid transparent;
-    font: inherit;
     font-weight: 600;
-    cursor: pointer;
-    transition: filter 0.12s, background 0.12s;
-}
-
-.btn:hover {
+    font-size: 14px;
+    font-family: inherit;
+    transition: transform .08s, background .15s, border-color .15s, color .15s;
+    background: var(--bg-2);
+    color: var(--text);
     text-decoration: none;
-    filter: brightness(1.08);
 }
 
-.btn-block {
-    width: 100%;
+.btn:active {
+    transform: translateY(1px);
 }
 
 .btn-primary {
     background: var(--accent);
-    color: #1a1300;
+    color: var(--accent-ink);
+    border-color: oklch(0.62 0.09 84);
+}
+
+.btn-primary:hover {
+    background: var(--accent-hi);
 }
 
 .btn-ghost {
     background: transparent;
+    color: var(--text-mute);
     border-color: var(--border);
+}
+
+.btn-ghost:hover {
+    color: var(--text);
+    border-color: var(--border-hi);
+    background: var(--surface-hi);
+}
+
+.btn-danger {
+    background: var(--danger);
+    color: var(--accent-ink);
+    border-color: oklch(0.55 0.18 25);
+}
+
+.btn-danger:hover {
+    filter: brightness(1.08);
+}
+
+.btn-sm {
+    padding: 7px 13px;
+    font-size: 13px;
+}
+
+.btn-block {
+    width: 100%;
+    justify-content: center;
+}
+
+.btn.is-disabled {
+    opacity: 0.4;
+    pointer-events: none;
+    cursor: default;
+}
+
+/* ───────── Results meta ───────── */
+.results-meta {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.count {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-mute);
+    letter-spacing: 0.04em;
+}
+
+.count strong {
     color: var(--text);
 }
 
-/* Hero + panels */
-.hero {
-    margin-bottom: 36px;
-}
-
-.hero h1 {
-    font-size: clamp(26px, 4vw, 36px);
-}
-
-.lede {
-    color: var(--text-dim);
-    font-size: 17px;
-    max-width: 60ch;
-}
-
+/* ───────── Panels ───────── */
 .panel {
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 24px;
+    box-shadow: var(--shadow);
+    overflow: hidden;
 }
 
-.panel h2 {
-    font-size: 18px;
+.panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 22px;
+    border-bottom: 1px solid var(--border);
+    background: linear-gradient(to bottom,
+    oklch(0.25 0.016 80 / 0.6),
+    oklch(0.22 0.014 80 / 0));
 }
 
-/* Status lines (API connectivity) */
+.panel-head h2 {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: -0.005em;
+    color: var(--text);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.panel-head .panel-num {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--accent);
+    letter-spacing: 0.14em;
+}
+
+.panel-head .panel-aside {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-mute);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.panel-body {
+    padding: 18px 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.panel-body .lede {
+    font-size: 14px;
+    max-width: 72ch;
+}
+
+/* ───────── Stat tiles ───────── */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: 1px;
+    background: var(--border);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    box-shadow: var(--shadow);
+}
+
+.stat-tile {
+    padding: 22px 20px 18px;
+    background: var(--surface);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    position: relative;
+}
+
+.stat-tile .num {
+    font-size: 38px;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    color: var(--text);
+    font-feature-settings: "tnum" 1;
+}
+
+.stat-tile .num.zero {
+    color: var(--text-dim);
+}
+
+.stat-tile .num.ok {
+    color: var(--success);
+}
+
+.stat-tile .lbl {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-mute);
+    margin-top: 6px;
+}
+
+/* ───────── Progress (approval) ───────── */
+.progress {
+    height: 12px;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, var(--success-dim), var(--success));
+    border-radius: inherit;
+    transition: width 0.3s ease;
+}
+
+.progress-caption {
+    margin: 0;
+    color: var(--text-mute);
+    font-size: 13.5px;
+}
+
+.progress-caption strong {
+    color: var(--text);
+    font-feature-settings: "tnum" 1;
+}
+
+/* ───────── Badges ───────── */
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 9px 3px 7px;
+    border-radius: 999px;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border: 1px solid transparent;
+    white-space: nowrap;
+}
+
+.badge .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex: 0 0 auto;
+}
+
+.badge-success {
+    background: var(--success-soft);
+    color: var(--success-hi);
+    border-color: var(--success-dim);
+}
+
+.badge-success .dot {
+    background: var(--success);
+    box-shadow: 0 0 0 3px oklch(0.78 0.14 150 / 0.18);
+}
+
+.badge-warning {
+    background: var(--warning-soft);
+    color: var(--warning-hi);
+    border-color: var(--warning-dim);
+}
+
+.badge-warning .dot {
+    background: var(--warning);
+}
+
+.badge-danger {
+    background: var(--danger-soft);
+    color: var(--danger-hi);
+    border-color: var(--danger-dim);
+}
+
+.badge-danger .dot {
+    background: var(--danger-hi);
+}
+
+.badge-neutral {
+    background: var(--bg-2);
+    color: var(--text-mute);
+    border-color: var(--border);
+}
+
+.badge-neutral .dot {
+    background: var(--text-dim);
+}
+
+/* ───────── Status lines (inline API feedback) ───────── */
 .status-line {
     display: flex;
     align-items: center;
     gap: 10px;
     margin: 0;
-    font-size: 15px;
+    font-size: 14.5px;
 }
 
 .status-line .dot {
-    width: 10px;
-    height: 10px;
+    width: 9px;
+    height: 9px;
     border-radius: 50%;
     flex-shrink: 0;
 }
@@ -254,252 +738,114 @@ code {
 }
 
 .status-ok .dot {
-    background: var(--ok);
+    background: var(--success);
+    box-shadow: 0 0 0 3px oklch(0.78 0.14 150 / 0.18);
 }
 
 .status-down .dot {
     background: var(--danger);
+    box-shadow: 0 0 0 3px oklch(0.65 0.20 25 / 0.18);
 }
 
 .status-warning .dot {
-    background: var(--warn);
+    background: var(--warning);
+    box-shadow: 0 0 0 3px oklch(0.78 0.14 60 / 0.18);
 }
 
-/* Status / error pages */
-.status-stage {
-    display: grid;
-    place-items: center;
-    min-height: 60vh;
-}
-
-.status-card {
-    text-align: center;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 48px 40px;
-    max-width: 480px;
-}
-
-.status-card.status-danger {
-    border-color: rgba(217, 83, 79, 0.4);
-}
-
-.status-card.status-warning {
-    border-color: rgba(217, 164, 65, 0.4);
-}
-
-.status-code {
-    font-family: var(--font-mono);
-    font-size: 44px;
-    font-weight: 700;
-    color: var(--accent-strong);
-}
-
-.status-desc {
-    color: var(--text-dim);
-}
-
-.status-detail {
-    margin: 18px 0;
-    font-size: 13px;
-    color: var(--text-dim);
-}
-
-.det-k {
-    display: block;
-    margin-bottom: 4px;
-}
-
-.status-actions {
-    margin-top: 24px;
-}
-
-/* Inline status message (error boundary) */
+/* ───────── Status message (layout banners) ───────── */
 .status-message {
-    padding: 16px 20px;
-    border-radius: var(--radius);
+    padding: 14px 18px;
+    border-radius: var(--radius-sm);
     border: 1px solid var(--border);
-}
-
-.status-message.status-error {
-    border-color: rgba(217, 83, 79, 0.4);
-    background: rgba(217, 83, 79, 0.08);
-}
-
-.status-message.status-warning {
-    border-color: rgba(217, 164, 65, 0.4);
-    background: rgba(217, 164, 65, 0.08);
+    background: var(--surface);
 }
 
 .status-message p {
     margin: 0;
 }
 
-/* Page head */
-.page-head {
-    margin-bottom: 24px;
+.status-message.status-error {
+    border-color: var(--danger-dim);
+    background: var(--danger-soft);
+    color: var(--danger-hi);
 }
 
-.page-head h1 {
-    font-size: clamp(24px, 3.5vw, 32px);
+.status-message.status-warning {
+    border-color: var(--warning-dim);
+    background: var(--warning-soft);
+    color: var(--warning-hi);
 }
 
-/* Filters */
-.filters {
-    margin-bottom: 20px;
+.status-message.status-success {
+    border-color: var(--success-dim);
+    background: var(--success-soft);
+    color: var(--success-hi);
 }
 
-.filter-form {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    gap: 14px;
-}
-
-.filter-field {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
-.filter-search {
-    flex: 1 1 280px;
-    min-width: 200px;
-}
-
-.filter-field label {
-    font-size: 12px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--text-dim);
-}
-
-.filter-field input,
-.filter-field select {
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    border-radius: 8px;
+/* ───────── Rich error box ───────── */
+.error-message {
+    padding: 14px 18px;
+    border-radius: var(--radius-sm);
+    background: var(--danger-soft);
+    border: 1px solid var(--danger-dim);
     color: var(--text);
-    font: inherit;
-    padding: 9px 12px;
-}
-
-.filter-field input:focus,
-.filter-field select:focus {
-    outline: none;
-    border-color: var(--accent);
-}
-
-.filter-actions {
-    display: flex;
-    gap: 8px;
-}
-
-/* Results meta */
-.results-meta {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 18px;
-    margin-bottom: 14px;
-    color: var(--text-dim);
-    font-size: 14px;
-}
-
-.results-meta .count strong {
-    color: var(--text);
-}
-
-.loading-indicator {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    color: var(--text-dim);
-}
-
-.li-spin {
-    width: 14px;
-    height: 14px;
-    border: 2px solid var(--border);
-    border-top-color: var(--accent);
-    border-radius: 50%;
-    animation: li-spin 0.7s linear infinite;
-}
-
-@keyframes li-spin {
-    to {
-        transform: rotate(360deg);
-    }
-}
-
-/* Dashboard — stat cards + progress */
-.stat-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 14px;
-    margin-bottom: 18px;
+    gap: 6px;
 }
 
-.stat-card {
+.error-message:has(.em-body) {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 18px 20px;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+
+.error-message .em-ico {
+    width: 38px;
+    height: 38px;
+    flex: 0 0 38px;
+    border-radius: 10px;
+    border: 1px solid var(--danger-dim);
+    background: oklch(0.30 0.07 25 / 0.5);
+    color: var(--danger-hi);
+    display: grid;
+    place-items: center;
+}
+
+.error-message .em-body {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    padding: 18px 20px;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
 }
 
-.stat-label {
-    color: var(--text-dim);
+.error-message .em-body .t {
+    font-size: 14.5px;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.error-message .em-body .s {
     font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    color: var(--text-mute);
+    line-height: 1.5;
 }
 
-.stat-value {
-    font-size: 30px;
-    font-weight: 600;
-    color: var(--text);
+.error-message .em-retry {
+    flex: 0 0 auto;
+    margin: 0;
 }
 
-.stat-value-ok {
-    color: var(--ok);
-}
-
-.progress {
-    height: 12px;
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    overflow: hidden;
-}
-
-.progress-bar {
-    height: 100%;
-    background: var(--ok);
-    border-radius: inherit;
-    transition: width 0.3s ease;
-}
-
-.progress-caption {
-    margin: 10px 0 0;
-    color: var(--text-dim);
-    font-size: 14px;
-}
-
-.progress-caption strong {
-    color: var(--text);
-}
-
-/* Data table */
+/* ───────── Data table ───────── */
 .table-wrap {
     border: 1px solid var(--border);
     border-radius: var(--radius);
     overflow-x: auto;
     background: var(--surface);
+    box-shadow: var(--shadow);
 }
 
 .data-table {
@@ -511,17 +857,19 @@ code {
 .data-table th,
 .data-table td {
     text-align: left;
-    padding: 11px 14px;
+    padding: 12px 16px;
     border-bottom: 1px solid var(--border);
     vertical-align: top;
 }
 
 .data-table thead th {
-    background: var(--surface-2);
-    color: var(--text-dim);
-    font-size: 12px;
+    background: var(--bg-2);
+    color: var(--text-mute);
+    font-family: var(--font-mono);
+    font-weight: 500;
+    font-size: 10.5px;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.1em;
     white-space: nowrap;
     position: sticky;
     top: 0;
@@ -531,8 +879,12 @@ code {
     border-bottom: none;
 }
 
+.data-table tbody tr {
+    transition: background .15s;
+}
+
 .data-table tbody tr:hover {
-    background: var(--surface-2);
+    background: var(--surface-hi);
 }
 
 .col-num {
@@ -556,102 +908,430 @@ code {
     word-break: break-word;
 }
 
+/* ───────── Pager ───────── */
+.pager {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.pager .btn {
+    padding: 9px 14px;
+    font-size: 13px;
+}
+
+.pager-status {
+    font-family: var(--font-mono);
+    color: var(--text-mute);
+    font-size: 12px;
+    letter-spacing: 0.06em;
+    font-variant-numeric: tabular-nums;
+    padding: 0 8px;
+}
+
+/* ───────── Loading / empty ───────── */
+.loading-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 11px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-mute);
+    letter-spacing: 0.04em;
+}
+
+.li-spin {
+    width: 15px;
+    height: 15px;
+    flex: 0 0 15px;
+    border-radius: 50%;
+    border: 2px solid var(--border-hi);
+    border-top-color: var(--accent);
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.empty {
+    padding: 56px 24px;
+    text-align: center;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    color: var(--text-mute);
+}
+
+.empty .empty-glyph {
+    width: 64px;
+    height: 64px;
+    border-radius: 18px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--border-hi);
+    background: var(--bg-2);
+    color: var(--accent-hi);
+}
+
+.empty h2 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: var(--text);
+}
+
+.empty p {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text-mute);
+    max-width: 40ch;
+    line-height: 1.6;
+}
+
+/* ───────── Checkbox (SSR, pure CSS) ───────── */
+.checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    font-size: 13.5px;
+    color: var(--text-mute);
+    user-select: none;
+}
+
+.checkbox input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.checkbox .box {
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
+    background: var(--bg-2);
+    border: 1px solid var(--border-hi);
+    display: grid;
+    place-items: center;
+    transition: background .15s, border-color .15s;
+    flex: 0 0 18px;
+}
+
+.checkbox .box svg {
+    width: 12px;
+    height: 12px;
+    color: var(--accent-ink);
+    opacity: 0;
+    transform: scale(0.7);
+    transition: opacity .12s, transform .12s;
+}
+
+.checkbox input:checked ~ .box {
+    background: var(--accent);
+    border-color: var(--accent);
+}
+
+.checkbox input:checked ~ .box svg {
+    opacity: 1;
+    transform: scale(1);
+}
+
+.checkbox input:focus-visible ~ .box {
+    box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.25);
+}
+
+.checkbox:hover .box {
+    border-color: var(--text-mute);
+}
+
+.notice-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+/* ───────── Side-by-side editor ───────── */
+.editor-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 22px;
+    align-items: start;
+    padding-bottom: 8px;
+}
+
+.editor-source {
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 14px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.6;
+    font-size: 14.5px;
+}
+
+.editor-source.is-superseded {
+    opacity: 0.7;
+}
+
+.editor-superseded {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.editor-pane-subtitle {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.editor-textarea {
+    width: 100%;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 14px;
+    line-height: 1.6;
+    font-size: 14.5px;
+    resize: vertical;
+    min-height: 96px;
+    transition: border-color .15s, box-shadow .15s;
+}
+
+.editor-textarea:hover:not(:disabled) {
+    border-color: var(--border-hi);
+}
+
+.editor-textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.18);
+}
+
+.editor-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.editor-approve {
+    margin: 0;
+    padding-top: 14px;
+    border-top: 1px dashed var(--border);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.ph-token {
+    background: var(--accent-soft);
+    color: var(--accent-hi);
+    border: 1px solid var(--accent-dim);
+    border-radius: 4px;
+    padding: 0 4px;
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+}
+
+/* ───────── Status pages (404 / 403 / 400 / 500) ───────── */
+.status-stage {
+    display: grid;
+    place-items: center;
+    padding: 72px var(--container-px);
+    min-height: 60vh;
+}
+
+.status-card {
+    --tone: var(--accent);
+    --tone-hi: var(--accent-hi);
+    --tone-dim: var(--accent-dim);
+    --tone-soft: var(--accent-soft);
+
+    width: 100%;
+    max-width: 560px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 42px 38px 34px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 18px;
+}
+
+.status-card.status-danger {
+    --tone: var(--danger);
+    --tone-hi: var(--danger-hi);
+    --tone-dim: var(--danger-dim);
+    --tone-soft: var(--danger-soft);
+}
+
+.status-card.status-warning {
+    --tone: var(--warning);
+    --tone-hi: var(--warning-hi);
+    --tone-dim: var(--warning-dim);
+    --tone-soft: var(--warning-soft);
+}
+
+.status-glyph {
+    width: 76px;
+    height: 76px;
+    border-radius: 22px;
+    display: grid;
+    place-items: center;
+    color: var(--tone-hi);
+    background: var(--tone-soft);
+    border: 1px solid var(--tone-dim);
+    box-shadow: 0 0 0 6px color-mix(in oklch, var(--tone) 12%, transparent);
+}
+
+.status-glyph svg {
+    width: 34px;
+    height: 34px;
+}
+
+.status-code {
+    font-family: var(--font-mono);
+    font-size: clamp(46px, 9vw, 60px);
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    color: var(--tone-hi);
+    font-feature-settings: "tnum" 1;
+}
+
+.status-card h1 {
+    margin: 0;
+    font-size: 26px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: var(--text);
+    line-height: 1.15;
+    text-wrap: balance;
+}
+
+.status-desc {
+    margin: 0;
+    font-size: 15px;
+    color: var(--text-mute);
+    line-height: 1.6;
+    max-width: 44ch;
+    text-wrap: pretty;
+}
+
+.status-detail {
+    width: 100%;
+    margin-top: 4px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-2);
+    padding: 4px 16px;
+    text-align: left;
+}
+
+.status-detail .det-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 6px 14px;
+    flex-wrap: wrap;
+    padding: 12px 0;
+}
+
+.status-detail .det-k {
+    font-family: var(--font-mono);
+    font-size: 9.5px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-mute);
+    white-space: nowrap;
+}
+
+.status-detail code {
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--text);
+    letter-spacing: -0.01em;
+    white-space: nowrap;
+    margin-left: auto;
+    text-align: right;
+}
+
+.status-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 6px;
+}
+
+.status-actions .btn {
+    white-space: nowrap;
+}
+
+/* ───────── Footer ───────── */
+.foot {
+    margin-top: auto;
+    padding-top: 28px;
+    padding-bottom: 40px;
+    border-top: 1px solid var(--border);
+    text-align: center;
+}
+
+.foot p {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    color: var(--text-mute);
+}
+
+.foot-links {
+    margin-top: 10px !important;
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.foot-links a {
+    color: var(--text-dim);
+    transition: color .15s;
+}
+
+.foot-links a:hover {
+    color: var(--accent-hi);
+}
+
+/* ───────── Utilities ───────── */
 .mono {
     font-family: var(--font-mono);
     font-size: 0.92em;
-    color: var(--text-dim);
 }
 
 .text-dim {
     color: var(--text-dim);
 }
 
-/* Badges */
-.badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 3px 9px;
-    border-radius: 999px;
-    border: 1px solid var(--border);
-    font-size: 12px;
-    font-weight: 600;
-    white-space: nowrap;
-}
-
-.badge .dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: currentColor;
-    flex-shrink: 0;
-}
-
-.badge-success {
-    color: var(--ok);
-    border-color: rgba(76, 175, 120, 0.4);
-    background: rgba(76, 175, 120, 0.1);
-}
-
-.badge-warning {
-    color: var(--warn);
-    border-color: rgba(217, 164, 65, 0.4);
-    background: rgba(217, 164, 65, 0.1);
-}
-
-.badge-danger {
-    color: var(--danger);
-    border-color: rgba(217, 83, 79, 0.4);
-    background: rgba(217, 83, 79, 0.1);
-}
-
-.badge-neutral {
-    color: var(--text-dim);
-}
-
-/* Buttons — small + disabled variants */
-.btn-sm {
-    padding: 6px 12px;
-    font-size: 13px;
-}
-
-.btn.is-disabled {
-    opacity: 0.4;
-    pointer-events: none;
-    cursor: default;
-}
-
-/* Pager */
-.pager {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 14px;
-    margin-top: 20px;
-}
-
-.pager-status {
-    color: var(--text-dim);
-    font-size: 14px;
-    font-variant-numeric: tabular-nums;
-}
-
-/* Empty state */
-.empty {
-    text-align: center;
-    padding: 20px 0;
-}
-
-.empty h2 {
-    font-size: 18px;
-}
-
-.empty p {
-    color: var(--text-dim);
-    margin: 0;
-}
-
-/* Accessibility helper */
 .visually-hidden {
     position: absolute;
     width: 1px;
@@ -664,152 +1344,97 @@ code {
     border: 0;
 }
 
-/* Side-by-side editor */
-.editor-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-    align-items: start;
-}
-
-.editor-pane {
+/* ───────── Content sections ───────── */
+.content-wrap {
+    padding-top: 8px;
+    padding-bottom: 48px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 22px;
 }
 
-.editor-pane-title {
-    margin: 0;
-    font-size: 15px;
-    color: var(--text-dim);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.editor-pane-subtitle {
-    margin: 0;
-    font-size: 13px;
-    color: var(--text-dim);
-}
-
-.editor-source {
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 14px;
-    white-space: pre-wrap;
-    word-break: break-word;
-    line-height: 1.6;
-}
-
-.editor-source.is-superseded {
-    opacity: 0.75;
-}
-
-.editor-superseded {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-
-.editor-textarea {
-    width: 100%;
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    color: var(--text);
-    padding: 14px;
-    line-height: 1.6;
-    resize: vertical;
-}
-
-.editor-textarea:focus {
-    outline: none;
-    border-color: var(--accent);
-}
-
-.editor-actions {
-    margin-top: 12px;
-    display: flex;
-    gap: 10px;
-}
-
-.editor-approve {
-    margin-top: 16px;
-    padding-top: 16px;
-    border-top: 1px solid var(--border);
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.ph-token {
-    background: rgba(200, 164, 92, 0.18);
-    color: var(--accent-strong);
-    border-radius: 4px;
-    padding: 0 4px;
-    font-family: var(--font-mono);
-    font-size: 0.92em;
-}
-
-/* Import / Export */
-.checkbox-label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    text-transform: none;
-    letter-spacing: normal;
-    color: var(--text);
-}
-
-.checkbox-label input {
-    width: auto;
-}
-
-.notice-list {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-
-/* Responsive — stack the sidebar on top on small screens */
-@media (max-width: 760px) {
-    .editor-grid {
-        grid-template-columns: 1fr;
+/* ───────── Responsive ───────── */
+@media (max-width: 880px) {
+    :root {
+        --container-px: 20px;
     }
 
-    .app-shell {
-        flex-direction: column;
-    }
-
-    .sidebar {
-        width: 100%;
-        flex-direction: row;
+    .nav-inner {
         flex-wrap: wrap;
-        align-items: center;
         gap: 12px;
-        padding: 14px 16px;
+        padding-top: 12px;
+        padding-bottom: 12px;
     }
 
-    .sidebar-brand {
-        flex: 1;
+    .nav-links {
+        order: 3;
+        width: 100%;
+        overflow-x: auto;
+        margin-left: 0;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
     }
 
-    .brand-sub {
+    .nav-links::-webkit-scrollbar {
         display: none;
     }
 
-    .sidebar-nav {
-        flex-direction: row;
-        flex-wrap: wrap;
-        flex: 1 0 100%;
+    .nav-link {
+        flex: 0 0 auto;
     }
 
-    .sidebar-auth {
-        border-top: none;
-        padding-top: 0;
+    .hero {
+        padding-top: 48px;
+        padding-bottom: 24px;
+    }
+
+    .page-head {
+        padding-top: 32px;
+    }
+
+    .filter {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+
+    .filter-actions {
+        width: 100%;
+    }
+
+    .filter-actions .btn-primary {
+        flex: 1;
+        justify-content: center;
+    }
+
+    .editor-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 480px) {
+    .status-card {
+        padding: 32px 22px 28px;
+        gap: 16px;
+    }
+
+    .status-glyph {
+        width: 66px;
+        height: 66px;
+        border-radius: 19px;
+    }
+
+    .status-stage {
+        padding: 48px 16px;
+        min-height: 56vh;
+    }
+
+    .status-detail .det-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 5px;
+    }
+
+    .status-detail code {
+        text-align: left;
     }
 }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/NavMenuTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/NavMenuTests.cs
@@ -28,8 +28,8 @@ public sealed class NavMenuTests : BunitContext
 
         IRenderedComponent<NavMenu> component = RenderNavMenu();
 
-        IElement loginLink = component.Find("a.btn-primary");
-        loginLink.GetAttribute("href").ShouldBe(AuthenticationDependencyInjectionExtensions.LoginPath);
+        IElement loginLink = component.Find($"a[href='{AuthenticationDependencyInjectionExtensions.LoginPath}']");
+        loginLink.ClassList.ShouldContain("nav-link");
         component.FindAll("form").ShouldBeEmpty();
     }
 
@@ -40,12 +40,12 @@ public sealed class NavMenuTests : BunitContext
 
         IRenderedComponent<NavMenu> component = RenderNavMenu();
 
-        component.Find("span.auth-user").TextContent.ShouldBe("Frodo");
+        component.Find("span.nav-user").TextContent.ShouldBe("Frodo");
 
         IElement logoutForm = component.Find("form");
         logoutForm.GetAttribute("method").ShouldBe("post");
         logoutForm.GetAttribute("action").ShouldBe(AuthenticationDependencyInjectionExtensions.LogoutPath);
-        component.FindAll("a.btn-primary").ShouldBeEmpty();
+        component.FindAll($"a[href='{AuthenticationDependencyInjectionExtensions.LoginPath}']").ShouldBeEmpty();
     }
 
     [Fact]
@@ -56,11 +56,16 @@ public sealed class NavMenuTests : BunitContext
         IRenderedComponent<NavMenu> component = RenderNavMenu();
 
         string[] navTargets = component
-            .FindAll("nav.sidebar-nav a")
+            .FindAll("nav.nav-links a")
             .Select(anchor => anchor.GetAttribute("href")!)
             .ToArray();
 
-        navTargets.ShouldBe(["/", "/translations", "/import-export", "/game-versions", "/dashboard"]);
+        // The topbar hosts the auth affordance in the same nav; anonymous renders the login link last.
+        navTargets.ShouldBe(
+        [
+            "/", "/translations", "/import-export", "/game-versions", "/dashboard",
+            AuthenticationDependencyInjectionExtensions.LoginPath
+        ]);
     }
 
     /// <summary>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
@@ -95,7 +95,7 @@ public sealed class EditorTests : BunitContext
 
         IRenderedComponent<EditorComponent> component = RenderEditor();
 
-        component.Find(".status-down").TextContent.ShouldContain("Nie znaleziono.");
+        component.Find(".error-message").TextContent.ShouldContain("Nie znaleziono.");
         component.FindAll(".editor-grid").ShouldBeEmpty();
     }
 
@@ -187,7 +187,37 @@ public sealed class EditorTests : BunitContext
 
         // Behaviour-visible proof the upsert href (read from the loaded detail's links) was followed:
         // only a PUT to that exact href is stubbed to succeed, so the confirmation renders iff it was used.
-        component.Find(".status-ok").TextContent.ShouldContain("Tłumaczenie zapisano");
+        component.Find(".status-message.status-success").TextContent.ShouldContain("Tłumaczenie zapisano");
+    }
+
+    [Fact]
+    public async Task Save_WhenSaveFailsAndTheRowCannotBeReloaded_KeepsTheDraftInAResubmittableRecoveryForm()
+    {
+        // The SSR recovery guarantee: when the post's reload AND the PUT fail in the same request, the
+        // translator's typed text must come back in a resubmittable form (hidden key fields + textarea)
+        // instead of vanishing. First GET succeeds (the form renders), every later GET fails (the reload).
+        _client
+            .GetApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                ApiResult.Success(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canEdit: true)),
+                ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Nie znaleziono." }));
+        _client
+            .PutApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Zapis odrzucony." }));
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        await component.Find("form").SubmitAsync();
+        // The failed save keeps the draft in component state; the next lifecycle pass re-runs the load,
+        // which now fails — exactly the state a real SSR resubmit request lands in.
+        component.Render();
+
+        component.Find(".error-message").TextContent.ShouldContain("Zapis odrzucony.");
+        IElement recoveryForm = component.Find("form");
+        recoveryForm.QuerySelectorAll("input[type=hidden][name=FileIdField]").Length.ShouldBe(1);
+        recoveryForm.QuerySelectorAll("input[type=hidden][name=GossipIdField]").Length.ShouldBe(1);
+        recoveryForm.QuerySelectorAll("textarea[name=DraftField]").Length.ShouldBe(1);
+        recoveryForm.QuerySelector("button[type=submit]")!.TextContent.ShouldContain("Zapisz ponownie");
+        component.FindAll(".editor-grid").ShouldBeEmpty();
     }
 
     [Fact]
@@ -203,7 +233,7 @@ public sealed class EditorTests : BunitContext
 
         // Behaviour-visible proof the approve link href was followed: only a POST to that exact href is
         // stubbed to succeed, so the success confirmation renders iff the editor used it.
-        component.Find(".status-ok").TextContent.ShouldContain("Tłumaczenie zatwierdzono");
+        component.Find(".status-message.status-success").TextContent.ShouldContain("Tłumaczenie zatwierdzono");
     }
 
     private IRenderedComponent<EditorComponent> RenderEditor() =>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
@@ -116,7 +116,7 @@ public sealed class GameVersionsTests : BunitContext
 
         await component.Find("form").SubmitAsync();
 
-        component.Find(".status-down").TextContent.ShouldContain("Podaj wersję");
+        component.Find(".status-message.status-error").TextContent.ShouldContain("Podaj wersję");
         await _client.DidNotReceive().PostApiResultAsync<GameVersionResponse>(
             Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
         // A rejected register must not wipe the list (the reload still renders the table).
@@ -136,7 +136,7 @@ public sealed class GameVersionsTests : BunitContext
         await component.Find(".col-actions form").SubmitAsync();
 
         // Behaviour-visible proof the delete ran: the confirmation only renders when the loader succeeded.
-        component.Find(".status-ok").TextContent.ShouldContain("Usunięto");
+        component.Find(".status-message.status-success").TextContent.ShouldContain("Usunięto");
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public sealed class GameVersionsTests : BunitContext
 
         await component.Find(".col-actions form").SubmitAsync();
 
-        component.Find(".status-down").TextContent.ShouldContain("Nie można usunąć");
+        component.Find(".status-message.status-error").TextContent.ShouldContain("Nie można usunąć");
         // The refused delete must not wipe the list (the reload still renders the table).
         component.FindAll("table.data-table").ShouldNotBeEmpty();
     }
@@ -177,7 +177,7 @@ public sealed class GameVersionsTests : BunitContext
 
         IRenderedComponent<GameVersionsComponent> component = RenderPage();
 
-        component.Find(".status-down").TextContent.ShouldContain("Nie udało się wczytać wersji.");
+        component.Find(".error-message").TextContent.ShouldContain("Nie udało się wczytać wersji.");
         component.FindAll("#new-version").ShouldBeEmpty();
         component.FindAll("table.data-table").ShouldBeEmpty();
     }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportTests.cs
@@ -136,7 +136,7 @@ public sealed class ImportExportTests : BunitContext
         IRenderedComponent<ImportExportComponent> component = RenderPage();
 
         component.FindAll("input[type=file]").ShouldBeEmpty();
-        component.Find(".status-down").TextContent.ShouldContain("Nie udało się wczytać wersji.");
+        component.Find(".error-message").TextContent.ShouldContain("Nie udało się wczytać wersji.");
         component.Find("a[download]").GetAttribute("href").ShouldBe("/import-export/download");
     }
 


### PR DESCRIPTION
## Summary
- Lifts the TheKittySaver `layout.css` design system and re-themes it to the hobbit-gold palette anchored to the previous accent `#c8a45c` (≈ oklch hue 84).
- Hue map vs. the TKS original: accent mint 168 → gold 84 · neutral scaffolding 165 → warm 80 · warning → orange 60 · success decoupled from the accent → green 150 (approved ≠ accent) · danger 25 unchanged. Cat-only sections (photo slider, wizard, gallery, cookie bar) deliberately not ported.
- Restyles every Frontend page (Home, Dashboard, Translations, Editor, GameVersions, ImportExport, error pages) plus MainLayout/NavMenu to the new class vocabulary.
- Duplicates the tokens into the six AuthSystem account `.cshtml` pages (Login, Register, ConfirmEmail, ForgotPassword, ResetPassword, PrivacyPolicy) — they don't share the Frontend `wwwroot`.
- Updates Frontend unit tests to the new rendered markup.

## Verification
- `scripts/check-ssr-purity.sh` — clean
- `dotnet build LotroKoniecDev.slnx` — 0 warnings / 0 errors
- `dotnet test tests/LotroKoniecDev.Frontend.Tests.Unit` — 241/241 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)