### PR TITLE
ci: skip Pull Request Verification for non-dotnet-only changes (#325)

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -5,13 +5,14 @@ name: Pull Request Verification
 # author merges their own PRs (loop workflow), so the PR — not a post-merge job — is where
 # main is kept green. The CI workflow re-runs the same suite on main as a backstop.
 #
-# Docs-only PRs (the former deadlock): the main ruleset REQUIRES the "Pull Request Verification"
-# check, but a workflow filtered out by `on.paths-ignore` never reports it — so a docs-only PR
-# could never merge (the workaround was smuggling a non-ignored file into the PR). The workflow
-# therefore ALWAYS triggers and the heavy job self-skips via the `changes` gate below: a job
-# skipped by `if:` reports success to required status checks — GitHub's documented pattern for
-# combining required checks with path filtering. CI (main) keeps its paths-ignore on purpose:
-# a docs-only push must keep triggering no CI and therefore no CD (audit 0001 M2).
+# Non-.NET-only PRs (and the former docs-only deadlock): the main ruleset REQUIRES the "Pull
+# Request Verification" check, but a workflow filtered out by `on.paths-ignore` never reports it —
+# so such a PR could never merge (the old workaround was smuggling a build-relevant file into the
+# PR). The workflow therefore ALWAYS triggers and the heavy job self-skips via the `changes` gate
+# below when nothing in the PR can affect the .NET build/tests/SSR guard: a job skipped by `if:`
+# reports success to required status checks — GitHub's documented pattern for combining required
+# checks with path filtering. CI (main) keeps its own paths-ignore on purpose: a docs-only push
+# must keep triggering no CI and therefore no CD (audit 0001 M2).
 on:
   pull_request:
     branches: ["main"]
@@ -26,7 +27,7 @@ permissions:
 
 jobs:
   changes:
-    name: Detect non-docs changes
+    name: Detect build-relevant changes
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -40,23 +41,37 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
-      # Mirrors the ignore list the `on.paths-ignore` used to carry: **/*.md, docs/**, LICENSE,
-      # .gitignore. No untrusted input reaches this script (pure git against the checked-out merge
-      # commit). Fails OPEN (code=true) if the diff cannot be computed — a redundant build beats a
-      # false green.
+      # A PR that changes ONLY files which cannot affect the .NET build, the unit/integration tests
+      # or the SSR-purity guard skips the heavy job below. No untrusted input reaches this script
+      # (pure git against the checked-out merge commit). Fails OPEN (code=true) if the diff cannot be
+      # computed — a redundant build beats a false green.
       - name: Classify changed paths
         id: diff
         run: |
           set -euo pipefail
+          # Inert paths: docs, shell/PowerShell scripts, IaC (infra.yml gates it separately),
+          # Docker (only the flavors we actually ship — a NEW flavor safely triggers a redundant
+          # build until it is listed here, never a false skip) / compose, the .docker/ trust
+          # material, editor/run configs, .env examples, and everything under .github/ (workflows,
+          # issue/PR templates). A PR touching only these cannot break the .NET build, the tests, or
+          # the SSR guard. NEVER add a build input here (.editorconfig, Directory.*.props/.targets,
+          # global.json, nuget.config, test fixtures) — that would be a false green.
+          inert='\.md$|^docs/|^LICENSE$|^\.gitignore$|^\.gitattributes$|\.sh$|\.ps1$|^iac/|(^|/)Dockerfile(\.migrator(\.prod)?|\.tests)?$|^compose[^/]*\.ya?ml$|^\.docker/|^\.github/|^\.run/|^\.vscode/|^\.idea/|(^|/)\.env[^/]*\.example$'
+          # Build-relevant despite matching `inert`: check-ssr-purity.sh is EXECUTED by the build
+          # job, and pr-verify/ci define the .NET gate itself — a change to any of them must run the
+          # gate so it validates its own new definition.
+          force_build='^scripts/check-ssr-purity\.sh$|^\.github/workflows/pr-verify\.yml$|^\.github/workflows/ci\.yml$'
           code=true
           if files="$(git diff --name-only HEAD^1 HEAD)"; then
-            non_docs="$(printf '%s\n' "$files" | grep -vE '\.md$|^docs/|^LICENSE$|^\.gitignore$' || true)"
-            if [ -n "$files" ] && [ -z "$non_docs" ]; then
+            build_relevant="$(printf '%s\n' "$files" | grep -vE "$inert" || true)"
+            forced="$(printf '%s\n' "$files" | grep -E "$force_build" || true)"
+            if [ -n "$files" ] && [ -z "$build_relevant" ] && [ -z "$forced" ]; then
               code=false
             fi
             echo "Changed files:"
             printf '%s\n' "$files" | sed 's/^/  /'
-            echo "Non-docs files: ${non_docs:-<none>}"
+            echo "Build-relevant files: ${build_relevant:-<none>}"
+            echo "Forced-build files:   ${forced:-<none>}"
           else
             echo "::warning::Could not compute the PR diff — running the full gate."
           fi
@@ -65,7 +80,7 @@ jobs:
   build:
     name: Pull Request Verification
     needs: changes
-    # Docs-only PR ⇒ skipped, and a skipped job satisfies the required "Pull Request Verification"
+    # Inert-only PR ⇒ skipped, and a skipped job satisfies the required "Pull Request Verification"
     # status check (see the header comment).
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Closes #325

## What

`pr-verify.yml` (the required **"Pull Request Verification"** check) already skipped its heavy Release-build + NuGet-restore + unit + integration job for **docs-only** PRs. This broadens that `changes` gate so a PR whose files **cannot affect the .NET build, tests or the SSR-purity guard** also skips it — so changing only a `.sh` script (the ticket's example), a `Dockerfile`, or a non-gate workflow no longer forces a full rebuild. A job skipped by `if:` still reports success to the required check (GitHub's documented pattern), so those PRs stay mergeable.

## Design (denylist / fail-open — a redundant build beats a false green)

- Skips **only** when every changed file is inert **and** nothing is force-listed; builds when the diff can't be computed.
- **Inert (skip):** docs, `.sh`/`.ps1`, `iac/`, the Dockerfile flavors we ship, root `compose*.yaml`, `.docker/`, `.github/`, `.run`/`.vscode`/`.idea`, `.env*.example`.
- **Always build (NOT inert):** `.editorconfig`, `Directory.*.props/.targets`, `global.json`, `nuget.config`, test fixtures, `.cs/.razor/.cshtml/.csproj/.slnx`.
- **Force build despite looking inert:** `scripts/check-ssr-purity.sh` (it's *executed* by the job) and `pr-verify.yml`/`ci.yml` (they *define* the gate, so a change self-validates).

## Scope decisions (made while author was away — easy to revisit)

- **Breadth:** broad denylist incl. `.github/**` — the .NET gate runs iff a change can affect the .NET build/test/SSR outcome. Other file types are already covered by their own workflows (`iac/**`→`infra.yml`, secrets→gitleaks/GitGuardian, `.cs`→codeql).
- **Only `pr-verify.yml`.** `ci.yml`/`codeql.yml` keep their `paths-ignore`, so the CI→CD `workflow_run` deploy linkage on `main` is untouched. Mirroring the inert list into `ci.yml` for main-side savings is a deliberate follow-up, not this PR.

## Verification

- **Classification matrix:** 43 cases green — the `.sh`-only ask, docs-only regression, every build-input, forced self-validation, and the code-review adversarial false-green vectors (`Dockerfile.cs`, `composeThing/deep/x.yaml`, `config/.environment/x.example`).
- **YAML** validates; **Release build** 0 warnings / 0 errors; **unit tests** 239 passed.
- **`code-reviewer`: APPROVE.** Its two real findings — a latent `Dockerfile.*` false-green and over-broad `compose`/`.env` globs — are fixed here (Dockerfile match tightened to shipped flavors; both globs anchored to a single path segment). Stale "Docs-only" comment updated; a "never add a build input to the inert list" guard comment added.

## Deferred

No committed regression test for the bash classifier (the repo has no precedent for testing workflow bash, and wiring one in means extracting the logic to a script + a new CI job — scope creep for a one-file change). The logic is instead pinned by inline guard comments and the reproducible 43-case matrix above. Say the word and I'll extract + CI-wire it as a follow-up.
