### PR TITLE
313 feature resend account activation e mail standalone anti enumeration page auth

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
@@ -636,6 +636,7 @@
                     </section>
 
                     <p class="auth-switch">Nie masz jeszcze konta? <a href="@registerUrl">Zarejestruj się →</a></p>
+                    <p class="auth-switch">Nie dostałeś linku aktywacyjnego? <a href="/Account/ResendConfirmation">Wyślij ponownie →</a></p>
 
                     <div class="auth-meta">
                         <svg viewBox="0 0 24 24" class="lock" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResendConfirmation.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResendConfirmation.cshtml
@@ -1,5 +1,5 @@
 @page
-@model LotroKoniecDev.AuthSystem.API.Pages.Account.ConfirmEmailModel
+@model LotroKoniecDev.AuthSystem.API.Pages.Account.ResendConfirmationModel
 @{
     Layout = null;
 }
@@ -9,7 +9,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Potwierdzenie e-maila — lotro-translator.pl</title>
+    <title>Wyślij link aktywacyjny ponownie — lotro-translator.pl</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
@@ -197,6 +197,47 @@
             line-height: 1.5;
         }
 
+        .auth-field { display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+        .auth-field label {
+            font-family: var(--font-mono);
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--text-mute);
+        }
+        .auth-input-wrap { position: relative; }
+        .auth-input-wrap > svg.leading {
+            position: absolute;
+            left: 14px; top: 50%;
+            transform: translateY(-50%);
+            color: var(--text-mute);
+            pointer-events: none;
+            width: 16px; height: 16px;
+        }
+        .auth-input {
+            width: 100%;
+            padding: 12px 14px 12px 42px;
+            background: var(--bg-2);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            color: var(--text);
+            font: inherit;
+            font-size: 14.5px;
+            transition: border-color .15s, box-shadow .15s, background .15s;
+        }
+        .auth-input::placeholder { color: var(--text-dim); }
+        .auth-input:hover:not(:disabled) { border-color: var(--border-hi); }
+        .auth-input:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px oklch(0.78 0.11 84 / 0.18);
+        }
+        .auth-field-help {
+            font-size: 12.5px;
+            color: var(--text-dim);
+            line-height: 1.5;
+        }
+
         .auth-alert {
             display: flex;
             align-items: flex-start;
@@ -255,6 +296,27 @@
 
         .auth-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 2px; }
 
+        .auth-panel-foot {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            padding: 15px 24px;
+            border-top: 1px solid var(--border);
+            background: var(--bg-2);
+            font-size: 13px;
+            color: var(--text-mute);
+        }
+        .auth-panel-foot a {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            color: var(--accent-hi);
+            font-weight: 600;
+        }
+        .auth-panel-foot a:hover { color: var(--accent); }
+        .auth-panel-foot a svg { width: 13px; height: 13px; }
+
         .auth-meta {
             margin-top: 16px;
             font-family: var(--font-mono);
@@ -300,36 +362,29 @@
 
         <div class="auth-main">
             <div class="auth-stack">
-                @if (Model.IsCompleted)
+                <p class="auth-eyebrow">Aktywacja konta</p>
+                @if (Model.IsSubmitted)
                 {
-                    <p class="auth-eyebrow">Dostęp do konta</p>
-                    <section class="auth-panel" aria-labelledby="confirm-h">
+                    <section class="auth-panel" aria-labelledby="resend-h">
                         <header class="auth-panel-head">
-                            <h2 id="confirm-h">
+                            <h2 id="resend-h">
                                 <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 8 9 6 9-6"/></svg></span>
-                                Potwierdzenie e-maila
+                                Link aktywacyjny
                             </h2>
-                            <span class="panel-aside">Krok 2/2</span>
+                            <span class="panel-aside">Wysłano</span>
                         </header>
                         <div class="auth-panel-body">
-                            <div class="auth-alert success" role="status" data-testid="confirm-email-success">
+                            <div class="auth-alert success" role="status" data-testid="resend-confirmation-success">
                                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
                                 <div>
-                                    <span class="t">Twój adres e-mail został potwierdzony — możesz się zalogować</span>
-                                    @if (!string.IsNullOrEmpty(Model.Email))
-                                    {
-                                        <span class="s">Dziękujemy! Konto <strong>@Model.Email</strong> jest aktywne. Od teraz możesz logować się i tłumaczyć LOTRO na polski.</span>
-                                    }
-                                    else
-                                    {
-                                        <span class="s">Dziękujemy! Twoje konto jest aktywne. Od teraz możesz logować się i tłumaczyć LOTRO na polski.</span>
-                                    }
+                                    <span class="t">Jeśli konto istnieje i wymaga aktywacji, wysłaliśmy nowy link na podany adres</span>
+                                    <span class="s">Sprawdź skrzynkę odbiorczą oraz folder Spam. Link aktywacyjny jest ważny 24 godziny i można go użyć tylko raz.</span>
                                 </div>
                             </div>
                             <div class="auth-actions">
-                                <a href="/Account/Login" class="btn btn-primary btn-block">
-                                    Zaloguj się
-                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m13 5 7 7-7 7"/></svg>
+                                <a href="/Account/Login" class="btn btn-ghost btn-block">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m11 19-7-7 7-7"/></svg>
+                                    Powrót do logowania
                                 </a>
                             </div>
                         </div>
@@ -337,34 +392,47 @@
                 }
                 else
                 {
-                    <p class="auth-eyebrow danger">Dostęp do konta</p>
-                    <section class="auth-panel" aria-labelledby="confirm-h">
+                    <section class="auth-panel" aria-labelledby="resend-h">
                         <header class="auth-panel-head">
-                            <h2 id="confirm-h">
+                            <h2 id="resend-h">
                                 <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 8 9 6 9-6"/></svg></span>
-                                Potwierdzenie e-maila
+                                Link aktywacyjny
                             </h2>
-                            <span class="panel-aside">Błąd</span>
+                            <span class="panel-aside">Publiczna</span>
                         </header>
-                        <div class="auth-panel-body">
-                            <div class="auth-alert" role="alert">
-                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.7 3h16.94a2 2 0 0 0 1.7-3L13.69 3.86a2 2 0 0 0-3.4 0z"/></svg>
-                                <div>
-                                    <span class="t">Link wygasł lub jest nieprawidłowy</span>
-                                    <span class="s">@(string.IsNullOrEmpty(Model.ErrorMessage) ? "Link potwierdzający jest ważny 24 godziny i można go użyć tylko raz. Wyślij nowy link aktywacyjny na swój adres e-mail." : Model.ErrorMessage)</span>
+                        <form class="auth-panel-body" method="post">
+                            @if (!ViewData.ModelState.IsValid)
+                            {
+                                <div class="auth-alert" role="alert">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.7 3h16.94a2 2 0 0 0 1.7-3L13.69 3.86a2 2 0 0 0-3.4 0z"/></svg>
+                                    <div>
+                                        <span class="t">Nie udało się wysłać linku</span>
+                                        <span class="s">@string.Join(" ", ViewData.ModelState.Values.SelectMany(v => v.Errors).Select(e => e.ErrorMessage))</span>
+                                    </div>
                                 </div>
+                            }
+                            <p class="auth-lead">Podaj adres e-mail powiązany z kontem — jeśli konto istnieje i nie zostało jeszcze aktywowane, wyślemy na nie nowy link aktywacyjny.</p>
+                            <div class="auth-field">
+                                <label asp-for="Email">Adres e-mail</label>
+                                <div class="auth-input-wrap">
+                                    <svg class="leading" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
+                                    <input asp-for="Email" type="email" class="auth-input" placeholder="@("ty@example.com")" autocomplete="email" required autofocus />
+                                </div>
+                                <p class="auth-field-help">Ze względów bezpieczeństwa nie ujawniamy, czy konto o podanym adresie istnieje ani czy zostało już aktywowane.</p>
                             </div>
                             <div class="auth-actions">
-                                <a href="/Account/ResendConfirmation" class="btn btn-primary btn-block">
-                                    Wyślij nowy link aktywacyjny
+                                <button type="submit" class="btn btn-primary btn-block">
+                                    Wyślij link aktywacyjny
                                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m13 5 7 7-7 7"/></svg>
-                                </a>
-                                <a href="/Account/Login" class="btn btn-ghost btn-block">
-                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m11 19-7-7 7-7"/></svg>
-                                    Powrót do logowania
-                                </a>
+                                </button>
                             </div>
-                        </div>
+                        </form>
+                        <footer class="auth-panel-foot">
+                            <span>Masz już aktywne konto?</span>
+                            <a href="/Account/Login">Wróć do logowania
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m13 5 7 7-7 7"/></svg>
+                            </a>
+                        </footer>
                     </section>
                 }
                 <p class="auth-meta"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg> Połączenie szyfrowane · TLS 1.3</p>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResendConfirmation.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResendConfirmation.cshtml.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.RateLimiting;
+using LotroKoniecDev.AuthSystem.API.Features.Auth;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
+
+[EnableRateLimiting("resend-confirmation-limit")]
+internal sealed class ResendConfirmationModel : PageModel
+{
+    private readonly ICommandHandler<ResendEmailConfirmation.Command, Result> _handler;
+
+    public ResendConfirmationModel(ICommandHandler<ResendEmailConfirmation.Command, Result> handler)
+    {
+        _handler = handler;
+    }
+
+    [BindProperty]
+    public string Email { get; set; } = string.Empty;
+
+    public bool IsSubmitted { get; set; }
+
+    public void OnGet()
+    {
+        IsSubmitted = false;
+    }
+
+    public async Task<IActionResult> OnPostAsync(CancellationToken cancellationToken)
+    {
+        // The handler owns the anti-enumeration logic (find user → dummy work when absent,
+        // no-op when already confirmed, generate token + send otherwise) and always succeeds
+        // for well-formed input, so account existence never leaks. Only a malformed address —
+        // which cannot map to any account — comes back as a failure worth surfacing.
+        Result result = await _handler.Handle(new ResendEmailConfirmation.Command(Email), cancellationToken);
+
+        if (result.IsFailure)
+        {
+            ModelState.AddModelError(string.Empty, "Podaj prawidłowy adres e-mail.");
+            return Page();
+        }
+
+        IsSubmitted = true;
+        return Page();
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResendConfirmationPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResendConfirmationPageTests.cs
@@ -1,0 +1,225 @@
+using System.Text.RegularExpressions;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.SharedKernel.Constants;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+public sealed partial class ResendConfirmationPageTests : EndpointsTestBase
+{
+    private const string SuccessMarker = "data-testid=\"resend-confirmation-success\"";
+
+    public ResendConfirmationPageTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public async Task ResendConfirmationPage_ShouldReturnOk_WhenAccessed()
+    {
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.GetAsync(
+            new Uri("/Account/ResendConfirmation", UriKind.Relative));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Link aktywacyjny");
+        html.ShouldContain("Adres e-mail");
+        html.ShouldContain("Wyślij link aktywacyjny");
+    }
+
+    [Fact]
+    public async Task LoginPage_ShouldOfferLinkToResendConfirmation()
+    {
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.GetAsync(
+            new Uri("/Account/Login", UriKind.Relative));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("/Account/ResendConfirmation");
+    }
+
+    [Fact]
+    public async Task ConfirmEmailPage_ShouldOfferLinkToResendConfirmation_WhenTokenIsInvalid()
+    {
+        // Act — a bare ConfirmEmail GET (no email/token) renders the expired/invalid panel
+        HttpResponseMessage response = await ApiClient.Http.GetAsync(
+            new Uri("/Account/ConfirmEmail", UriKind.Relative));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Link wygasł lub jest nieprawidłowy");
+        html.ShouldContain("/Account/ResendConfirmation");
+    }
+
+    [Fact]
+    public async Task ResendConfirmationPage_ShouldSendConfirmationEmail_WhenAccountIsUnconfirmed()
+    {
+        // Arrange
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserUnconfirmedAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        AccountConfirmationEmailSpy.Reset();
+
+        // Act
+        HttpResponseMessage response = await PostToResendConfirmationPageAsync(request.Email);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain(SuccessMarker);
+
+        AccountConfirmationEmailSpy.CallCount.ShouldBe(1);
+        AccountConfirmationEmailSpy.LastEmail.ShouldBe(request.Email);
+        AccountConfirmationEmailSpy.LastConfirmationToken.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ResendConfirmationPage_ShouldNotSendEmail_WhenAccountIsAlreadyConfirmed()
+    {
+        // Arrange
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        AccountConfirmationEmailSpy.Reset();
+
+        // Act
+        HttpResponseMessage response = await PostToResendConfirmationPageAsync(request.Email);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain(SuccessMarker);
+
+        AccountConfirmationEmailSpy.CallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ResendConfirmationPage_ShouldNotSendEmail_WhenEmailIsUnknown()
+    {
+        // Arrange
+        AccountConfirmationEmailSpy.Reset();
+
+        // Act
+        HttpResponseMessage response = await PostToResendConfirmationPageAsync("nobody@example.com");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain(SuccessMarker);
+
+        AccountConfirmationEmailSpy.CallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ResendConfirmationPage_ShouldRenderIdenticalConfirmation_ForUnknownConfirmedAndUnconfirmed()
+    {
+        // Arrange — one account per confirmation state, plus a never-registered address
+        (RegisterRequest unconfirmed, _) =
+            await UserFactory.RegisterRandomUserUnconfirmedAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+        (RegisterRequest confirmed, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+        string unknownEmail = Faker.Internet.Email();
+
+        // Act — the neutral confirmation each input produces
+        string unconfirmedHtml = await (await PostToResendConfirmationPageAsync(unconfirmed.Email)).Content.ReadAsStringAsync();
+        string confirmedHtml = await (await PostToResendConfirmationPageAsync(confirmed.Email)).Content.ReadAsStringAsync();
+        string unknownHtml = await (await PostToResendConfirmationPageAsync(unknownEmail)).Content.ReadAsStringAsync();
+
+        // Assert — anti-enumeration: the rendered confirmation must be byte-identical
+        unconfirmedHtml.ShouldContain(SuccessMarker);
+        confirmedHtml.ShouldBe(unconfirmedHtml);
+        unknownHtml.ShouldBe(unconfirmedHtml);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-an-email")]
+    [InlineData("missing-domain@")]
+    [InlineData("with spaces@example.com")]
+    public async Task ResendConfirmationPage_ShouldShowOpaqueError_AndNotSend_WhenEmailIsInvalid(string invalidEmail)
+    {
+        // Arrange
+        AccountConfirmationEmailSpy.Reset();
+
+        // Act
+        HttpResponseMessage response = await PostToResendConfirmationPageAsync(invalidEmail);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Podaj prawidłowy adres e-mail.");
+        html.ShouldNotContain(SuccessMarker);
+
+        AccountConfirmationEmailSpy.CallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ResendConfirmationPage_ShouldShowOpaqueError_AndNotSend_WhenEmailExceedsMaxLength()
+    {
+        // Arrange — one over EmailConstants.MaxLength, so the shared validator rejects it before any lookup
+        AccountConfirmationEmailSpy.Reset();
+        string overLongEmail = new string('a', EmailConstants.MaxLength) + "@example.com";
+
+        // Act
+        HttpResponseMessage response = await PostToResendConfirmationPageAsync(overLongEmail);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Podaj prawidłowy adres e-mail.");
+        html.ShouldNotContain(SuccessMarker);
+
+        AccountConfirmationEmailSpy.CallCount.ShouldBe(0);
+    }
+
+    private async Task<HttpResponseMessage> PostToResendConfirmationPageAsync(string email)
+    {
+        HttpResponseMessage pageResponse = await ApiClient.Http.GetAsync(
+            new Uri("/Account/ResendConfirmation", UriKind.Relative));
+        pageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await pageResponse.Content.ReadAsStringAsync();
+        Dictionary<string, string> formFields = new() { ["Email"] = email };
+
+        string? antiForgeryToken = ExtractAntiForgeryToken(html);
+        if (antiForgeryToken is not null)
+        {
+            formFields["__RequestVerificationToken"] = antiForgeryToken;
+        }
+
+        using FormUrlEncodedContent content = new(formFields);
+        using HttpRequestMessage request = new(HttpMethod.Post, "/Account/ResendConfirmation");
+        request.Content = content;
+
+        if (pageResponse.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
+        {
+            foreach (string cookie in cookies)
+            {
+                request.Headers.Add("Cookie", cookie.Split(';')[0]);
+            }
+        }
+
+        return await ApiClient.Http.SendAsync(request);
+    }
+
+    private static string? ExtractAntiForgeryToken(string html)
+    {
+        Match match = AntiForgeryTokenRegex().Match(html);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [GeneratedRegex("""name="__RequestVerificationToken".*?value="([^"]+)""")]
+    private static partial Regex AntiForgeryTokenRegex();
+}


### PR DESCRIPTION
- **Bug: Unconfirmed-account login guides the user to confirm e-mail, anti-enumeration preserved (#304) (#312)**
- **Auth: Resend account activation e-mail — standalone anti-enumeration page (#313)**
