### PR TITLE
PERF-06: Bootstrap Polish seeder — replace per-line lookup N+1 with chunked loads

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Bootstrap/BootstrapSettings.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Bootstrap/BootstrapSettings.cs
@@ -26,4 +26,12 @@ internal sealed class BootstrapSettings
 
     /// <summary>Path to the production Polish translations merged onto the baseline as Approved.</summary>
     public string PolishTextPath { get; init; } = "translations/polish.txt";
+
+    /// <summary>
+    /// How many rows the Polish seed's apply pass mutates per chunk (load by id → provide + approve →
+    /// save → clear tracker), bounding the working set no matter how many rows the merge changes
+    /// (PERF-06, mirroring <c>ImportSettings.ApplyChunkSize</c>). Default sits in the same 2–5k band;
+    /// configurable mainly so tests can force chunk boundaries cheaply.
+    /// </summary>
+    public int SeedChunkSize { get; init; } = 5_000;
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Bootstrap/PolishTranslationSeeder.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Bootstrap/PolishTranslationSeeder.cs
@@ -3,14 +3,17 @@ using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Services;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Repositories;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace LotroKoniecDev.TranslationSystem.API.Features.Bootstrap;
 
@@ -20,6 +23,9 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.Bootstrap;
 /// and provides+approves the Polish content, stamping a well-known system principal. It is
 /// merge-only — a line with no baseline row is reported, never inserted — and idempotent: an
 /// already-approved identical row is left untouched, so re-running updates and never duplicates.
+/// The whole catalog is read once into an in-memory view and every line is decided from memory
+/// (PERF-06): only the rows that actually change are then reloaded as tracked aggregates in bounded
+/// id-chunks, so the round-trips scale with the changed set, not the file.
 /// </summary>
 internal sealed class PolishTranslationSeeder : IPolishTranslationSeeder
 {
@@ -41,6 +47,7 @@ internal sealed class PolishTranslationSeeder : IPolishTranslationSeeder
     private readonly ITranslatorRepository _translatorRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly TimeProvider _timeProvider;
+    private readonly BootstrapSettings _settings;
     private readonly ILogger<PolishTranslationSeeder> _logger;
 
     public PolishTranslationSeeder(
@@ -49,6 +56,7 @@ internal sealed class PolishTranslationSeeder : IPolishTranslationSeeder
         ITranslatorRepository translatorRepository,
         IUnitOfWork unitOfWork,
         TimeProvider timeProvider,
+        IOptions<BootstrapSettings> settings,
         ILogger<PolishTranslationSeeder> logger)
     {
         _parser = parser;
@@ -56,6 +64,7 @@ internal sealed class PolishTranslationSeeder : IPolishTranslationSeeder
         _translatorRepository = translatorRepository;
         _unitOfWork = unitOfWork;
         _timeProvider = timeProvider;
+        _settings = settings.Value;
         _logger = logger;
     }
 
@@ -83,10 +92,16 @@ internal sealed class PolishTranslationSeeder : IPolishTranslationSeeder
 
         TranslatorId systemTranslatorId = systemTranslatorResult.Value;
 
+        // One untracked pass over the whole catalog into an in-memory view keyed by fragment identity
+        // (PERF-06): every polish.txt line is then decided from memory, replacing the per-line
+        // GetByFragmentKeyAsync round-trip (tens of thousands during bootstrap).
+        Dictionary<FragmentKeyValue, StoredTranslationEntry> catalog = await LoadCatalogAsync(cancellationToken);
+
         int approved = 0;
         int alreadyApproved = 0;
         int skippedRemoved = 0;
         List<string> unmatched = [];
+        Dictionary<TranslationId, string> approvalsById = [];
 
         foreach (ParsedExportRow row in parsed.Rows)
         {
@@ -98,46 +113,45 @@ internal sealed class PolishTranslationSeeder : IPolishTranslationSeeder
             }
 
             FragmentKey key = keyResult.Value;
-            Maybe<Translation> existing = await _translationRepository.GetByFragmentKeyAsync(key, cancellationToken);
+            FragmentKeyValue keyValue = FragmentKeyValue.From(key);
 
             // Merge-only (#28): a line without a baseline row is reported, never inserted.
-            if (existing.HasNoValue)
+            if (!catalog.TryGetValue(keyValue, out StoredTranslationEntry entry))
             {
                 unmatched.Add(key.ToString());
                 continue;
             }
 
-            Translation translation = existing.Value;
-
             // A soft-removed row is out of the distributed set and cannot be approved; leave it be.
-            if (translation.IsRemoved)
+            if (entry.IsRemoved)
             {
                 skippedRemoved++;
                 continue;
             }
 
             // Idempotent re-run: an identical already-approved row needs no write.
-            if (translation.Status is TranslationStatus.Approved
-                && string.Equals(translation.TranslatedText, row.Content, StringComparison.Ordinal))
+            if (entry.Status is TranslationStatus.Approved
+                && string.Equals(entry.TranslatedText, row.Content, StringComparison.Ordinal))
             {
                 alreadyApproved++;
                 continue;
             }
 
-            // Any other matched state is (re)written to the seeded Polish and approved under the
-            // system principal. The bootstrap targets a fresh/empty DB (#28), so in practice this only
-            // ever fills Untranslated baseline rows — it does not race a live translator's draft.
-            translation.ProvideTranslation(row.Content, systemTranslatorId, now);
-            Result approveResult = translation.Approve(systemTranslatorId, now);
-            if (approveResult.IsFailure)
-            {
-                return Result.Failure<PolishSeedSummary>(approveResult.Error);
-            }
-
+            // Any other matched state is queued to be (re)written to the seeded Polish and approved
+            // under the system principal (the bootstrap targets a fresh/empty DB (#28), so in practice
+            // this only ever fills Untranslated baseline rows). The in-memory view is advanced so a
+            // later duplicate line for the same key sees this outcome — exactly as the old per-line
+            // loop saw its own tracked mutation — and the last write wins on the persisted row.
             approved++;
+            catalog[keyValue] = entry with { Status = TranslationStatus.Approved, TranslatedText = row.Content };
+            approvalsById[entry.Id] = row.Content;
         }
 
-        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        Result applyResult = await ApplyApprovalsInChunksAsync(approvalsById, systemTranslatorId, now, cancellationToken);
+        if (applyResult.IsFailure)
+        {
+            return Result.Failure<PolishSeedSummary>(applyResult.Error);
+        }
 
         PolishSeedSummary summary = new(approved, alreadyApproved, skippedRemoved, unmatched);
         _logger.LogInformation(
@@ -146,6 +160,72 @@ internal sealed class PolishTranslationSeeder : IPolishTranslationSeeder
             summary.Approved, summary.AlreadyApproved, summary.SkippedRemoved, summary.Unmatched.Count);
 
         return Result.Success(summary);
+    }
+
+    /// <summary>
+    /// Streams the whole catalog once into an in-memory view keyed by fragment identity (PERF-06),
+    /// the single read that replaces the old per-line lookup.
+    /// </summary>
+    private async Task<Dictionary<FragmentKeyValue, StoredTranslationEntry>> LoadCatalogAsync(CancellationToken cancellationToken)
+    {
+        Dictionary<FragmentKeyValue, StoredTranslationEntry> catalog = [];
+        await foreach (StoredTranslationEntry entry in _translationRepository.StreamCatalogEntriesAsync(cancellationToken))
+        {
+            catalog[entry.Key] = entry;
+        }
+
+        return catalog;
+    }
+
+    /// <summary>
+    /// Reloads only the rows the merge changes as tracked aggregates, in bounded id-chunks
+    /// (<see cref="BootstrapSettings.SeedChunkSize"/>), and mutates each through the domain methods
+    /// before saving and clearing the tracker per chunk — so the working set scales with the changed
+    /// set, not the catalog (PERF-06). Each chunk commits on its own; a mid-way failure leaves a
+    /// partial seed the idempotent re-run completes. Unlike the import's chunked apply
+    /// (<c>ExecuteInTransactionAsync</c>), this deliberately skips a wrapping transaction: the seed has
+    /// no bulk-<c>COPY</c> leg to enlist, runs once before the app serves traffic and is idempotent, so
+    /// per-chunk commits keep the <c>Approve</c>-failure path a clean <see cref="Result"/>
+    /// (no throw through a transaction seam) at no real atomicity cost.
+    /// </summary>
+    private async Task<Result> ApplyApprovalsInChunksAsync(
+        Dictionary<TranslationId, string> approvalsById,
+        TranslatorId systemTranslatorId,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        if (approvalsById.Count == 0)
+        {
+            return Result.Success();
+        }
+
+        List<TranslationId> ids = [.. approvalsById.Keys];
+        for (int offset = 0; offset < ids.Count; offset += _settings.SeedChunkSize)
+        {
+            int chunkSize = Math.Min(_settings.SeedChunkSize, ids.Count - offset);
+            List<TranslationId> chunk = new(chunkSize);
+            for (int index = 0; index < chunkSize; index++)
+            {
+                chunk.Add(ids[offset + index]);
+            }
+
+            IReadOnlyList<Translation> translations = await _translationRepository.GetByIdsAsync(chunk, cancellationToken);
+            foreach (Translation translation in translations)
+            {
+                string translatedText = approvalsById[translation.Id];
+                translation.ProvideTranslation(translatedText, systemTranslatorId, now);
+                Result approveResult = translation.Approve(systemTranslatorId, now);
+                if (approveResult.IsFailure)
+                {
+                    return approveResult;
+                }
+            }
+
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            _unitOfWork.ClearChangeTracker();
+        }
+
+        return Result.Success();
     }
 
     /// <summary>

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Repositories/ITranslationRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Repositories/ITranslationRepository.cs
@@ -19,6 +19,15 @@ public interface ITranslationRepository : IRepository<Translation, TranslationId
     IAsyncEnumerable<StoredSourceDigest> StreamSourceDigestsAsync(CancellationToken cancellationToken);
 
     /// <summary>
+    /// Streams the whole catalog as untracked <see cref="StoredTranslationEntry"/> value rows for the
+    /// bootstrap Polish seed (PERF-06): each row's identity, key, status, current Polish text and
+    /// removal flag, so the seed decides every <c>polish.txt</c> line from an in-memory view instead
+    /// of a per-line <see cref="GetByFragmentKeyAsync"/> round-trip. Bootstrap-only, roughly once per
+    /// fresh deployment.
+    /// </summary>
+    IAsyncEnumerable<StoredTranslationEntry> StreamCatalogEntriesAsync(CancellationToken cancellationToken);
+
+    /// <summary>
     /// Loads one chunk of tracked aggregates by id for the import's chunked apply (spec 0006) —
     /// callers keep chunks small (see <c>ImportSettings.ApplyChunkSize</c>) and clear the change
     /// tracker between chunks.

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/StoredTranslationEntry.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/StoredTranslationEntry.cs
@@ -1,0 +1,18 @@
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Services;
+
+/// <summary>
+/// One stored translation row compacted for the bootstrap Polish seed (PERF-06): its identity,
+/// fragment key and the three facts the merge decision needs — status, the current Polish text (for
+/// the idempotent already-approved check) and whether it is soft-removed — never a tracked aggregate.
+/// The seed streams the whole catalog into an in-memory view once and decides every <c>polish.txt</c>
+/// line from memory, replacing the per-line <c>GetByFragmentKeyAsync</c> round-trip.
+/// </summary>
+public readonly record struct StoredTranslationEntry(
+    TranslationId Id,
+    FragmentKeyValue Key,
+    TranslationStatus Status,
+    string? TranslatedText,
+    bool IsRemoved);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
@@ -35,6 +35,18 @@ internal sealed class TranslationRepository : GenericRepository<Translation, Tra
         FROM translation."Translations"
         """;
 
+    /// <summary>
+    /// The bootstrap-seed sibling of <see cref="SourceDigestQuery"/> (PERF-06): it drops the source
+    /// triple and reads the current Polish text instead, so the seed can decide the idempotent
+    /// already-approved case from memory. Same schema-drift caveat — the column list must track
+    /// <c>TranslationConfiguration</c>.
+    /// </summary>
+    private const string CatalogEntryQuery =
+        """
+        SELECT "Id", "FileId", "GossipId", "Status", "TranslatedText", "RemovedInVersion"
+        FROM translation."Translations"
+        """;
+
     public TranslationRepository(ApplicationWriteDbContext db) : base(db)
     {
     }
@@ -73,6 +85,37 @@ internal sealed class TranslationRepository : GenericRepository<Translation, Tra
                 SourceHash.Compute(text, argsOrder, argsId),
                 Enum.Parse<TranslationStatus>(reader.GetString(6)),
                 !reader.IsDBNull(7));
+        }
+    }
+
+    /// <summary>
+    /// The bootstrap-seed twin of <see cref="StreamSourceDigestsAsync"/> (PERF-06): same raw-Npgsql
+    /// streaming — buffered-reader retry would materialize the whole catalog and OOM the constrained
+    /// bootstrap container — reading the current Polish text and status the merge decides on rather
+    /// than the source hash. It forfeits retry for the same reason: it runs before any write, so a
+    /// transient fault just fails the one-time seed and the next start retries it (idempotent).
+    /// </summary>
+    public async IAsyncEnumerable<StoredTranslationEntry> StreamCatalogEntriesAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        NpgsqlConnection connection = (NpgsqlConnection)DbContext.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        await using NpgsqlCommand command = new(CatalogEntryQuery, connection);
+        command.CommandTimeout = (int)SourceDigestReadTimeout.TotalSeconds;
+
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            yield return new StoredTranslationEntry(
+                TranslationId.FromValue(reader.GetGuid(0)),
+                new FragmentKeyValue(reader.GetInt32(1), reader.GetInt64(2)),
+                Enum.Parse<TranslationStatus>(reader.GetString(3)),
+                reader.IsDBNull(4) ? null : reader.GetString(4),
+                !reader.IsDBNull(5));
         }
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Bootstrap/PolishTranslationSeederTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Bootstrap/PolishTranslationSeederTests.cs
@@ -4,11 +4,13 @@ using LotroKoniecDev.TranslationSystem.API.Features.Bootstrap;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Services;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Repositories;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -26,12 +28,18 @@ public sealed class PolishTranslationSeederTests
     private readonly ITranslatorRepository _translatorRepository = Substitute.For<ITranslatorRepository>();
     private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
 
+    // The baseline rows the seed sees: the catalog stream projects them, and GetByIdsAsync hands back
+    // the very same tracked instances the assertions inspect.
+    private readonly List<Translation> _baseline = [];
+
     private Translator? _insertedSystemTranslator;
 
     public PolishTranslationSeederTests()
     {
-        _translationRepository.GetByFragmentKeyAsync(Arg.Any<FragmentKey>(), Arg.Any<CancellationToken>())
-            .Returns(Maybe<Translation>.None);
+        _translationRepository.StreamCatalogEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => CatalogStream([.. _baseline]));
+        _translationRepository.GetByIdsAsync(Arg.Any<IReadOnlyList<TranslationId>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => ResolveByIds(callInfo.Arg<IReadOnlyList<TranslationId>>()));
 
         // No system translator yet — the seed provisions one; capture it to assert the stamped FK.
         _translatorRepository.GetByIdentityIdAsync(Arg.Any<SharedKernel.StronglyTypedIds.IdentityId>(), Arg.Any<CancellationToken>())
@@ -40,13 +48,14 @@ public sealed class PolishTranslationSeederTests
             .Do(callInfo => _insertedSystemTranslator = callInfo.Arg<Translator>());
     }
 
-    private PolishTranslationSeeder CreateSeeder()
+    private PolishTranslationSeeder CreateSeeder(int seedChunkSize = 5_000)
         => new(
             new TranslationExportParser(),
             _translationRepository,
             _translatorRepository,
             _unitOfWork,
             TimeProvider.System,
+            Microsoft.Extensions.Options.Options.Create(new BootstrapSettings { SeedChunkSize = seedChunkSize }),
             NullLogger<PolishTranslationSeeder>.Instance);
 
     private static Stream Seed(params string[] lines)
@@ -70,9 +79,26 @@ public sealed class PolishTranslationSeederTests
         return row;
     }
 
-    private void GivenBaseline(Translation row)
-        => _translationRepository.GetByFragmentKeyAsync(row.FragmentKey, Arg.Any<CancellationToken>())
-            .Returns(Maybe<Translation>.From(row));
+    // A polish.txt line resolves to a baseline row (the seed then approves it) — register the row so
+    // both the catalog projection and the chunked tracked-load see the same instance.
+    private void GivenBaseline(Translation row) => _baseline.Add(row);
+
+    private static async IAsyncEnumerable<StoredTranslationEntry> CatalogStream(params Translation[] rows)
+    {
+        await Task.Yield();
+        foreach (Translation row in rows)
+        {
+            yield return new StoredTranslationEntry(
+                row.Id,
+                FragmentKeyValue.From(row.FragmentKey),
+                row.Status,
+                row.TranslatedText,
+                row.IsRemoved);
+        }
+    }
+
+    private IReadOnlyList<Translation> ResolveByIds(IReadOnlyList<TranslationId> ids)
+        => _baseline.Where(row => ids.Contains(row.Id)).ToList();
 
     [Fact]
     public async Task SeedAsync_WhenLineMatchesBaselineRow_ShouldApproveWithSystemTranslatorAttribution()
@@ -208,5 +234,68 @@ public sealed class PolishTranslationSeederTests
         // Assert
         result.IsFailure.ShouldBeTrue();
         result.Error.Code.ShouldBe("Bootstrap.PolishSeedInvalidRow");
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenChangedRowsSpanMultipleChunks_ShouldReadCatalogOnceAndLoadTrackedRowsInIdChunks()
+    {
+        // Arrange — three baseline rows to approve; a chunk size of two forces two id-chunk loads.
+        Translation row1 = BaselineRow(1);
+        Translation row2 = BaselineRow(2);
+        Translation row3 = BaselineRow(3);
+        GivenBaseline(row1);
+        GivenBaseline(row2);
+        GivenBaseline(row3);
+
+        // Act
+        Result<PolishSeedSummary> result = await CreateSeeder(seedChunkSize: 2)
+            .SeedAsync(Seed(Line(1, "Jeden"), Line(2, "Dwa"), Line(3, "Trzy")), CancellationToken.None);
+
+        // Assert — all three approved, the catalog is read exactly once, and the tracked rows arrive in
+        // two id-chunks (ceil(3/2)) rather than one round-trip per line (PERF-06).
+        result.Value.Approved.ShouldBe(3);
+        row1.Status.ShouldBe(TranslationStatus.Approved);
+        row2.Status.ShouldBe(TranslationStatus.Approved);
+        row3.Status.ShouldBe(TranslationStatus.Approved);
+        _translationRepository.Received(1).StreamCatalogEntriesAsync(Arg.Any<CancellationToken>());
+        await _translationRepository.Received(2).GetByIdsAsync(Arg.Any<IReadOnlyList<TranslationId>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenDuplicateKeyWithDifferentContent_ShouldApproveEachLineAndPersistTheLastWrite()
+    {
+        // Arrange — one baseline row; the file repeats its key with two different translations. The
+        // in-memory view is advanced per line, so the second line sees the first as already Approved.
+        Translation row = BaselineRow(1);
+        GivenBaseline(row);
+
+        // Act
+        Result<PolishSeedSummary> result = await CreateSeeder()
+            .SeedAsync(Seed(Line(1, "Pierwsza"), Line(1, "Druga")), CancellationToken.None);
+
+        // Assert — each line counts as an approval (as the old per-line loop did) and the last write wins.
+        result.Value.Approved.ShouldBe(2);
+        result.Value.AlreadyApproved.ShouldBe(0);
+        row.TranslatedText.ShouldBe("Druga");
+        row.Status.ShouldBe(TranslationStatus.Approved);
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenDuplicateKeyWithIdenticalContent_ShouldApproveOnceAndCountTheRepeatAsAlreadyApproved()
+    {
+        // Arrange — one baseline row; the file repeats its key with the same translation twice.
+        Translation row = BaselineRow(1);
+        GivenBaseline(row);
+
+        // Act
+        Result<PolishSeedSummary> result = await CreateSeeder()
+            .SeedAsync(Seed(Line(1, "Ta sama"), Line(1, "Ta sama")), CancellationToken.None);
+
+        // Assert — the first line approves, the second sees that in-memory approval and is skipped as
+        // idempotent (matching the old loop, whose second lookup returned the just-approved row).
+        result.Value.Approved.ShouldBe(1);
+        result.Value.AlreadyApproved.ShouldBe(1);
+        row.TranslatedText.ShouldBe("Ta sama");
+        row.Status.ShouldBe(TranslationStatus.Approved);
     }
 }


### PR DESCRIPTION
Closes #291

## What
`PolishTranslationSeeder` ran one `GetByFragmentKeyAsync` per `polish.txt` line — tens of thousands of round-trips during bootstrap (which blocks app start). This replaces the N+1 with:

1. **One untracked catalog projection** (`id, key, status, translated text, removed flag`) streamed into an in-memory dictionary keyed by fragment identity.
2. **Per-line decision in memory** — merge-only / idempotent / skip-removed semantics unchanged.
3. **Chunked tracked loads**: only the rows that actually change are reloaded as tracked aggregates via the existing `GetByIdsAsync`, in bounded id-chunks (`BootstrapSettings.SeedChunkSize`, default 5000), mutated via `ProvideTranslation`/`Approve`, saved + tracker-cleared per chunk.

Round-trips drop from **O(lines)** to **O(changed/chunk)**.

## Mirrors the Import feature
The new `ITranslationRepository.StreamCatalogEntriesAsync` is the bootstrap-seed twin of `StreamSourceDigestsAsync` (same raw-Npgsql streaming so buffered-reader retry can't OOM the constrained container), and the chunked apply mirrors `ApplyByIdsInChunksAsync`. `SeedChunkSize` mirrors `ImportSettings.ApplyChunkSize`.

## Behavior preservation
Summary counts are byte-identical to the old per-line loop for every branch — unmatched (never inserted), skip-removed, idempotent already-approved, re-approve on content change, **and duplicate keys within one file** (the in-memory view is advanced per line, so last-write-wins on the persisted row and the approved/already-approved counters match the old tracked-entity loop). Verified by hand-trace + tests.

Deliberate tradeoff (documented in code): the seed commits per chunk without a wrapping transaction — unlike Import it has no bulk-COPY leg, runs once before the app serves traffic, and is idempotent, so a partial seed is completed by the next start, and the `Approve`-failure path stays a clean `Result` rather than throwing through a transaction seam.

## Tests
- Existing bootstrap **unit** (`PolishTranslationSeederTests`) and **integration** (`BootstrapSeedTests`) assertions untouched — identical counts.
- Added: catalog-read-once + chunked-load-count assertion (proves the O(changed/chunk) round-trips), and duplicate-key coverage (differing vs identical content).

## Verification
- `dotnet build LotroKoniecDev.slnx`: **0 warnings**, 0 errors
- Seeder unit: 11/11 · Bootstrap integration: 2/2 · Full API unit: 158→160 · Domain: 145/145 · Import integration: 24/24 (shared `TranslationRepository` change is safe)
- `code-reviewer` agent: reviewed; its one blocking finding (untested duplicate-key branch) is addressed by the added tests.

## Files
- `Features/Bootstrap/PolishTranslationSeeder.cs` (the refactor)
- `Features/Bootstrap/BootstrapSettings.cs` (`SeedChunkSize`)
- `Domain/.../Services/StoredTranslationEntry.cs` (new projection)
- `Domain/.../Repositories/ITranslationRepository.cs` + `Persistence/.../TranslationRepository.cs` (`StreamCatalogEntriesAsync`)
- `tests/.../Bootstrap/PolishTranslationSeederTests.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)