### PR TITLE
chore: fix line-ending policy to LF so dotnet format is usable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = true
 
 #### .NET Coding Conventions ####

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Line-ending policy for this cross-platform .NET repo.
+#
+# The repo is developed on macOS/Linux and builds & runs in Linux Docker/CI, so LF
+# is the canonical line ending. Forcing eol=lf on checkout (not just in the index)
+# keeps every working tree consistent with `.editorconfig` (end_of_line = lf) on
+# every platform, including a Windows dev machine, so `dotnet format` never wants to
+# rewrite line endings again.
+
+# Auto-detect text vs binary; normalize text to LF in the repo and check it out as LF everywhere.
+* text=auto eol=lf
+
+# Windows-only patcher wrappers. cmd.exe can mis-parse multi-line parenthesized blocks
+# (e.g. `if errorlevel 1 ( ... )`) with LF-only endings, so these must stay CRLF in the
+# working tree. The blob is still normalized to LF in the repo, keeping diffs clean.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Native interop binaries and DAT game files — never apply EOL normalization.
+*.dll binary
+*.dat binary

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ExceptionHandlers/ArgumentExceptionHandler.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ExceptionHandlers/ArgumentExceptionHandler.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LotroKoniecDev.AuthSystem.API.ExceptionHandlers;
+
 internal sealed partial class ArgumentExceptionHandler : IExceptionHandler
 {
     private readonly ILogger<ArgumentExceptionHandler> _logger;

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/EmailMaskingExtensions.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/EmailMaskingExtensions.cs
@@ -7,7 +7,7 @@ internal static class EmailMaskingExtensions
         public string MaskEmail()
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(email);
-            
+
             int atIndex = email.IndexOf('@', StringComparison.Ordinal);
             return atIndex <= 0 ? "***" : string.Concat(email[0].ToString(), "***", email[atIndex..]);
         }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -118,7 +118,7 @@ try
     {
         openTelemetryBuilder.UseOtlpExporter();
     }
-    
+
     builder.Services.AddResponseCompression(options =>
     {
         options.EnableForHttps = true;

--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -173,7 +173,7 @@ try
 
     app.UseAuthentication();
     app.UseAuthorization();
-    
+
     app.UseAntiforgery();
 
     app.MapStaticAssets();

--- a/src/Patcher/LotroKoniecDev.Application/Abstractions/IGameVersionFileStore.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Abstractions/IGameVersionFileStore.cs
@@ -11,7 +11,7 @@ public interface IGameVersionFileStore
     /// Reads the stored version info. Returns null if the file does not exist (first run).
     /// </summary>
     Result<StoredVersionInfo?> ReadStoredVersion(string versionFilePath);
-    
+
     Result SaveVersion(
         string versionFilePath,
         string? forumVersion,

--- a/src/Patcher/LotroKoniecDev.Application/Features/Exporting/ExportTextsQueryHandler.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/Exporting/ExportTextsQueryHandler.cs
@@ -22,7 +22,7 @@ internal sealed class ExportTextsQueryHandler : IQueryHandler<ExportTextsQuery, 
         _datFileHandler = datFileHandler;
         _progressReporter = progressReporter;
     }
-    
+
     public async ValueTask<Result<ExportSummaryResponse>> Handle(ExportTextsQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -44,9 +44,9 @@ internal sealed class ExportTextsQueryHandler : IQueryHandler<ExportTextsQuery, 
         {
             return Result.Failure<ExportSummaryResponse>(openResult.Error);
         }
-        
+
         int handle = openResult.Value;
-        
+
         try
         {
             Dictionary<int, (int Size, int Iteration)> fileSizes = _datFileHandler.GetAllSubfileSizes(handle);
@@ -63,8 +63,8 @@ internal sealed class ExportTextsQueryHandler : IQueryHandler<ExportTextsQuery, 
                 if (!SubFile.IsTextFile(fileId))
                 {
                     continue;
-                }            
-                
+                }
+
                 Result<SubFile> loadResult = _datFileHandler.LoadSubFile(handle, fileId, size);
                 if (loadResult.IsSuccess)
                 {
@@ -107,7 +107,7 @@ internal sealed class ExportTextsQueryHandler : IQueryHandler<ExportTextsQuery, 
                     _progressReporter.Report(new OperationProgress(processedFiles, totalTextFiles));
                 }
             }
-            
+
             return Result.Success(new ExportSummaryResponse(
                 processedFiles,
                 totalFragments,
@@ -122,9 +122,9 @@ internal sealed class ExportTextsQueryHandler : IQueryHandler<ExportTextsQuery, 
         {
             _datFileHandler.Close(handle);
         }
-        
+
     }
-    
+
     private static async Task WriteHeaderAsync(StreamWriter writer)
     {
         await writer.WriteLineAsync("# LOTRO Text Export - Ready for Translation");

--- a/src/Patcher/LotroKoniecDev.Application/Features/GameLaunching/SimplifiedGameLaunchingStrategy.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/GameLaunching/SimplifiedGameLaunchingStrategy.cs
@@ -61,11 +61,11 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
                 Result.Failure<GameLaunchingResponse>(hashResult.Error));
         }
         string currentHash = hashResult.Value;
-        
+
         _logger.LogInformation("Current translation hash: {Hash}", currentHash);
 
         _logger.LogInformation("Step 2: Reading stored version info...");
-        
+
         Result<StoredVersionInfo?> storedResult = _gameVersionFileStore.ReadStoredVersion(command.GameVersionFilePath);
         if (storedResult.IsFailure)
         {
@@ -108,7 +108,7 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
                     Result.Failure<GameLaunchingResponse>(
                         DomainErrors.GameLaunch.RepatchFailed(patchResult.Error.Message)));
             }
-            
+
             PatchSummaryResponse patchSummary = patchResult.Value;
 
             translationsApplied = true;
@@ -120,7 +120,7 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
 
             // Save new hash + current vnum
             _logger.LogInformation("Reading DAT vnum to save alongside hash...");
-            
+
             Result<DatVersionInfo> vnumResult = _datVersionReader.ReadVersion(command.DatFilePath);
             if (vnumResult.IsFailure)
             {
@@ -129,7 +129,7 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
                     Result.Failure<GameLaunchingResponse>(vnumResult.Error));
             }
             DatVersionInfo datVersion = vnumResult.Value;
-            
+
             _logger.LogInformation("DAT vnum: VnumDat={VnumDat}, VnumGame={VnumGame}",
                 datVersion.VnumDatFile, datVersion.VnumGameData);
 

--- a/src/Patcher/LotroKoniecDev.Application/Features/PreflightChecking/PreflightCheckQueryHandler.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/PreflightChecking/PreflightCheckQueryHandler.cs
@@ -19,7 +19,7 @@ internal sealed class PreflightCheckQueryHandler : IQueryHandler<PreflightCheckQ
         _gameProcessDetector = gameProcessDetector;
         _writeAccessChecker = writeAccessChecker;
     }
-    
+
     public async ValueTask<Result<PreflightReportResponse>> Handle(PreflightCheckQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -37,13 +37,13 @@ internal sealed class PreflightCheckQueryHandler : IQueryHandler<PreflightCheckQ
         }
 
         bool isGameRunning = _gameProcessDetector.IsLotroRunning();
-        
+
         string? directory = Path.GetDirectoryName(query.DatFilePath);
         bool hasWriteAccess = directory is not null && _writeAccessChecker.CanWriteTo(directory);
-        
-        Result<GameUpdateCheckSummary> gameUpdateCheckSummaryResult = 
+
+        Result<GameUpdateCheckSummary> gameUpdateCheckSummaryResult =
             await _gameUpdateChecker.CheckForUpdateAsync(query.VersionFilePath);
-        
+
         return Result.Success(new PreflightReportResponse(isGameRunning, hasWriteAccess, gameUpdateCheckSummaryResult));
     }
 }

--- a/src/Patcher/LotroKoniecDev.Cli/Commands/ExportCommand.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/Commands/ExportCommand.cs
@@ -22,7 +22,7 @@ internal sealed class ExportCommand : AsyncCommand<ExportCommand.Settings>
         _datPathResolver = datPathResolver;
         _reporter = reporter;
     }
-    
+
     public sealed class Settings : GlobalSettings
     {
         [CommandOption("-d|--dat-file-path")]
@@ -33,7 +33,7 @@ internal sealed class ExportCommand : AsyncCommand<ExportCommand.Settings>
         [Description("Optional output path. Defaults to data/exported.txt")]
         public string? OutputPath { get; init; }
     }
-    
+
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         string? actualDatPath = _datPathResolver.Resolve(settings.DatFilePath);
@@ -41,13 +41,13 @@ internal sealed class ExportCommand : AsyncCommand<ExportCommand.Settings>
         {
             return ExitCodes.FileNotFound;
         }
-        
+
         string actualOutputPath = settings.OutputPath ?? Path.Combine(GlobalSettings.DataDir, "exported.txt");
 
         ExportTextsQuery query = new(
             DatFilePath: actualDatPath,
             OutputPath: actualOutputPath);
-        
+
         try
         {
             Result<ExportSummaryResponse> result = await _exportTextsHandler.Handle(query, cancellationToken);
@@ -65,7 +65,7 @@ internal sealed class ExportCommand : AsyncCommand<ExportCommand.Settings>
             _reporter.Report("Operation cancelled by user.");
             return ExitCodes.OperationCancelled;
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             _reporter.Report(ex.ToString());
             return ExitCodes.OperationFailed;

--- a/src/Patcher/LotroKoniecDev.Cli/Commands/GlobalSettings.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/Commands/GlobalSettings.cs
@@ -16,7 +16,7 @@ internal class GlobalSettings : CommandSettings
 
     public static string DataDir => Path.GetFullPath("data");
     public static string VersionFilePath => Path.Combine(DataDir, "last_known_game_version.txt");
-    
+
     [CommandOption("-v|--verbose")]
     [Description("Enable verbose output")]
     [DefaultValue(false)]

--- a/src/Patcher/LotroKoniecDev.Cli/Commands/LaunchCommand.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/Commands/LaunchCommand.cs
@@ -33,7 +33,7 @@ internal sealed class LaunchCommand : AsyncCommand<LaunchCommand.Settings>
         _reporter = reporter;
         _datPathResolver = datPathResolver;
     }
-    
+
     public sealed class Settings : GlobalSettings
     {
         [CommandArgument(0, "<NAME>")]
@@ -53,7 +53,7 @@ internal sealed class LaunchCommand : AsyncCommand<LaunchCommand.Settings>
         [DefaultValue(false)]
         public bool SkipSync { get; init; }
     }
-    
+
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings,
         CancellationToken cancellationToken)
     {
@@ -98,7 +98,7 @@ internal sealed class LaunchCommand : AsyncCommand<LaunchCommand.Settings>
             return ExitCodes.OperationFailed;
         }
     }
-    
+
     private async Task<int?> SyncTranslationFileAsync(Settings settings, CancellationToken cancellationToken)
     {
         string translationsPath = ResolveTranslationsPath(settings.TranslationName);
@@ -123,7 +123,7 @@ internal sealed class LaunchCommand : AsyncCommand<LaunchCommand.Settings>
             _reporter.Report($"Translation file not found: {actualTranslationsPath}");
             return null;
         }
-        
+
         string? datFilePath = _datPathResolver.Resolve(settings.DatFilePath);
         if (datFilePath is null)
         {
@@ -138,7 +138,7 @@ internal sealed class LaunchCommand : AsyncCommand<LaunchCommand.Settings>
         _reporter.Report($"DAT file not found: {datFilePath}");
         return null;
     }
-    
+
     private static string ResolveTranslationsPath(string input)
     {
         return input.Contains(Path.DirectorySeparatorChar) ||

--- a/src/Patcher/LotroKoniecDev.Cli/DatPathResolver.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/DatPathResolver.cs
@@ -13,14 +13,14 @@ internal sealed class DatPathResolver : IDatPathResolver
     {
         _datFileLocator = datFileLocator;
     }
-    
+
     public string? Resolve(string? explicitPath)
     {
         if (!string.IsNullOrWhiteSpace(explicitPath))
         {
             return explicitPath;
         }
-        
+
         Result<IReadOnlyList<DatFileLocation>> result = _datFileLocator.LocateAll(WriteInfo);
 
         if (result.IsFailure)

--- a/src/Patcher/LotroKoniecDev.Cli/Program.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/Program.cs
@@ -28,23 +28,23 @@ public sealed class Program
             cancellationTokenSource.Cancel();
             Console.WriteLine("Cancellation requested...");
         };
-        
+
         ServiceCollection services = new();
         services.AddLogging(builder => builder.AddSerilog());
         services.AddApplicationServices();
         services.AddInfrastructureServices();
         services.AddCliServices();
-        
+
         TypeRegistrar typeRegistrar = new(services);
         CommandApp app = new(typeRegistrar);
 
         app.Configure(config =>
         {
             config.SetApplicationName("LotroKoniecDev");
-            
+
             config.AddCommand<ExportCommand>("export")
                   .WithDescription("EXPORT texts from game");
-            
+
             config.AddCommand<PatchCommand>("patch")
                   .WithDescription("PATCH (inject translations)");
 

--- a/src/Patcher/LotroKoniecDev.Domain/Core/Errors/InfrastructureDomainErrors.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Core/Errors/InfrastructureDomainErrors.cs
@@ -50,7 +50,7 @@ public static partial class DomainErrors
         public static Error VersionNotFoundInPage =>
             OperationFailed("GameUpdateCheck",
                 "Could not find version information on the LOTRO release notes page.");
-        
+
         public static Error GameUpdateRequired =>
             OperationFailed("GameUpdateCheck",
                 "Game update is required");

--- a/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatExportNative.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatExportNative.cs
@@ -70,7 +70,7 @@ internal static partial class DatExportNative
         out uint datFileId,
         [Out, MarshalAs(UnmanagedType.LPArray, SizeConst = 64)] byte[] datIdStamp,
         [Out, MarshalAs(UnmanagedType.LPArray, SizeConst = 64)] byte[] firstIterGuid);
-    
+
 
     /// <summary>
     /// Retrieves the total number of subfiles present in the specified DAT file.

--- a/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatFileHandler.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatFileHandler.cs
@@ -121,7 +121,7 @@ public sealed class DatFileHandler : IDatFileHandler, IDatVersionReader
             return Result.Failure<DatVersionInfo>(DomainErrors.DatFile.CannotOpen($"{datFilePath}: {ex.Message}"));
         }
     }
-    
+
     public Dictionary<int, (int Size, int Iteration)> GetAllSubfileSizes(int handle)
     {
         ThrowIfDisposed();

--- a/src/Utilities/LotroKoniecDev.Hateoas/LinkFactories/LinkFactory.cs
+++ b/src/Utilities/LotroKoniecDev.Hateoas/LinkFactories/LinkFactory.cs
@@ -42,9 +42,9 @@ internal sealed partial class LinkFactory : ILinkFactory
         {
             return new LinkDto(Href: href, Rel: rel, Method: method);
         }
-        
+
         LogHateoasLinksGenerationFailure(_logger, endpoint, rel, method, values);
-        
+
         return null;
     }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConcurrencyEndpointsTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConcurrencyEndpointsTests.cs
@@ -43,7 +43,7 @@ public sealed class ConcurrencyEndpointsTests : EndpointsTestBase
             {
                 continue;
             }
-            
+
             ProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
             ((int)response.StatusCode).ShouldBeLessThan(500,
                 $"Internal Server Error: {problemDetails?.Detail}");

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
@@ -107,14 +107,14 @@ public sealed partial class RegisterPageTests : EndpointsTestBase
         string confirmPassword,
         bool acceptedPrivacyPolicy = true,
         bool acceptedDataProcessingConsent = true) => new()
-    {
-        ["Username"] = request.Username,
-        ["Email"] = request.Email,
-        ["Password"] = request.Password,
-        ["ConfirmPassword"] = confirmPassword,
-        ["AcceptedPrivacyPolicy"] = acceptedPrivacyPolicy ? "true" : "false",
-        ["AcceptedDataProcessingConsent"] = acceptedDataProcessingConsent ? "true" : "false"
-    };
+        {
+            ["Username"] = request.Username,
+            ["Email"] = request.Email,
+            ["Password"] = request.Password,
+            ["ConfirmPassword"] = confirmPassword,
+            ["AcceptedPrivacyPolicy"] = acceptedPrivacyPolicy ? "true" : "false",
+            ["AcceptedDataProcessingConsent"] = acceptedDataProcessingConsent ? "true" : "false"
+        };
 
     private async Task<HttpResponseMessage> PostToRegisterPageAsync(Dictionary<string, string> formFields)
     {

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/OpenIddictSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/OpenIddictSettingsValidatorTests.cs
@@ -316,17 +316,17 @@ public sealed class OpenIddictSettingsValidatorTests
         string? issuer = ValidIssuer,
         string[]? redirectUris = null,
         string[]? postLogoutRedirectUris = null) => new()
-    {
-        Issuer = issuer!,
-        ApiClientSecret = apiClientSecret!,
-        EncryptionKey = new EncryptionKeySettings { Key = encryptionKey! },
-        SigningKey = new SigningKeySettings { RsaPrivateKeyXml = signingKeyXml! },
-        WebClient = new WebClientSettings
         {
-            RedirectUris = redirectUris ?? ValidRedirectUris,
-            PostLogoutRedirectUris = postLogoutRedirectUris ?? ValidPostLogoutRedirectUris
-        }
-    };
+            Issuer = issuer!,
+            ApiClientSecret = apiClientSecret!,
+            EncryptionKey = new EncryptionKeySettings { Key = encryptionKey! },
+            SigningKey = new SigningKeySettings { RsaPrivateKeyXml = signingKeyXml! },
+            WebClient = new WebClientSettings
+            {
+                RedirectUris = redirectUris ?? ValidRedirectUris,
+                PostLogoutRedirectUris = postLogoutRedirectUris ?? ValidPostLogoutRedirectUris
+            }
+        };
 
     private static OpenIddictSettingsValidator CreateValidator(string environmentName)
         => new(new FakeWebHostEnvironment(environmentName));

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/AuthSystemSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Settings/AuthSystemSettingsValidatorTests.cs
@@ -90,12 +90,12 @@ public sealed class AuthSystemSettingsValidatorTests
         string clientId = "lotrokoniecdev-web",
         string callbackPath = "/callback",
         IReadOnlyList<string>? scopes = null) => new()
-    {
-        BaseUrl = baseUrl,
-        Authority = authority,
-        ClientId = clientId,
-        CallbackPath = callbackPath,
-        SignedOutCallbackPath = "/signout-callback-oidc",
-        Scopes = scopes ?? ["openid", "profile", "api"]
-    };
+        {
+            BaseUrl = baseUrl,
+            Authority = authority,
+            ClientId = clientId,
+            CallbackPath = callbackPath,
+            SignedOutCallbackPath = "/signout-callback-oidc",
+            Scopes = scopes ?? ["openid", "profile", "api"]
+        };
 }

--- a/tests/LotroKoniecDev.Tests.E2E/TestFixture.cs
+++ b/tests/LotroKoniecDev.Tests.E2E/TestFixture.cs
@@ -217,7 +217,7 @@ public sealed class E2ETestFixture : IAsyncLifetime
         string exeName = $"{CliProjectName}.exe";
         string exePath = Directory.GetFiles(cliBinDir, exeName, SearchOption.AllDirectories)
             .OrderByDescending(File.GetLastWriteTimeUtc)
-            .FirstOrDefault() 
+            .FirstOrDefault()
             ?? throw new InvalidOperationException(
                 $"CLI exe '{exeName}' not found under {cliBinDir}. Build the CLI first: dotnet build src/Patcher/{CliProjectName}");
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/AuthSettingsValidatorTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/AuthSettingsValidatorTests.cs
@@ -91,9 +91,9 @@ public sealed class AuthSettingsValidatorTests
         string issuer = "https://auth.lotro-translator.pl",
         string audience = "lotrokoniecdev-api",
         string? authority = "https://auth.lotro-translator.pl") => new()
-    {
-        Issuer = issuer,
-        Audience = audience,
-        Authority = authority
-    };
+        {
+            Issuer = issuer,
+            Audience = audience,
+            Authority = authority
+        };
 }


### PR DESCRIPTION
Closes #296

## What
- `.editorconfig`: `[*.cs] end_of_line` `crlf` -> `lf`.
- New `.gitattributes`: LF as the cross-platform default (checkout `eol=lf` on every platform, matching `.editorconfig`), with `*.bat`/`*.cmd` pinned to CRLF and `*.dll`/`*.dat` marked binary.
- `dotnet format whitespace`: ~100 genuine whitespace fixes across 23 files.

## Why
`[*.cs] end_of_line = crlf` on a repo where every tracked file is committed as LF (and builds/runs on Linux CI/Docker) made `dotnet format` want to rewrite ~51k lines `LF -> CRLF` — a diff that would trash `git blame` repo-wide and risk breakage on the Linux runners. This corrects the policy and locks it in at the git level so it cannot drift back.

## Deviation from the ticket's proposed snippet
The ticket proposed a blanket `* text=auto eol=lf` + `*.cs text eol=lf`. That would force LF onto the Windows-only patcher wrappers (`export/patch/lotro.bat`), whose multi-line `if errorlevel 1 ( ... )` blocks `cmd.exe` mis-parses with LF-only endings. So `*.bat`/`*.cmd` are pinned to `eol=crlf`, and the native binaries (`*.dll`, `*.dat`) are marked `binary` so they are never EOL-normalized.

## Tests
- `dotnet format whitespace LotroKoniecDev.slnx --verify-no-changes` -> exit `0` (no ENDOFLINE, no WHITESPACE).
- `git add --renormalize .` -> no-op: every blob is already LF, so this is a policy fix, not a repo-wide CRLF rewrite.
- `dotnet build LotroKoniecDev.slnx` -> 0 warnings, 0 errors.
- Unit tests: 859 passed, 0 failed, 0 skipped. No `.bat`/`.sh`/`.dll` touched by the format pass.

## Deferred
- Optional CI gate (`dotnet format --verify-no-changes`) is left as a separate follow-up to keep this PR narrow, per the ticket's own "optional / follow-up" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
