### PR TITLE
feat: user-selectable page size on the translation list (#323)

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListQuery.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListQuery.cs
@@ -15,8 +15,15 @@ internal sealed record TranslationListQuery
     /// <summary>The only language the catalog holds today; mirrors the API's single supported language.</summary>
     internal const string Language = "pl";
 
-    /// <summary>Rows per page on the list view. Fixed for now — no user-facing page-size control (YAGNI).</summary>
+    /// <summary>The rows-per-page used when the user has not picked one; must be one of <see cref="PageSizeOptions"/>.</summary>
     internal const int DefaultPageSize = 50;
+
+    /// <summary>
+    /// The user-selectable rows-per-page sizes offered by the list's page-size control (#323). Any other
+    /// requested size (e.g. a hand-typed URL) falls back to <see cref="DefaultPageSize"/>, so the rendered
+    /// dropdown always reflects the size actually in effect. Every value stays within the API's 1–100 clamp.
+    /// </summary>
+    internal static readonly IReadOnlyList<int> PageSizeOptions = [25, 50, 100];
 
     private const string ApiPath = "/api/v1/translations";
     private const string PagePath = "/translations";
@@ -26,7 +33,7 @@ internal sealed record TranslationListQuery
         Search = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
         Status = status;
         Page = Math.Max(page, 1);
-        PageSize = Math.Clamp(pageSize, 1, 100);
+        PageSize = PageSizeOptions.Contains(pageSize) ? pageSize : DefaultPageSize;
     }
 
     public string? Search { get; }
@@ -40,11 +47,12 @@ internal sealed record TranslationListQuery
     /// <summary>
     /// Builds the normalized state from raw query-string inputs: a blank search collapses to
     /// <c>null</c>, an unknown or <see cref="TranslationStatus.Unset"/> status is ignored (treated as
-    /// "all"), and the page is floored at 1.
+    /// "all"), the page is floored at 1, and an absent or unsupported <paramref name="pageSize"/> falls
+    /// back to <see cref="DefaultPageSize"/>.
     /// </summary>
-    public static TranslationListQuery From(string? search, string? status, int page)
+    public static TranslationListQuery From(string? search, string? status, int page, int? pageSize = null)
     {
-        return new TranslationListQuery(search, ParseStatus(status), page, DefaultPageSize);
+        return new TranslationListQuery(search, ParseStatus(status), page, pageSize ?? DefaultPageSize);
     }
 
     /// <summary>
@@ -65,14 +73,16 @@ internal sealed record TranslationListQuery
 
     /// <summary>
     /// The relative URI for this page's own route (<c>/translations</c>) targeting
-    /// <paramref name="page"/> — used to compose pager links. Unlike <see cref="ToApiRelativeUri"/> it
-    /// omits the API-only <c>lang</c>/<c>pageSize</c> so the user-facing URL stays clean, while sharing
-    /// the same encoding path for the <c>search</c>/<c>status</c> filter so the two can never drift.
+    /// <paramref name="page"/> — used to compose pager links. It omits the API-only <c>lang</c> and the
+    /// default <c>pageSize</c> so the user-facing URL stays clean, but carries a non-default page size so
+    /// a chosen size survives paging (#323), while sharing the same encoding path for the
+    /// <c>search</c>/<c>status</c> filter so the two can never drift.
     /// </summary>
     public string ToPageRelativeUri(int page)
     {
         Dictionary<string, string?> parameters = new();
         AddPagingAndFilterParameters(parameters, Math.Max(page, 1));
+        AddNonDefaultPageSize(parameters);
 
         return QueryHelpers.AddQueryString(PagePath, parameters);
     }
@@ -86,6 +96,7 @@ internal sealed record TranslationListQuery
     {
         Dictionary<string, string?> parameters = new();
         AddPagingAndFilterParameters(parameters);
+        AddNonDefaultPageSize(parameters);
         parameters["approved"] = approved.ToString(CultureInfo.InvariantCulture);
         parameters["skipped"] = skipped.ToString(CultureInfo.InvariantCulture);
 
@@ -104,6 +115,19 @@ internal sealed record TranslationListQuery
         if (Status is { } status)
         {
             parameters["status"] = status.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Adds the chosen <c>pageSize</c> to a page-facing URL only when it differs from
+    /// <see cref="DefaultPageSize"/>, so the selected size survives paging and the bulk-approve redirect
+    /// while the default keeps the URL clean — mirroring how <c>search</c>/<c>status</c> appear only when set.
+    /// </summary>
+    private void AddNonDefaultPageSize(Dictionary<string, string?> parameters)
+    {
+        if (PageSize != DefaultPageSize)
+        {
+            parameters["pageSize"] = PageSize.ToString(CultureInfo.InvariantCulture);
         }
     }
 

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
@@ -45,6 +45,18 @@
                     <span class="select-chev" aria-hidden="true">▾</span>
                 </div>
             </div>
+            <div class="field field-page-size">
+                <label for="pageSize">Na stronie</label>
+                <div class="select-wrap">
+                    <select id="pageSize" name="pageSize">
+                        @foreach (int size in TranslationListQuery.PageSizeOptions)
+                        {
+                            <option value="@size" selected="@(_query.PageSize == size)">@size</option>
+                        }
+                    </select>
+                    <span class="select-chev" aria-hidden="true">▾</span>
+                </div>
+            </div>
             <div class="filter-actions">
                 <a class="btn btn-ghost" href="/translations">Wyczyść</a>
                 <button type="submit" class="btn btn-primary">Filtruj</button>
@@ -279,6 +291,14 @@
     private int Page { get; set; }
 
     /// <summary>
+    /// The user-chosen rows-per-page, carried in the query by the filter form's page-size select and the
+    /// pager links (#323). Null on a fresh visit — <see cref="TranslationListQuery.From"/> then falls back
+    /// to <see cref="TranslationListQuery.DefaultPageSize"/>; an unsupported value snaps back to the default.
+    /// </summary>
+    [SupplyParameterFromQuery]
+    private int? PageSize { get; set; }
+
+    /// <summary>
     /// Post-Redirect-Get result counts carried in the query by the redirect target after a bulk approve,
     /// so the confirmation survives the redirect with no per-user server state — the page stays SSR-pure
     /// (#321, #322). Null on a fresh GET (no flash); 0 renders a "nothing approved" note; a positive count
@@ -303,7 +323,7 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        _query = TranslationListQuery.From(Search, Status, Page);
+        _query = TranslationListQuery.From(Search, Status, Page, PageSize);
         _result = await Loader.LoadAsync(_query, CancellationToken.None);
     }
 

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -310,10 +310,14 @@ code {
     border-radius: var(--radius);
     padding: 18px;
     display: grid;
-    grid-template-columns: 1fr 1fr auto;
+    grid-template-columns: 1fr 1fr auto auto;
     gap: 14px;
     align-items: end;
     box-shadow: var(--shadow);
+}
+
+.field-page-size .select-wrap select {
+    min-width: 5rem;
 }
 
 .field {

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListQueryTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListQueryTests.cs
@@ -181,4 +181,89 @@ public sealed class TranslationListQueryTests
         uri.ShouldContain("approved=2");
         uri.ShouldContain("skipped=1");
     }
+
+    [Fact]
+    public void From_WithoutPageSize_DefaultsToDefaultPageSize()
+    {
+        TranslationListQuery query = TranslationListQuery.From(search: null, status: null, page: 1);
+
+        query.PageSize.ShouldBe(TranslationListQuery.DefaultPageSize);
+    }
+
+    [Theory]
+    [InlineData(25)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public void From_WithSupportedPageSize_UsesItAndSendsItToTheApi(int pageSize)
+    {
+        TranslationListQuery query = TranslationListQuery.From(search: null, status: null, page: 1, pageSize: pageSize);
+
+        query.PageSize.ShouldBe(pageSize);
+        query.ToApiRelativeUri().ShouldContain($"pageSize={pageSize}");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(7)]
+    [InlineData(99)]
+    [InlineData(101)]
+    [InlineData(1000)]
+    public void From_WithUnsupportedPageSize_SnapsBackToTheDefault(int pageSize)
+    {
+        // The list snaps an out-of-allowlist size back to the default (unlike the API's raw 1–100 clamp),
+        // so the rendered dropdown can always mark a real option selected (#323).
+        TranslationListQuery query = TranslationListQuery.From(search: null, status: null, page: 1, pageSize: pageSize);
+
+        query.PageSize.ShouldBe(TranslationListQuery.DefaultPageSize);
+    }
+
+    [Fact]
+    public void PageSizeOptions_IncludeTheDefault_SoTheDropdownAlwaysHasASelectedOption()
+    {
+        TranslationListQuery.PageSizeOptions.ShouldContain(TranslationListQuery.DefaultPageSize);
+    }
+
+    [Fact]
+    public void ToPageRelativeUri_WithNonDefaultPageSize_PreservesItAcrossPaging()
+    {
+        TranslationListQuery query = TranslationListQuery.From(search: null, status: null, page: 1, pageSize: 100);
+
+        string uri = query.ToPageRelativeUri(3);
+
+        uri.ShouldContain("page=3");
+        uri.ShouldContain("pageSize=100");
+    }
+
+    [Fact]
+    public void ToPageRelativeUri_WithDefaultPageSize_OmitsPageSizeToKeepTheUrlClean()
+    {
+        TranslationListQuery query =
+            TranslationListQuery.From(search: null, status: null, page: 1, pageSize: TranslationListQuery.DefaultPageSize);
+
+        query.ToPageRelativeUri(3).ShouldNotContain("pageSize=");
+    }
+
+    [Fact]
+    public void ToPageRelativeUriWithApprovalResult_WithNonDefaultPageSize_PreservesIt()
+    {
+        // Continuity with the bulk-approve Post-Redirect-Get (#322): approving on a custom page size must
+        // land back on the same-sized page, not silently reset to the default.
+        TranslationListQuery query = TranslationListQuery.From(search: "Bilbo", status: "Draft", page: 2, pageSize: 25);
+
+        string uri = query.ToPageRelativeUriWithApprovalResult(approved: 1, skipped: 0);
+
+        uri.ShouldContain("page=2");
+        uri.ShouldContain("pageSize=25");
+        uri.ShouldContain("approved=1");
+    }
+
+    [Fact]
+    public void ToPageRelativeUriWithApprovalResult_WithDefaultPageSize_OmitsPageSize()
+    {
+        TranslationListQuery query = TranslationListQuery.From(
+            search: "Bilbo", status: "Draft", page: 2, pageSize: TranslationListQuery.DefaultPageSize);
+
+        query.ToPageRelativeUriWithApprovalResult(approved: 1, skipped: 0).ShouldNotContain("pageSize=");
+    }
 }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
@@ -202,6 +202,61 @@ public sealed class TranslationsTests : BunitContext
         component.Find(".status-message.status-warning").TextContent.ShouldContain("Nie zatwierdzono żadnego");
     }
 
+    [Fact]
+    public void Render_AlwaysOffersThePageSizeSelectWithEveryOption()
+    {
+        // #323: the fixed page size is now a user-facing control — the select must expose exactly the
+        // allowlisted sizes, in order, so the UI and the query builder can never drift.
+        StubPage(SinglePageOf(Row(canEdit: true)));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("#pageSize option")
+            .Select(option => option.GetAttribute("value")!)
+            .ShouldBe(TranslationListQuery.PageSizeOptions.Select(size => size.ToString()));
+    }
+
+    [Fact]
+    public void Render_WhenNoPageSizeInTheQuery_MarksTheDefaultSizeSelected()
+    {
+        StubPage(SinglePageOf(Row(canEdit: true)));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.Find($"#pageSize option[value=\"{TranslationListQuery.DefaultPageSize}\"]")
+            .HasAttribute("selected").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Render_WhenPageSizeInTheQuery_MarksThatSizeSelected()
+    {
+        // The dropdown reflects the size requested in the query string (what the user picked), never a
+        // locally recomputed value — so it always mirrors the page the caller asked for (#323).
+        StubPage(SinglePageOf(Row(canEdit: true)));
+        Navigation().NavigateTo("/translations?pageSize=100");
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.Find("#pageSize option[value=\"100\"]").HasAttribute("selected").ShouldBeTrue();
+        component.Find($"#pageSize option[value=\"{TranslationListQuery.DefaultPageSize}\"]")
+            .HasAttribute("selected").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Render_WhenPageSizeInTheQueryIsUnsupported_MarksTheDefaultSelectedAndRendersNoBogusOption()
+    {
+        // AC4 (#323): a hand-typed, unsupported size must snap to the default in the UI too — the select
+        // exposes no "7" option and marks the default selected, never left with nothing chosen.
+        StubPage(SinglePageOf(Row(canEdit: true)));
+        Navigation().NavigateTo("/translations?pageSize=7");
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("#pageSize option[value=\"7\"]").ShouldBeEmpty();
+        component.Find($"#pageSize option[value=\"{TranslationListQuery.DefaultPageSize}\"]")
+            .HasAttribute("selected").ShouldBeTrue();
+    }
+
     private IRenderedComponent<TranslationsComponent> RenderPage() =>
         Render<TranslationsComponent>();
 


### PR DESCRIPTION
Closes #323

## What

Adds a user-selectable page size to the translation list (`/translations`). Previously the page size was fixed at 50 with no way to change it from the UI.

## Why

The ticket: *"From UI, we cannot choose page size. It's fixed and we can't do nothing about it."* This adds a **"Na stronie"** (per page) dropdown to the filter form.

## How

- The API already accepts and clamps `pageSize` to `[1,100]` (`ListTranslations.cs`), and the FE query already plumbed it through — it was just hard-coded to 50. So this is a **frontend-only** change.
- `TranslationListQuery` gains a `PageSizeOptions` allowlist. An absent or unsupported size (e.g. a hand-typed `?pageSize=7`) snaps back to the default, so the rendered dropdown always shows a real, selected option (deliberately stricter than the API's raw clamp).
- The chosen **non-default** size is preserved across the pager links and the bulk-approve Post-Redirect-Get (#322), so paging or approving never silently resets it; the default is kept out of the user-facing URL to keep it clean (mirrors how `search`/`status` appear only when set).
- The `<select name="pageSize">` mirrors the existing Status select 1:1; `[SupplyParameterFromQuery] int? PageSize` binds it. Stays Static-SSR pure.

## Decision to confirm

Preset ladder **25 / 50 / 100** (default 50), bracketing the current fixed 50. Trivial to adjust — the values live in one place (`TranslationListQuery.PageSizeOptions`).

## Tests

- **Query-builder unit tests** — supported / unsupported / out-of-range sizes, persistence across paging and the approve PRG, default-omit symmetry.
- **bUnit render tests** — the select renders exactly the allowlist in order; the correct option is marked `selected` for the absent / explicit / unsupported query cases.
- ✅ 313 Frontend unit tests green · ✅ full solution build **0 warnings / 0 errors** · ✅ SSR-purity check passes · `code-reviewer`: **APPROVE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
