### PR TITLE
PERF-07: Cache translator provisioning lookup with HybridCache

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -67,6 +68,22 @@ internal static class ApiDependencyInjection
             // Cross-cutting clock shared by every command handler that stamps timestamps
             // (import diff, translation upsert, …) — registered once at the API root, not per feature.
             services.AddSingleton(TimeProvider.System);
+
+            // L1-only HybridCache (PERF-07): no IDistributedCache is registered, so it falls back to
+            // its in-memory store — the translator-provisioning lookup that runs on every authenticated
+            // request is process-local and tiny, and a distributed backend would add latency for no
+            // gain. Mirrors TheKittySaver's AuthSystem HybridCache setup; the short TTL is set here as
+            // the default and restated at the provisioning call site.
+            services.AddHybridCache(options =>
+            {
+                options.MaximumPayloadBytes = 1024 * 64;
+                options.MaximumKeyLength = 256;
+                options.DefaultEntryOptions = new HybridCacheEntryOptions
+                {
+                    Expiration = TimeSpan.FromMinutes(5),
+                    LocalCacheExpiration = TimeSpan.FromMinutes(5)
+                };
+            });
 
             services.AddImportFeature();
             services.AddProgressFeature();

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/Provisioning/TranslatorProvisioner.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/Provisioning/TranslatorProvisioner.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
 using LotroKoniecDev.SharedKernel.Enums;
 using LotroKoniecDev.SharedKernel.Monads;
@@ -9,6 +11,7 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Val
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
 
 namespace LotroKoniecDev.TranslationSystem.API.Auth.Provisioning;
 
@@ -17,24 +20,48 @@ namespace LotroKoniecDev.TranslationSystem.API.Auth.Provisioning;
 /// identity, refreshing the display name / email from the current claims on each touch. Idempotency
 /// is guaranteed by the unique index on <c>Translators.IdentityId</c> plus a get-then-create guard
 /// that, on a concurrent first-write race (unique-constraint violation), re-reads the committed row.
+///
+/// Because this runs on every authenticated request (ADR-0004 amendment 2026-06-24), the
+/// identity → (<see cref="TranslatorId"/> + claims fingerprint) resolution is cached in an L1-only
+/// <see cref="HybridCache"/> under a short TTL (PERF-07): a request whose identity-affecting claims
+/// are unchanged resolves from memory and never queries the <c>Translators</c> table. A fingerprint
+/// mismatch (the account was renamed / its e-mail changed) bypasses the cached value, refreshes the
+/// profile against the live row, and re-sets the entry; a resolution failure is never cached.
 /// </summary>
 internal sealed class TranslatorProvisioner : ITranslatorProvisioner
 {
+    private const string CacheKeyPrefix = "translator-provisioning:";
+
+    /// <summary>
+    /// Short TTL keyed by identity: within the window an authenticated request whose identity-affecting
+    /// claims are unchanged resolves entirely from L1 memory, skipping the <c>Translators</c> query.
+    /// Restated here at the call site (mirroring TheKittySaver's per-consumer entry-options pattern)
+    /// even though the DI default matches it, so the provisioning TTL is explicit where it is used.
+    /// </summary>
+    private static readonly HybridCacheEntryOptions ShortTtlEntryOptions = new()
+    {
+        Expiration = TimeSpan.FromMinutes(5),
+        LocalCacheExpiration = TimeSpan.FromMinutes(5)
+    };
+
     private readonly ICurrentUserAccessor _currentUserAccessor;
     private readonly ITranslatorRepository _translatorRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly TimeProvider _timeProvider;
+    private readonly HybridCache _hybridCache;
 
     public TranslatorProvisioner(
         ICurrentUserAccessor currentUserAccessor,
         ITranslatorRepository translatorRepository,
         IUnitOfWork unitOfWork,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        HybridCache hybridCache)
     {
         _currentUserAccessor = currentUserAccessor;
         _translatorRepository = translatorRepository;
         _unitOfWork = unitOfWork;
         _timeProvider = timeProvider;
+        _hybridCache = hybridCache;
     }
 
     public async ValueTask<Result<TranslatorId>> ProvisionCurrentAsync(CancellationToken cancellationToken)
@@ -52,6 +79,8 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
 
         // The display name is the 'name' claim, falling back to the 'email' claim — an authenticated
         // token always carries at least one; if neither is present the VO surfaces a validation error.
+        // Resolved (and validated) before the cache is touched so an unprovisionable token never lands
+        // an entry.
         Result<DisplayName> displayNameResult = DisplayName.Create(
             _currentUserAccessor.Username ?? _currentUserAccessor.Email ?? string.Empty);
         if (displayNameResult.IsFailure)
@@ -59,7 +88,86 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
             return Result.Failure<TranslatorId>(displayNameResult.Error);
         }
 
+        DisplayName displayName = displayNameResult.Value;
         Email? email = ResolveEmail();
+        string claimsFingerprint = ComputeClaimsFingerprint(displayName, email);
+        string cacheKey = CacheKeyPrefix + identityId.Value;
+
+        try
+        {
+            CachedProvisioning cached = await _hybridCache.GetOrCreateAsync(
+                cacheKey,
+                (self: this, identityId, displayName, email, claimsFingerprint),
+                static (state, ct) => state.self.ResolveAndCacheAsync(
+                    state.identityId, state.displayName, state.email, state.claimsFingerprint, ct),
+                ShortTtlEntryOptions,
+                cancellationToken: cancellationToken);
+
+            if (string.Equals(cached.ClaimsFingerprint, claimsFingerprint, StringComparison.Ordinal))
+            {
+                // Steady state: the cached entry already reflects the current claims, so the
+                // Translators table is not queried within the TTL.
+                return Result.Success(TranslatorId.FromValue(cached.TranslatorId));
+            }
+
+            // The claims changed since the entry was cached (a renamed account / changed e-mail):
+            // bypass the stale value, refresh the profile against the live row, then overwrite the
+            // entry so subsequent requests resume the fast path.
+            Result<TranslatorId> refreshed = await ResolveAsync(identityId, displayName, email, cancellationToken);
+            if (refreshed.IsFailure)
+            {
+                return refreshed;
+            }
+
+            await _hybridCache.SetAsync(
+                cacheKey,
+                new CachedProvisioning(refreshed.Value.Value, claimsFingerprint),
+                ShortTtlEntryOptions,
+                cancellationToken: cancellationToken);
+
+            return refreshed;
+        }
+        catch (TranslatorProvisioningFailedException exception)
+        {
+            // A resolution failure must never be cached: the factory rethrows it as this sentinel so
+            // HybridCache discards the entry and the next request retries against the live row.
+            return Result.Failure<TranslatorId>(exception.Error);
+        }
+    }
+
+    /// <summary>
+    /// Cache-miss factory: resolves the translator against the database and projects it into the cached
+    /// (<see cref="TranslatorId"/> + fingerprint) tuple. Throws <see cref="TranslatorProvisioningFailedException"/>
+    /// on a resolution failure so <see cref="HybridCache"/> discards the entry rather than caching a
+    /// failure. A <see cref="DbUpdateException"/> from the write path propagates unchanged.
+    /// </summary>
+    private async ValueTask<CachedProvisioning> ResolveAndCacheAsync(
+        IdentityId identityId,
+        DisplayName displayName,
+        Email? email,
+        string claimsFingerprint,
+        CancellationToken cancellationToken)
+    {
+        Result<TranslatorId> result = await ResolveAsync(identityId, displayName, email, cancellationToken);
+        if (result.IsFailure)
+        {
+            throw new TranslatorProvisioningFailedException(result.Error);
+        }
+
+        return new CachedProvisioning(result.Value.Value, claimsFingerprint);
+    }
+
+    /// <summary>
+    /// The authoritative database resolution: returns the existing translator's id (refreshing its
+    /// profile only when the claims actually changed) or creates a new row, re-reading the committed
+    /// row on a concurrent first-write race.
+    /// </summary>
+    private async ValueTask<Result<TranslatorId>> ResolveAsync(
+        IdentityId identityId,
+        DisplayName displayName,
+        Email? email,
+        CancellationToken cancellationToken)
+    {
         DateTimeOffset now = _timeProvider.GetUtcNow();
 
         Maybe<Translator> existing = await _translatorRepository.GetByIdentityIdAsync(identityId, cancellationToken);
@@ -67,22 +175,20 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
         {
             Translator translator = existing.Value;
 
-            // Steady state on the hot path: the row exists and the claims are unchanged, so there is
-            // nothing to write. Provisioning now runs on every authenticated request (ADR-0004
-            // amendment 2026-06-24), so it must be a pure read here — a write fires only when an
-            // account was actually renamed, never on a plain re-touch.
-            bool claimsChanged = !translator.DisplayName.Equals(displayNameResult.Value)
+            // A write fires only when an account was actually renamed / had its e-mail changed, never
+            // on a plain re-touch — this authoritative check backs the fast-path fingerprint gate.
+            bool claimsChanged = !translator.DisplayName.Equals(displayName)
                                  || !Equals(translator.Email, email);
             if (claimsChanged)
             {
-                translator.RefreshProfile(displayNameResult.Value, email);
+                translator.RefreshProfile(displayName, email);
                 await _unitOfWork.SaveChangesAsync(cancellationToken);
             }
 
             return Result.Success(translator.Id);
         }
 
-        Result<Translator> createResult = Translator.Create(identityId, displayNameResult.Value, email, now);
+        Result<Translator> createResult = Translator.Create(identityId, displayName, email, now);
         if (createResult.IsFailure)
         {
             return Result.Failure<TranslatorId>(createResult.Error);
@@ -109,7 +215,7 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
                 throw;
             }
 
-            raced.Value.RefreshProfile(displayNameResult.Value, email);
+            raced.Value.RefreshProfile(displayName, email);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
             return Result.Success(raced.Value.Id);
         }
@@ -131,4 +237,40 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
 
         return emailResult.IsSuccess ? emailResult.Value : null;
     }
+
+    /// <summary>
+    /// Hashes the exact claims that determine the provisioned profile — the resolved display name and
+    /// e-mail — into a stable fingerprint. A change flips the fingerprint, so the cached entry is
+    /// bypassed and the profile refreshed; matching the fingerprint provably means the profile is
+    /// unchanged, so the DB query is safely skipped. Roles are excluded: they never alter the
+    /// <c>Translator</c> row, so including them would only trigger needless cache misses. The unit
+    /// separator keeps ("ab", "c") distinct from ("a", "bc").
+    /// </summary>
+    private static string ComputeClaimsFingerprint(DisplayName displayName, Email? email)
+    {
+        string material = string.Concat(displayName.Value, "\u001f", email?.Value ?? string.Empty);
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(material));
+        return Convert.ToHexString(hash);
+    }
+}
+
+/// <summary>
+/// The cached projection of a provisioned translator: its stable id plus a fingerprint of the claims
+/// that produced it. Kept small and JSON-serializable for <see cref="HybridCache"/>.
+/// </summary>
+internal sealed record CachedProvisioning(Guid TranslatorId, string ClaimsFingerprint);
+
+/// <summary>
+/// Sentinel that bubbles a resolution <see cref="Error"/> out of the <see cref="HybridCache"/> factory
+/// so a failure is not cached as success — <c>HybridCache</c> discards the entry when the factory
+/// throws, so the next request retries the live resolution.
+/// </summary>
+internal sealed class TranslatorProvisioningFailedException : Exception
+{
+    public TranslatorProvisioningFailedException(Error error)
+    {
+        Error = error;
+    }
+
+    public Error Error { get; }
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/LotroKoniecDev.TranslationSystem.API.csproj
@@ -16,6 +16,7 @@
         <!-- Direct pin forces the patched Microsoft.OpenApi (advisory GHSA-v5pm-xwqc-g5wc) over the vulnerable
              2.0.0 pulled transitively by Microsoft.AspNetCore.OpenApi; version lives in Directory.Packages.props. -->
         <PackageReference Include="Microsoft.OpenApi" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
         <PackageReference Include="Scalar.AspNetCore" />
         <PackageReference Include="Serilog.AspNetCore" />
         <PackageReference Include="Serilog.Enrichers.Environment" />

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/TranslatorProvisionerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/TranslatorProvisionerTests.cs
@@ -8,6 +8,8 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Val
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
@@ -27,7 +29,20 @@ public sealed class TranslatorProvisionerTests
         => Translator.Create(Identity, DisplayName.Create(displayName).Value, email: null, Now).Value;
 
     private TranslatorProvisioner CreateProvisioner(StubCurrentUserAccessor accessor)
-        => new(accessor, _translatorRepository, _unitOfWork, new FixedTimeProvider(Now));
+        => CreateProvisioner(accessor, CreateHybridCache());
+
+    private TranslatorProvisioner CreateProvisioner(StubCurrentUserAccessor accessor, HybridCache hybridCache)
+        => new(accessor, _translatorRepository, _unitOfWork, new FixedTimeProvider(Now), hybridCache);
+
+    // A fresh in-memory (L1-only) HybridCache per provisioner keeps each test isolated. The default
+    // real implementation is a purely in-process memory store, so the unit test stays pure (no I/O).
+    private static HybridCache CreateHybridCache()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
 
     private static StubCurrentUserAccessor Accessor(
         ValueMaybe<IdentityId>? identity = null,
@@ -225,6 +240,94 @@ public sealed class TranslatorProvisionerTests
         // Act + Assert
         await Should.ThrowAsync<DbUpdateException>(
             async () => await provisioner.ProvisionCurrentAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ProvisionCurrentAsync_WhenCalledTwiceWithUnchangedClaims_ShouldQueryTranslatorsOnlyOnce()
+    {
+        // Arrange — the row already carries the current claims. The first call warms the cache; the
+        // second must resolve from L1 memory without touching the Translators table (PERF-07 steady
+        // state), the behaviour the acceptance criterion pins.
+        Translator existing = Translator.Create(
+            Identity,
+            DisplayName.Create("Aragorn").Value,
+            Email.Create("aragorn@gondor.test").Value,
+            Now).Value;
+        _translatorRepository.GetByIdentityIdAsync(Identity, Arg.Any<CancellationToken>())
+            .Returns(Maybe<Translator>.From(existing));
+        TranslatorProvisioner provisioner = CreateProvisioner(Accessor());
+
+        // Act
+        Result<TranslatorId> first = await provisioner.ProvisionCurrentAsync(CancellationToken.None);
+        Result<TranslatorId> second = await provisioner.ProvisionCurrentAsync(CancellationToken.None);
+
+        // Assert — both resolve the same id and the second call skipped the DB entirely: the Translators
+        // lookup ran exactly once across the two authenticated requests. Nothing observable in the
+        // returned id distinguishes a cache hit from a re-query, so the call count is the only proof.
+        first.IsSuccess.ShouldBeTrue();
+        second.IsSuccess.ShouldBeTrue();
+        second.Value.ShouldBe(first.Value);
+        await _translatorRepository.Received(1).GetByIdentityIdAsync(Identity, Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("Strider", "ranger@rivendell.test", "Aragorn", "ranger@rivendell.test")] // display name only
+    [InlineData("Aragorn", "before@gondor.test", "Aragorn", "after@gondor.test")]        // email only
+    [InlineData("Strider", "strider@rangers.test", "Aragorn", "aragorn@gondor.test")]    // both
+    public async Task ProvisionCurrentAsync_WhenAClaimChangesBetweenRequests_ShouldBypassCacheAndRefreshProfile(
+        string firstName, string firstEmail, string secondName, string secondEmail)
+    {
+        // Arrange — one identity, one process-wide cache, two requests. The existing row starts on the
+        // first request's exact claims (so that request only warms the cache), then a later request
+        // changes the display name, the email, or both. Two provisioners sharing a cache model two
+        // scoped requests over the singleton HybridCache; the existing row is returned on every lookup.
+        Translator existing = Translator.Create(
+            Identity,
+            DisplayName.Create(firstName).Value,
+            Email.Create(firstEmail).Value,
+            Now).Value;
+        _translatorRepository.GetByIdentityIdAsync(Identity, Arg.Any<CancellationToken>())
+            .Returns(Maybe<Translator>.From(existing));
+        HybridCache sharedCache = CreateHybridCache();
+        TranslatorProvisioner firstRequest =
+            CreateProvisioner(Accessor(username: firstName, email: firstEmail), sharedCache);
+        TranslatorProvisioner secondRequest =
+            CreateProvisioner(Accessor(username: secondName, email: secondEmail), sharedCache);
+
+        // Act — the first request warms the cache with the first fingerprint; the second presents a
+        // changed fingerprint, so the cached value is bypassed and the profile refreshed.
+        await firstRequest.ProvisionCurrentAsync(CancellationToken.None);
+        Result<TranslatorId> afterChange = await secondRequest.ProvisionCurrentAsync(CancellationToken.None);
+
+        // Assert — the profile converged on the latest claims (existing behaviour preserved). Had the
+        // stale entry been served the refresh would never have run, so the converged state is itself the
+        // proof the changed fingerprint bypassed the cache — whether the name, the email, or both moved.
+        afterChange.IsSuccess.ShouldBeTrue();
+        existing.DisplayName.Value.ShouldBe(secondName);
+        existing.Email.ShouldNotBeNull();
+        existing.Email.Value.ShouldBe(secondEmail);
+    }
+
+    [Fact]
+    public async Task ProvisionCurrentAsync_WhenFirstResolutionThrows_ShouldNotCacheAndRetryOnNextCall()
+    {
+        // Arrange — the first call fails with a non-race DB fault (no committed row to fall back on),
+        // so it throws and must cache nothing; the second call with identical claims must resolve live.
+        _translatorRepository.GetByIdentityIdAsync(Identity, Arg.Any<CancellationToken>())
+            .Returns(Maybe<Translator>.None);
+        _unitOfWork.SaveChangesAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => throw new DbUpdateException("transient failure"), _ => Task.FromResult(1));
+        TranslatorProvisioner provisioner = CreateProvisioner(Accessor());
+
+        // Act — the first call bubbles the fault; the second succeeds against the live row.
+        await Should.ThrowAsync<DbUpdateException>(
+            async () => await provisioner.ProvisionCurrentAsync(CancellationToken.None));
+        Result<TranslatorId> second = await provisioner.ProvisionCurrentAsync(CancellationToken.None);
+
+        // Assert — the failure was never cached: the second call re-ran the full resolution (a fresh
+        // insert attempt), proving no cached entry short-circuited it.
+        second.IsSuccess.ShouldBeTrue();
+        _translatorRepository.Received(2).Insert(Arg.Any<Translator>());
     }
 
     private sealed class FixedTimeProvider : TimeProvider


### PR DESCRIPTION
Closes #292

## PERF-07: Cache translator provisioning lookup with HybridCache

`TranslatorProvisioningMiddleware` runs on every authenticated request and, in steady state, paid a `Translators` query each time even though nothing needed writing. This caches the identity → translator resolution in an **L1-only HybridCache** (no Redis/distributed backend), mirroring TheKittySaver's HybridCache pattern.

### What changed
- **`AddHybridCache`** registered in `ApiDependencyInjection.AddApi()` — KittySaver-style options (L1-only, 64 KB max payload, 256 max key length, 5-minute default entry).
- **`TranslatorProvisioner`** now caches `identity → (TranslatorId + claims fingerprint)` under a ~5-minute TTL:
  - **Cache hit + matching fingerprint** → returns the cached `TranslatorId`, **no `Translators` query** (the steady-state win).
  - **Fingerprint mismatch** (renamed account / changed e-mail) → bypasses the cached value, runs the authoritative refresh against the live row, then re-sets the entry.
  - **Failures are never cached** — the cache-miss factory rethrows a `TranslatorProvisioningFailedException` sentinel so HybridCache discards the entry (mirrors KittySaver's `CurrentPersonAccessor` idiom); a `DbUpdateException` from the write path still propagates unchanged.
- The identity id is the stable cache key; the fingerprint is a SHA-256 over the resolved `DisplayName` + `Email` — exactly the claims the authoritative change-detection compares, so a matching fingerprint provably means "profile unchanged" and skipping the DB is always safe. The `TranslatorId` for an identity never changes on refresh, so even a stale entry only ever gates whether a refresh runs, never which id is returned.

### Assumption (noted per ticket ambiguity on which claims form the fingerprint)
The ticket lists "email/name/roles" as example fingerprint inputs. **Roles are intentionally excluded**: the `Translator` row carries only display name + e-mail (roles live purely in the JWT and drive authorization, never the provisioned profile), so folding roles into the fingerprint would only cause needless cache misses with no behavioral benefit. The defensible default here is the exact set of claims the provisioning outcome depends on.

### Acceptance criteria
- ✅ Steady-state authenticated request performs no `Translators` query within the TTL — unit test `ProvisionCurrentAsync_WhenCalledTwiceWithUnchangedClaims_ShouldQueryTranslatorsOnlyOnce` (one lookup across two calls).
- ✅ Claims change still refreshes the profile — unit `ProvisionCurrentAsync_WhenClaimsChangeBetweenRequests_ShouldBypassCacheAndRefreshProfile` + integration `RenamedAccount_ShouldRefreshDisplayNameOnNextWrite_StillOneRow`.
- ✅ Failures not cached — unit `ProvisionCurrentAsync_WhenFirstResolutionThrows_ShouldNotCacheAndRetryOnNextCall`.
- ✅ Zero warnings (`dotnet build LotroKoniecDev.slnx` → 0 warnings / 0 errors).

### Tests
- API unit suite: 160 passed (incl. 3 new cache tests + the 9 preserved provisioner tests, assertions untouched).
- API integration suite (real PostgreSQL via Testcontainers): 161 passed, incl. the 10-way `ConcurrentUpsert` first-write-race test (HybridCache stampede protection + the preserved DB-race re-read both converge on exactly one Translator).
