### PR TITLE
fix: serve a 503 login-unavailable page instead of a raw 500 when auth-api is down (#311)

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/LoginUnavailable.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/LoginUnavailable.razor
@@ -1,0 +1,24 @@
+@page "/auth/login-unavailable"
+@layout MainLayout
+@attribute [AllowAnonymous]
+@using Microsoft.AspNetCore.Authorization
+
+<PageTitle>Logowanie niedostępne — lotro-translator.pl</PageTitle>
+
+<div class="status-stage">
+    <div class="status-card status-warning">
+        <div class="status-glyph" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/>
+                <polyline points="10 17 15 12 10 7"/>
+                <line x1="15" y1="12" x2="3" y2="12"/>
+            </svg>
+        </div>
+        <div class="status-code">503</div>
+        <h1>Logowanie chwilowo niedostępne</h1>
+        <p class="status-desc">Nie możemy teraz połączyć się z usługą logowania. Spróbuj ponownie za chwilę.</p>
+        <div class="status-actions">
+            <a href="/" class="btn btn-primary">Wróć na stronę główną</a>
+        </div>
+    </div>
+</div>

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthEndpointsExtensions.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace LotroKoniecDev.Frontend.Infrastructure.Auth;
 
@@ -15,19 +17,19 @@ internal static class AuthEndpointsExtensions
     private const string EndSessionPath = "connect/logout";
     private const string IdTokenName = "id_token";
 
+    private static readonly Action<ILogger, Exception?> LogOidcAuthorityUnreachable =
+        LoggerMessage.Define(
+            LogLevel.Warning,
+            new EventId(1, nameof(LogOidcAuthorityUnreachable)),
+            "OIDC authority unreachable during login challenge; serving the login-unavailable page.");
+
     extension(IEndpointRouteBuilder endpoints)
     {
         public IEndpointRouteBuilder MapAuthEndpoints()
         {
             endpoints.MapGet(
                 AuthenticationDependencyInjectionExtensions.LoginPath,
-                (HttpContext context, string? returnUrl) =>
-                {
-                    string redirectUri = IsLocalUrl(returnUrl) ? returnUrl! : "/";
-                    return Results.Challenge(
-                        new AuthenticationProperties { RedirectUri = redirectUri },
-                        [OpenIdConnectDefaults.AuthenticationScheme]);
-                });
+                LoginAsync);
 
             endpoints.MapPost(
                 AuthenticationDependencyInjectionExtensions.LogoutPath,
@@ -35,6 +37,46 @@ internal static class AuthEndpointsExtensions
 
             return endpoints;
         }
+    }
+
+    /// <summary>
+    /// The login route's request delegate, exposed internally so it can be unit-tested without a web
+    /// host. The OIDC challenge builds its redirect from the authority's discovery document, which the
+    /// handler fetches lazily — when the auth server is unreachable that fetch throws deep inside
+    /// <c>HandleChallenge</c> and would surface as a raw 500. Warming the discovery cache here first
+    /// (the same <see cref="IConfigurationManager{T}"/> the handler uses) turns an outage into an honest
+    /// "login temporarily unavailable" (503) page; the challenge below then reuses the now-cached
+    /// document and 302s to the authority exactly as before when auth is up.
+    /// </summary>
+    internal static async Task<IResult> LoginAsync(
+        HttpContext context,
+        string? returnUrl,
+        IOptionsMonitor<OpenIdConnectOptions> openIdConnectOptionsMonitor,
+        ILoggerFactory loggerFactory)
+    {
+        string redirectUri = IsLocalUrl(returnUrl) ? returnUrl! : "/";
+
+        IConfigurationManager<OpenIdConnectConfiguration>? configurationManager = openIdConnectOptionsMonitor
+            .Get(OpenIdConnectDefaults.AuthenticationScheme)
+            .ConfigurationManager;
+
+        if (configurationManager is not null)
+        {
+            try
+            {
+                await configurationManager.GetConfigurationAsync(context.RequestAborted);
+            }
+            catch (Exception exception)
+            {
+                ILogger logger = loggerFactory.CreateLogger(typeof(AuthEndpointsExtensions).FullName!);
+                LogOidcAuthorityUnreachable(logger, exception);
+                return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+            }
+        }
+
+        return Results.Challenge(
+            new AuthenticationProperties { RedirectUri = redirectUri },
+            [OpenIdConnectDefaults.AuthenticationScheme]);
     }
 
     private static async Task<IResult> LogoutAsync(

--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -162,6 +162,7 @@ try
             StatusCodes.Status400BadRequest => "/bad-request",
             StatusCodes.Status401Unauthorized or StatusCodes.Status403Forbidden => "/auth/access-denied",
             StatusCodes.Status404NotFound => "/not-found",
+            StatusCodes.Status503ServiceUnavailable => "/auth/login-unavailable",
             _ => "/Error"
         },
         createScopeForStatusCodePages: true);

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/AuthEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/AuthEndpointsExtensionsTests.cs
@@ -1,0 +1,116 @@
+using LotroKoniecDev.Frontend.Infrastructure.Auth;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using NSubstitute;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Auth;
+
+/// <summary>
+/// Drives the login route's request delegate directly (no web host): when the OIDC authority is
+/// reachable it must produce the OIDC challenge (302), but when the discovery fetch fails — the auth
+/// server is down — it must warm-fail into a 503 so the status-code pages serve the friendly
+/// "login unavailable" page instead of letting the challenge bubble a raw 500 (#311).
+/// </summary>
+public sealed class AuthEndpointsExtensionsTests
+{
+    public static TheoryData<Exception> AuthorityUnreachableFailures() => new()
+    {
+        new InvalidOperationException("IDX20803: Unable to obtain configuration from the authority."),
+        new HttpRequestException("Connection refused."),
+        new TaskCanceledException("The discovery request timed out."),
+    };
+
+    [Theory]
+    [MemberData(nameof(AuthorityUnreachableFailures))]
+    public async Task LoginAsync_WhenDiscoveryFetchFails_ReturnsServiceUnavailableInsteadOfRaw500(
+        Exception discoveryFailure)
+    {
+        IConfigurationManager<OpenIdConnectConfiguration> configurationManager =
+            Substitute.For<IConfigurationManager<OpenIdConnectConfiguration>>();
+        configurationManager.GetConfigurationAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<OpenIdConnectConfiguration>(discoveryFailure));
+
+        IResult result = await AuthEndpointsExtensions.LoginAsync(
+            new DefaultHttpContext(),
+            "/dashboard",
+            CreateOptionsMonitor(configurationManager),
+            NullLoggerFactory.Instance);
+
+        StatusCodeHttpResult statusResult = result.ShouldBeOfType<StatusCodeHttpResult>();
+        statusResult.StatusCode.ShouldBe(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task LoginAsync_WhenAuthorityReachable_ReturnsTheOidcChallenge()
+    {
+        IResult result = await AuthEndpointsExtensions.LoginAsync(
+            new DefaultHttpContext(),
+            "/dashboard",
+            CreateOptionsMonitor(CreateReachableConfigurationManager()),
+            NullLoggerFactory.Instance);
+
+        ChallengeHttpResult challenge = result.ShouldBeOfType<ChallengeHttpResult>();
+        challenge.AuthenticationSchemes.ShouldHaveSingleItem()
+            .ShouldBe(OpenIdConnectDefaults.AuthenticationScheme);
+    }
+
+    [Theory]
+    [InlineData("/dashboard", "/dashboard")]
+    [InlineData("/translations?status=NeedsReview", "/translations?status=NeedsReview")]
+    [InlineData("https://evil.example.com/harvest", "/")]
+    [InlineData("//evil.example.com", "/")]
+    [InlineData("/\\evil.example.com", "/")]
+    [InlineData("", "/")]
+    [InlineData(null, "/")]
+    public async Task LoginAsync_WhenAuthorityReachable_SanitizesReturnUrlToALocalRedirect(
+        string? returnUrl, string expectedRedirectUri)
+    {
+        IResult result = await AuthEndpointsExtensions.LoginAsync(
+            new DefaultHttpContext(),
+            returnUrl,
+            CreateOptionsMonitor(CreateReachableConfigurationManager()),
+            NullLoggerFactory.Instance);
+
+        ChallengeHttpResult challenge = result.ShouldBeOfType<ChallengeHttpResult>();
+        challenge.Properties.ShouldNotBeNull();
+        challenge.Properties!.RedirectUri.ShouldBe(expectedRedirectUri);
+    }
+
+    [Fact]
+    public async Task LoginAsync_WhenNoConfigurationManager_StillReturnsTheOidcChallenge()
+    {
+        // Once the OIDC handler post-configures, ConfigurationManager is always set; the null-guard
+        // mirrors CookieTokenRefresher so a missing manager can never turn a login into a false 503.
+        IResult result = await AuthEndpointsExtensions.LoginAsync(
+            new DefaultHttpContext(),
+            "/dashboard",
+            CreateOptionsMonitor(configurationManager: null),
+            NullLoggerFactory.Instance);
+
+        result.ShouldBeOfType<ChallengeHttpResult>();
+    }
+
+    private static IOptionsMonitor<OpenIdConnectOptions> CreateOptionsMonitor(
+        IConfigurationManager<OpenIdConnectConfiguration>? configurationManager)
+    {
+        IOptionsMonitor<OpenIdConnectOptions> optionsMonitor =
+            Substitute.For<IOptionsMonitor<OpenIdConnectOptions>>();
+        optionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme)
+            .Returns(new OpenIdConnectOptions { ConfigurationManager = configurationManager });
+        return optionsMonitor;
+    }
+
+    private static IConfigurationManager<OpenIdConnectConfiguration> CreateReachableConfigurationManager()
+    {
+        IConfigurationManager<OpenIdConnectConfiguration> configurationManager =
+            Substitute.For<IConfigurationManager<OpenIdConnectConfiguration>>();
+        configurationManager.GetConfigurationAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new OpenIdConnectConfiguration()));
+        return configurationManager;
+    }
+}


### PR DESCRIPTION
Closes #311

## Problem
An anonymous request to any `[Authorize]` page routes through the `/auth/login` endpoint, which issues an OIDC challenge. The challenge lazily fetches the authority's discovery document, and when **auth-api is down** that fetch threw uncaught deep inside the OIDC handler — surfacing as a raw **HTTP 500**. With auth-api up, the same request correctly 302s to `/connect/authorize`.

## Fix
`/auth/login` is the single choke point for every anonymous OIDC challenge (the `RedirectToLogin` component and the cookie `LoginPath` both funnel here). `LoginAsync` now **warms the shared OIDC `ConfigurationManager`** before challenging — the same manager the handler uses, guarded for null like `CookieTokenRefresher`:

- **auth-api down** → the warm-up throws, we log a warning and return **503**, which the existing `UseStatusCodePagesByStatusCode` middleware re-executes to a new dedicated, anonymous **"Logowanie chwilowo niedostępne"** page (mirrors the existing `AccessDenied`/`NotFound`/`BadRequest` pages).
- **auth-api up** → the challenge reuses the now-cached discovery document and **302s exactly as before** (no extra network round-trip in steady state).

Moving the single throwing call (`GetConfigurationAsync`) out of the un-catchable handler internals into a try/catch we own is what fixes it in every environment (Development included — the 503 is returned before any exception reaches the pipeline).

## Acceptance criteria
- [x] Anonymous hit on an `[Authorize]` page with auth-api unreachable renders a friendly error page (no raw 500) — now a 503 "login temporarily unavailable" page.
- [x] Behavior with auth-api up is unchanged (302 challenge).

## Verification
- `dotnet build LotroKoniecDev.slnx` → 0 warnings, 0 errors.
- `dotnet test tests/LotroKoniecDev.Frontend.Tests.Unit` → 279 passed (12 new: 503-on-failure across 3 failure shapes, unchanged challenge, a 7-row return-url open-redirect sanitization matrix, and the null-`ConfigurationManager` guard).
- Runtime smoke: ran the Frontend host with no auth-api → `GET /auth/login` returned **HTTP 503** with the friendly page; logs show the warning + re-execution of `/auth/login-unavailable`.
- `code-reviewer`: APPROVE. Security review: no findings (the user-controlled `returnUrl` stays constrained by the existing local-URL guard, now test-covered; discovery fetch is driven by trusted config; the new page/log paths expose no secrets or PII).

🤖 Generated with [Claude Code](https://claude.com/claude-code)