### PR TITLE
Bug: Unconfirmed-account login guides the user to confirm e-mail, anti-enumeration preserved (#304)

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
@@ -10,6 +10,17 @@ namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
 internal sealed partial class LoginModel : PageModel
 {
     /// <summary>
+    /// Single source of truth for every credential-failure branch. Kept identical across
+    /// user-not-found, lockout, wrong-password and unconfirmed-email so no branch ever reveals
+    /// which check failed (anti-enumeration). The activation hint is generic — it neither confirms
+    /// the account exists nor that it is unconfirmed — yet still nudges a brand-new user to finish
+    /// registration.
+    /// </summary>
+    private const string GenericCredentialErrorMessage =
+        "Nieprawidłowa nazwa użytkownika lub hasło. Jeśli konto zostało dopiero co utworzone, " +
+        "dokończ rejestrację, potwierdzając swój adres e-mail — kliknij link aktywacyjny, który do Ciebie wysłaliśmy.";
+
+    /// <summary>
     /// Pre-computed hash for timing-equalization when user is not found.
     /// </summary>
     private static readonly string DummyPasswordHash =
@@ -62,7 +73,7 @@ internal sealed partial class LoginModel : PageModel
             _ = _userManager.PasswordHasher.VerifyHashedPassword(
                 new ApplicationUser(), DummyPasswordHash, Password);
             LogUserNotFound(_logger, Username, HttpContext.Connection.RemoteIpAddress);
-            ErrorMessage = "Nieprawidłowa nazwa użytkownika lub hasło.";
+            ErrorMessage = GenericCredentialErrorMessage;
             return Page();
         }
 
@@ -70,7 +81,7 @@ internal sealed partial class LoginModel : PageModel
         {
             LogAccountLockedOut(_logger, user.Id, HttpContext.Connection.RemoteIpAddress);
             // Use the same generic message to prevent account enumeration
-            ErrorMessage = "Nieprawidłowa nazwa użytkownika lub hasło.";
+            ErrorMessage = GenericCredentialErrorMessage;
             return Page();
         }
 
@@ -80,7 +91,7 @@ internal sealed partial class LoginModel : PageModel
         {
             await _userManager.AccessFailedAsync(user);
             LogWrongPassword(_logger, user.Id, HttpContext.Connection.RemoteIpAddress);
-            ErrorMessage = "Nieprawidłowa nazwa użytkownika lub hasło.";
+            ErrorMessage = GenericCredentialErrorMessage;
             return Page();
         }
 
@@ -91,7 +102,7 @@ internal sealed partial class LoginModel : PageModel
             // CheckPasswordAsync, which does not run PreSignInCheck. Enforce confirmation explicitly.
             // Same generic message as the other branches — never reveal that the account exists but is
             // unconfirmed — and placed after the password hash above so there is no timing oracle.
-            ErrorMessage = "Nieprawidłowa nazwa użytkownika lub hasło.";
+            ErrorMessage = GenericCredentialErrorMessage;
             return Page();
         }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
@@ -1,0 +1,140 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+public sealed partial class LoginPageTests : EndpointsTestBase
+{
+    public LoginPageTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public async Task LoginPage_ShouldGuideToConfirmEmail_WhenAccountIsUnconfirmed()
+    {
+        // Arrange — a registered account whose e-mail was never confirmed, with a valid password
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserUnconfirmedAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        // Act — the correct credentials, but the account is still unconfirmed
+        HttpResponseMessage response = await PostToLoginPageAsync(new Dictionary<string, string>
+        {
+            ["Username"] = request.Username,
+            ["Password"] = request.Password
+        });
+
+        // Assert — the message guides the user to activate, without ever stating the account exists but is unconfirmed
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Nieprawidłowa nazwa użytkownika lub hasło");
+        html.ShouldContain("aktywacyjny");
+    }
+
+    [Fact]
+    public async Task LoginPage_ShouldReturnIdenticalMessage_ForEveryCredentialFailure()
+    {
+        // Arrange — a confirmed account (wrong-password + lockout branches) and an unconfirmed one
+        (RegisterRequest confirmed, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+        (RegisterRequest unconfirmed, _) =
+            await UserFactory.RegisterRandomUserUnconfirmedAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+        (RegisterRequest lockedOut, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+        await LockOutAsync(lockedOut.Username);
+
+        // Act — one probe per credential-failure branch of /Account/Login
+        string nonExistentMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
+        {
+            ["Username"] = "nobody-" + Faker.Random.AlphaNumeric(8),
+            ["Password"] = "WhateverPass1!"
+        });
+        string wrongPasswordMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
+        {
+            ["Username"] = confirmed.Username,
+            ["Password"] = confirmed.Password + "WRONG"
+        });
+        string unconfirmedMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
+        {
+            ["Username"] = unconfirmed.Username,
+            ["Password"] = unconfirmed.Password
+        });
+        string lockedOutMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
+        {
+            ["Username"] = lockedOut.Username,
+            ["Password"] = lockedOut.Password // correct password — the lockout branch must still win
+        });
+
+        // Assert — no branch reveals which check failed: identical text is the anti-enumeration invariant
+        nonExistentMessage.ShouldNotBeNullOrWhiteSpace();
+        wrongPasswordMessage.ShouldBe(nonExistentMessage);
+        unconfirmedMessage.ShouldBe(nonExistentMessage);
+        lockedOutMessage.ShouldBe(nonExistentMessage);
+    }
+
+    private async Task LockOutAsync(string username)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        UserManager<ApplicationUser> userManager =
+            scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        ApplicationUser user = await userManager.FindByNameAsync(username)
+            ?? throw new InvalidOperationException($"Test user '{username}' was not found.");
+
+        await userManager.SetLockoutEnabledAsync(user, true);
+        await userManager.SetLockoutEndDateAsync(user, DateTimeOffset.UtcNow.AddMinutes(30));
+    }
+
+    private async Task<string> PostAndExtractRenderedAlertAsync(Dictionary<string, string> formFields)
+    {
+        HttpResponseMessage response = await PostToLoginPageAsync(formFields);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        Match match = AlertMessageRegex().Match(html);
+        match.Success.ShouldBeTrue("Expected the login page to render an error alert.");
+        return match.Groups[1].Value.Trim();
+    }
+
+    private async Task<HttpResponseMessage> PostToLoginPageAsync(Dictionary<string, string> formFields)
+    {
+        HttpResponseMessage pageResponse = await ApiClient.Http.GetAsync(
+            new Uri("/Account/Login", UriKind.Relative));
+        pageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await pageResponse.Content.ReadAsStringAsync();
+        string? antiForgeryToken = ExtractAntiForgeryToken(html);
+        if (antiForgeryToken is not null)
+        {
+            formFields["__RequestVerificationToken"] = antiForgeryToken;
+        }
+
+        using FormUrlEncodedContent content = new(formFields);
+        using HttpRequestMessage request = new(HttpMethod.Post, "/Account/Login");
+        request.Content = content;
+
+        if (pageResponse.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
+        {
+            foreach (string cookie in cookies)
+            {
+                request.Headers.Add("Cookie", cookie.Split(';')[0]);
+            }
+        }
+
+        return await ApiClient.Http.SendAsync(request);
+    }
+
+    private static string? ExtractAntiForgeryToken(string html)
+    {
+        Match match = AntiForgeryTokenRegex().Match(html);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [GeneratedRegex("""name="__RequestVerificationToken".*?value="([^"]+)""")]
+    private static partial Regex AntiForgeryTokenRegex();
+
+    [GeneratedRegex("""<span class="s">(.*?)</span>""", RegexOptions.Singleline)]
+    private static partial Regex AlertMessageRegex();
+}


### PR DESCRIPTION
Closes #304

## What
Logowanie niepotwierdzonego konta na serwerze Auth (`/Account/Login`) pokazywało samo
„Nieprawidłowa nazwa użytkownika lub hasło." — bez informacji, że konto wymaga tylko
aktywacji e-maila. Teraz kieruje użytkownika do dokończenia rejestracji.

## How — i dlaczego tak
Strona logowania **celowo** zwraca identyczny komunikat dla każdej porażki uwierzytelnienia
(brak użytkownika, lockout, złe hasło, niepotwierdzony e-mail), by uniknąć enumeracji kont i
timing oracle — to udokumentowana, wcześniejsza decyzja bezpieczeństwa. Zamiast ją **odwracać**
(ujawniać „to konto jest niepotwierdzone"), wspólny komunikat został wzbogacony o **generyczną**
wskazówkę aktywacji i wyciągnięty do jednej stałej `GenericCredentialErrorMessage` używanej
przez wszystkie cztery gałęzie. Efekt:

- niepotwierdzony użytkownik jest kierowany do aktywacji (Expected Result z ticketu),
- zero wycieku informacji: bajt-w-bajt identyczny tekst dla każdego stanu konta; kolejność
  (dummy hash dla brakującego usera, sprawdzenie potwierdzenia **po** haśle) niezmieniona →
  brak nowego wektora enumeracji/timing,
- jedno źródło prawdy czyni niezmiennik anti-enumeracji odpornym na refaktor.

## Testy
`LoginPageTests` (integracyjne, realny PostgreSQL):
- `LoginPage_ShouldGuideToConfirmEmail_WhenAccountIsUnconfirmed` — poprawne hasło +
  niepotwierdzony e-mail renderuje wskazówkę aktywacji.
- `LoginPage_ShouldReturnIdenticalMessage_ForEveryCredentialFailure` — cztery gałęzie
  (not-found, złe hasło, niepotwierdzony, **lockout**) renderują identyczny komunikat.

`dotnet build LotroKoniecDev.slnx` → 0 warningów. Suite `AuthSystem.API.Tests.Integration` → 188/188.
`code-reviewer`: **APPROVE**.

## Świadomie poza zakresem (follow-upy)
- Brak UI resendu aktywacji (endpoint `POST auth/resend-email-confirmation` istnieje, ale nic
  go nie wywołuje; user z wygasłym linkiem jest w ślepej uliczce) — osobny ticket.
- Pre-existing timing lockout (gałąź lockout pomija hash hasła) — osobny ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
