### PR TITLE
fix: Post-Redirect-Get for the translation editor save and approve (#321)

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
@@ -1,5 +1,6 @@
 @page "/editor/{Id:guid}"
 @attribute [Authorize]
+@using System.Globalization
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Mvc
 @using LotroKoniecDev.Frontend.Components.Pages.Translations
@@ -10,6 +11,7 @@
 @using LotroKoniecDev.TranslationSystem.Contracts.Translations
 @using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate
 @inject TranslationEditorLoader Loader
+@inject NavigationManager Navigation
 
 <PageTitle>Edytor tłumaczenia — lotro-translator.pl</PageTitle>
 
@@ -99,13 +101,15 @@
             </span>
         </div>
 
+        @* A success flag lingers in the URL from its redirect; suppress the stale flash when the OTHER
+           action just failed on this render, so a fresh error is never sat next to a stale confirmation. *@
         @if (_saveProblem is not null)
         {
             <div class="status-message status-error" role="alert">
                 <p>@(_saveProblem.Title ?? "Nie udało się zapisać tłumaczenia.")</p>
             </div>
         }
-        else if (_saved)
+        else if (Saved && _approveProblem is null)
         {
             <div class="status-message status-success" role="status">
                 <p>Tłumaczenie zapisano.</p>
@@ -118,7 +122,7 @@
                 <p>@(_approveProblem.Title ?? "Nie udało się zatwierdzić tłumaczenia.")</p>
             </div>
         }
-        else if (_approved)
+        else if (Approved && _saveProblem is null)
         {
             <div class="status-message status-success" role="status">
                 <p>Tłumaczenie zatwierdzono i dołączono do dystrybucji.</p>
@@ -217,13 +221,23 @@
     [SupplyParameterFromForm(FormName = "save-translation")]
     private long GossipIdField { get; set; }
 
+    /// <summary>
+    /// Post-Redirect-Get success flags carried in the query string by the redirect target, so the save /
+    /// approve confirmation survives the redirect without any per-user server state — the page stays
+    /// SSR-pure (#321). They linger on a manual reload of the same URL, which is a deliberate,
+    /// harmless trade-off against the heavier one-shot-cookie flash.
+    /// </summary>
+    [SupplyParameterFromQuery]
+    private bool Saved { get; set; }
+
+    [SupplyParameterFromQuery]
+    private bool Approved { get; set; }
+
     private TranslationDetailResponse? _detail;
     private ProblemDetails? _loadProblem;
     private ProblemDetails? _saveProblem;
     private ProblemDetails? _approveProblem;
     private string? _draftText;
-    private bool _saved;
-    private bool _approved;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -242,7 +256,6 @@
 
     private async Task SaveAsync()
     {
-        _saved = false;
         _saveProblem = null;
         _draftText = DraftField ?? string.Empty;
 
@@ -256,19 +269,19 @@
 
         if (result.IsSuccess)
         {
-            _detail = result.Value;
-            _draftText = null;
-            _saved = true;
+            // Post-Redirect-Get (#321): redirect to the row's GET view so a browser reload becomes a safe
+            // GET (no "resubmit the post?" prompt) and the fresh load re-derives the server's HATEOAS
+            // links — the approve button appears on a just-saved row with no manual refresh. On failure we
+            // deliberately do NOT redirect, so the typed draft and the error stay on screen for recovery.
+            Navigation.NavigateTo(EditorUriWithFlag("saved"));
+            return;
         }
-        else
-        {
-            _saveProblem = result.ProblemDetails;
-        }
+
+        _saveProblem = result.ProblemDetails;
     }
 
     private async Task ApproveAsync()
     {
-        _approved = false;
         _approveProblem = null;
 
         // Link-driven: the API emits the approve rel only for a reviewer on a Draft/NeedsReview row, so
@@ -282,19 +295,23 @@
         ApiResult result = await Loader.ApproveAsync(approveLink.Href, CancellationToken.None);
         if (result.IsSuccess)
         {
-            _approved = true;
+            // Post-Redirect-Get (#321): the redirect's GET reloads the row, so the status badge and the
+            // now-withdrawn approve affordance reflect the approved state — replaces the inline reload and
+            // makes a browser refresh safe.
+            Navigation.NavigateTo(EditorUriWithFlag("approved"));
+            return;
+        }
 
-            ApiResult<TranslationDetailResponse> reload = await Loader.LoadAsync(TranslationId.FromValue(Id), CancellationToken.None);
-            if (reload.IsSuccess)
-            {
-                _detail = reload.Value;
-            }
-        }
-        else
-        {
-            _approveProblem = result.ProblemDetails;
-        }
+        _approveProblem = result.ProblemDetails;
     }
+
+    /// <summary>
+    /// The Post-Redirect-Get target: this row's own GET view carrying a one-shot success flag. Redirecting
+    /// after a successful post turns a browser reload into a safe GET and re-runs the load, so the server's
+    /// fresh HATEOAS links render without a manual refresh — all with no per-user server state (#321).
+    /// </summary>
+    private string EditorUriWithFlag(string successFlag) =>
+        string.Create(CultureInfo.InvariantCulture, $"/editor/{Id}?{successFlag}=true");
 
     private static RenderFragment RenderHighlighted(string text) => builder =>
     {

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
@@ -8,6 +8,7 @@ using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using EditorComponent = LotroKoniecDev.Frontend.Components.Pages.Editor.Editor;
@@ -19,8 +20,9 @@ namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Editor;
 /// locking down the render wiring the pure <see cref="PlaceholderAnalyzer"/> tests cannot reach: that
 /// every <c>&lt;--DO_NOT_TOUCH!--&gt;</c> marker in the English source is wrapped in a highlight span,
 /// and that a placeholder-count mismatch between source and the persisted Polish surfaces the advisory
-/// warning (the M3-04 placeholder validation feature). The authenticated-but-non-approver state keeps
-/// the assertions on the highlighting path.
+/// warning (the M3-04 placeholder validation feature). Also covers the Post-Redirect-Get flow (#321):
+/// a successful save / approve redirects to the row's GET view with a one-shot success flag, while a
+/// failed save stays put so the typed draft survives.
 /// </summary>
 public sealed class EditorTests : BunitContext
 {
@@ -174,20 +176,100 @@ public sealed class EditorTests : BunitContext
     }
 
     [Fact]
-    public async Task Save_WhenSubmitted_FollowsTheUpsertLinkHrefAndConfirms()
+    public async Task Save_WhenSucceeds_RedirectsToTheRowWithASavedFlagFollowingTheUpsertLinkHref()
     {
+        // Post-Redirect-Get (#321): a successful save redirects to the row's GET view so a browser reload
+        // is a safe GET and the fresh load re-derives the approve affordance — no inline render after post.
+        Guid id = Guid.NewGuid();
         StubLoad(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canEdit: true));
         _client
             .PutApiResultAsync<TranslationDetailResponse>(SaveHref, Arg.Any<object>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult.Success(BuildDetail("Hello.", "Cześć.", canEdit: true)));
-        IRenderedComponent<EditorComponent> component = RenderEditor();
+        BunitNavigationManager navigation = Navigation();
+        IRenderedComponent<EditorComponent> component = RenderEditor(id);
 
         // The fixture carries the upsert rel but not the approve rel, so the save form is the only form.
         await component.Find("form").SubmitAsync();
 
         // Behaviour-visible proof the upsert href (read from the loaded detail's links) was followed:
-        // only a PUT to that exact href is stubbed to succeed, so the confirmation renders iff it was used.
+        // only a PUT to that exact href is stubbed to succeed, so the redirect happens iff it was used.
+        navigation.Uri.ShouldEndWith($"/editor/{id}?saved=true");
+    }
+
+    [Fact]
+    public void Render_WhenSavedFlagIsInTheQuery_ShowsTheSaveConfirmation()
+    {
+        // The GET side of PRG: the just-saved row is loaded fresh and the one-shot query flag surfaces the
+        // "saved" confirmation, so the translator still gets positive feedback after the redirect.
+        Guid id = Guid.NewGuid();
+        StubLoad(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canEdit: true));
+        Navigation().NavigateTo($"/editor/{id}?saved=true");
+
+        IRenderedComponent<EditorComponent> component = RenderEditor(id);
+
         component.Find(".status-message.status-success").TextContent.ShouldContain("Tłumaczenie zapisano");
+    }
+
+    [Fact]
+    public async Task Save_WhenSaveFails_DoesNotRedirectAndShowsTheErrorInline()
+    {
+        // On a rejected save there is deliberately NO redirect, so the error (and the still-mounted save
+        // form the translator can resubmit) stays on screen instead of being lost to a PRG round-trip.
+        // The resubmittable-draft structure itself is pinned by the recovery test below.
+        Guid id = Guid.NewGuid();
+        StubLoad(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canEdit: true));
+        _client
+            .PutApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Zapis odrzucony." }));
+        BunitNavigationManager navigation = Navigation();
+        string uriBeforeSubmit = navigation.Uri;
+        IRenderedComponent<EditorComponent> component = RenderEditor(id);
+
+        await component.Find("form").SubmitAsync();
+
+        navigation.Uri.ShouldBe(uriBeforeSubmit);
+        component.Find(".status-message.status-error").TextContent.ShouldContain("Zapis odrzucony.");
+        component.FindAll("textarea#translated").Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Approve_WhenApproveFails_DoesNotRedirectAndShowsTheErrorInline()
+    {
+        // Symmetric to the save-failure path: a rejected approve (API 403 / 409 / 422 / …) must not
+        // redirect, so the reviewer sees the error in place rather than being bounced to a "success" GET.
+        Guid id = Guid.NewGuid();
+        StubLoad(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canApprove: true));
+        _client
+            .PostApiResultAsync(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure(new() { Title = "Zatwierdzenie odrzucone." }));
+        BunitNavigationManager navigation = Navigation();
+        string uriBeforeSubmit = navigation.Uri;
+        IRenderedComponent<EditorComponent> component = RenderEditor(id);
+
+        await component.Find(".editor-approve").SubmitAsync();
+
+        navigation.Uri.ShouldBe(uriBeforeSubmit);
+        component.Find(".status-message.status-error").TextContent.ShouldContain("Zatwierdzenie odrzucone.");
+    }
+
+    [Fact]
+    public async Task Approve_WhenFailsWhileASavedFlagLingers_SuppressesTheStaleSaveBannerAndShowsTheError()
+    {
+        // The lingering-flag guard: the `?saved=true` from an earlier save redirect is still in the URL, so
+        // a failed approve on that page must show ONLY its own error — never the stale "saved" confirmation
+        // next to it.
+        Guid id = Guid.NewGuid();
+        StubLoad(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canApprove: true));
+        _client
+            .PostApiResultAsync(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure(new() { Title = "Zatwierdzenie odrzucone." }));
+        Navigation().NavigateTo($"/editor/{id}?saved=true");
+        IRenderedComponent<EditorComponent> component = RenderEditor(id);
+
+        await component.Find(".editor-approve").SubmitAsync();
+
+        component.Find(".status-message.status-error").TextContent.ShouldContain("Zatwierdzenie odrzucone.");
+        component.Markup.ShouldNotContain("Tłumaczenie zapisano");
     }
 
     [Fact]
@@ -221,23 +303,45 @@ public sealed class EditorTests : BunitContext
     }
 
     [Fact]
-    public async Task Approve_WhenSubmitted_FollowsTheApproveLinkHrefAndConfirms()
+    public async Task Approve_WhenSucceeds_RedirectsToTheRowWithAnApprovedFlagFollowingTheApproveLinkHref()
     {
+        // Post-Redirect-Get (#321): a successful approve redirects to the row's GET view, replacing the
+        // old inline reload and making a browser refresh safe.
+        Guid id = Guid.NewGuid();
         StubLoad(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canApprove: true));
         _client
             .PostApiResultAsync(ApproveHref, Arg.Any<object>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult.Success());
-        IRenderedComponent<EditorComponent> component = RenderEditor();
+        BunitNavigationManager navigation = Navigation();
+        IRenderedComponent<EditorComponent> component = RenderEditor(id);
 
         await component.Find(".editor-approve").SubmitAsync();
 
         // Behaviour-visible proof the approve link href was followed: only a POST to that exact href is
-        // stubbed to succeed, so the success confirmation renders iff the editor used it.
+        // stubbed to succeed, so the redirect happens iff the editor used it.
+        navigation.Uri.ShouldEndWith($"/editor/{id}?approved=true");
+    }
+
+    [Fact]
+    public void Render_WhenApprovedFlagIsInTheQuery_ShowsTheApproveConfirmation()
+    {
+        Guid id = Guid.NewGuid();
+        StubLoad(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canApprove: true));
+        Navigation().NavigateTo($"/editor/{id}?approved=true");
+
+        IRenderedComponent<EditorComponent> component = RenderEditor(id);
+
         component.Find(".status-message.status-success").TextContent.ShouldContain("Tłumaczenie zatwierdzono");
     }
 
+    private BunitNavigationManager Navigation() =>
+        (BunitNavigationManager)Services.GetRequiredService<NavigationManager>();
+
     private IRenderedComponent<EditorComponent> RenderEditor() =>
-        Render<EditorComponent>(parameters => parameters.Add(component => component.Id, Guid.NewGuid()));
+        RenderEditor(Guid.NewGuid());
+
+    private IRenderedComponent<EditorComponent> RenderEditor(Guid id) =>
+        Render<EditorComponent>(parameters => parameters.Add(component => component.Id, id));
 
     private void StubLoad(TranslationDetailResponse detail)
     {


### PR DESCRIPTION
Closes #321

## Problem
On the Blazor SSR translation editor (`/editor/{id}`), after an admin adds (upserts) a translation the page rendered inline right after the POST. Two weird UX results:
1. Reloading the page re-submitted the form — the browser "do you want to repeat the POST?" prompt.
2. The **approve** button only appeared after a manual reload.

## Root cause
- No **Post-Redirect-Get**: `SaveAsync`/`ApproveAsync` rendered the result of the POST directly, so the last navigation stayed a POST → unsafe reload.
- The API's `UpsertTranslation` endpoint returns the bare projection with **no HATEOAS links**, unlike `GetTranslation`, which enriches role/status-aware links (including `approve`). So `_detail = result.Value` after a save had no approve link — the button stayed hidden until a fresh GET re-derived the links.

## Fix
Post-Redirect-Get. On a successful save/approve, redirect to the row's own GET view (`/editor/{id}?saved=true` / `?approved=true`):
- Reload becomes a **safe GET** (no resubmit prompt).
- The GET **re-derives the server's fresh links**, so the approve button shows on a just-saved row with **no manual refresh** (the redirect reproduces the exact GET a manual reload already did).
- The success confirmation survives the redirect via **one-shot `[SupplyParameterFromQuery]` flags** — no per-user server state, so the page stays **static SSR** (SSR-purity guard passes).
- A **failed** save/approve deliberately does **not** redirect, so the typed draft and the error stay on screen (the existing recovery guarantee holds). Lingering success flags are suppressed when the other action failed on the same render.

The redirect target is always a same-origin relative path with a `Guid`-typed route id, so there's no open-redirect surface, and the "never trust a client-submitted upsert href" logic is unchanged.

## How each acceptance criterion is met
- **Safe reload after add** → PRG redirect makes the last navigation a GET.
- **Approve button appears without manual reload** → the redirect's GET re-derives the `approve` link.
- **Success confirmation preserved** → one-shot query flags render the "saved"/"approved" banner after the redirect.
- **Failed save keeps the draft** → failure path does not redirect (unchanged recovery form).

## Tests
`EditorTests` (bUnit): redirect targets for save/approve success, query-flag confirmation banners, no-redirect + inline error on save **and** approve failure, and the lingering-flag suppression guard. Full Frontend unit suite **284/0**, solution build **0 warnings**, SSR-purity guard green. `code-reviewer` verdict: **APPROVE**.