### PR TITLE
feat: bulk approve translations from the list for admins (#322)

### DIFF
--- a/docs/specs/0007-bulk-approve-from-translations-list.md
+++ b/docs/specs/0007-bulk-approve-from-translations-list.md
@@ -1,0 +1,154 @@
+# Spec 0007: Bulk approve from the translations list (admin)
+
+- **Status:** Agreed
+- **Date:** 2026-07-04
+- **Author:** koniecdev
+- **Ticket:** #322 (Feature: Bulk approve for admin)
+- **Related:** Spec 0001 (approve = publish, §review), #101/M2-12 (single `ApproveTranslation`
+  slice), #158/spec 0002 (HATEOAS-driven affordances), #321 (Post-Redirect-Get on the editor),
+  ADR-0021/PERF-04 (debounced artifact rebuild), `Features/Translations/ApproveTranslation.cs`
+  (sibling slice), `Components/Pages/GameVersions/` (admin SSR page pattern)
+
+## Business context
+
+Approving is a per-row reviewer action today: an admin opens the side-by-side editor and clicks
+**Zatwierdź** on one translation (#101). After a game update invalidates a batch of rows, or when a
+translator submits many drafts, the reviewer has to open and approve each row one at a time. The
+translations list (`/translations`) already shows the whole catalog with status filters (e.g.
+`NeedsReview`), so it is the natural place to approve several rows at once. #322 asks for checkboxes
+on the list so an admin can select rows and approve them in one action.
+
+## Goal
+
+An admin can select several rows on the translations list with checkboxes and approve them all in a
+single action, instead of opening each row in the editor.
+
+## In scope
+
+- **New backend slice** `Features/Translations/BulkApproveTranslations.cs`:
+  `POST /api/v1/translations/approve` (admin-only) — body `{ ids: [guid, …] }`, returns a summary
+  `{ requested, approved, skipped }`. Best-effort: approve every requested row that is currently
+  approvable, skip the rest, save once, schedule **one** artifact rebuild.
+- **New collection HATEOAS rel** `bulk-approve`, emitted on the translation list's collection
+  `Links` **only for admins** (mirrors GameVersions' collection `register` rel); the FE reads the
+  POST href from it.
+- **Translations list UI** (`Components/Pages/Translations/Translations.razor`, Static SSR): an
+  admin-only checkbox column, a checkbox per **approvable** row (a row that advertises the per-item
+  `approve` rel), and a "Zatwierdź zaznaczone" submit button that POSTs the selected ids through the
+  typed client, then Post-Redirect-Gets back to the list (filters preserved) with an `approved`
+  count flash.
+- `TranslationListLoader.BulkApproveAsync(href, ids)` (thin client seam).
+- `BulkApproveTranslationsRequest` / `BulkApproveTranslationsResponse` in `Contracts`.
+- Tests: handler unit (validation + best-effort matrix + save/rebuild), endpoint integration (real
+  PostgreSQL), loader test, bUnit render/gating + submit/redirect tests.
+
+## Out of scope
+
+- **Select-all / approve-all-filtered across pages** — a "select all on page" toggle needs client
+  JS, which Static SSR forbids; "approve every `NeedsReview` in the whole filter" is a different,
+  more powerful feature (a server-side set operation, not checkboxes). The ticket asks for
+  checkboxes → per-page manual selection only. Revisit as its own ticket if needed.
+- **Bulk of any other transition** (bulk edit, bulk delete) — the ticket names approve.
+- **Cross-page selection persistence** — each page render is a fresh GET; checking rows then
+  paginating clears the selection (standard SSR behavior).
+
+## Business rules & edge cases
+
+- **Admin-only**, exactly like single approve (`RequireAdminRole`). A translator or anonymous caller
+  gets no `bulk-approve` collection rel and no per-row `approve` rels → no checkbox column, no button.
+- **Approvable row = the existing per-item `approve` affordance:** a non-removed row in `Draft` or
+  `NeedsReview` (the link factory already emits `approve` for exactly these — §`TranslationAggregateLinkFactory`).
+  The FE renders a checkbox **only** on rows carrying that rel, so the admin can only select
+  genuinely approvable rows — no local role/status recompute.
+- **Best-effort, not all-or-nothing.** The selection is a snapshot; between list render and submit a
+  row can change (someone else approved it, an import invalidated/removed it). The handler approves
+  every requested row that is *still* approvable and **silently skips** the rest — a single stale row
+  must never block the whole batch. Rationale: the FE only offers approvable rows, so the happy path
+  approves all; skips absorb the race. Consistent with idempotent approve + errors-as-values.
+- **What counts as skipped:** an id not found; a row in `Untranslated`/`Approved` (not offered by the
+  FE, but tolerated on a stale submit — an already-`Approved` row is a no-op, we do **not** re-stamp
+  its approver); a `Draft`/`NeedsReview` row whose `Approve` still fails its domain guard (e.g. a
+  draft that was soft-removed) — the domain guard stays authoritative.
+- **Ids are de-duplicated** before the DB lookup; `requested` is the distinct count, and
+  `approved + skipped == requested` always holds.
+- **One transaction, one rebuild.** All approvals are stamped and saved in a single
+  `SaveChangesAsync`; the debounced rebuild (PERF-04/ADR-0021) is scheduled **once**, and **only when
+  at least one row was approved** (nothing published ⇒ no rebuild). The schedule follows the commit
+  (ADR-0021 §1), like the single slice.
+- **Reviewer provisioning** is the same first-touch lazy provision as single approve (ADR-0004):
+  provision the current identity **once** before the loop; a provisioning failure fails the whole
+  request (403) — the batch cannot be attributed to an empty approver.
+- **Batch cap = 100**, matching the list's max `pageSize` (a single page is the most a checkbox
+  selection can carry). Over the cap ⇒ validation failure (400). Empty ids ⇒ validation failure (400).
+- **PRG after submit (#321):** on success the page redirects to the list with the current filters
+  preserved plus `?approved=<count>`, so a browser reload is a safe GET and the list re-derives fresh
+  links (just-approved rows lose their checkbox). `approved=0` (everything was skipped) shows a
+  "nothing approved" note rather than a success flash.
+- **Failed POST** (transport / 4xx) → no redirect; surface the `ProblemDetails` on the list, keep it
+  intact (mirrors GameVersions' action-error banner).
+
+## Contract
+
+- **Endpoint:** `POST /api/v1/translations/approve` — `RequireAdminRole`. Distinct route from the
+  single `POST /api/v1/translations/{id:guid}/approve` (different segment count, no conflict).
+- **Input:** `BulkApproveTranslationsRequest(IReadOnlyList<Guid> Ids)` →
+  `BulkApproveTranslations.Command(IReadOnlyList<TranslationId> Ids) : ICommand<Result<BulkApproveTranslationsResponse>>`.
+- **Output:** `200 OK` `BulkApproveTranslationsResponse(int Requested, int Approved, int Skipped)`
+  even when everything was skipped (a well-formed request that published nothing is still a success).
+- **Errors:** empty ids / over-cap ⇒ `Validation` (400); provisioning failure ⇒ `Forbidden` (403);
+  auth ⇒ 401/403 by policy. No 404/422 — individual non-approvable rows are counted as `skipped`,
+  never surfaced as request errors.
+- **HATEOAS:** `Rels.BulkApprove = "bulk-approve"` on the list collection `Links` for admins, POST to
+  `nameof(BulkApproveTranslations)`.
+- **Files touched:** new `Features/Translations/BulkApproveTranslations.cs`; `Rels.BulkApprove`; the
+  list slice + `TranslationAggregateLinkFactory`/pagination wiring to emit the collection rel; new
+  `Contracts/Translations/BulkApproveTranslations{Request,Response}.cs`; DI in `ApiDependencyInjection`;
+  `Translations.razor` + `TranslationListLoader`; tests on both sides.
+
+## Acceptance criteria
+
+- [ ] `POST /api/v1/translations/approve` as admin with a mix of a `Draft` and a `NeedsReview` id
+      approves both, returns `{requested:2, approved:2, skipped:0}`, and both appear in the
+      distributed file after the rebuild.
+- [ ] The same endpoint with a `Draft` id + an `Untranslated` id + an unknown id returns
+      `{requested:3, approved:1, skipped:2}` and does not fail.
+- [ ] A request whose ids are all non-approvable approves nothing, returns `approved:0`, and
+      schedules **no** rebuild.
+- [ ] Empty `ids` ⇒ 400; more than 100 ids ⇒ 400.
+- [ ] A translator token ⇒ 403; no token ⇒ 401.
+- [ ] The list shows a checkbox column and a "Zatwierdź zaznaczone" button **only** for an admin, and
+      a checkbox **only** on rows that advertise the `approve` rel.
+- [ ] Selecting rows and submitting POSTs the ids to the collection `bulk-approve` href and, on
+      success, redirects to `/translations?…&approved=<n>` preserving the active filters.
+- [ ] A failed bulk POST surfaces the error and leaves the list intact (no redirect).
+- [ ] Tests: `BulkApproveTranslations` handler unit tests (validation + best-effort matrix + single
+      save + single rebuild + schedule-after-commit) and endpoint integration tests (real
+      PostgreSQL); `TranslationListLoader.BulkApproveAsync` test; bUnit render/gating + submit/redirect
+      tests.
+
+## Open questions
+
+None left open for the user. The ticket ("bulk approval from the translations list for admin,
+checkboxes for approve") is crisp; every remaining choice is **derived from existing repo
+conventions**, not a fresh business decision, so the worker resolved them inline:
+
+1. **Best-effort vs all-or-nothing** → best-effort. Derived from the link-driven affordance model
+   (#158 — the FE only offers approvable rows) + idempotent approve + errors-as-values. Rejected
+   all-or-nothing: one stale row blocking a 50-row batch is bad UX and inconsistent with those
+   patterns.
+2. **Response shape** → counts only (`requested/approved/skipped`). Rejected a per-id skip-reason
+   breakdown as YAGNI — the flash only needs the approved count; a breakdown is an additive change
+   if ever wanted.
+3. **Where the FE reads the POST url** → a collection `bulk-approve` rel (like GameVersions'
+   `register`), not a hardcoded path. Rejected hardcoding as inconsistent with #158.
+4. **Batch cap** → 100, from `ListTranslations`'s max `pageSize` (a checkbox selection can't exceed
+   one page). Rejected "unbounded" (a pathological `IN (…)` footgun) and an arbitrary magic number.
+5. **Post-submit UX** → Post-Redirect-Get with the filters preserved + an `approved` count flash,
+   following the just-landed #321 precedent. Rejected in-place reload (re-post on refresh).
+
+## Assumptions
+
+- Polish, one-language catalog (as everywhere else in the UI today).
+- The list page stays `[AllowAnonymous]` + Static SSR: the whole bulk affordance is server-gated by
+  the admin-only rels, so no page-level auth change is needed (the typed client carries the admin's
+  bearer token server-side).

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListLoader.cs
@@ -30,4 +30,23 @@ internal sealed class TranslationListLoader
             query.ToApiRelativeUri(),
             cancellationToken);
     }
+
+    /// <summary>
+    /// Approves several rows at once (#322) by POSTing the selected ids to the collection
+    /// <c>bulk-approve</c> link. <paramref name="bulkApproveHref"/> is the server-advertised URI —
+    /// present only when the API deems the caller a reviewer — never a FE-constructed path.
+    /// </summary>
+    public Task<ApiResult<BulkApproveTranslationsResponse>> BulkApproveAsync(
+        string bulkApproveHref,
+        IReadOnlyList<Guid> ids,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bulkApproveHref);
+        ArgumentNullException.ThrowIfNull(ids);
+
+        return _client.PostApiResultAsync<BulkApproveTranslationsResponse>(
+            bulkApproveHref,
+            new BulkApproveTranslationsRequest(ids),
+            cancellationToken);
+    }
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListQuery.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListQuery.cs
@@ -77,6 +77,21 @@ internal sealed record TranslationListQuery
         return QueryHelpers.AddQueryString(PagePath, parameters);
     }
 
+    /// <summary>
+    /// The page-relative URI for the Post-Redirect-Get target after a bulk approve (#322): this page's own
+    /// route carrying the current filters and page, plus the <c>approved</c>/<c>skipped</c> result counts,
+    /// so the confirmation flash survives the redirect while the active filters stay preserved.
+    /// </summary>
+    public string ToPageRelativeUriWithApprovalResult(int approved, int skipped)
+    {
+        Dictionary<string, string?> parameters = new();
+        AddPagingAndFilterParameters(parameters);
+        parameters["approved"] = approved.ToString(CultureInfo.InvariantCulture);
+        parameters["skipped"] = skipped.ToString(CultureInfo.InvariantCulture);
+
+        return QueryHelpers.AddQueryString(PagePath, parameters);
+    }
+
     private void AddPagingAndFilterParameters(Dictionary<string, string?> parameters, int? page = null)
     {
         parameters["page"] = (page ?? Page).ToString(CultureInfo.InvariantCulture);

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
@@ -2,13 +2,16 @@
 @attribute [AllowAnonymous]
 @attribute [StreamRendering]
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Mvc
 @using LotroKoniecDev.Frontend.Infrastructure.Hateoas
 @using LotroKoniecDev.Frontend.Infrastructure.HttpClients
+@using LotroKoniecDev.Hateoas.Abstractions
 @using LotroKoniecDev.TranslationSystem.Contracts.Common
 @using LotroKoniecDev.TranslationSystem.Contracts.Hateoas
 @using LotroKoniecDev.TranslationSystem.Contracts.Translations
 @using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums
 @inject TranslationListLoader Loader
+@inject NavigationManager Navigation
 
 <PageTitle>Tłumaczenia — lotro-translator.pl</PageTitle>
 
@@ -75,6 +78,12 @@
     {
         PaginationResponse<TranslationListItemResponse> pageData = _result.Value;
 
+        // The bulk-approve affordance is server-gated: the admin-only `bulk-approve` collection rel
+        // decides the checkbox column, and per-row the item's own `approve` rel decides which rows are
+        // selectable — never a locally recomputed role (#158, #322).
+        bool canBulkApprove = pageData.Links.HasLink(Rels.BulkApprove);
+        bool anyApprovable = canBulkApprove && pageData.Items.Any(item => item.Links.HasLink(Rels.Approve));
+
         <div class="results-meta">
             <span class="count">Znaleziono: <strong>@pageData.TotalCount</strong></span>
             @if (pageData.TotalPages > 0)
@@ -82,6 +91,36 @@
                 <span class="count">Strona @pageData.Page z @pageData.TotalPages</span>
             }
         </div>
+
+        @if (_bulkProblem is not null)
+        {
+            <div class="status-message status-error" role="alert">
+                <p>@(_bulkProblem.Detail ?? _bulkProblem.Title ?? "Nie udało się zatwierdzić tłumaczeń.")</p>
+            </div>
+        }
+        else if (_bulkNotice is not null)
+        {
+            <div class="status-message status-warning" role="status">
+                <p>@_bulkNotice</p>
+            </div>
+        }
+        else if (Approved is { } approvedCount)
+        {
+            @if (approvedCount > 0)
+            {
+                <div class="status-message status-success" role="status">
+                    <p>
+                        Zatwierdzono @approvedCount @TranslationsPlural(approvedCount).@((Skipped ?? 0) > 0 ? $" Pominięto {Skipped}." : "")
+                    </p>
+                </div>
+            }
+            else
+            {
+                <div class="status-message status-warning" role="status">
+                    <p>Nie zatwierdzono żadnego tłumaczenia — wybrane wiersze mogły być już zatwierdzone lub nieaktualne.</p>
+                </div>
+            }
+        }
 
         @if (pageData.Items.Count == 0)
         {
@@ -98,10 +137,16 @@
         }
         else
         {
-            <div class="table-wrap">
+            // One table shared by the admin (wrapped in the bulk-approve form) and the read-only paths,
+            // so the row markup is never duplicated; the checkbox column renders only when selectable.
+            RenderFragment resultsTable = @<div class="table-wrap">
                 <table class="data-table">
                     <thead>
                         <tr>
+                            @if (canBulkApprove)
+                            {
+                                <th scope="col" class="col-check"><span class="visually-hidden">Zaznacz</span></th>
+                            }
                             <th scope="col" class="col-num">FileId</th>
                             <th scope="col" class="col-num">GossipId</th>
                             <th scope="col">Tekst angielski</th>
@@ -114,6 +159,18 @@
                         @foreach (TranslationListItemResponse item in pageData.Items)
                         {
                             <tr>
+                                @if (canBulkApprove)
+                                {
+                                    <td class="col-check">
+                                        @* A checkbox appears only on a row the server marks approvable — the same
+                                           `approve` rel that gates the editor's per-row Zatwierdź. *@
+                                        @if (item.Links.HasLink(Rels.Approve))
+                                        {
+                                            <input type="checkbox" name="SelectedRows[@item.Id.Value]" value="true"
+                                                   aria-label="Zaznacz do zatwierdzenia"/>
+                                        }
+                                    </td>
+                                }
                                 <td class="col-num mono">@item.FileId</td>
                                 <td class="col-num mono">@item.GossipId</td>
                                 <td class="col-text">@item.SourceText</td>
@@ -142,7 +199,25 @@
                         }
                     </tbody>
                 </table>
-            </div>
+            </div>;
+
+            @if (canBulkApprove)
+            {
+                <form method="post" @formname="bulk-approve" @onsubmit="ApproveSelectedAsync">
+                    <AntiforgeryToken/>
+                    @if (anyApprovable)
+                    {
+                        <div class="bulk-bar">
+                            <button type="submit" class="btn btn-primary btn-sm">Zatwierdź zaznaczone</button>
+                        </div>
+                    }
+                    @resultsTable
+                </form>
+            }
+            else
+            {
+                @resultsTable
+            }
 
             @* The pager controls' availability is driven by the server's pagination link rels (#158); the
                user-facing /translations?... URLs stay FE-built via ToPageRelativeUri so they remain clean. *@
@@ -203,8 +278,28 @@
     [SupplyParameterFromQuery]
     private int Page { get; set; }
 
+    /// <summary>
+    /// Post-Redirect-Get result counts carried in the query by the redirect target after a bulk approve,
+    /// so the confirmation survives the redirect with no per-user server state — the page stays SSR-pure
+    /// (#321, #322). Null on a fresh GET (no flash); 0 renders a "nothing approved" note; a positive count
+    /// renders the success flash. They linger on a manual reload, a deliberate, harmless trade-off.
+    /// </summary>
+    [SupplyParameterFromQuery]
+    private int? Approved { get; set; }
+
+    [SupplyParameterFromQuery]
+    private int? Skipped { get; set; }
+
+    // A sparse checkbox selection maps to a dictionary keyed by row id: Blazor static-SSR form binding
+    // reads keyed names (`SelectedRows[<id>]`) — a repeated flat name does NOT bind to a collection —
+    // and only the checked rows post, so every entry that arrives is a selected row.
+    [SupplyParameterFromForm(FormName = "bulk-approve")]
+    private Dictionary<Guid, bool>? SelectedRows { get; set; }
+
     private TranslationListQuery _query = TranslationListQuery.From(null, null, 1);
     private ApiResult<PaginationResponse<TranslationListItemResponse>>? _result;
+    private ProblemDetails? _bulkProblem;
+    private string? _bulkNotice;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -212,6 +307,62 @@
         _result = await Loader.LoadAsync(_query, CancellationToken.None);
     }
 
+    private async Task ApproveSelectedAsync()
+    {
+        _bulkProblem = null;
+        _bulkNotice = null;
+
+        // Link-driven: the API emits the `bulk-approve` collection rel only for a reviewer, so its
+        // presence on the freshly loaded page is the whole gate — no local role recompute.
+        LinkDto? bulkLink = _result is { IsSuccess: true }
+            ? _result.Value.Links.FindLink(Rels.BulkApprove)
+            : null;
+        if (bulkLink is null)
+        {
+            return;
+        }
+
+        Guid[] ids = SelectedRows is null
+            ? []
+            : [.. SelectedRows.Where(pair => pair.Value).Select(pair => pair.Key)];
+        if (ids.Length == 0)
+        {
+            _bulkNotice = "Zaznacz co najmniej jeden wiersz do zatwierdzenia.";
+            return;
+        }
+
+        ApiResult<BulkApproveTranslationsResponse> result =
+            await Loader.BulkApproveAsync(bulkLink.Href, ids, CancellationToken.None);
+        if (result.IsSuccess)
+        {
+            // Post-Redirect-Get (#321, #322): a successful mutation redirects to the list's GET view with
+            // the result counts in the query, so a browser reload is a safe GET (no "resubmit?" prompt),
+            // the fresh load re-derives the server's HATEOAS links (just-approved rows drop their checkbox),
+            // and the confirmation needs no per-user server state. On failure we deliberately do NOT
+            // redirect — the ProblemDetails and the intact pre-approval list stay on screen.
+            Navigation.NavigateTo(
+                _query.ToPageRelativeUriWithApprovalResult(result.Value.Approved, result.Value.Skipped));
+            return;
+        }
+
+        _bulkProblem = result.ProblemDetails;
+    }
+
     private static string EditorHref(TranslationListItemResponse item) =>
         $"/editor/{item.Id.Value}";
+
+    /// <summary>Polish plural of "tłumaczenie" for the approved-count flash (1 / 2-4 / 5+ forms).</summary>
+    private static string TranslationsPlural(int count)
+    {
+        if (count == 1)
+        {
+            return "tłumaczenie";
+        }
+
+        int lastTwo = count % 100;
+        int last = count % 10;
+        return last is >= 2 and <= 4 && lastTwo is < 12 or > 14
+            ? "tłumaczenia"
+            : "tłumaczeń";
+    }
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -1064,6 +1064,27 @@ code {
     word-break: break-word;
 }
 
+.col-check {
+    width: 1%;
+    white-space: nowrap;
+    text-align: center;
+}
+
+.col-check input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: var(--accent);
+}
+
+.bulk-bar {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
 /* ───────── Pager ───────── */
 .pager {
     display: flex;

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -143,6 +143,11 @@ internal static class ApiDependencyInjection
             services.AddScoped<
                 ICommandHandler<ApproveTranslation.Command, Result>,
                 ApproveTranslation.Handler>();
+
+            services.AddScoped<IValidator<BulkApproveTranslations.Command>, BulkApproveTranslations.Validator>();
+            services.AddScoped<
+                ICommandHandler<BulkApproveTranslations.Command, Result<BulkApproveTranslationsResponse>>,
+                BulkApproveTranslations.Handler>();
         }
 
         private void AddTranslationFilesFeature()

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/BulkApproveTranslations.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/BulkApproveTranslations.cs
@@ -1,0 +1,174 @@
+using FluentValidation;
+using FluentValidation.Results;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Auth.Provisioning;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
+
+/// <summary>
+/// Approves several translation rows in one admin action (#322), the collection counterpart of the
+/// single <see cref="ApproveTranslation"/> slice: the reviewer selects rows on the list and this
+/// publishes them together. Best-effort — the selection is a snapshot, so every requested row that is
+/// <em>still</em> approvable (a non-removed <see cref="TranslationStatus.Draft"/> /
+/// <see cref="TranslationStatus.NeedsReview"/> row) is approved and the rest are silently skipped; a
+/// single stale row never fails the batch. All approvals are stamped in one <c>SaveChanges</c>, and a
+/// single debounced artifact rebuild is scheduled after the commit (PERF-04, ADR-0021) — only when at
+/// least one row was actually approved. Requires the admin (reviewer) policy. The response reports
+/// how many were requested / approved / skipped; it never 404s or 422s on an individual row.
+/// </summary>
+internal sealed class BulkApproveTranslations : IEndpoint
+{
+    /// <summary>
+    /// The most ids one request may carry — the translations list's max page size, since a checkbox
+    /// selection can never span more than a single rendered page.
+    /// </summary>
+    internal const int MaxIds = 100;
+
+    internal sealed record Command(IReadOnlyList<TranslationId> Ids)
+        : ICommand<Result<BulkApproveTranslationsResponse>>;
+
+    internal sealed class Validator : AbstractValidator<Command>
+    {
+        public Validator()
+        {
+            RuleFor(command => command.Ids)
+                .NotEmpty()
+                .WithMessage("At least one translation id is required.");
+
+            RuleFor(command => command.Ids)
+                .Must(ids => ids.Count <= MaxIds)
+                .WithMessage($"A bulk approve carries at most {MaxIds} translations.");
+
+            RuleForEach(command => command.Ids)
+                .NotEqual(TranslationId.Empty)
+                .WithMessage("A translation id is required.");
+        }
+    }
+
+    internal sealed class Handler : ICommandHandler<Command, Result<BulkApproveTranslationsResponse>>
+    {
+        private readonly IValidator<Command> _validator;
+        private readonly ITranslationRepository _translationRepository;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly ITranslatorProvisioner _translatorProvisioner;
+        private readonly TimeProvider _timeProvider;
+        private readonly ITranslationFileRebuildScheduler _rebuildScheduler;
+
+        public Handler(
+            IValidator<Command> validator,
+            ITranslationRepository translationRepository,
+            IUnitOfWork unitOfWork,
+            ITranslatorProvisioner translatorProvisioner,
+            TimeProvider timeProvider,
+            ITranslationFileRebuildScheduler rebuildScheduler)
+        {
+            _validator = validator;
+            _translationRepository = translationRepository;
+            _unitOfWork = unitOfWork;
+            _translatorProvisioner = translatorProvisioner;
+            _timeProvider = timeProvider;
+            _rebuildScheduler = rebuildScheduler;
+        }
+
+        public async ValueTask<Result<BulkApproveTranslationsResponse>> Handle(Command command, CancellationToken cancellationToken)
+        {
+            ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                string message = string.Join("; ", validationResult.Errors.Select(failure => failure.ErrorMessage));
+                return Result.Failure<BulkApproveTranslationsResponse>(new Error("Translations.Validation", message, TypeOfError.Validation));
+            }
+
+            // De-duplicate so the row lookup and the approved/skipped tally stay consistent
+            // (Approved + Skipped == Requested), even if the client repeats an id.
+            List<TranslationId> distinctIds = command.Ids.Distinct().ToList();
+
+            // First-touch lazy provisioning (ADR-0004): resolve the reviewer's local TranslatorId once,
+            // before stamping any row. A failure means the batch cannot be attributed, so it fails whole
+            // — the same guard the single approve slice applies.
+            Result<TranslatorId> provisionResult = await _translatorProvisioner.ProvisionCurrentAsync(cancellationToken);
+            if (provisionResult.IsFailure)
+            {
+                return Result.Failure<BulkApproveTranslationsResponse>(provisionResult.Error);
+            }
+
+            IReadOnlyList<Translation> rows = await _translationRepository.GetByIdsAsync(distinctIds, cancellationToken);
+            DateTimeOffset now = _timeProvider.GetUtcNow();
+
+            int approved = 0;
+            foreach (Translation row in rows)
+            {
+                // Only Draft/NeedsReview rows are approvable — mirrors the per-item `approve` affordance
+                // (the FE offers a checkbox for exactly these). Anything else (Untranslated, or an
+                // already-Approved row) is skipped, so an already-approved row keeps its original approver.
+                if (row.Status is not (TranslationStatus.Draft or TranslationStatus.NeedsReview))
+                {
+                    continue;
+                }
+
+                // A Draft/NeedsReview row can still fail the domain guard (e.g. it was soft-removed after
+                // the list was rendered): leave it untouched and count it as skipped — the guard is
+                // authoritative, never bypassed by the batch.
+                Result approveResult = row.Approve(provisionResult.Value, now);
+                if (approveResult.IsSuccess)
+                {
+                    approved++;
+                }
+            }
+
+            if (approved > 0)
+            {
+                await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+                // At least one row (re)entered the distributed set, so the pre-built Polish artifact is
+                // stale. Scheduled once, after the commit (PERF-04, ADR-0021 §1): the rebuild runs
+                // debounced in the background, so the response returns now. Nothing approved ⇒ nothing to
+                // publish ⇒ no rebuild.
+                _rebuildScheduler.Schedule(SupportedLanguages.Polish);
+            }
+
+            int requested = distinctIds.Count;
+            return Result.Success(new BulkApproveTranslationsResponse(requested, approved, requested - approved));
+        }
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapPost("/api/v1/translations/approve", async (
+                BulkApproveTranslationsRequest request,
+                ICommandHandler<Command, Result<BulkApproveTranslationsResponse>> handler,
+                CancellationToken cancellationToken) =>
+            {
+                // A missing/empty body binds Ids to null; normalize to an empty list so validation
+                // (not a NullReferenceException) turns it into a 400.
+                IReadOnlyList<Guid> ids = request.Ids ?? [];
+                Command command = new([.. ids.Select(TranslationId.FromValue)]);
+
+                Result<BulkApproveTranslationsResponse> result = await handler.Handle(command, cancellationToken);
+
+                return result.IsSuccess
+                    ? Results.Ok(result.Value)
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(BulkApproveTranslations))
+            .WithTags("Translations")
+            .RequireAuthorization(AuthorizationPolicies.RequireAdminRole)
+            .Produces<BulkApproveTranslationsResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
@@ -176,8 +176,12 @@ internal sealed class ListTranslations : IEndpoint
                             item.Id, item.Status, isRemoved: false, callerIsTranslator, callerIsAdmin);
                     }
 
-                    paged.Links = paginationLinkFactory.CreatePaginationLinks(
-                        nameof(ListTranslations), paged, new { lang, search, status, sort });
+                    paged.Links =
+                    [
+                        .. paginationLinkFactory.CreatePaginationLinks(
+                            nameof(ListTranslations), paged, new { lang, search, status, sort }),
+                        .. translationLinkFactory.CreateCollectionLinks(callerIsAdmin)
+                    ];
                 });
             })
             .WithName(nameof(ListTranslations))

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/TranslationAggregateFactories/ITranslationAggregateLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/TranslationAggregateFactories/ITranslationAggregateLinkFactory.cs
@@ -25,4 +25,11 @@ internal interface ITranslationAggregateLinkFactory
         bool isRemoved,
         bool callerIsTranslator,
         bool callerIsAdmin);
+
+    /// <summary>
+    /// Builds the collection-level links for the translation list: today only the admin-only
+    /// <c>bulk-approve</c> action (#322), so a non-admin caller gets an empty list.
+    /// </summary>
+    /// <param name="callerIsAdmin">Whether the caller holds the reviewer (Admin) role (gates <c>bulk-approve</c>).</param>
+    List<LinkDto> CreateCollectionLinks(bool callerIsAdmin);
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/TranslationAggregateFactories/TranslationAggregateLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/TranslationAggregateFactories/TranslationAggregateLinkFactory.cs
@@ -65,4 +65,21 @@ internal sealed class TranslationAggregateLinkFactory : ITranslationAggregateLin
 
         return links;
     }
+
+    public List<LinkDto> CreateCollectionLinks(bool callerIsAdmin)
+    {
+        List<LinkDto> links = [];
+
+        // The bulk-approve action is reviewer-only (#322): a translator or anonymous caller never
+        // sees the collection affordance, mirroring the per-item approve gate.
+        if (callerIsAdmin)
+        {
+            links.AddIfPresent(_linkFactory.Create(
+                endpoint: nameof(BulkApproveTranslations),
+                rel: Rels.BulkApprove,
+                method: HttpMethods.Post));
+        }
+
+        return links;
+    }
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
@@ -8,6 +8,9 @@ public static class Rels
     public const string Upsert = "upsert";
     public const string Approve = "approve";
 
+    // Translation collection actions
+    public const string BulkApprove = "bulk-approve";
+
     // GameVersion aggregate actions
     public const string Register = "register";
     public const string Delete = "delete";

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/BulkApproveTranslationsRequest.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/BulkApproveTranslationsRequest.cs
@@ -1,0 +1,8 @@
+namespace LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+/// <summary>
+/// Approves several translation rows in one admin action (#322): the ids of the rows selected on the
+/// translations list. Best-effort — rows that are no longer approvable when the request lands are
+/// skipped, not rejected (see <see cref="BulkApproveTranslationsResponse"/>).
+/// </summary>
+public sealed record BulkApproveTranslationsRequest(IReadOnlyList<Guid> Ids);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/BulkApproveTranslationsResponse.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translations/BulkApproveTranslationsResponse.cs
@@ -1,0 +1,8 @@
+namespace LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+/// <summary>
+/// The outcome of a bulk approve (#322): how many distinct rows were requested, how many were
+/// actually approved and published, and how many were skipped (unknown id, already approved, or no
+/// longer approvable). <c>Approved + Skipped == Requested</c> always holds.
+/// </summary>
+public sealed record BulkApproveTranslationsResponse(int Requested, int Approved, int Skipped);

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListLoaderTests.cs
@@ -131,6 +131,44 @@ public sealed class TranslationListLoaderTests
         result.ProblemDetails!.Status.ShouldBe(400);
     }
 
+    [Fact]
+    public async Task BulkApproveAsync_PostsTheSelectedIdsToTheHref_AndReturnsTheSummary()
+    {
+        Guid first = Guid.NewGuid();
+        Guid second = Guid.NewGuid();
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(new BulkApproveTranslationsResponse(2, 2, 0), ApiJsonOptions));
+        TranslationListLoader loader = new(CreateClient(handler));
+
+        ApiResult<BulkApproveTranslationsResponse> result =
+            await loader.BulkApproveAsync("/api/v1/translations/approve", [first, second]);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Approved.ShouldBe(2);
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.ToString().ShouldEndWith("/api/v1/translations/approve");
+        handler.LastRequestBody.ShouldNotBeNull();
+        handler.LastRequestBody!.ShouldContain(first.ToString());
+        handler.LastRequestBody.ShouldContain(second.ToString());
+    }
+
+    [Fact]
+    public async Task BulkApproveAsync_WhenApiRejectsTheBatch_ReturnsFailureWithProblemDetails()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.BadRequest,
+            """{ "title": "Za dużo pozycji", "status": 400 }""");
+        TranslationListLoader loader = new(CreateClient(handler));
+
+        ApiResult<BulkApproveTranslationsResponse> result =
+            await loader.BulkApproveAsync("/api/v1/translations/approve", [Guid.NewGuid()]);
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails.ShouldNotBeNull();
+        result.ProblemDetails!.Status.ShouldBe(400);
+    }
+
     private static PaginationResponse<TranslationListItemResponse> EmptyPage() =>
         PageOf([], page: 1, pageSize: 50, totalCount: 0);
 

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListQueryTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListQueryTests.cs
@@ -163,4 +163,22 @@ public sealed class TranslationListQueryTests
 
         query.ToPageRelativeUri(requested).ShouldContain($"page={expected}");
     }
+
+    [Fact]
+    public void ToPageRelativeUriWithApprovalResult_PreservesTheActiveFiltersAndPageAndAppendsTheCounts()
+    {
+        // AC #7 (#322): the bulk-approve Post-Redirect-Get target must land back on the current filtered
+        // page with search+status intact, plus the approved/skipped result counts — so a reload is a safe
+        // GET showing the same filtered list with the confirmation flash.
+        TranslationListQuery query = TranslationListQuery.From(search: "Bilbo", status: "Draft", page: 3);
+
+        string uri = query.ToPageRelativeUriWithApprovalResult(approved: 2, skipped: 1);
+
+        uri.ShouldStartWith("/translations?");
+        uri.ShouldContain("page=3");
+        uri.ShouldContain("search=Bilbo");
+        uri.ShouldContain("status=Draft");
+        uri.ShouldContain("approved=2");
+        uri.ShouldContain("skipped=1");
+    }
 }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
@@ -11,6 +11,7 @@ using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using TranslationsComponent = LotroKoniecDev.Frontend.Components.Pages.Translations.Translations;
@@ -29,6 +30,7 @@ public sealed class TranslationsTests : BunitContext
 
     public TranslationsTests()
     {
+        Services.AddAntiforgery();
         Services.AddSingleton(_client);
         Services.AddScoped<TranslationListLoader>();
         AddAuthorization().SetAuthorized("Frodo");
@@ -96,16 +98,134 @@ public sealed class TranslationsTests : BunitContext
         component.FindAll("nav.pager").ShouldBeEmpty();
     }
 
+    [Fact]
+    public void Render_WhenCollectionHasBulkApproveRel_ShowsTheCheckboxColumnAndBulkButton()
+    {
+        // An admin's list carries the bulk-approve collection rel and an approvable row: the checkbox
+        // column, a per-row checkbox and the "Zatwierdź zaznaczone" button all appear.
+        StubPage(AdminPageOf(Row(canEdit: true, canApprove: true)));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("th.col-check").Count.ShouldBe(1);
+        component.FindAll("input[type=checkbox]").Count.ShouldBe(1);
+        component.FindAll("button[type=submit]").ShouldContain(button => button.TextContent.Contains("Zatwierdź zaznaczone"));
+    }
+
+    [Fact]
+    public void Render_WhenCollectionLacksBulkApproveRel_HidesTheCheckboxColumnAndButton()
+    {
+        // The same approvable row, but no admin collection rel (translator / anonymous): the read-only
+        // list, no checkbox column and no bulk button — server-gated, never role-recomputed.
+        StubPage(SinglePageOf(Row(canEdit: true, canApprove: true)));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("th.col-check").ShouldBeEmpty();
+        component.FindAll("input[type=checkbox]").ShouldBeEmpty();
+        component.FindAll("button[type=submit]").Where(button => button.TextContent.Contains("Zatwierdź")).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenAdminButNoRowIsApprovable_ShowsTheColumnButNoCheckboxOrButton()
+    {
+        // Admin, but the only row is not approvable (e.g. already Approved): the column renders, yet the
+        // row offers no checkbox and there is nothing to approve, so no bulk button.
+        StubPage(AdminPageOf(Row(canEdit: true, canApprove: false)));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("th.col-check").Count.ShouldBe(1);
+        component.FindAll("input[type=checkbox]").ShouldBeEmpty();
+        component.FindAll("button[type=submit]").Where(button => button.TextContent.Contains("Zatwierdź")).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenRowIsApprovable_NamesItsCheckboxAfterTheDictionaryKeyBinding()
+    {
+        // Regression guard for the SSR binding contract (mirrors the ImportExport name guard): the row
+        // checkbox MUST be named SelectedRows[<id>] so Blazor static-SSR maps the checked rows into the
+        // Dictionary<Guid, bool> handler property — a bare or wrong name binds nothing and bulk approve
+        // silently no-ops.
+        TranslationListItemResponse row = Row(canEdit: true, canApprove: true);
+        StubPage(AdminPageOf(row));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.Find("input[type=checkbox]").GetAttribute("name").ShouldBe($"SelectedRows[{row.Id.Value}]");
+    }
+
+    [Fact]
+    public async Task ApproveSelected_WhenNothingIsChecked_ShowsTheSelectPromptAndDoesNotCallTheApi()
+    {
+        StubPage(AdminPageOf(Row(canEdit: true, canApprove: true)));
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        await component.Find("form[method=post]").SubmitAsync();
+
+        component.Find(".status-message.status-warning").TextContent.ShouldContain("Zaznacz co najmniej jeden wiersz");
+        await _client.DidNotReceive().PostApiResultAsync<BulkApproveTranslationsResponse>(
+            Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Render_WhenApprovedCountIsInTheQuery_ShowsTheSuccessFlashWithSkippedCount()
+    {
+        // The GET side of Post-Redirect-Get (#321/#322): after the bulk-approve redirect the result counts
+        // ride in the query, and the list surfaces the "Zatwierdzono N (Pominięto M)" confirmation with no
+        // per-user server state, so the flash survives the redirect and a reload stays a safe GET.
+        // (The checked-rows → POST → redirect leg itself is exercised at the loader seam — bUnit's
+        // SubmitAsync invokes only @onsubmit and does not model SSR form-data binding — while the
+        // DOM→form-data→dictionary bind belongs to the Playwright E2E suite, not yet populated for this flow.)
+        StubPage(AdminPageOf(Row(canEdit: true, canApprove: true)));
+        Navigation().NavigateTo("/translations?approved=2&skipped=1");
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        string flash = component.Find(".status-message.status-success").TextContent;
+        flash.ShouldContain("Zatwierdzono 2");
+        flash.ShouldContain("Pominięto 1");
+    }
+
+    [Fact]
+    public void Render_WhenApprovedIsZeroInTheQuery_ShowsTheNothingApprovedNoteNotASuccessFlash()
+    {
+        // A well-formed bulk approve that published nothing (every selected row was already approved or went
+        // stale between render and submit) redirects with approved=0: the list must show the "nothing
+        // approved" note, never a success flash — approved:0 is a success response, not an error.
+        StubPage(AdminPageOf(Row(canEdit: true, canApprove: true)));
+        Navigation().NavigateTo("/translations?approved=0");
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll(".status-message.status-success").ShouldBeEmpty();
+        component.Find(".status-message.status-warning").TextContent.ShouldContain("Nie zatwierdzono żadnego");
+    }
+
     private IRenderedComponent<TranslationsComponent> RenderPage() =>
         Render<TranslationsComponent>();
+
+    private BunitNavigationManager Navigation() =>
+        (BunitNavigationManager)Services.GetRequiredService<NavigationManager>();
 
     private void StubPage(PaginationResponse<TranslationListItemResponse> page) =>
         _client
             .GetApiResultAsync<PaginationResponse<TranslationListItemResponse>>(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult.Success(page));
 
-    private static TranslationListItemResponse Row(bool canEdit)
+    private static TranslationListItemResponse Row(bool canEdit, bool canApprove = false)
     {
+        List<LinkDto> links = [];
+        if (canEdit)
+        {
+            links.Add(new LinkDto("https://tms.example/api/v1/translations", Rels.Upsert, "PUT"));
+        }
+
+        if (canApprove)
+        {
+            links.Add(new LinkDto("https://tms.example/api/v1/translations/abc/approve", Rels.Approve, "POST"));
+        }
+
         TranslationListItemResponse row = new(
             TranslationId.Create(),
             FileId: 620756992,
@@ -116,7 +236,7 @@ public sealed class TranslationsTests : BunitContext
             Submitter: null,
             UpdatedAt: DateTimeOffset.UnixEpoch)
         {
-            Links = canEdit ? [new LinkDto("https://tms.example/api/v1/translations", Rels.Upsert, "PUT")] : []
+            Links = links
         };
         return row;
     }
@@ -132,6 +252,19 @@ public sealed class TranslationsTests : BunitContext
             PageSize = 50,
             TotalCount = 1
         };
+
+    /// <summary>A page carrying the admin-only <c>bulk-approve</c> collection rel, as the API emits for a reviewer.</summary>
+    private static PaginationResponse<TranslationListItemResponse> AdminPageOf(params TranslationListItemResponse[] rows) =>
+        new()
+        {
+            Items = rows,
+            Page = 1,
+            PageSize = 50,
+            TotalCount = rows.Length,
+            Links = [new LinkDto(BulkApproveHref, Rels.BulkApprove, "POST")]
+        };
+
+    private const string BulkApproveHref = "https://tms.example/api/v1/translations/approve";
 
     private static PaginationResponse<TranslationListItemResponse> MultiPageOf(int page, IReadOnlyCollection<LinkDto> links) =>
         new()

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/TranslationAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/TranslationAggregateHateoasTests.cs
@@ -184,6 +184,9 @@ public sealed class TranslationAggregateHateoasTests : IAsyncLifetime
         response.Links.ShouldContain(l => l.Rel == Rels.Self && l.Method == "GET");
         response.Links.ShouldContain(l => l.Rel == Rels.FirstPage);
         response.Links.ShouldContain(l => l.Rel == Rels.LastPage);
+
+        // Assert — the admin-only bulk-approve collection affordance (#322) drives the FE checkbox toolbar.
+        response.Links.ShouldContain(l => l.Rel == Rels.BulkApprove && l.Method == "POST");
     }
 
     [Fact]
@@ -204,6 +207,8 @@ public sealed class TranslationAggregateHateoasTests : IAsyncLifetime
         response.Links.ShouldContain(l => l.Rel == Rels.Self && l.Method == "GET");
         response.Links.ShouldContain(l => l.Rel == Rels.FirstPage);
         response.Links.ShouldContain(l => l.Rel == Rels.LastPage);
+        // The bulk-approve affordance is reviewer-only, so the anonymous envelope must not carry it.
+        response.Links.ShouldNotContain(l => l.Rel == Rels.BulkApprove);
     }
 
     [Fact]
@@ -222,6 +227,8 @@ public sealed class TranslationAggregateHateoasTests : IAsyncLifetime
         item.Links.ShouldContain(l => l.Rel == Rels.Self);
         item.Links.ShouldContain(l => l.Rel == Rels.Upsert);
         item.Links.ShouldNotContain(l => l.Rel == Rels.Approve);
+        // Bulk approve is reviewer-only: a translator's envelope must not advertise it either.
+        response.Links.ShouldNotContain(l => l.Rel == Rels.BulkApprove);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/BulkApproveTranslationsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/BulkApproveTranslationsTests.cs
@@ -1,0 +1,262 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
+
+[Collection("TranslationApi")]
+public sealed class BulkApproveTranslationsTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+    private const string BulkApproveRoute = "/api/v1/translations/approve";
+    private const string FileRoute = "/api/v1/translation-files/pl";
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+    private TranslatorId _seederId;
+
+    public BulkApproveTranslationsTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+
+        Translator seeder = Translator.Create(
+            IdentityId.Create(), DisplayName.Create("Seed Author").Value, email: null, Now).Value;
+        dbContext.Translators.Add(seeder);
+
+        await dbContext.SaveChangesAsync();
+        _versionId = gameVersion.Id;
+        _seederId = seeder.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task BulkApprove_OnDraftAndNeedsReviewRows_ShouldApproveBothAndPublish()
+    {
+        // Arrange — both a plain draft and an invalidated (NeedsReview) row are approvable; approving
+        // publishes both and rebuilds the distributed artifact (spec 0001, #322).
+        Guid draftId = await SeedAsync(gossipId: 1, SeedStatus.Draft, polish: "Witaj");
+        Guid needsReviewId = await SeedAsync(gossipId: 2, SeedStatus.NeedsReview, polish: "Stary polski");
+        using HttpClient client = AdminClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            BulkApproveRoute, new BulkApproveTranslationsRequest([draftId, needsReviewId]), JsonOptions);
+        BulkApproveTranslationsResponse? summary =
+            await response.Content.ReadFromJsonAsync<BulkApproveTranslationsResponse>(JsonOptions);
+
+        (_, string file) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            FileRoute,
+            (download, content) => download.IsSuccessStatusCode
+                && content.Contains($"{FileId}||1||Witaj||NULL||NULL||1")
+                && content.Contains($"{FileId}||2||Stary polski||NULL||NULL||1"));
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        summary.ShouldNotBeNull();
+        summary.Requested.ShouldBe(2);
+        summary.Approved.ShouldBe(2);
+        summary.Skipped.ShouldBe(0);
+        file.ShouldContain($"{FileId}||1||Witaj||NULL||NULL||1");
+        file.ShouldContain($"{FileId}||2||Stary polski||NULL||NULL||1");
+    }
+
+    [Fact]
+    public async Task BulkApprove_WithApprovableUntranslatedAndUnknownIds_ShouldApproveOnlyTheApprovableOne()
+    {
+        // Arrange — best-effort: a Draft is approved, an Untranslated row and an unknown id are skipped;
+        // one stale/invalid id must never fail the whole batch.
+        Guid draftId = await SeedAsync(gossipId: 1, SeedStatus.Draft, polish: "Witaj");
+        Guid untranslatedId = await SeedAsync(gossipId: 2, SeedStatus.Untranslated, polish: null);
+        Guid unknownId = Guid.NewGuid();
+        using HttpClient client = AdminClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            BulkApproveRoute, new BulkApproveTranslationsRequest([draftId, untranslatedId, unknownId]), JsonOptions);
+        BulkApproveTranslationsResponse? summary =
+            await response.Content.ReadFromJsonAsync<BulkApproveTranslationsResponse>(JsonOptions);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        summary.ShouldNotBeNull();
+        summary.Requested.ShouldBe(3);
+        summary.Approved.ShouldBe(1);
+        summary.Skipped.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task BulkApprove_WhenNoRowIsApprovable_ShouldReturnZeroApproved()
+    {
+        // Arrange — an untranslated row has no Polish to publish; the request is well-formed but
+        // publishes nothing, which is still a success (200, approved:0).
+        Guid untranslatedId = await SeedAsync(gossipId: 1, SeedStatus.Untranslated, polish: null);
+        using HttpClient client = AdminClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            BulkApproveRoute, new BulkApproveTranslationsRequest([untranslatedId]), JsonOptions);
+        BulkApproveTranslationsResponse? summary =
+            await response.Content.ReadFromJsonAsync<BulkApproveTranslationsResponse>(JsonOptions);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        summary.ShouldNotBeNull();
+        summary.Approved.ShouldBe(0);
+        summary.Skipped.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task BulkApprove_WithEmptyIds_ShouldReturn400()
+    {
+        // Arrange
+        using HttpClient client = AdminClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            BulkApproveRoute, new BulkApproveTranslationsRequest([]), JsonOptions);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task BulkApprove_WithMoreThanOneHundredIds_ShouldReturn400()
+    {
+        // Arrange — the cap mirrors the list's max page size.
+        Guid[] ids = [.. Enumerable.Range(0, 101).Select(_ => Guid.NewGuid())];
+        using HttpClient client = AdminClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            BulkApproveRoute, new BulkApproveTranslationsRequest(ids), JsonOptions);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task BulkApprove_AsTranslator_ShouldReturn403()
+    {
+        // Arrange — bulk approve is an admin (reviewer) action; the translator role must not approve.
+        Guid draftId = await SeedAsync(gossipId: 1, SeedStatus.Draft, polish: "Witaj");
+        using HttpClient client = TranslatorClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            BulkApproveRoute, new BulkApproveTranslationsRequest([draftId]), JsonOptions);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task BulkApprove_WithoutToken_ShouldReturn401()
+    {
+        // Arrange
+        Guid draftId = await SeedAsync(gossipId: 1, SeedStatus.Draft, polish: "Witaj");
+
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().PostAsJsonAsync(
+            BulkApproveRoute, new BulkApproveTranslationsRequest([draftId]), JsonOptions);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task BulkApprove_WithNullIdsBody_ShouldReturn400()
+    {
+        // Arrange — a raw body whose ids field is null (or a missing field) binds Ids to null; the endpoint
+        // must normalize it to an empty list and fail validation with 400, never 500 from a null dereference.
+        using HttpClient client = AdminClient(Guid.NewGuid());
+        using StringContent body = new("""{"ids":null}""");
+        body.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(BulkApproveRoute, body);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    private enum SeedStatus
+    {
+        Untranslated,
+        Draft,
+        NeedsReview,
+    }
+
+    private async Task<Guid> SeedAsync(int gossipId, SeedStatus status, string? polish)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create("English", null, null).Value,
+            _versionId,
+            Now).Value;
+
+        switch (status)
+        {
+            case SeedStatus.Draft:
+                row.ProvideTranslation(polish!, _seederId, Now);
+                break;
+            case SeedStatus.NeedsReview:
+                row.ProvideTranslation(polish!, _seederId, Now);
+                row.ApplySourceChange(TranslationSource.Create("English reworded", null, null).Value, _versionId, Now);
+                break;
+        }
+
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+        return row.Id.Value;
+    }
+
+    private HttpClient AdminClient(Guid subject)
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Admin, AuthConstants.Scopes.Api, subject));
+        return client;
+    }
+
+    private HttpClient TranslatorClient(Guid subject)
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator, AuthConstants.Scopes.Api, subject));
+        return client;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/BulkApproveTranslationsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/BulkApproveTranslationsHandlerTests.cs
@@ -1,0 +1,263 @@
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Enums;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.API.Features.Translations;
+using LotroKoniecDev.TranslationSystem.API.Tests.Unit.Shared;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Translations;
+
+public sealed class BulkApproveTranslationsHandlerTests
+{
+    private const int FileId = 620756992;
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+    private static readonly GameVersionId VersionId = GameVersionId.Create();
+    private static readonly TranslatorId Submitter = TranslatorId.Create();
+    private static readonly TranslatorId Approver = TranslatorId.Create();
+
+    // ITranslationRepository / IUnitOfWork are genuine public boundaries (stubbed); the provisioner +
+    // rebuild scheduler are internal interfaces NSubstitute can't proxy, so each gets a hand-written
+    // double.
+    private readonly ITranslationRepository _translationRepository = Substitute.For<ITranslationRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+    private readonly List<string> _callOrder = [];
+    private readonly RecordingScheduler _rebuildScheduler;
+
+    private StubTranslatorProvisioner _provisioner = new(Result.Success(Approver));
+
+    public BulkApproveTranslationsHandlerTests()
+    {
+        _rebuildScheduler = new RecordingScheduler(_callOrder);
+        _unitOfWork.When(unitOfWork => unitOfWork.SaveChangesAsync(Arg.Any<CancellationToken>()))
+            .Do(_ => _callOrder.Add(nameof(IUnitOfWork.SaveChangesAsync)));
+    }
+
+    private BulkApproveTranslations.Handler CreateHandler()
+        => new(
+            new BulkApproveTranslations.Validator(),
+            _translationRepository,
+            _unitOfWork,
+            _provisioner,
+            TimeProvider.System,
+            _rebuildScheduler);
+
+    private void GivenStoredRows(params Translation[] rows)
+        => _translationRepository.GetByIdsAsync(Arg.Any<IReadOnlyList<TranslationId>>(), Arg.Any<CancellationToken>())
+            .Returns(rows);
+
+    private static BulkApproveTranslations.Command CommandFor(params TranslationId[] ids)
+        => new(ids);
+
+    private static Translation Draft(int gossipId, string polish = "Polski")
+    {
+        Translation row = Untranslated(gossipId);
+        row.ProvideTranslation(polish, Submitter, Now);
+        return row;
+    }
+
+    private static Translation NeedsReview(int gossipId, string polish = "Stary polski")
+    {
+        Translation row = Untranslated(gossipId, source: "Old English");
+        row.ProvideTranslation(polish, Submitter, Now);
+        row.ApplySourceChange(TranslationSource.Create("New English", null, null).Value, VersionId, Now);
+        return row;
+    }
+
+    private static Translation RemovedDraft(int gossipId, string polish = "Polski")
+    {
+        Translation row = Draft(gossipId, polish);
+        row.MarkRemoved(VersionId, Now);
+        return row;
+    }
+
+    private static Translation Untranslated(int gossipId, string source = "English")
+        => Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create(source, null, null).Value,
+            VersionId,
+            Now).Value;
+
+    [Fact]
+    public async Task Handle_WhenIdsEmpty_ShouldReturnValidationErrorAndNotPersist()
+    {
+        // Act
+        Result<BulkApproveTranslationsResponse> result =
+            await CreateHandler().Handle(CommandFor(), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translations.Validation");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Handle_WhenMoreThanOneHundredIds_ShouldReturnValidationError()
+    {
+        // Arrange — the cap mirrors the list's max page size; a selection can never span more.
+        TranslationId[] ids = [.. Enumerable.Range(0, BulkApproveTranslations.MaxIds + 1).Select(_ => TranslationId.Create())];
+
+        // Act
+        Result<BulkApproveTranslationsResponse> result =
+            await CreateHandler().Handle(CommandFor(ids), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translations.Validation");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenAnyIdIsEmpty_ShouldReturnValidationError()
+    {
+        // Act
+        Result<BulkApproveTranslationsResponse> result =
+            await CreateHandler().Handle(CommandFor(TranslationId.Create(), TranslationId.Empty), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translations.Validation");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenProvisioningFails_ShouldReturnFailureAndNotPersist()
+    {
+        // Arrange — a token without a parseable subject must never be attributed to an empty approver;
+        // the batch fails whole and nothing is approved or persisted.
+        Translation row = Draft(1);
+        GivenStoredRows(row);
+        _provisioner = new StubTranslatorProvisioner(Result.Failure<TranslatorId>(new Error(
+            "Translators.Unauthenticated", "no subject", TypeOfError.Forbidden)));
+
+        // Act
+        Result<BulkApproveTranslationsResponse> result =
+            await CreateHandler().Handle(CommandFor(row.Id), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translators.Unauthenticated");
+        row.Status.ShouldBe(TranslationStatus.Draft);
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Handle_WithMixedBatch_ShouldApproveOnlyApprovableRowsSkipTheRestPersistOnceAndRebuildOnce()
+    {
+        // Arrange — a Draft and a NeedsReview row are approvable; an Untranslated row, a removed Draft
+        // and an unknown id (no row returned) are not. Best-effort: approve the two, skip the three.
+        Translation draft = Draft(1, "Witaj");
+        Translation needsReview = NeedsReview(2, "Stary");
+        Translation untranslated = Untranslated(3);
+        Translation removed = RemovedDraft(4, "Gamma");
+        GivenStoredRows(draft, needsReview, untranslated, removed);
+        TranslationId unknownId = TranslationId.Create();
+
+        // Act
+        Result<BulkApproveTranslationsResponse> result = await CreateHandler().Handle(
+            CommandFor(draft.Id, needsReview.Id, untranslated.Id, removed.Id, unknownId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Requested.ShouldBe(5);
+        result.Value.Approved.ShouldBe(2);
+        result.Value.Skipped.ShouldBe(3);
+        draft.Status.ShouldBe(TranslationStatus.Approved);
+        draft.ApprovedById.ShouldBe(Approver);
+        needsReview.Status.ShouldBe(TranslationStatus.Approved);
+        needsReview.PreviousSourceText.ShouldBeNull();
+        untranslated.Status.ShouldBe(TranslationStatus.Untranslated);
+        removed.Status.ShouldBe(TranslationStatus.Draft);
+        // One commit and one debounced rebuild for the whole batch, regardless of how many rows changed.
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+        _rebuildScheduler.ScheduleCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoRowIsApprovable_ShouldReturnZeroApprovedAndNeitherPersistNorRebuild()
+    {
+        // Arrange — an already-Approved row keeps its original approver (it is skipped, not re-stamped),
+        // and an untranslated row has no Polish to publish; nothing enters the distributed set.
+        Translation approved = Draft(1, "Zatwierdzony");
+        approved.Approve(Submitter, Now);
+        Translation untranslated = Untranslated(2);
+        GivenStoredRows(approved, untranslated);
+
+        // Act
+        Result<BulkApproveTranslationsResponse> result =
+            await CreateHandler().Handle(CommandFor(approved.Id, untranslated.Id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Requested.ShouldBe(2);
+        result.Value.Approved.ShouldBe(0);
+        result.Value.Skipped.ShouldBe(2);
+        approved.ApprovedById.ShouldBe(Submitter);
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        _rebuildScheduler.ScheduleCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Handle_WithDuplicateIds_ShouldCountDistinctOnce()
+    {
+        // Arrange — a client that repeats an id must not double-count it (Approved + Skipped == Requested).
+        Translation draft = Draft(1, "Witaj");
+        GivenStoredRows(draft);
+
+        // Act
+        Result<BulkApproveTranslationsResponse> result =
+            await CreateHandler().Handle(CommandFor(draft.Id, draft.Id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Requested.ShouldBe(1);
+        result.Value.Approved.ShouldBe(1);
+        result.Value.Skipped.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Handle_OnSuccess_ShouldScheduleTheRebuildAfterTheCommit()
+    {
+        // Arrange — ADR-0021 §1: the dirty signal must follow SaveChanges, so a zero-debounce rebuild can
+        // never publish a snapshot missing its own trigger. Ordering is invisible in the return value.
+        Translation draft = Draft(1, "Witaj");
+        GivenStoredRows(draft);
+
+        // Act
+        Result<BulkApproveTranslationsResponse> result =
+            await CreateHandler().Handle(CommandFor(draft.Id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        _callOrder.ShouldBe([nameof(IUnitOfWork.SaveChangesAsync), nameof(ITranslationFileRebuildScheduler.Schedule)]);
+    }
+
+    private sealed class RecordingScheduler : ITranslationFileRebuildScheduler
+    {
+        private readonly List<string> _callOrder;
+
+        public RecordingScheduler(List<string> callOrder)
+        {
+            _callOrder = callOrder;
+        }
+
+        public int ScheduleCount { get; private set; }
+
+        public void Schedule(string language)
+        {
+            ScheduleCount++;
+            _callOrder.Add(nameof(ITranslationFileRebuildScheduler.Schedule));
+        }
+    }
+}


### PR DESCRIPTION
Closes #322

Bulk approve for admins from the translations list (spec 0007).

## What
An admin selects several rows on `/translations` and approves them in one action, instead of opening each in the editor.

- **Backend slice** `POST /api/v1/translations/approve` (admin-only): best-effort — approves every requested `Draft`/`NeedsReview` row that is still approvable, silently skips stale/non-approvable ones, de-duplicates ids, stamps all approvals in one `SaveChanges`, and schedules a single debounced artifact rebuild **only when** at least one row was approved. Returns `{ requested, approved, skipped }`; never 404/422 on an individual row. Cap 100 (the list's max page size); empty / over-cap / null body → 400; translator → 403; anonymous → 401.
- **HATEOAS** `bulk-approve` collection rel, emitted only for admins — the FE reads the POST href from it (no hardcoded path; mirrors GameVersions' `register`).
- **List UI** (Static SSR): an admin-only checkbox column on approvable rows + a "Zatwierdź zaznaczone" button. On success it **Post-Redirect-Gets** back to the list with the active filters preserved plus `?approved=<n>&skipped=<m>`, so a browser reload is a safe GET and just-approved rows drop their checkbox; on failure it stays put with the error and the intact list.

## Tests
- Handler unit (best-effort matrix, dedupe, single save, single rebuild, schedule-after-commit, provisioning-failure 403).
- Endpoint integration (real PostgreSQL): approve mix, best-effort skips, approved:0, empty / over-cap / null-body 400, translator 403, anonymous 401.
- `TranslationListQuery.ToPageRelativeUriWithApprovalResult` unit (preserves filters + page, appends the counts).
- Frontend bUnit: checkbox gating (admin / non-admin / no-approvable), the `SelectedRows[<id>]` name guard, empty-selection notice, and the PRG success flash / nothing-approved note read from the query.

The checked-rows → POST DOM round-trip is covered at the loader seam (real `HttpClient`) and belongs end-to-end to the Playwright suite — bUnit's `SubmitAsync` invokes only `@onsubmit` and does not model SSR form-data binding, so it cannot bind a checked `[SupplyParameterFromForm]` dictionary.

Build is zero-warning; all suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
