### PR TITLE
[Auth] Log in by email + password; username becomes a display-only unique handle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ POSTGRES_PASSWORD=changeme
 
 # --- Auth admin (seeded into the auth DB on first boot) ---
 # Leave blank to skip admin seeding. Set all three to seed a usable login.
+# USERNAME must match ^[a-zA-Z0-9]+$ (letters + digits only) or auth-api fails at startup.
 AUTH_ADMIN_USERNAME=
 AUTH_ADMIN_EMAIL=
 AUTH_ADMIN_PASSWORD=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -49,6 +49,7 @@ Email__Password=
 
 # --- Auth admin seed (optional; seeded into the auth DB on first boot) ---
 # Leave blank to skip admin seeding. Set all three to seed a usable login.
+# USERNAME must match ^[a-zA-Z0-9]+$ (letters + digits only) or auth-api fails at startup.
 AUTH_ADMIN_USERNAME=
 AUTH_ADMIN_EMAIL=
 AUTH_ADMIN_PASSWORD=

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -107,6 +107,7 @@ services:
       Email__Sender: ${Email__Sender}
       Email__Username: ${Email__Username:-}
       Email__Password: ${Email__Password:-}
+      # AUTH_ADMIN_USERNAME must match ^[a-zA-Z0-9]+$ or auth-api fails at startup (ADR-0022).
       AdminUser__Username: ${AUTH_ADMIN_USERNAME:-}
       AdminUser__Email: ${AUTH_ADMIN_EMAIL:-}
       AdminUser__Password: ${AUTH_ADMIN_PASSWORD:-}

--- a/docs/API.md
+++ b/docs/API.md
@@ -244,10 +244,13 @@ The login/consent UI is server-rendered Razor Pages: `/Account/Login`, `/Account
 | `GET` | `auth/account/data-export` | bearer token | `AccountDataExportResponse` — GDPR export |
 | `GET` | `/` | anonymous | discovery document (links into the auth flows) |
 
-`RegisterRequest`: `{ username, email, password, phoneNumber, acceptedPrivacyPolicy, acceptedDataProcessingConsent }`.
+`RegisterRequest`: `{ username, email, password, acceptedPrivacyPolicy, acceptedDataProcessingConsent }`.
 Both consent flags **must be `true`**. Password rules (`PasswordValidationRules.cs`): **8–128** chars,
-≥1 digit, ≥1 lowercase, ≥1 uppercase, ≥1 special. Email unique, ≤ 250, regex-validated; username ≤ 150;
-phone ≤ 30. Email confirmation is **required to sign in**; lockout is **5 failed attempts / 5 min**.
+≥1 digit, ≥1 lowercase, ≥1 uppercase, ≥1 special. Email unique (case-insensitively, physical via the
+unique `EmailIndex`), ≤ 250, regex-validated — **the e-mail is the login identifier** (ADR-0022).
+Username is a **display-only handle**: unique (case-insensitively), `^[a-zA-Z0-9]+$` (letters + digits
+only — `UsernameConstants`), ≤ 150; it never authenticates. Email confirmation is **required to sign
+in**; lockout is **5 failed attempts / 5 min**.
 
 > **No registration saga.** Registering creates only the AuthSystem user (ADR-0002 §7 / ADR-0004) —
 > the KittySaver `RegisterUser → CreatePerson` saga is deliberately **not** lifted. The TMS

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -235,15 +235,16 @@ Lifted wholesale (OpenIddict + ASP.NET Identity). Pełna narracja: [auth-tutoria
 | # | Invariant | Reguła | Lokalizacja |
 |---|-----------|--------|-------------|
 | INV-11.1 | 🔵 Hasło: **8–128**, ≥1 cyfra/mała/wielka/specjalny | FluentValidation; Identity `RequiredLength=8` (⚠️ bez górnego limitu na poziomie Identity). | `PasswordValidationRules.cs:13-22`, `PersistenceDependencyInjection.cs:41-45` |
-| INV-11.2 | 🔵 Email **unikalny** ≤ 250 regex; Username ≤ 150; Phone **wymagany** ≤ 30 | Walidator rejestracji. | `RegisterUser.cs:36-53` |
+| INV-11.2 | 🔵 **E-mail jest loginem** (ADR-0022): unikalny **case-insensitive** ≤ 250 regex; Username = **handle display-only**: unikalny (case-insensitive), `^[a-zA-Z0-9]+$` ≤ 150 | Walidator rejestracji + `UsernameConstants` + Identity `AllowedUserNameCharacters`; unikalność e-maila fizyczna przez **unikalny `EmailIndex`** na `NormalizedEmail`. | `RegisterUser.cs`, `UsernameConstants.cs`, `PersistenceDependencyInjection.cs`, `ApplicationUserConfiguration.cs` |
 | INV-11.3 | 🔵 Zgody privacy + data-processing **muszą być true** | Inaczej walidacja rejestracji odrzuca. | `RegisterUser.cs:55-59` |
 | INV-11.4 | 🔵 ⚠️ Nowy użytkownik dostaje rolę **`Translator`** | Self-register → `Translator`; seedowany admin → `Admin`. | `RegisterUser.cs:140`, `DatabaseSeederExtensions.cs:101` |
 | INV-11.5 | 🔵 Email confirmation **wymagane do logowania**; lockout **5 prób / 5 min** | `SignIn.RequireConfirmedEmail`, `Lockout.MaxFailedAccessAttempts=5`. | `PersistenceDependencyInjection.cs:47-49` |
 | INV-11.6 | 🔵 Tokeny: access **60 min**, refresh **14 dni** (referencyjne, rolling); email/reset **24 h** | Refresh tokeny w bazie ⇒ rewokowalne; rotacja przy użyciu. | `OpenIddictSettings.cs:16-17`, `:50`, `PersistenceDependencyInjection.cs:58` |
-| INV-11.7 | 🔵 Anti-enumeration | Forgot/Resend zawsze sukces; token endpoint dummy-hash przy braku usera. | `TokenEndpoint.cs:20`, `:85-87` |
+| INV-11.7 | 🔵 Anti-enumeration | Forgot/Resend zawsze sukces; token endpoint i strona logowania dummy-hash przy braku usera (i lockout); gate potwierdzenia e-maila **po** weryfikacji hasła. | `TokenEndpoint.cs:20-21`, `Login.cshtml.cs` |
 | INV-11.8 | 🔵 ⚠️ **Brak sagi rejestracji** | Rejestracja tworzy tylko usera Auth; profil `Translator` powstaje leniwie na pierwszym zapisie TMS (ADR-0002 §7 / ADR-0004). | `RegisterUser.cs:170-173` |
 | INV-11.9 | 🔵 `DeleteAccount` = erasure RODO + **permanentny lockout** | Wymaga hasła; `LockoutEnd = MaxValue`. | `DeleteAccount.cs:120-121`, `:187-191` |
 | INV-11.10 | 🔵 Produkcja: auth code + **PKCE**; klucze RSA-2048 / AES-256 walidowane | Dev/Testing = klucze ephemeralne; password flow tylko w `Testing`. | `OpenIddictExtensions.cs:45`, `:113-157` |
+| INV-11.11 | 🔵 **Logowanie = e-mail + hasło** na każdej ścieżce | Strona logowania i password grant robią `FindByEmailAsync`; username **nigdy nie uwierzytelnia** (charsety loginu i e-maila są rozłączne — username nie zawiera `@`). Claim `name` = username (ADR-0022). | `Login.cshtml.cs`, `TokenEndpoint.cs` |
 
 ---
 

--- a/docs/INVARIANTS.slim.md
+++ b/docs/INVARIANTS.slim.md
@@ -72,7 +72,8 @@ Wszystko w jednej transakcji (all-or-nothing, idempotentny re-upload); błędy =
 
 ## 11. Auth (AuthSystem — lift)
 - 🔵 Hasło **8–128** + ≥1 cyfra/mała/wielka/specjalny; Identity `RequiredLength=8` (⚠️ bez górnego limitu na poziomie Identity).
-- 🔵 Email unikalny ≤ 250 regex; Username ≤ 150; Phone **wymagany** ≤ 30. Zgody privacy + data-processing **muszą być true**.
+- 🔵 **E-mail jest loginem** (ADR-0022): unikalny **case-insensitive** ≤ 250 regex (fizycznie: unikalny `EmailIndex` na `NormalizedEmail`). Username = **handle display-only**: unikalny (case-insensitive), `^[a-zA-Z0-9]+$` ≤ 150. Zgody privacy + data-processing **muszą być true**.
+- 🔵 **Logowanie = e-mail + hasło** na każdej ścieżce (strona logowania + password grant, oba `FindByEmailAsync`); username **nigdy nie uwierzytelnia**; claim `name` = username.
 - 🔵 ⚠️ Nowy user ⇒ rola **`Translator`** (role: `Admin`/`Translator`); seedowany admin ⇒ `Admin`.
 - 🔵 Email confirmation **wymagane do logowania**; lockout **5 prób / 5 min**. Tokeny: access **60 min**, refresh **14 dni** (referencyjne, rolling, rewokowalne); email/reset **24 h**.
 - 🔵 Anti-enumeration (Forgot/Resend zawsze sukces; dummy-hash przy braku usera). Produkcja = auth code + **PKCE**, klucze RSA-2048/AES-256 walidowane; password flow tylko w `Testing`.

--- a/docs/adr/0022-email-login-username-display-only-handle.md
+++ b/docs/adr/0022-email-login-username-display-only-handle.md
@@ -47,8 +47,11 @@ uniqueness + charset survive here, so the concept "username" survives with them.
 
 ### 2. The username charset is an explicit decision, enforced in three layers from one constant
 
-`^[a-zA-Z0-9]+$` — ASCII letters + digits only; spaces, `-._@+` and diacritics all rejected;
-`Gandalf`/`gandalf` collide via Identity normalization, as desired. One source of truth —
+`\A[a-zA-Z0-9]+\z` — ASCII letters + digits only; spaces, `-._@+` and diacritics all rejected;
+`Gandalf`/`gandalf` collide via Identity normalization, as desired. The anchors are `\A`/`\z`,
+not `^`/`$`, because .NET's `$` also matches before a trailing `\n` — `"kasia92\n"` would slip
+through the validator and surface as the raw Identity error this ADR abolishes (same anchoring
+style as `EmailConstants`). One source of truth —
 `UsernameConstants` in `SharedKernel/Constants/` (next to `EmailConstants`): `MaxLength = 150`,
 `AllowedCharacters`, `RegexPattern`. Three enforcement layers:
 

--- a/docs/adr/0022-email-login-username-display-only-handle.md
+++ b/docs/adr/0022-email-login-username-display-only-handle.md
@@ -1,0 +1,155 @@
+# ADR-0022: Email is the login identifier; username is a display-only unique handle
+
+**Status:** Accepted
+**Date:** 2026-07-05
+**Decision-makers:** Solo maintainer (product-owner decision 2026-07-04)
+**Related:** ticket #333, TheKittySaver#256 (conceptual mirror, physically inverted), ADR-0004
+(lazy translator provisioning — load-bearing for why the TMS needs no changes), `docs/INVARIANTS.md`
+INV-11.2/11.5, QA #263
+
+## Context
+
+The product rule is: **authentication is e-mail + password**; the **username is a display-only
+handle** that stays **unique across the system**, with **no spaces and no special characters**.
+The implementation diverged on three points:
+
+1. **Login was by username.** The hosted login page bound `Username` and resolved
+   `FindByNameAsync`; the Testing-only password grant did the same.
+2. **The username charset was an accident.** The only thing rejecting `"kasia 92"` was ASP.NET
+   Identity's default `UserOptions.AllowedUserNameCharacters` — never configured, simultaneously
+   too loose for the product rule (it admits `-._@+`, so `kasia.92`, `kasia_92`, even `kasia@92`
+   registered happily) and surfacing as a raw English Identity error that the Polish register
+   page mapped to a misleading "check your password" fallback.
+3. **E-mail uniqueness was not physically case-insensitive.** `RequireUniqueEmail = true` is
+   app-level; the unique indexes were on **raw** `Email`/`UserName`, while Identity's
+   `EmailIndex` on `NormalizedEmail` was **non-unique**. A concurrent case-variant duplicate
+   (`Foo@x.com` + `foo@x.com`) slips past both — `RegisterUser` already documents that exact
+   race. With login moving to `FindByEmailAsync`, such a pair would throw
+   ("Sequence contains more than one element") on the login path and permanently lock **both**
+   accounts out — the switch turns a registration nuisance into a login outage.
+
+TheKittySaver#256 solved the same product conversation with the opposite physical design: there,
+the display name became non-unique free-form text, so Identity's `UserName` machinery (unique
+index, normalization, charset) was wrong for it and `UserName` was repurposed to carry the email.
+
+## Decision
+
+### 1. `ApplicationUser.UserName` remains the username — the physical design inverts TheKittySaver#256
+
+Here the handle **keeps** uniqueness and a restricted charset — exactly what Identity's
+`UserName` natively provides (unique `UserNameIndex` on `NormalizedUserName`, case-insensitive
+via normalization, `AllowedUserNameCharacters`). So there is no new column, no
+`Username → DisplayName` rename, no claims rework: `Claims.Name` ← `user.UserName` stays correct
+at all five issuance sites (authorize, token ×2, userinfo, login cookie), and the FE sidebar and
+the TMS `TranslatorProvisioner` (ADR-0004) keep working untouched. The same product conversation
+yields opposite physical designs in the two codebases because the *retained invariants* differ —
+uniqueness + charset survive here, so the concept "username" survives with them.
+
+### 2. The username charset is an explicit decision, enforced in three layers from one constant
+
+`^[a-zA-Z0-9]+$` — ASCII letters + digits only; spaces, `-._@+` and diacritics all rejected;
+`Gandalf`/`gandalf` collide via Identity normalization, as desired. One source of truth —
+`UsernameConstants` in `SharedKernel/Constants/` (next to `EmailConstants`): `MaxLength = 150`,
+`AllowedCharacters`, `RegexPattern`. Three enforcement layers:
+
+1. `RegisterUser.CommandValidator` — the authoritative rule; covers both public registration
+   surfaces (hosted page and `POST auth/register`) with an explicit English message instead of
+   raw Identity text.
+2. The hosted Register page — a Polish pre-check next to the existing ones, so the misleading
+   password-hint fallback is never reached for charset failures. UX-only duplication of the same
+   constant; both layers read `UsernameConstants` so they cannot drift.
+3. `options.User.AllowedUserNameCharacters = UsernameConstants.AllowedCharacters` — the
+   last-resort Identity invariant; it also guards the seeder path (a mis-configured
+   `AdminUser:Username` fails loudly at startup, by design).
+
+### 3. Login is e-mail + password on every path
+
+The hosted page binds `Email` and resolves `FindByEmailAsync`, with **every existing hardening
+preserved verbatim**: dummy-hash timing equalization on not-found and lockout,
+`AccessFailedAsync` on wrong password, the post-password `EmailConfirmed` gate (order matters —
+no enumeration/timing oracle), security-stamp cookie claim, one generic error copy. The
+user-not-found log line masks the attempted email (`MaskEmail()` — an email is PII; the old
+username was not). The Testing-only password grant authenticates by email too: the OIDC
+`username` wire parameter is a protocol constant and now semantically carries the email.
+
+### 4. The identifier spaces are provably disjoint
+
+The username charset excludes `@`; `EmailConstants.RegexPattern` requires `@`. An email typed
+into the wrong lookup can never match, in either direction. Registration keeps both duplicate
+pre-checks and both `DuplicateEmail`/`DuplicateUserName` race mappings — username uniqueness is
+a feature here, not a bug.
+
+### 5. `EmailIndex` on `NormalizedEmail` becomes UNIQUE
+
+Configured in `ApplicationUserConfiguration` keeping the database name `EmailIndex` (otherwise
+Identity's base mapping would create a second index), shipped as one Auth migration. This makes
+the case-variant duplicate physically impossible at the storage layer — the login-outage
+scenario above cannot occur. The raw-column unique indexes on `Email`/`UserName` are now
+redundant next to the normalized pair but kept (harmless, and dropping them is orthogonal).
+
+## Consequences
+
+### Positive
+
+- Login by e-mail matches the product rule and user expectations; the username stays a clean,
+  URL-safe, screen-safe handle.
+- Charset failures surface as explicit validator messages (English on the API, Polish on the
+  page), never as raw Identity text behind a misleading password hint.
+- Case-variant duplicate emails are impossible at the DB level, not merely improbable at the
+  app level — the documented registration race loses its damage potential entirely.
+- Zero TMS/Frontend changes: the claims contract is untouched, and ADR-0004's provisioner
+  self-refreshes `DisplayName` if a username ever changes.
+
+### Negative / Accepted trade-offs
+
+- Deployed `AUTH_ADMIN_USERNAME` values containing `-`/`.`/`_` must be re-set to alphanumeric,
+  or auth-api fails at startup (loud, by design; operator note in the runbook and PR).
+- Diacritics are rejected in usernames — a deliberate product cut for a Polish-audience app
+  (URL/display safety and zero homoglyph ambiguity outweigh naturalness of `kaśka92`).
+- The OIDC password-grant wire key stays literally `username` while carrying an email — a
+  protocol constant that now reads slightly dishonestly; locals/params are renamed for honesty,
+  the wire key never.
+- E-mail remains immutable post-registration; making it changeable while it is the login key
+  needs its own ticket + ADR.
+
+## Alternatives considered
+
+### A. Mirror TheKittySaver#256 physically (UserName carries the email, new DisplayName column)
+
+Rejected: the KittySaver design exists because its display name dropped uniqueness and charset
+restrictions, making Identity's `UserName` machinery wrong for it. Here the handle keeps both —
+repurposing `UserName` would discard exactly the native machinery (unique index, normalization,
+charset enforcement) the product rule needs, then rebuild it by hand for a new column, and
+ripple through claims issuance, the TMS provisioner and the FE.
+
+### B. Unicode letter charset (`\p{L}\p{Nd}`) instead of ASCII
+
+Rejected for now: `AllowedUserNameCharacters` is a flat char list (no regex), so Unicode classes
+cannot be expressed in the third enforcement layer; and the PO rule says "no special characters"
+with URL/display safety in mind. Revisit only on real user demand.
+
+### C. Enforce charset only in Identity options (single layer)
+
+Rejected: Identity failures surface post-`CreateAsync` as raw English error text — exactly the
+misleading-UX bug this ticket removes. The validator is the user-facing rule; Identity options
+are the invariant of last resort.
+
+## Implementation notes
+
+- `SharedKernel/Constants/UsernameConstants.cs` (new), `RegisterUser.CommandValidator`,
+  `PersistenceDependencyInjection` (Identity options), `Login.cshtml(.cs)`,
+  `Register.cshtml(.cs)`, `TokenEndpoint` (password grant), `ApplicationUserConfiguration` +
+  one Auth migration (unique `EmailIndex`).
+- HTML autofill semantics: the login email input keeps `autocomplete="username"` (the HTML spec
+  token for the login identifier); the register username input becomes
+  `autocomplete="nickname"`, its email input `autocomplete="username"`.
+- `rg -n "FindByNameAsync" src/` must hit exactly two sites after this change: the RegisterUser
+  duplicate pre-check and the seeder taken-username guard.
+
+## References
+
+- Ticket #333 — full change inventory and acceptance criteria
+- TheKittySaver#256 — the conceptual mirror whose physical design this ADR deliberately inverts
+- ADR-0004 — translator aggregate + lazy provisioning (why the TMS is untouched)
+- `docs/INVARIANTS.md` §11 — INV-11.2 (charset + display-only), INV-11.5 (confirmation gate)
+- WHATWG autofill guidance — `autocomplete` tokens for email-as-login

--- a/docs/auth-tutorial.md
+++ b/docs/auth-tutorial.md
@@ -28,7 +28,8 @@
 
 ## 1. Słownik na start
 
-- **Authentication (uwierzytelnianie)** — *kim jesteś*. Logowanie loginem + hasłem.
+- **Authentication (uwierzytelnianie)** — *kim jesteś*. Logowanie e-mailem + hasłem (ADR-0022;
+  nazwa użytkownika to unikalny handle wyłącznie do wyświetlania).
 - **Authorization (autoryzacja)** — *co możesz*. Role (`Admin`/`Translator`), scope'y (`api`/`service`).
 - **Authorization Server (AS)** — wydaje tokeny. U nas: **`auth-api`** (OpenIddict + ASP.NET Identity).
 - **Resource Server (RS)** — chroni dane, **waliduje** tokeny. U nas: **`tms-api`** (JwtBearer).
@@ -222,8 +223,9 @@ id tokenie. `sub`/`email`/`name`/`role` idą do obu.
 
 ### 6.5 Register endpoint (custom) — i **brak sagi**
 `POST auth/register` (`RegisterUser.cs`, `AllowAnonymous`, rate-limited):
-1. walidacja (email unikalny/regex ≤250, username ≤150, phone ≤30, hasło 8–128 + złożoność, **obie
-   zgody RODO `true`**);
+1. walidacja (email unikalny/regex ≤250 — **to e-mail jest loginem**, ADR-0022; username: unikalny
+   handle wyłącznie do wyświetlania, `^[a-zA-Z0-9]+$` ≤150 — `UsernameConstants`; hasło 8–128 +
+   złożoność, **obie zgody RODO `true`**);
 2. `userManager.CreateAsync` → przypisanie roli **`Translator`** (`:140`);
 3. wysyłka maila potwierdzającego; gdy mail padnie → **fallback auto-confirm** (`:148-157`);
 4. zwraca **201** z gołym `IdentityId`.

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -97,7 +97,7 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 | `Email__SenderEmail` | `noreply@lotro-translator.pl` | `no-reply@lotro-translator.pl` | ✅ all | plain | Must be a valid email. |
 | `Email__Sender` | `lotro-translator.pl` | `LOTRO PL` | ✅ all | plain | Display name. |
 | `Email__Username` / `Email__Password` | — | provider credentials | optional¹ | **secret** (Password) | ¹If `Username` is set, `Password` is required. |
-| `AdminUser__Username` / `AdminUser__Email` / `AdminUser__Password` | from `AUTH_ADMIN_*` | from `AUTH_ADMIN_*` | optional | **secret** (Password) | Seeds one admin on first boot; leave blank to skip. |
+| `AdminUser__Username` / `AdminUser__Email` / `AdminUser__Password` | from `AUTH_ADMIN_*` | from `AUTH_ADMIN_*` | optional | **secret** (Password) | Seeds one admin on first boot; leave blank to skip. Username must match `^[a-zA-Z0-9]+$` (ADR-0022) or auth-api fails at startup; the admin logs in **by e-mail**. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://aspire-dashboard:18889` | OTLP collector URL | optional | plain | Empty = telemetry export disabled. |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | `grpc` / `http/protobuf` | optional | plain | Defaults to `grpc`. |
 
@@ -208,10 +208,15 @@ boot. The connection-string password is a **secret** — keep it out of git.
 Set all three to seed one usable admin login into the auth DB on first boot; leave blank to skip:
 
 ```
-AUTH_ADMIN_USERNAME=…
+AUTH_ADMIN_USERNAME=…        # letters + digits only (^[a-zA-Z0-9]+$) — ADR-0022
 AUTH_ADMIN_EMAIL=…
 AUTH_ADMIN_PASSWORD=…        # secret
 ```
+
+The username is a display-only handle; the seeded admin **logs in by e-mail + password**. A
+username containing `-`, `.`, `_`, spaces or diacritics fails Identity's
+`AllowedUserNameCharacters` and crashes auth-api at startup (loud, by design) — re-set any such
+deployed `AUTH_ADMIN_USERNAME` value to alphanumeric before rolling this version out.
 
 ## Consistency rules that bite
 

--- a/iac/vars.tf
+++ b/iac/vars.tf
@@ -46,7 +46,12 @@ variable "smtp_sender_email" {
 
 variable "admin_username" {
   type        = string
-  description = "Seeded admin username"
+  description = "Seeded admin username. Letters + digits only (ADR-0022) — Identity's AllowedUserNameCharacters rejects anything else and auth-api fails at startup."
+
+  validation {
+    condition     = var.admin_username == "" || can(regex("^[a-zA-Z0-9]+$", var.admin_username))
+    error_message = "admin_username must match ^[a-zA-Z0-9]+$ (ASCII letters and digits only, no spaces or special characters); empty skips seeding."
+  }
 }
 
 variable "admin_email" {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
@@ -27,8 +27,6 @@ internal sealed partial class RegisterUser : IApiEndpoint
 
     internal sealed class CommandValidator : AbstractValidator<Command>
     {
-        private const int UsernameMaxLength = 150;
-
         public CommandValidator()
         {
             RuleFor(x => x.Email)
@@ -40,8 +38,10 @@ internal sealed partial class RegisterUser : IApiEndpoint
 
             RuleFor(x => x.Username)
                 .NotEmpty().WithMessage("Username is required.")
-                .MaximumLength(UsernameMaxLength)
-                    .WithMessage($"Username must not exceed {UsernameMaxLength} characters.");
+                .MaximumLength(UsernameConstants.MaxLength)
+                    .WithMessage($"Username must not exceed {UsernameConstants.MaxLength} characters.")
+                .Matches(UsernameConstants.RegexPattern)
+                    .WithMessage("Username may contain only letters and digits, without spaces.");
 
             RuleFor(x => x.Password).ApplyPasswordRules();
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/TokenEndpoint.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/TokenEndpoint.cs
@@ -78,7 +78,9 @@ internal sealed class TokenEndpoint : IEndpoint
         UserManager<ApplicationUser> userManager,
         SignInManager<ApplicationUser> signInManager)
     {
-        ApplicationUser? user = await userManager.FindByNameAsync(request.Username!);
+        // The OIDC "username" wire parameter is a protocol constant — semantically it carries
+        // the login identifier, which is the e-mail (ADR-0022).
+        ApplicationUser? user = await userManager.FindByEmailAsync(request.Username!);
 
         if (user is null)
         {
@@ -87,7 +89,7 @@ internal sealed class TokenEndpoint : IEndpoint
                 new ApplicationUser(), DummyPasswordHash, request.Password!);
             return Results.Problem(
                 title: Errors.InvalidGrant,
-                detail: "The username/password combination is invalid.",
+                detail: "The email/password combination is invalid.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
@@ -97,7 +99,7 @@ internal sealed class TokenEndpoint : IEndpoint
         {
             return Results.Problem(
                 title: Errors.InvalidGrant,
-                detail: "The username/password combination is invalid.",
+                detail: "The email/password combination is invalid.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
@@ -542,7 +542,7 @@
                             <h2 id="auth-h">
                                 Logowanie
                             </h2>
-                            <span class="panel-aside">Nazwa użytkownika + hasło</span>
+                            <span class="panel-aside">E-mail + hasło</span>
                         </header>
 
                         <form id="login-form" method="post" asp-route-returnUrl="@Model.ReturnUrl" class="auth-panel-body">
@@ -563,17 +563,17 @@
 
                             <div class="auth-field">
                                 <div class="auth-field-row">
-                                    <label asp-for="Username">Nazwa użytkownika</label>
+                                    <label asp-for="Email">Adres e-mail</label>
                                 </div>
                                 <div class="auth-input-wrap">
                                     <svg class="leading" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
-                                        <circle cx="12" cy="7" r="4"/>
+                                        <rect x="3" y="5" width="18" height="14" rx="2"/>
+                                        <path d="m3 7 9 6 9-6"/>
                                     </svg>
-                                    <input asp-for="Username"
-                                           type="text"
+                                    <input asp-for="Email"
+                                           type="email"
                                            class="auth-input"
-                                           placeholder="np. kasia92"
+                                           placeholder="np. kasia@example.com"
                                            autocomplete="username"
                                            required
                                            autofocus />

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
@@ -68,7 +68,9 @@ internal sealed partial class LoginModel : PageModel
             return Page();
         }
 
-        ApplicationUser? user = await _userManager.FindByEmailAsync(Email);
+        // Trim mirrors the register page's Email.Trim() — a pasted/autofilled trailing space must
+        // not turn a valid login into a not-found.
+        ApplicationUser? user = await _userManager.FindByEmailAsync(Email.Trim());
 
         if (user is null)
         {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 
 namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
@@ -17,7 +18,7 @@ internal sealed partial class LoginModel : PageModel
     /// registration.
     /// </summary>
     private const string GenericCredentialErrorMessage =
-        "Nieprawidłowa nazwa użytkownika lub hasło. Jeśli konto zostało dopiero co utworzone, " +
+        "Nieprawidłowy e-mail lub hasło. Jeśli konto zostało dopiero co utworzone, " +
         "dokończ rejestrację, potwierdzając swój adres e-mail — kliknij link aktywacyjny, który do Ciebie wysłaliśmy.";
 
     /// <summary>
@@ -40,7 +41,7 @@ internal sealed partial class LoginModel : PageModel
     }
 
     [BindProperty]
-    public string Username { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
 
     [BindProperty]
     public string Password { get; set; } = string.Empty;
@@ -61,20 +62,20 @@ internal sealed partial class LoginModel : PageModel
     {
         ReturnUrl = returnUrl;
 
-        if (string.IsNullOrWhiteSpace(Username) || string.IsNullOrWhiteSpace(Password))
+        if (string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Password))
         {
-            ErrorMessage = "Nazwa użytkownika i hasło są wymagane.";
+            ErrorMessage = "Adres e-mail i hasło są wymagane.";
             return Page();
         }
 
-        ApplicationUser? user = await _userManager.FindByNameAsync(Username);
+        ApplicationUser? user = await _userManager.FindByEmailAsync(Email);
 
         if (user is null)
         {
             // Perform a dummy password hash to prevent timing-based user enumeration
             _ = _userManager.PasswordHasher.VerifyHashedPassword(
                 new ApplicationUser(), DummyPasswordHash, Password);
-            LogUserNotFound(_logger, Username, HttpContext.Connection.RemoteIpAddress);
+            LogUserNotFound(_logger, Email.MaskEmail(), HttpContext.Connection.RemoteIpAddress);
             ErrorMessage = GenericCredentialErrorMessage;
             return Page();
         }
@@ -157,8 +158,8 @@ internal sealed partial class LoginModel : PageModel
         return LocalRedirect("/");
     }
 
-    [LoggerMessage(EventId = EventIds.LoginUserNotFound, Level = LogLevel.Warning, Message = "Failed login: user not found. Username: {Username}, IP: {IP}")]
-    private static partial void LogUserNotFound(ILogger logger, string username, System.Net.IPAddress? ip);
+    [LoggerMessage(EventId = EventIds.LoginUserNotFound, Level = LogLevel.Warning, Message = "Failed login: user not found. Email: {Email}, IP: {IP}")]
+    private static partial void LogUserNotFound(ILogger logger, string email, System.Net.IPAddress? ip);
 
     [LoggerMessage(EventId = EventIds.LoginAccountLockedOut, Level = LogLevel.Warning, Message = "Account locked out. UserId: {UserId}, IP: {IP}")]
     private static partial void LogAccountLockedOut(ILogger logger, Guid userId, System.Net.IPAddress? ip);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
@@ -503,15 +503,16 @@
                                 <label asp-for="Username">Nazwa użytkownika</label>
                                 <div class="auth-input-wrap">
                                     <svg class="leading" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-                                    <input asp-for="Username" type="text" class="auth-input" placeholder="np. kasia92" autocomplete="username" required autofocus />
+                                    <input asp-for="Username" type="text" class="auth-input" placeholder="np. kasia92" autocomplete="nickname" required autofocus />
                                 </div>
+                                <span class="auth-field-help">Tylko litery i cyfry, bez spacji. Ta nazwa będzie widoczna dla innych; logować się będziesz adresem e-mail.</span>
                             </div>
 
                             <div class="auth-field">
                                 <label asp-for="Email">Adres e-mail</label>
                                 <div class="auth-input-wrap">
                                     <svg class="leading" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
-                                    <input asp-for="Email" type="email" class="auth-input" placeholder="@("ty@example.com")" autocomplete="email" required />
+                                    <input asp-for="Email" type="email" class="auth-input" placeholder="@("ty@example.com")" autocomplete="username" required />
                                 </div>
                             </div>
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml.cs
@@ -1,7 +1,9 @@
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using LotroKoniecDev.AuthSystem.API.Features.Auth;
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Constants;
 using LotroKoniecDev.SharedKernel.Messaging;
 using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds;
@@ -65,6 +67,14 @@ internal sealed partial class RegisterModel : PageModel
             string.IsNullOrWhiteSpace(Password))
         {
             ErrorMessage = "Wszystkie pola są wymagane.";
+            return Page();
+        }
+
+        // UX-only mirror of the authoritative UsernameConstants rule in RegisterUser.CommandValidator —
+        // without it a charset failure would fall through to the generic (password-hinting) message.
+        if (!UsernameRegex().IsMatch(Username.Trim()))
+        {
+            ErrorMessage = "Nazwa użytkownika może zawierać tylko litery i cyfry, bez spacji.";
             return Page();
         }
 
@@ -135,4 +145,7 @@ internal sealed partial class RegisterModel : PageModel
 
     [LoggerMessage(EventId = EventIds.RegisterCompletedViaUi, Level = LogLevel.Information, Message = "User {UserId} registered via UI")]
     private static partial void LogRegisteredViaUi(ILogger logger, IdentityId userId);
+
+    [GeneratedRegex(UsernameConstants.RegexPattern)]
+    private static partial Regex UsernameRegex();
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
@@ -12,6 +12,14 @@ internal sealed class ApplicationUserConfiguration : IEntityTypeConfiguration<Ap
         builder.HasIndex(u => u.UserName).IsUnique();
         builder.HasIndex(u => u.Email).IsUnique();
 
+        // Identity's base mapping creates this index non-unique. RequireUniqueEmail is app-level
+        // only, and the login path resolves FindByEmailAsync — a case-variant duplicate pair
+        // (Foo@x.com / foo@x.com) would throw there and lock both accounts out (ADR-0022).
+        // The database name must stay "EmailIndex", or the base mapping yields a second index.
+        builder.HasIndex(u => u.NormalizedEmail)
+            .IsUnique()
+            .HasDatabaseName("EmailIndex");
+
         builder.Property(u => u.DataProcessingConsentGiven)
             .HasDefaultValue(false);
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/LotroKoniecDev.AuthSystem.Persistence.csproj
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/LotroKoniecDev.AuthSystem.Persistence.csproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\LotroKoniecDev.AuthSystem.Domain\LotroKoniecDev.AuthSystem.Domain.csproj" />
+        <ProjectReference Include="..\..\SharedKernel\LotroKoniecDev.SharedKernel\LotroKoniecDev.SharedKernel.csproj" />
         <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Options\LotroKoniecDev.Options.csproj" />
     </ItemGroup>
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260704224834_UniqueEmailIndex.Designer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260704224834_UniqueEmailIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260704224834_UniqueEmailIndex")]
+    partial class UniqueEmailIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260704224834_UniqueEmailIndex.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260704224834_UniqueEmailIndex.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class UniqueEmailIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "EmailIndex",
+                schema: "authsystem",
+                table: "Users");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                schema: "authsystem",
+                table: "Users",
+                column: "NormalizedEmail",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "EmailIndex",
+                schema: "authsystem",
+                table: "Users");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                schema: "authsystem",
+                table: "Users",
+                column: "NormalizedEmail");
+        }
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/PersistenceDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/PersistenceDependencyInjection.cs
@@ -8,6 +8,7 @@ using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using LotroKoniecDev.AuthSystem.Persistence.Settings;
 using LotroKoniecDev.Options;
+using LotroKoniecDev.SharedKernel.Constants;
 namespace LotroKoniecDev.AuthSystem.Persistence;
 
 public static class PersistenceDependencyInjection
@@ -44,6 +45,7 @@ public static class PersistenceDependencyInjection
                     options.Password.RequireNonAlphanumeric = true;
                     options.Password.RequiredLength = 8;
                     options.User.RequireUniqueEmail = true;
+                    options.User.AllowedUserNameCharacters = UsernameConstants.AllowedCharacters;
                     options.SignIn.RequireConfirmedEmail = true;
                     options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(5);
                     options.Lockout.MaxFailedAccessAttempts = 5;

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Constants/UsernameConstants.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Constants/UsernameConstants.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.SharedKernel.Constants;
+
+/// <summary>
+/// The username charset rule (ADR-0022): ASCII letters + digits only. The username is a
+/// display-only handle — unique, spaceless, special-char-free — while the login identifier is
+/// the e-mail. Excluding '@' keeps the two identifier spaces provably disjoint
+/// (<see cref="EmailConstants.RegexPattern"/> requires '@').
+/// </summary>
+public static class UsernameConstants
+{
+    public const int MaxLength = 150;
+    public const string AllowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    public const string RegexPattern = "^[a-zA-Z0-9]+$";
+}

--- a/src/SharedKernel/LotroKoniecDev.SharedKernel/Constants/UsernameConstants.cs
+++ b/src/SharedKernel/LotroKoniecDev.SharedKernel/Constants/UsernameConstants.cs
@@ -10,5 +10,7 @@ public static class UsernameConstants
 {
     public const int MaxLength = 150;
     public const string AllowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    public const string RegexPattern = "^[a-zA-Z0-9]+$";
+    // \A…\z, not ^…$ — in .NET, $ also matches before a trailing \n, which would let
+    // "kasia92\n" through the validator (same anchoring style as EmailConstants).
+    public const string RegexPattern = @"\A[a-zA-Z0-9]+\z";
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -45,7 +45,7 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
                 { "OpenIddict:ApiClientSecret", TestApiClientSecret },
                 { "OpenIddict:WebClient:RedirectUris:0", "https://localhost:5001/callback" },
                 { "OpenIddict:WebClient:PostLogoutRedirectUris:0", "https://localhost:5001" },
-                { "AdminUser:Username", "seeded-admin" },
+                { "AdminUser:Username", "seededadmin" },
                 { "AdminUser:Email", "admin@lotro-translator.pl" },
                 { "AdminUser:Password", "AdminTest123!" },
                 // Email identity is no longer baked into base appsettings.json (M6-06); supply it here

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Bases/EndpointsTestBase.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Bases/EndpointsTestBase.cs
@@ -17,12 +17,13 @@ public abstract class EndpointsTestBase : AsyncLifetimeTestBase
         ApiClient = new TestApiClient(appFactory.CreateClient(), jsonSerializerOptions);
     }
 
-    protected async Task<string> GetAccessTokenAsync(string username, string password)
+    protected async Task<string> GetAccessTokenAsync(string email, string password)
     {
+        // The OIDC "username" wire key is a protocol constant — it carries the e-mail (ADR-0022).
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = username,
+            ["username"] = email,
             ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api"

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Factories/UserFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Factories/UserFactory.cs
@@ -10,7 +10,8 @@ internal static class UserFactory
     private const string DefaultPassword = "TestPass1!";
 
     public static RegisterRequest GenerateRandomRegisterRequest(Faker faker, string? password = null) => new(
-        faker.Internet.UserName() + faker.Random.AlphaNumeric(4),
+        // Faker.Internet.UserName() emits dots/underscores — illegal since ADR-0022 (letters + digits only).
+        faker.Random.AlphaNumeric(16),
         faker.Internet.Email(),
         password ?? DefaultPassword,
         AcceptedPrivacyPolicy: true,

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AdminSeedingTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AdminSeedingTests.cs
@@ -12,7 +12,7 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
 public sealed class AdminSeedingTests : EndpointsTestBase
 {
     private const string AdminEmail = "admin@lotro-translator.pl";
-    private const string AdminUsername = "seeded-admin";
+    private const string AdminUsername = "seededadmin";
     private const string AdminPassword = "AdminTest123!";
 
     public AdminSeedingTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
@@ -23,8 +23,8 @@ public sealed class AdminSeedingTests : EndpointsTestBase
         // Arrange — the cleaner wipes users before every test, so re-run the (idempotent) seed
         await ReseedAsync();
 
-        // Act
-        string accessToken = await GetAccessTokenAsync(AdminUsername, AdminPassword);
+        // Act — the seeded admin logs in by e-mail (ADR-0022)
+        string accessToken = await GetAccessTokenAsync(AdminEmail, AdminPassword);
 
         // Assert
         accessToken.ShouldNotBeNullOrWhiteSpace();
@@ -87,6 +87,29 @@ public sealed class AdminSeedingTests : EndpointsTestBase
 
         ApplicationUser? admin = await assertUserManager.FindByEmailAsync(AdminEmail);
         admin.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateUser_ShouldFailWithInvalidUserName_WhenUsernameViolatesAllowedCharacters()
+    {
+        // Identity's AllowedUserNameCharacters (UsernameConstants) is the last-resort layer that
+        // also guards the seeder: a mis-configured AdminUser:Username surfaces THIS error as the
+        // loud startup failure documented in the runbook (ADR-0022).
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        UserManager<ApplicationUser> userManager =
+            scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        ApplicationUser user = new()
+        {
+            UserName = "bad-admin",
+            Email = "badadmin@lotro-translator.pl",
+            EmailConfirmed = true
+        };
+
+        IdentityResult result = await userManager.CreateAsync(user, AdminPassword);
+
+        result.Succeeded.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Code == "InvalidUserName");
     }
 
     private async Task ReseedAsync()

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AuthorizationCodeFlowTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AuthorizationCodeFlowTests.cs
@@ -95,7 +95,7 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
 
         Dictionary<string, string> loginFormData = new()
         {
-            ["Username"] = registerRequest.Username,
+            ["Email"] = registerRequest.Email,
             ["Password"] = password,
         };
 
@@ -214,7 +214,7 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
 
         string html = await response.Content.ReadAsStringAsync();
         html.ShouldContain("Zaloguj się");
-        html.ShouldContain("Nazwa użytkownika");
+        html.ShouldContain("Adres e-mail");
         html.ShouldContain("Hasło");
     }
 
@@ -231,7 +231,7 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
 
         Dictionary<string, string> loginFormData = new()
         {
-            ["Username"] = "nonexistent_user",
+            ["Email"] = "nonexistent@example.com",
             ["Password"] = "WrongPassword1!"
         };
 
@@ -261,7 +261,7 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK); // Returns 200 with error message on page
         string html = await response.Content.ReadAsStringAsync();
-        html.ShouldContain("Nieprawidłowa nazwa użytkownika lub hasło");
+        html.ShouldContain("Nieprawidłowy e-mail lub hasło");
     }
 
     [Fact]
@@ -282,7 +282,7 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
 
         Dictionary<string, string> loginFormData = new()
         {
-            ["Username"] = registerRequest.Username,
+            ["Email"] = registerRequest.Email,
             ["Password"] = password
         };
 
@@ -310,7 +310,7 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         string html = await response.Content.ReadAsStringAsync();
-        html.ShouldContain("Nieprawidłowa nazwa użytkownika lub hasło");
+        html.ShouldContain("Nieprawidłowy e-mail lub hasło");
     }
 
     [Fact]
@@ -445,7 +445,7 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
 
         Dictionary<string, string> loginFormData = new()
         {
-            ["Username"] = registerRequest.Username,
+            ["Email"] = registerRequest.Email,
             ["Password"] = password,
         };
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ChangePasswordEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ChangePasswordEndpointTests.cs
@@ -20,7 +20,7 @@ public sealed class ChangePasswordEndpointTests : EndpointsTestBase
         (RegisterRequest registerRequest, _) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, currentPassword);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, currentPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, currentPassword);
 
         ChangePasswordRequest changeRequest = new(currentPassword, newPassword);
 
@@ -45,7 +45,7 @@ public sealed class ChangePasswordEndpointTests : EndpointsTestBase
         (RegisterRequest registerRequest, _) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, currentPassword);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, currentPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, currentPassword);
 
         using HttpRequestMessage changeReq = new(HttpMethod.Post, "auth/change-password");
         changeReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
@@ -57,7 +57,7 @@ public sealed class ChangePasswordEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = registerRequest.Username,
+            ["username"] = registerRequest.Email,
             ["password"] = newPassword,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api"
@@ -83,7 +83,7 @@ public sealed class ChangePasswordEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = registerRequest.Username,
+            ["username"] = registerRequest.Email,
             ["password"] = currentPassword,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api offline_access"
@@ -130,7 +130,7 @@ public sealed class ChangePasswordEndpointTests : EndpointsTestBase
         (RegisterRequest registerRequest, _) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, currentPassword);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, currentPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, currentPassword);
 
         ChangePasswordRequest changeRequest = new("WrongPassword1!", "NewPass99!");
 
@@ -154,7 +154,7 @@ public sealed class ChangePasswordEndpointTests : EndpointsTestBase
         (RegisterRequest registerRequest, _) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, currentPassword);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, currentPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, currentPassword);
 
         ChangePasswordRequest changeRequest = new(currentPassword, "weak");
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConcurrencyEndpointsTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConcurrencyEndpointsTests.cs
@@ -21,7 +21,7 @@ public sealed class ConcurrencyEndpointsTests : EndpointsTestBase
 
         RegisterRequest[] requests = Enumerable.Range(0, concurrentRequests)
             .Select(i => new RegisterRequest(
-                Faker.Internet.UserName() + Faker.Random.AlphaNumeric(4) + i,
+                Faker.Random.AlphaNumeric(12) + i,
                 sharedEmail,
                 sharedPassword,
                 AcceptedPrivacyPolicy: true,
@@ -72,7 +72,7 @@ public sealed class ConcurrencyEndpointsTests : EndpointsTestBase
                 using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
                 {
                     ["grant_type"] = "password",
-                    ["username"] = request.Username,
+                    ["username"] = request.Email,
                     ["password"] = password,
                     ["client_id"] = "lotrokoniecdev-test",
                     ["scope"] = "email profile roles api offline_access"
@@ -106,7 +106,7 @@ public sealed class ConcurrencyEndpointsTests : EndpointsTestBase
         using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = request.Username,
+            ["username"] = request.Email,
             ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api offline_access"

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConfirmEmailEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConfirmEmailEndpointTests.cs
@@ -43,7 +43,7 @@ public sealed class ConfirmEmailEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = registerRequest.Username,
+            ["username"] = registerRequest.Email,
             ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api"
@@ -73,7 +73,7 @@ public sealed class ConfirmEmailEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = registerRequest.Username,
+            ["username"] = registerRequest.Email,
             ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api"

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeleteAccountEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeleteAccountEndpointTests.cs
@@ -26,7 +26,7 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
         (RegisterRequest registerRequest, _) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, password);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, password);
 
         DeleteAccountRequest deleteRequest = new(password);
 
@@ -50,7 +50,7 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
         (RegisterRequest registerRequest, _) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, password);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, password);
 
         DeleteAccountRequest deleteRequest = new(password);
 
@@ -64,7 +64,7 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = registerRequest.Username,
+            ["username"] = registerRequest.Email,
             ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api"
@@ -86,7 +86,7 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
         (RegisterRequest registerRequest, _) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, password);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, password);
 
         DeleteAccountRequest deleteRequest = new("WrongPassword1!");
 
@@ -125,7 +125,7 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
         (RegisterRequest registerRequest, IdentityId identityId) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, password);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, password);
 
         DeleteAccountRequest deleteRequest = new(password);
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ExportAccountDataEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ExportAccountDataEndpointTests.cs
@@ -19,7 +19,7 @@ public sealed class ExportAccountDataEndpointTests : EndpointsTestBase
         (RegisterRequest registerRequest, _) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, password);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, password);
 
         using HttpRequestMessage request = new(HttpMethod.Get, "auth/account/data-export");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
@@ -22,15 +22,35 @@ public sealed partial class LoginPageTests : EndpointsTestBase
         // Act — the correct credentials, but the account is still unconfirmed
         HttpResponseMessage response = await PostToLoginPageAsync(new Dictionary<string, string>
         {
-            ["Username"] = request.Username,
+            ["Email"] = request.Email,
             ["Password"] = request.Password
         });
 
         // Assert — the message guides the user to activate, without ever stating the account exists but is unconfirmed
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         string html = await response.Content.ReadAsStringAsync();
-        html.ShouldContain("Nieprawidłowa nazwa użytkownika lub hasło");
+        html.ShouldContain("Nieprawidłowy e-mail lub hasło");
         html.ShouldContain("aktywacyjny");
+    }
+
+    [Fact]
+    public async Task LoginPage_ShouldRejectLogin_WhenIdentifierIsUsernameInsteadOfEmail()
+    {
+        // Arrange — a confirmed account; the login identifier is the e-mail (ADR-0022)
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        // Act — the valid username with the valid password must behave like any wrong credential
+        HttpResponseMessage response = await PostToLoginPageAsync(new Dictionary<string, string>
+        {
+            ["Email"] = request.Username,
+            ["Password"] = request.Password
+        });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Nieprawidłowy e-mail lub hasło");
     }
 
     [Fact]
@@ -48,22 +68,22 @@ public sealed partial class LoginPageTests : EndpointsTestBase
         // Act — one probe per credential-failure branch of /Account/Login
         string nonExistentMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
         {
-            ["Username"] = "nobody-" + Faker.Random.AlphaNumeric(8),
+            ["Email"] = "nobody-" + Faker.Random.AlphaNumeric(8) + "@example.com",
             ["Password"] = "WhateverPass1!"
         });
         string wrongPasswordMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
         {
-            ["Username"] = confirmed.Username,
+            ["Email"] = confirmed.Email,
             ["Password"] = confirmed.Password + "WRONG"
         });
         string unconfirmedMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
         {
-            ["Username"] = unconfirmed.Username,
+            ["Email"] = unconfirmed.Email,
             ["Password"] = unconfirmed.Password
         });
         string lockedOutMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
         {
-            ["Username"] = lockedOut.Username,
+            ["Email"] = lockedOut.Email,
             ["Password"] = lockedOut.Password // correct password — the lockout branch must still win
         });
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterEndpointTests.cs
@@ -133,6 +133,8 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
     [InlineData("kasia@92")]
     [InlineData("kaśka92")]
     [InlineData("kasia-92")]
+    [InlineData("kasia92\n")] // .NET's $ matches before a trailing \n — \A…\z anchoring must reject this
+    [InlineData(" kasia92")]
     public async Task Register_ShouldReturnBadRequestWithCharsetMessage_WhenUsernameHasIllegalCharacters(
         string username)
     {

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterEndpointTests.cs
@@ -36,7 +36,7 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
 
         RegisterRequest duplicateRequest = new(
-            Faker.Internet.UserName() + Faker.Random.AlphaNumeric(4),
+            Faker.Random.AlphaNumeric(16),
             existingRequest.Email,
             "TestPass1!",
             AcceptedPrivacyPolicy: true,
@@ -48,6 +48,33 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Register_ShouldReturnUnprocessableEntity_WhenEmailDiffersOnlyByCase()
+    {
+        // Arrange
+        (RegisterRequest existingRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        string caseVariantEmail = existingRequest.Email.ToUpperInvariant();
+        caseVariantEmail.ShouldNotBe(existingRequest.Email);
+
+        RegisterRequest duplicateRequest = new(
+            Faker.Random.AlphaNumeric(16),
+            caseVariantEmail,
+            "TestPass1!",
+            AcceptedPrivacyPolicy: true,
+            AcceptedDataProcessingConsent: true);
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/register", UriKind.Relative), duplicateRequest);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        string content = await response.Content.ReadAsStringAsync();
+        content.ShouldContain("Auth.UserAlreadyExistsByEmail");
     }
 
     [Fact]
@@ -73,11 +100,90 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
     }
 
     [Fact]
+    public async Task Register_ShouldReturnUnprocessableEntity_WhenUsernameDiffersOnlyByCase()
+    {
+        // Arrange — Identity normalization makes the handle uniqueness case-insensitive (ADR-0022)
+        (RegisterRequest existingRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        string caseVariantUsername = existingRequest.Username.ToUpperInvariant();
+        caseVariantUsername.ShouldNotBe(existingRequest.Username);
+
+        RegisterRequest duplicateRequest = new(
+            caseVariantUsername,
+            Faker.Internet.Email(),
+            "TestPass1!",
+            AcceptedPrivacyPolicy: true,
+            AcceptedDataProcessingConsent: true);
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/register", UriKind.Relative), duplicateRequest);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        string content = await response.Content.ReadAsStringAsync();
+        content.ShouldContain("Auth.UserAlreadyExistsByUsername");
+    }
+
+    [Theory]
+    [InlineData("kasia 92")]
+    [InlineData("kasia.92")]
+    [InlineData("kasia_92")]
+    [InlineData("kasia@92")]
+    [InlineData("kaśka92")]
+    [InlineData("kasia-92")]
+    public async Task Register_ShouldReturnBadRequestWithCharsetMessage_WhenUsernameHasIllegalCharacters(
+        string username)
+    {
+        // Arrange
+        RegisterRequest request = new(
+            username,
+            Faker.Internet.Email(),
+            "TestPass1!",
+            AcceptedPrivacyPolicy: true,
+            AcceptedDataProcessingConsent: true);
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/register", UriKind.Relative), request);
+
+        // Assert — the explicit validator message, never Identity's raw English error surfacing late
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string content = await response.Content.ReadAsStringAsync();
+        content.ShouldContain("Username may contain only letters and digits, without spaces.");
+        content.ShouldContain("RegisterUser.Validation");
+        content.ShouldNotContain("Auth.RegistrationFailed");
+    }
+
+    [Theory]
+    [InlineData("kasia92")]
+    [InlineData("KASIA92")]
+    public async Task Register_ShouldReturnCreated_WhenUsernameIsAlphanumeric(string username)
+    {
+        // Arrange
+        RegisterRequest request = new(
+            username,
+            Faker.Internet.Email(),
+            "TestPass1!",
+            AcceptedPrivacyPolicy: true,
+            AcceptedDataProcessingConsent: true);
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/register", UriKind.Relative), request);
+
+        // Assert
+        await response.EnsureSuccessWithDetailsAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+    }
+
+    [Fact]
     public async Task Register_ShouldReturnBadRequest_WhenPrivacyPolicyNotAccepted()
     {
         // Arrange
         RegisterRequest request = new(
-            Faker.Internet.UserName() + Faker.Random.AlphaNumeric(4),
+            Faker.Random.AlphaNumeric(16),
             Faker.Internet.Email(),
             "TestPass1!",
             AcceptedPrivacyPolicy: false,
@@ -126,7 +232,7 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = request.Username,
+            ["username"] = request.Email,
             ["password"] = request.Password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api offline_access"

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
@@ -81,6 +81,32 @@ public sealed partial class RegisterPageTests : EndpointsTestBase
         AccountConfirmationEmailSpy.LastEmail.ShouldBeNull();
     }
 
+    [Theory]
+    [InlineData("kasia 92")]
+    [InlineData("kasia.92")]
+    [InlineData("kasia_92")]
+    [InlineData("kasia@92")]
+    [InlineData("kaśka92")]
+    public async Task RegisterPage_ShouldShowCharsetError_WhenUsernameHasIllegalCharacters(string username)
+    {
+        // Arrange
+        AccountConfirmationEmailSpy.Reset();
+        RegisterRequest request = UserFactory.GenerateRandomRegisterRequest(Faker);
+        Dictionary<string, string> form = BuildForm(request, request.Password);
+        form["Username"] = username;
+
+        // Act
+        HttpResponseMessage response = await PostToRegisterPageAsync(form);
+
+        // Assert — the explicit Polish charset rule, never the misleading password hint
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Nazwa użytkownika może zawierać tylko litery i cyfry, bez spacji.");
+        html.ShouldNotContain("hasło spełnia wymagania");
+        AccountConfirmationEmailSpy.LastEmail.ShouldBeNull();
+    }
+
     [Fact]
     public async Task RegisterPage_ShouldShowError_WhenEmailAlreadyExists()
     {

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordEndpointTests.cs
@@ -61,7 +61,7 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = registerRequest.Username,
+            ["username"] = registerRequest.Email,
             ["password"] = newPassword,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api"
@@ -102,7 +102,7 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = registerRequest.Username,
+            ["username"] = registerRequest.Email,
             ["password"] = originalPassword,
             ["client_id"] = "lotrokoniecdev-test"
         });
@@ -127,7 +127,7 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = registerRequest.Username,
+            ["username"] = registerRequest.Email,
             ["password"] = originalPassword,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api offline_access"

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordPageTests.cs
@@ -23,7 +23,7 @@ public sealed partial class ResetPasswordPageTests : EndpointsTestBase
         using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = registerRequest.Username,
+            ["username"] = registerRequest.Email,
             ["password"] = originalPassword,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api offline_access"

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/SecurityStampCookieValidationTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/SecurityStampCookieValidationTests.cs
@@ -45,7 +45,7 @@ public sealed partial class SecurityStampCookieValidationTests : AsyncLifetimeTe
         (RegisterRequest registerRequest, _) =
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, originalPassword);
 
-        List<string> authCookies = await EstablishAuthCookieAsync(registerRequest.Username, originalPassword);
+        List<string> authCookies = await EstablishAuthCookieAsync(registerRequest.Email, originalPassword);
 
         // Baseline — before the stamp changes, the live cookie authenticates /connect/authorize and an
         // authorization code is minted (proves the cookie is genuinely usable, so the post-reset
@@ -65,7 +65,7 @@ public sealed partial class SecurityStampCookieValidationTests : AsyncLifetimeTe
         afterLocation.ShouldContain("/Account/Login");
     }
 
-    private async Task<List<string>> EstablishAuthCookieAsync(string username, string password)
+    private async Task<List<string>> EstablishAuthCookieAsync(string email, string password)
     {
         HttpResponseMessage loginPage = await _noRedirectClient.GetAsync(
             new Uri("/Account/Login", UriKind.Relative));
@@ -76,7 +76,7 @@ public sealed partial class SecurityStampCookieValidationTests : AsyncLifetimeTe
 
         Dictionary<string, string> loginFormData = new()
         {
-            ["Username"] = username,
+            ["Email"] = email,
             ["Password"] = password
         };
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/TokenEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/TokenEndpointTests.cs
@@ -23,7 +23,7 @@ public sealed class TokenEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = request.Username,
+            ["username"] = request.Email,
             ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api offline_access"
@@ -55,7 +55,7 @@ public sealed class TokenEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = request.Username,
+            ["username"] = request.Email,
             ["password"] = "WrongPassword1!",
             ["client_id"] = "lotrokoniecdev-test"
         });
@@ -75,8 +75,32 @@ public sealed class TokenEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = "nonexistent_user",
+            ["username"] = "nonexistent@example.com",
             ["password"] = "TestPass1!",
+            ["client_id"] = "lotrokoniecdev-test"
+        });
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), tokenRequest);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PasswordGrant_ShouldReturnBadRequest_WhenIdentifierIsUsernameInsteadOfEmail()
+    {
+        // Arrange — the login identifier is the e-mail (ADR-0022); a valid username must not authenticate
+        const string password = "TestPass1!";
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
+
+        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = request.Username,
+            ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test"
         });
 
@@ -99,7 +123,7 @@ public sealed class TokenEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = request.Username,
+            ["username"] = request.Email,
             ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api offline_access"
@@ -144,7 +168,7 @@ public sealed class TokenEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = request.Username,
+            ["username"] = request.Email,
             ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "openid email profile roles api offline_access"
@@ -245,7 +269,7 @@ public sealed class TokenEndpointTests : EndpointsTestBase
         using FormUrlEncodedContent loginRequest = new(new Dictionary<string, string>
         {
             ["grant_type"] = "password",
-            ["username"] = request.Username,
+            ["username"] = request.Email,
             ["password"] = password,
             ["client_id"] = "lotrokoniecdev-test",
             ["scope"] = "email profile roles api offline_access"

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/UniqueEmailIndexTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/UniqueEmailIndexTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+public sealed class UniqueEmailIndexTests : EndpointsTestBase
+{
+    public UniqueEmailIndexTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public async Task Users_ShouldRejectCaseVariantDuplicateEmail_AtTheDatabaseLevel()
+    {
+        // Arrange — first account through the normal path
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        string caseVariantEmail = request.Email.ToUpperInvariant();
+        caseVariantEmail.ShouldNotBe(request.Email); // raw-column uniqueness must NOT be what trips below
+
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext dbContext = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        // A raw insert bypasses every app-level pre-check — the exact race window RegisterUser
+        // documents. Only the unique EmailIndex on NormalizedEmail stands between this pair and
+        // a permanent two-account login outage (ADR-0022).
+        string username = "dup" + Faker.Random.AlphaNumeric(12);
+        ApplicationUser duplicate = new()
+        {
+            UserName = username,
+            NormalizedUserName = username.ToUpperInvariant(),
+            Email = caseVariantEmail,
+            NormalizedEmail = request.Email.ToUpperInvariant(),
+            SecurityStamp = Guid.NewGuid().ToString()
+        };
+        dbContext.Users.Add(duplicate);
+
+        // Act + Assert
+        await Should.ThrowAsync<DbUpdateException>(async () => await dbContext.SaveChangesAsync());
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ContentNegotiation/ContentNegotiationTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ContentNegotiation/ContentNegotiationTests.cs
@@ -246,7 +246,7 @@ public sealed class ContentNegotiationTests : EndpointsTestBase
         (RegisterRequest registerRequest, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
             ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
 
-        return await GetAccessTokenAsync(registerRequest.Username, TestPassword);
+        return await GetAccessTokenAsync(registerRequest.Email, TestPassword);
     }
 
     private static async Task<JsonNode?> ReadBodyAsJsonNodeAsync(HttpResponseMessage response)

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Hateoas/AccountAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Hateoas/AccountAggregateHateoasTests.cs
@@ -36,7 +36,7 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
         // Arrange - confirmed users see self, change-password, delete-account only
         (RegisterRequest registerRequest, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
             ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, TestPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
         // Act
         AccountDataExportResponse response = await RequestHateoasResponseAsync(accessToken);
@@ -61,7 +61,7 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
         // so the handler sees EmailConfirmed=false and must advertise the resend transition.
         (RegisterRequest registerRequest, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
             ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, TestPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
         await SetEmailConfirmedAsync(registerRequest.Username, confirmed: false);
 
@@ -82,7 +82,7 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
         // Arrange
         (RegisterRequest registerRequest, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
             ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, TestPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
         // Act
         AccountDataExportResponse response = await RequestHateoasResponseAsync(accessToken);
@@ -100,7 +100,7 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
         // force clients to guess the base address and break cross-origin consumers.
         (RegisterRequest registerRequest, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
             ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, TestPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
         // Act
         AccountDataExportResponse response = await RequestHateoasResponseAsync(accessToken);
@@ -124,7 +124,7 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
         // key itself is suppressed from the wire by HateoasJsonTypeInfoModifiers).
         (RegisterRequest registerRequest, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
             ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, TestPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
         using HttpRequestMessage request = new(HttpMethod.Get, new Uri(DataExportPath, UriKind.Relative));
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Hateoas/DiscoveryHateoasTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Hateoas/DiscoveryHateoasTests.cs
@@ -49,7 +49,7 @@ public sealed class DiscoveryHateoasTests : EndpointsTestBase
         // Arrange
         (RegisterRequest registerRequest, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
             ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
-        string accessToken = await GetAccessTokenAsync(registerRequest.Username, TestPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
         using HttpRequestMessage request = new(HttpMethod.Get, new Uri("", UriKind.Relative));
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/RegisterConfirmLoginLogoutTests.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/RegisterConfirmLoginLogoutTests.cs
@@ -35,6 +35,10 @@ public sealed class RegisterConfirmLoginLogoutTests : E2ETestBase
         (await Page.GetByRole(AriaRole.Button, new() { Name = Buttons.Logout, Exact = true }).IsVisibleAsync())
             .ShouldBeTrue();
 
+        // The nav greets with the USERNAME (the `name` claim), not the e-mail the user logged in
+        // with — the display-only-handle half of ADR-0022, proven across the whole OIDC loop.
+        (await Page.GetByText(user.Username).IsVisibleAsync()).ShouldBeTrue();
+
         // Log out — the anonymous nav (the login link) returns.
         await AuthActions.LogoutAsync(Page);
         (await Page.GetByRole(AriaRole.Link, new() { Name = Links.Login, Exact = true }).IsVisibleAsync())

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
@@ -48,7 +48,7 @@ internal static class AuthActions
         await page.GotoAsync($"{fixture.FrontendBaseUrl}/");
         await page.GetByRole(AriaRole.Link, new() { Name = Links.Login, Exact = true }).ClickAsync();
 
-        await page.GetByLabel(FieldLabels.Username).FillAsync(user.Username);
+        await page.GetByLabel(FieldLabels.Email).FillAsync(user.Email);
         await page.GetByLabel(FieldLabels.Password, new() { Exact = true }).FillAsync(user.Password);
         await page.GetByRole(AriaRole.Button, new() { Name = Buttons.Login, Exact = true }).ClickAsync();
 

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
@@ -73,7 +73,7 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
     private const string ApiClientSecret = "fe-e2e-api-client-secret-min-32-characters";
     private const string WebClientId = "lotrokoniecdev-web";
 
-    private const string AdminUsername = "fe-e2e-admin";
+    private const string AdminUsername = "fee2eadmin";
     private const string AdminEmail = "fe-e2e-admin@lotro-translator.pl";
     private const string AdminPassword = "FeE2eAdminPass123!";
 

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/TestUser.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/TestUser.cs
@@ -25,8 +25,8 @@ internal sealed class TestUser
     {
         string suffix = Guid.NewGuid().ToString("N")[..10];
         return new TestUser(
-            username: $"e2e_{suffix}",
-            email: $"e2e_{suffix}@example.com",
+            username: $"e2e{suffix}",
+            email: $"e2e{suffix}@example.com",
             password: "E2ePassw0rd!");
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/AuthApiClient.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/AuthApiClient.cs
@@ -34,23 +34,24 @@ public sealed class AuthApiClient : IDisposable
     public async Task<HttpResponseMessage> RegisterRawAsync(RegisterRequest request) =>
         await _client.PostAsJsonAsync("auth/register", request, _jsonOptions);
 
-    public async Task<TokenResponse> LoginAsync(string username, string password)
+    public async Task<TokenResponse> LoginAsync(string email, string password)
     {
-        HttpResponseMessage response = await PostPasswordGrantAsync(username, password);
+        HttpResponseMessage response = await PostPasswordGrantAsync(email, password);
         await response.EnsureSuccessWithDetailsAsync();
         return await response.Content.ReadFromJsonAsync<TokenResponse>(_jsonOptions)
                ?? throw new InvalidOperationException("Null response from the token endpoint.");
     }
 
-    public async Task<HttpResponseMessage> LoginRawAsync(string username, string password) =>
-        await PostPasswordGrantAsync(username, password);
+    public async Task<HttpResponseMessage> LoginRawAsync(string email, string password) =>
+        await PostPasswordGrantAsync(email, password);
 
-    private async Task<HttpResponseMessage> PostPasswordGrantAsync(string username, string password)
+    private async Task<HttpResponseMessage> PostPasswordGrantAsync(string email, string password)
     {
+        // The OIDC "username" wire key is a protocol constant — it carries the e-mail (ADR-0022).
         Dictionary<string, string> parameters = new()
         {
             ["grant_type"] = "password",
-            ["username"] = username,
+            ["username"] = email,
             ["password"] = password,
             ["client_id"] = E2ETestFixture.TestClientId,
             ["scope"] = PasswordGrantScope

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/TranslationSystemApiClient.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Clients/TranslationSystemApiClient.cs
@@ -64,6 +64,9 @@ public sealed class TranslationSystemApiClient : IDisposable
     public async Task<HttpResponseMessage> ListTranslationsRawAsync() =>
         await _client.GetAsync(new Uri(TranslationsRoute, UriKind.Relative));
 
+    public async Task<HttpResponseMessage> GetStatsRawAsync() =>
+        await _client.GetAsync(new Uri($"{TranslationsRoute}/stats", UriKind.Relative));
+
     public async Task<TranslationDetailResponse> GetTranslationAsync(Guid id)
     {
         HttpResponseMessage response = await _client.GetAsync(new Uri($"{TranslationsRoute}/{id}", UriKind.Relative));

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
@@ -43,14 +43,14 @@ public abstract class E2ETestBase : IAsyncLifetime
     /// <summary>Logs in the seeded admin (Admin role, email pre-confirmed) via the password grant and returns its access token.</summary>
     protected async Task<string> LoginAsAdminAsync()
     {
-        TokenResponse token = await AuthApi.LoginAsync(E2ETestFixture.AdminUsername, E2ETestFixture.AdminPassword);
+        TokenResponse token = await AuthApi.LoginAsync(E2ETestFixture.AdminEmail, E2ETestFixture.AdminPassword);
         return token.AccessToken;
     }
 
     /// <summary>Registers a fresh user (granted the Translator role, email auto-confirmed) and logs it in.</summary>
     protected async Task<RegisteredTranslator> RegisterAndLoginTranslatorAsync()
     {
-        string username = $"translator_{Faker.Random.AlphaNumeric(10)}";
+        string username = $"translator{Faker.Random.AlphaNumeric(10)}";
         string email = $"{username}@lotro-translator.pl";
 
         RegisterRequest request = new(
@@ -61,7 +61,7 @@ public abstract class E2ETestBase : IAsyncLifetime
             AcceptedDataProcessingConsent: true);
 
         IdentityId identityId = await AuthApi.RegisterAsync(request);
-        TokenResponse token = await AuthApi.LoginAsync(username, TranslatorPassword);
+        TokenResponse token = await AuthApi.LoginAsync(email, TranslatorPassword);
         return new RegisteredTranslator(identityId, username, email, token.AccessToken);
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
@@ -40,7 +40,7 @@ public sealed class E2ETestFixture : IAsyncLifetime
     /// Seeded by auth-api on startup from <c>AdminUser__*</c> config, with <c>EmailConfirmed = true</c> and the
     /// <c>Admin</c> role — so a password-grant login yields a real Admin token without the email-confirmation dance.
     /// </summary>
-    public const string AdminUsername = "e2e-admin";
+    public const string AdminUsername = "e2eadmin";
     public const string AdminEmail = "e2e-admin@lotro-translator.pl";
     public const string AdminPassword = "E2eAdminPass123!";
 

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/AuthFlowE2ETests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/Tests/AuthFlowE2ETests.cs
@@ -73,12 +73,15 @@ public sealed class AuthFlowE2ETests : E2ETestBase
         }
     }
 
+    // The stats endpoint stands in for "any protected endpoint": the translations LIST went
+    // deliberately anonymous in #310 (public read-only landing page), which these two probes
+    // originally targeted.
     [Fact]
     public async Task TmsApi_RejectsProtectedEndpoint_WithoutToken()
     {
         TranslationSystemApiClient anonymous = CreateTmsClient();
 
-        HttpResponseMessage response = await anonymous.ListTranslationsRawAsync();
+        HttpResponseMessage response = await anonymous.GetStatsRawAsync();
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
@@ -88,7 +91,7 @@ public sealed class AuthFlowE2ETests : E2ETestBase
     {
         TranslationSystemApiClient client = CreateTmsClient("not-a-real-jwt");
 
-        HttpResponseMessage response = await client.ListTranslationsRawAsync();
+        HttpResponseMessage response = await client.GetStatsRawAsync();
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }


### PR DESCRIPTION
Closes #333

## What

- Login is now **e-mail + password** everywhere: the hosted login page binds `Email` and resolves `FindByEmailAsync` (every hardening preserved verbatim — dummy-hash timing equalization on not-found and lockout, failed-attempt counting, the post-password `EmailConfirmed` gate, security-stamp cookie claim, one generic error message); the Testing-only password grant also looks up by e-mail (the OIDC `username` wire key stays, as the protocol constant). The user-not-found log line carries a **masked** e-mail.
- The username becomes a **display-only handle**: still unique (case-insensitively), now restricted to `\A[a-zA-Z0-9]+\z` — enforced in three layers from one constant (`UsernameConstants`): the `RegisterUser` validator (authoritative, both registration surfaces), a Polish pre-check on the hosted Register page (the misleading password-hint fallback is unreachable for charset failures), and Identity's `AllowedUserNameCharacters` (last resort; also guards the admin seeder).
- Identity's `EmailIndex` on `NormalizedEmail` becomes **UNIQUE** (one Auth migration, database name kept) — a concurrent case-variant duplicate pair is now physically impossible, so the documented registration race can no longer grow into a two-account login outage.
- `ApplicationUser.UserName` stays the username — no rename, no claims rework, zero TMS/Frontend code changes (ADR-0022 records why this deliberately inverts TheKittySaver#256's physical design).

## Why

Product-owner decision (2026-07-04): authentication is e-mail + password; the username is a display-only handle — unique, no spaces, no special characters. Before this change, login was by username, the username charset was an accident of Identity defaults (with a misleading Polish error), and e-mail uniqueness was app-level only.

## Decision record

**ADR-0022** — *Email is the login identifier; username is a display-only unique handle*: the kept-`UserName` decision, the three-layer charset enforcement, the unique `EmailIndex`, and the disjoint-identifier-spaces argument (username can't contain `@`, e-mail must).

## Tests

- Build zero warnings; `scripts/check-ssr-purity.sh` green; `rg FindByNameAsync src/` hits exactly the two allowed sites (RegisterUser duplicate pre-check + seeder guard).
- AuthSystem integration **223/223** — incl. new cases: charset rejection `[Theory]` on the API (incl. the .NET `$`-anchor trap `"kasia92\n"`) and the hosted page (Polish message, never the password hint), case-variant duplicate e-mail and username, login **by username** fails on both paths, DB-level case-variant insert throws on the unique `EmailIndex`, Identity `InvalidUserName` pins the seeder guard.
- TMS integration 167/167; all unit suites green.
- TMS E2E **6/6** (fixture admin logs in by e-mail; migrator replayed the new migration on a fresh DB). Two pre-existing stale probes asserting 401 on the translations LIST (deliberately anonymous since #310) were re-pointed at the still-protected stats endpoint.
- Playwright browser E2E **8/8** — register → Mailpit confirm → **login by e-mail** through the FE OIDC challenge → nav greets with the **username** → logout.

## Operator notes

- Deployed `AUTH_ADMIN_USERNAME` values containing `-`/`.`/`_` must be re-set to alphanumeric **before** rolling this out — auth-api fails at startup otherwise (loud, by design; also pinned by a Terraform variable validation).
- Any **pre-existing user row** with a now-illegal username (e.g. registered on staging with `kasia.92`) can still log in by e-mail, but flows that call `UserManager.UpdateAsync` (password change/reset, e-mail confirm) will fail with `InvalidUserName` until the row is fixed. Pre-release, zero production users — staging accounts are disposable.

## Ticket AC deviation (surfaced, not silently changed)

The AC says charset rejection returns "API: 422 with the FluentValidation text" — in this codebase validation errors map to **400** (`ErrorExtensions`: `Validation→400`, `DataConflict→422`), like every sibling validation failure. Implemented as 400 with the validator message; noted on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)