### PR TITLE
PERF-08: Pool TMS DbContexts (AddDbContextPool)

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/PersistenceDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/PersistenceDependencyInjection.cs
@@ -26,7 +26,7 @@ public static class PersistenceDependencyInjection
             services.AddSingleton<IValidator<ConnectionStringSettings>, ConnectionStringSettingsValidator>();
             services.AddOptionsWithFluentValidation<ConnectionStringSettings>(ConnectionStringSettings.ConfigurationSection);
 
-            services.AddDbContext<ApplicationWriteDbContext>((sp, options) =>
+            services.AddDbContextPool<ApplicationWriteDbContext>((sp, options) =>
                 options.UseNpgsql(
                     sp.GetRequiredService<IOptions<ConnectionStringSettings>>().Value.TranslationDatabase,
                     npgsqlOptions =>
@@ -39,7 +39,7 @@ public static class PersistenceDependencyInjection
                         npgsqlOptions.MigrationsHistoryTable("__EFMigrationsHistory", DatabaseSchemas.Translation);
                     }));
 
-            services.AddDbContext<ApplicationReadDbContext>((sp, options) =>
+            services.AddDbContextPool<ApplicationReadDbContext>((sp, options) =>
                 options.UseNpgsql(
                         sp.GetRequiredService<IOptions<ConnectionStringSettings>>().Value.TranslationDatabase,
                         npgsqlOptions =>


### PR DESCRIPTION
## Summary
Swaps the two TMS DbContext registrations in `PersistenceDependencyInjection` from `AddDbContext` to `AddDbContextPool` (`ApplicationWriteDbContext` and `ApplicationReadDbContext`). The `(sp, options) =>` configuration lambdas are byte-identical — only the method name changed; default pool size.

Both contexts have **options-only constructors** (`DbContextOptions<T>`), inject no scoped services, and hold no mutable instance fields, so pooling is a drop-in that removes per-request context construction/DI overhead. The single service resolved in the lambda (`IOptions<ConnectionStringSettings>`) is a singleton, safe to resolve from the root provider that builds the pooled singleton options. Downstream scoped `IUnitOfWork`/`IApplicationReadDbContext` factories (and the background projector's `CreateAsyncScope`-per-operation) remain valid — `AddDbContextPool` still registers the context as scoped via a lease.

AuthSystem's `AuthDbContext` is intentionally left on `AddDbContext` (separate module, outside this ticket).

## Verification
- `dotnet build LotroKoniecDev.slnx`: **0 warnings, 0 errors**.
- Full PR-gated suite: **1276 passed / 0 failed / 0 skipped** — incl. `TranslationSystem.API.Tests.Integration` 161/161 (real Postgres; exercises pooling plus the test factory's `AddDbContext` interceptor-append composition) and `AuthSystem.API.Tests.Integration` 202/202.
- TMS real-process E2E (published container, production pooling DI): core-loop + update-cycle suites (which drive both pooled contexts through import/upsert/approve/download) **passed**. Two `AuthFlowE2ETests` assert `401` from `GET /api/v1/translations`, which is `.AllowAnonymous()` (#309); those are stale pre-existing assertions, off the PR gate by name, and unrelated to a DbContext-lifetime change (auth is decided before any handler touches a DbContext).
- `code-reviewer` agent: **APPROVE**, no findings.

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)