### PR TITLE
fix: equalize login lockout branch timing to close the account-state oracle (#314)

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
@@ -21,7 +21,9 @@ internal sealed partial class LoginModel : PageModel
         "dokończ rejestrację, potwierdzając swój adres e-mail — kliknij link aktywacyjny, który do Ciebie wysłaliśmy.";
 
     /// <summary>
-    /// Pre-computed hash for timing-equalization when user is not found.
+    /// Pre-computed hash for timing-equalization on the credential-failure branches that would
+    /// otherwise skip password hashing — user-not-found and lockout — so their latency matches the
+    /// wrong-password branch and no branch is distinguishable by response time.
     /// </summary>
     private static readonly string DummyPasswordHash =
         new PasswordHasher<ApplicationUser>().HashPassword(new ApplicationUser(), "DummyP@ssw0rd!");
@@ -79,6 +81,10 @@ internal sealed partial class LoginModel : PageModel
 
         if (await _userManager.IsLockedOutAsync(user))
         {
+            // Perform a dummy password hash so the lockout branch's latency matches the not-found
+            // branch — otherwise this early return skips hashing and leaks the locked-out state via timing.
+            _ = _userManager.PasswordHasher.VerifyHashedPassword(
+                new ApplicationUser(), DummyPasswordHash, Password);
             LogAccountLockedOut(_logger, user.Id, HttpContext.Connection.RemoteIpAddress);
             // Use the same generic message to prevent account enumeration
             ErrorMessage = GenericCredentialErrorMessage;


### PR DESCRIPTION
Closes #314

## Problem
The login lockout branch returned early without ever hashing a password. The wrong-password and not-found branches do hash, so a locked-out account was distinguishable purely by response latency — a timing oracle that leaks account state and undermines the anti-enumeration design.

## Fix
Run a dummy `PasswordHasher.VerifyHashedPassword` on the lockout branch (reusing the existing `DummyPasswordHash`), so its latency matches the other credential-failure branches. No observable output changes — same generic message, same status code.

## Verification
- Zero-warning solution build.
- `LoginPageTests` (real PostgreSQL) 2/2 green, including `LoginPage_ShouldReturnIdenticalMessage_ForEveryCredentialFailure`, which probes the lockout branch — the anti-enumeration invariant still holds.
- Security review of the diff: no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
