### PR TITLE
MIGR-03: CI gate — reject unsafe/destructive migrations on PR (the ssr-purity analog for schema)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # fetch-depth: 2 brings the pushed commit plus its parent, so the migration-safety
+          # guard can diff newly-added files against HEAD^1. Main is squash-merge-only, so a
+          # push is normally one commit; a rare multi-commit direct push gets only its last
+          # commit scanned here — pr-verify is the enforcement, this job is the backstop.
+          fetch-depth: 2
           persist-credentials: false
 
       # Same Static-SSR gate as pr-verify — backstops direct pushes to main.
       - name: Pure-SSR guard
         run: ./scripts/check-ssr-purity.sh
+
+      # Same migration-safety gate as pr-verify (ADR-0023 / MIGR-03) — backstops direct
+      # pushes to main.
+      - name: Migration-safety guard self-test
+        run: ./scripts/tests/check-migration-safety.tests.sh
+
+      - name: Migration-safety guard
+        run: ./scripts/check-migration-safety.sh HEAD^1
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -57,10 +57,11 @@ jobs:
           # the SSR guard. NEVER add a build input here (.editorconfig, Directory.*.props/.targets,
           # global.json, nuget.config, test fixtures) — that would be a false green.
           inert='\.md$|^docs/|^LICENSE$|^\.gitignore$|^\.gitattributes$|\.sh$|\.ps1$|^iac/|(^|/)Dockerfile(\.migrator(\.prod)?|\.tests)?$|^compose[^/]*\.ya?ml$|^\.docker/|^\.github/|^\.run/|^\.vscode/|^\.idea/|(^|/)\.env[^/]*\.example$'
-          # Build-relevant despite matching `inert`: check-ssr-purity.sh is EXECUTED by the build
-          # job, and pr-verify/ci define the .NET gate itself — a change to any of them must run the
-          # gate so it validates its own new definition.
-          force_build='^scripts/check-ssr-purity\.sh$|^\.github/workflows/pr-verify\.yml$|^\.github/workflows/ci\.yml$'
+          # Build-relevant despite matching `inert`: check-ssr-purity.sh and the migration-safety
+          # guard + its self-test are EXECUTED by the build job (the .ps1 twin runs through the
+          # self-test's pwsh leg), and pr-verify/ci define the .NET gate itself — a change to any
+          # of them must run the gate so it validates its own new definition.
+          force_build='^scripts/check-ssr-purity\.sh$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^\.github/workflows/pr-verify\.yml$|^\.github/workflows/ci\.yml$'
           code=true
           if files="$(git diff --name-only HEAD^1 HEAD)"; then
             build_relevant="$(printf '%s\n' "$files" | grep -vE "$inert" || true)"
@@ -90,12 +91,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # fetch-depth: 2 brings the PR merge commit plus both parents, so the migration-safety
+          # guard can diff newly-added files against HEAD^1 (the base tip).
+          fetch-depth: 2
           persist-credentials: false
 
       # Fast, dependency-free gate: the Frontend must stay Static SSR. Runs before
       # the .NET setup so a stray @rendermode/@onclick fails in seconds, not minutes.
       - name: Pure-SSR guard
         run: ./scripts/check-ssr-purity.sh
+
+      # Schema analog of the SSR gate (ADR-0023 / MIGR-03): a newly-added destructive
+      # migration fails in seconds unless it carries the in-file acknowledgment marker
+      # (MIGRATION-SAFETY: acknowledged). The self-test runs first so the guard itself
+      # can never rot green.
+      - name: Migration-safety guard self-test
+        run: ./scripts/tests/check-migration-safety.tests.sh
+
+      - name: Migration-safety guard
+        run: ./scripts/check-migration-safety.sh HEAD^1
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/scripts/check-migration-safety.ps1
+++ b/scripts/check-migration-safety.ps1
@@ -1,0 +1,149 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Migration-safety guard (PowerShell twin of check-migration-safety.sh).
+
+.DESCRIPTION
+    ADR-0023: migrations are forward-only and N-1 backward-compatible - the previous app
+    revision keeps serving on the new schema during every deploy's smoke window and after
+    any failed rollout (rollback moves traffic, never schema). A destructive migration
+    turns that window into an outage, so it must be a deliberate expand -> backfill ->
+    contract step, never an accident that passes a green gate.
+
+    Scans migration files NEWLY ADDED relative to a base ref (plus staged and untracked
+    files, so it works pre-commit). Only the Up() body is checked - every Down() contains
+    drops by construction and never runs in shared environments (ADR-0023 section 1).
+    Designer files and model snapshots are excluded; already-shipped migrations are never
+    re-flagged. A flagged file passes when it carries a comment line with the token
+    `MIGRATION-SAFETY: acknowledged` followed by the reason.
+
+    CI runs the .sh; this .ps1 is the local twin for Windows devs - keep the two in sync.
+    Tests for the .sh: scripts/tests/check-migration-safety.tests.sh.
+
+.PARAMETER Base
+    Base ref to diff against (CI uses HEAD^1). Defaults to origin/main, then main.
+#>
+
+param(
+    [string] $Base
+)
+
+$ErrorActionPreference = 'Stop'
+
+# The generic-args group is [^(] (not [^>]) so nested generics still match:
+# AlterColumn<Dictionary<string, string>>(.
+$destructive  = '(DropColumn|DropTable|RenameColumn|RenameTable|DropIndex|AlterColumn)\s*(<[^(]*>)?\s*[(]'
+$acknowledged = 'MIGRATION-SAFETY:\s*acknowledged'
+
+$repoRoot = git rev-parse --show-toplevel 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host 'Migration-safety guard: not inside a git repository.'
+    exit 2
+}
+
+Push-Location $repoRoot
+try {
+    if ($Base) {
+        git rev-parse --quiet --verify "$Base^{commit}" *> $null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Migration-safety guard: cannot resolve base ref '$Base'."
+            exit 2
+        }
+    }
+    else {
+        foreach ($candidate in 'origin/main', 'main') {
+            git rev-parse --quiet --verify "$candidate^{commit}" *> $null
+            if ($LASTEXITCODE -eq 0) { $Base = $candidate; break }
+        }
+        if (-not $Base) {
+            Write-Host 'Migration-safety guard: no base ref given and neither origin/main nor main exists;'
+            Write-Host 'scanning only staged and untracked migration files.'
+        }
+    }
+
+    # --no-renames: default rename detection pairs a deleted migration with a similar
+    # new one (the regenerate-a-migration flow) and hides the addition from
+    # --diff-filter=A. Each git leg fails CLOSED (exit 2) - a gate that cannot compute
+    # its input must not pass.
+    $candidateFiles = @()
+    if ($Base) {
+        $candidateFiles += @(git diff --no-renames --name-only --diff-filter=A "$Base...HEAD" --)
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Migration-safety guard: git diff against base '$Base' failed."
+            exit 2
+        }
+    }
+    $candidateFiles += @(git diff --no-renames --cached --name-only --diff-filter=A --)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host 'Migration-safety guard: git diff --cached failed.'
+        exit 2
+    }
+    $candidateFiles += @(git ls-files --others --exclude-standard)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host 'Migration-safety guard: git ls-files failed.'
+        exit 2
+    }
+
+    $newFiles = $candidateFiles |
+        Where-Object { $_ -cmatch '(^|/)Migrations/[^/]+\.cs$' } |
+        Where-Object { $_ -cnotmatch '(\.Designer\.cs|ModelSnapshot\.cs)$' } |
+        Sort-Object -Unique
+
+    if (-not $newFiles) {
+        Write-Host 'OK Migration-safety guard passed - no newly-added migration files.'
+        exit 0
+    }
+
+    $fail = $false
+    $scanned = 0
+
+    foreach ($file in $newFiles) {
+        if (-not (Test-Path $file)) { continue }
+        $scanned++
+
+        # Only the Up() body: lines from `void Up(` up to (excluding) `void Down(` or EOF.
+        $inUp = $false
+        $hits = @()
+        $lineNumber = 0
+        foreach ($line in Get-Content $file) {
+            $lineNumber++
+            if ($line -cmatch 'void\s+Up\s*\(')   { $inUp = $true }
+            if ($line -cmatch 'void\s+Down\s*\(') { $inUp = $false }
+            if ($inUp -and $line -cmatch $destructive) {
+                $hits += ('    {0}:{1}: {2}' -f $file, $lineNumber, $line.Trim())
+            }
+        }
+        if (-not $hits) { continue }
+
+        $marker = Select-String -Path $file -Pattern $acknowledged -CaseSensitive |
+            Select-Object -First 1
+        if ($marker) {
+            Write-Host 'OK Acknowledged destructive migration (deliberate - ADR-0023 section 3 step):'
+            Write-Host ('    {0}:{1}: {2}' -f $file, $marker.LineNumber, $marker.Line.Trim())
+            Write-Host ''
+            continue
+        }
+
+        $fail = $true
+        Write-Host 'X Destructive operation(s) in a newly-added migration, without acknowledgment:'
+        $hits | ForEach-Object { Write-Host $_ }
+        Write-Host ''
+    }
+
+    if ($fail) {
+        Write-Host '----------------------------------------------------------------------'
+        Write-Host 'Migration-safety guard FAILED - migrations must be N-1 backward-compatible.'
+        Write-Host 'The previous app revision serves on this schema during every deploy (ADR-0023).'
+        Write-Host 'Split the change: expand -> backfill -> contract, across >= 2 deploys.'
+        Write-Host 'Deliberate contract step (or the dropped shape never shipped)? Add a comment'
+        Write-Host 'line inside the migration file:'
+        Write-Host '    // MIGRATION-SAFETY: acknowledged - <reason>'
+        Write-Host "See CLAUDE.md -> 'Migrations are forward-only' and docs/adr/0023-*.md."
+        exit 1
+    }
+
+    Write-Host "OK Migration-safety guard passed - $scanned newly-added migration file(s) scanned."
+}
+finally {
+    Pop-Location
+}

--- a/scripts/check-migration-safety.sh
+++ b/scripts/check-migration-safety.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Migration-safety guard (MIGR-03) — the schema analog of check-ssr-purity.sh.
+#
+# ADR-0023: migrations are forward-only and N-1 backward-compatible — the previous app
+# revision keeps serving on the new schema during every deploy's smoke window and after
+# any failed rollout (rollback moves traffic, never schema). A destructive migration
+# turns that window into an outage, so it must be a deliberate expand → backfill →
+# contract step, never an accident that passes a green gate.
+#
+# This is a pure text scan (no SDK — it runs before setup-dotnet, in the exact slot
+# check-ssr-purity.sh occupies in ci.yml and pr-verify.yml). It looks at migration
+# files NEWLY ADDED relative to a base ref (CI passes HEAD^1; locally it defaults to
+# the merge-base with origin/main, plus staged and untracked files so it works
+# pre-commit). Only the Up() body is scanned — every Down() contains drops by
+# construction and never runs in shared environments (ADR-0023 §1). Designer files and
+# model snapshots are excluded. Already-shipped migrations are never re-flagged.
+#
+# Escape hatch (ADR-0023 §4): a deliberate destructive step carries a comment line
+# containing the token `MIGRATION-SAFETY: acknowledged` followed by the reason —
+# e.g.  // MIGRATION-SAFETY: acknowledged — contract step of #123; expand shipped in #120
+# A flagged file carrying the token passes.
+#
+# Accepted false negatives (ADR-0023 trade-offs): destructive raw migrationBuilder.Sql(),
+# and DDL edited into an ALREADY-MERGED migration file (modified, not added). Squawk over
+# `dotnet ef migrations script` is the recorded upgrade path if this regex proves too
+# coarse. AlterColumn always flags — type changes are destructive regardless of
+# nullability (ADR-0023 §3); a benign widening costs one acknowledgment line.
+#
+# Usage: check-migration-safety.sh [<base-ref>]
+# Exit codes: 0 = clean, 1 = unacknowledged destructive migration, 2 = cannot run.
+# Tests: scripts/tests/check-migration-safety.tests.sh (CI runs them right before this
+# guard). Keep this in sync with its check-migration-safety.ps1 twin.
+
+set -euo pipefail
+
+# The generic-args group is [^(] (not [^>]) so nested generics still match:
+# AlterColumn<Dictionary<string, string>>(. The trailing paren is a character
+# class, not \( — awk -v applies C-escape processing to the pattern, and BSD
+# awk turns \( into a bare group-opener.
+DESTRUCTIVE='(DropColumn|DropTable|RenameColumn|RenameTable|DropIndex|AlterColumn)[[:space:]]*(<[^(]*>)?[[:space:]]*[(]'
+ACKNOWLEDGED='MIGRATION-SAFETY:[[:space:]]*acknowledged'
+
+if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    echo "Migration-safety guard: not inside a git repository." >&2
+    exit 2
+fi
+cd "$repo_root"
+
+base="${1:-}"
+if [ -n "$base" ]; then
+    if ! git rev-parse --quiet --verify "$base^{commit}" >/dev/null; then
+        echo "Migration-safety guard: cannot resolve base ref '$base'." >&2
+        exit 2
+    fi
+else
+    for candidate in origin/main main; do
+        if git rev-parse --quiet --verify "$candidate^{commit}" >/dev/null; then
+            base="$candidate"
+            break
+        fi
+    done
+    if [ -z "$base" ]; then
+        echo "Migration-safety guard: no base ref given and neither origin/main nor main exists;" >&2
+        echo "scanning only staged and untracked migration files." >&2
+    fi
+fi
+
+# Newly-added migration files = added vs base (merge-base semantics via A...HEAD)
+# + staged-new + untracked, so the guard is useful before anything is committed.
+# --no-renames: default rename detection pairs a deleted migration with a similar
+# new one (the regenerate-a-migration flow) and hides the addition from
+# --diff-filter=A. Each git leg fails CLOSED (exit 2) — a gate that cannot compute
+# its input must not pass. Designer files and model snapshots restate the model,
+# not the DDL — excluded.
+added_committed=""
+if [ -n "$base" ]; then
+    if ! added_committed="$(git diff --no-renames --name-only --diff-filter=A "$base...HEAD" --)"; then
+        echo "Migration-safety guard: git diff against base '$base' failed." >&2
+        exit 2
+    fi
+fi
+if ! added_staged="$(git diff --no-renames --cached --name-only --diff-filter=A --)"; then
+    echo "Migration-safety guard: git diff --cached failed." >&2
+    exit 2
+fi
+if ! untracked="$(git ls-files --others --exclude-standard)"; then
+    echo "Migration-safety guard: git ls-files failed." >&2
+    exit 2
+fi
+
+new_files="$(
+    printf '%s\n%s\n%s\n' "$added_committed" "$added_staged" "$untracked" \
+        | grep -E '(^|/)Migrations/[^/]+\.cs$' \
+        | grep -vE '(\.Designer\.cs|ModelSnapshot\.cs)$' \
+        | sort -u || true
+)"
+
+if [ -z "$new_files" ]; then
+    echo "✓ Migration-safety guard passed — no newly-added migration files."
+    exit 0
+fi
+
+fail=0
+scanned=0
+
+while IFS= read -r file; do
+    [ -f "$file" ] || continue
+    scanned=$((scanned + 1))
+
+    # Only the Up() body: lines from `void Up(` up to (excluding) `void Down(` or EOF.
+    hits="$(awk -v pattern="$DESTRUCTIVE" '
+        /void[[:space:]]+Up[[:space:]]*\(/  { in_up = 1 }
+        /void[[:space:]]+Down[[:space:]]*\(/ { in_up = 0 }
+        in_up && $0 ~ pattern {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            printf "    %s:%d: %s\n", FILENAME, FNR, line
+        }
+    ' "$file")"
+    [ -n "$hits" ] || continue
+
+    if marker="$(grep -nE "$ACKNOWLEDGED" "$file" | head -1 | sed -E 's/^([0-9]+):[[:space:]]*/\1: /')"; then
+        echo "✓ Acknowledged destructive migration (deliberate — ADR-0023 §3 step):"
+        printf '    %s:%s\n\n' "$file" "$marker"
+        continue
+    fi
+
+    fail=1
+    echo "✗ Destructive operation(s) in a newly-added migration, without acknowledgment:"
+    printf '%s\n\n' "$hits"
+done <<< "$new_files"
+
+if [ "$fail" -ne 0 ]; then
+    echo "──────────────────────────────────────────────────────────────────────"
+    echo "Migration-safety guard FAILED — migrations must be N-1 backward-compatible."
+    echo "The previous app revision serves on this schema during every deploy (ADR-0023)."
+    echo "Split the change: expand → backfill → contract, across ≥ 2 deploys."
+    echo "Deliberate contract step (or the dropped shape never shipped)? Add a comment"
+    echo "line inside the migration file:"
+    echo "    // MIGRATION-SAFETY: acknowledged — <reason>"
+    echo "See CLAUDE.md → 'Migrations are forward-only' and docs/adr/0023-*.md."
+    exit 1
+fi
+
+echo "✓ Migration-safety guard passed — $scanned newly-added migration file(s) scanned."

--- a/scripts/tests/check-migration-safety.tests.sh
+++ b/scripts/tests/check-migration-safety.tests.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Test suite for the migration-safety guard (MIGR-03, ADR-0023 §4).
+#
+# Each case builds a throwaway git repo whose initial commit already contains a
+# DESTRUCTIVE legacy migration — proving shipped migrations are never re-flagged —
+# then adds fixture migrations and asserts the guard's exit code and output.
+# CI runs this right before the guard itself, so the gate cannot rot silently.
+# When pwsh is available (it is on the ubuntu runners), the whole suite re-runs
+# against the check-migration-safety.ps1 twin, keeping the two in sync mechanically.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Isolate from the developer's git config (gpg signing, hooks, defaults).
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+export GIT_AUTHOR_NAME=migration-safety-tests GIT_AUTHOR_EMAIL=tests@localhost
+export GIT_COMMITTER_NAME=migration-safety-tests GIT_COMMITTER_EMAIL=tests@localhost
+
+CHECKER=""
+LABEL=""
+LAST_OUTPUT=""
+cases=0
+
+fail() {
+    printf '✗ [%s] %s\n' "$LABEL" "$1"
+    if [ -n "${2:-}" ]; then
+        printf '%s\n' "$2" | sed 's/^/    /'
+    fi
+    exit 1
+}
+
+write_migration() {
+    # $1 repo, $2 file name, $3 Up() body, $4 Down() body
+    local dir="$1/src/App.Persistence/Migrations"
+    mkdir -p "$dir"
+    cat > "$dir/$2" <<EOF
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Persistence.Migrations
+{
+    public partial class Fixture : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            $3
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            $4
+        }
+    }
+}
+EOF
+}
+
+new_repo() {
+    local repo
+    repo="$(mktemp -d "$TMP_ROOT/repo.XXXXXX")"
+    git -C "$repo" init -q -b main
+    write_migration "$repo" "20260101000000_LegacyDropColumn.cs" \
+        'migrationBuilder.DropColumn(name: "Old", table: "Legacy");' \
+        'migrationBuilder.AddColumn<string>(name: "Old", table: "Legacy");'
+    git -C "$repo" add -A
+    git -C "$repo" commit -qm "initial schema (destructive legacy migration, unacknowledged)"
+    printf '%s' "$repo"
+}
+
+commit_all() {
+    git -C "$1" add -A
+    git -C "$1" commit -qm "$2"
+}
+
+run_case() {
+    # $1 expected exit code, $2 description, $3 repo; remaining args go to the checker
+    local expected="$1" desc="$2" repo="$3"
+    shift 3
+    local rc=0
+    LAST_OUTPUT="$( (cd "$repo" && "$CHECKER" "$@") 2>&1 )" || rc=$?
+    if [ "$rc" -ne "$expected" ]; then
+        fail "$desc — expected exit $expected, got $rc" "$LAST_OUTPUT"
+    fi
+    cases=$((cases + 1))
+    printf '✓ [%s] %s\n' "$LABEL" "$desc"
+}
+
+expect_in_output() {
+    printf '%s' "$LAST_OUTPUT" | grep -qF "$1" \
+        || fail "output should contain '$1'" "$LAST_OUTPUT"
+}
+
+run_suite() {
+    local repo
+
+    # 1. Additive migration passes — and the destructive legacy file is not re-flagged.
+    repo="$(new_repo)"
+    write_migration "$repo" "20260705000001_AddThing.cs" \
+        'migrationBuilder.AddColumn<string>(name: "New", table: "T", nullable: true);' \
+        'migrationBuilder.DropColumn(name: "New", table: "T");'
+    commit_all "$repo" "additive"
+    run_case 0 "additive migration passes; legacy destructive file stays unflagged" "$repo" HEAD^1
+    expect_in_output "1 newly-added migration file(s) scanned"
+
+    # 2. Destructive migration fails and names every flagged operation.
+    repo="$(new_repo)"
+    write_migration "$repo" "20260705000002_DropStuff.cs" \
+        'migrationBuilder.DropColumn(name: "Gone", table: "T");
+            migrationBuilder.AlterColumn<string>(name: "Kept", table: "T", nullable: false);
+            migrationBuilder.RenameTable(name: "T", newName: "T2");' \
+        'migrationBuilder.AddColumn<string>(name: "Gone", table: "T");'
+    commit_all "$repo" "destructive"
+    run_case 1 "destructive migration fails" "$repo" HEAD^1
+    expect_in_output "DropColumn"
+    expect_in_output "AlterColumn"
+    expect_in_output "RenameTable"
+    expect_in_output "20260705000002_DropStuff.cs"
+    expect_in_output "MIGRATION-SAFETY: acknowledged"
+
+    # 3. The in-file acknowledgment token turns the same failure into a pass.
+    repo="$(new_repo)"
+    write_migration "$repo" "20260705000003_ContractStep.cs" \
+        '// MIGRATION-SAFETY: acknowledged — contract step; the expand release shipped in the previous deploy
+            migrationBuilder.DropColumn(name: "Gone", table: "T");' \
+        'migrationBuilder.AddColumn<string>(name: "Gone", table: "T");'
+    commit_all "$repo" "acknowledged contract step"
+    run_case 0 "acknowledged destructive migration passes" "$repo" HEAD^1
+    expect_in_output "Acknowledged destructive migration"
+
+    # 4. Destructive ops in Down() only — the shape of every additive EF migration — pass.
+    repo="$(new_repo)"
+    write_migration "$repo" "20260705000004_CreateTable.cs" \
+        'migrationBuilder.CreateTable(name: "Fresh");' \
+        'migrationBuilder.DropTable(name: "Fresh");'
+    commit_all "$repo" "create table"
+    run_case 0 "destructive operations in Down() only are ignored" "$repo" HEAD^1
+
+    # 5. Designer files and model snapshots are excluded even when destructive text matches.
+    repo="$(new_repo)"
+    write_migration "$repo" "20260705000005_Whatever.Designer.cs" \
+        'migrationBuilder.DropTable(name: "T");' \
+        'migrationBuilder.CreateTable(name: "T");'
+    write_migration "$repo" "AppWriteDbContextModelSnapshot.cs" \
+        'migrationBuilder.DropColumn(name: "X", table: "T");' \
+        'migrationBuilder.AddColumn<string>(name: "X", table: "T");'
+    commit_all "$repo" "designer + snapshot"
+    run_case 0 "Designer and ModelSnapshot files are excluded" "$repo" HEAD^1
+    expect_in_output "no newly-added migration files"
+
+    # 6. An uncommitted (untracked) destructive migration is caught with no base argument.
+    repo="$(new_repo)"
+    write_migration "$repo" "20260705000006_UncommittedDrop.cs" \
+        'migrationBuilder.DropTable(name: "T");' \
+        'migrationBuilder.CreateTable(name: "T");'
+    run_case 1 "untracked destructive migration is caught pre-commit" "$repo"
+    expect_in_output "20260705000006_UncommittedDrop.cs"
+
+    # 7. An unresolvable explicit base ref is a setup error, not a pass.
+    repo="$(new_repo)"
+    run_case 2 "unresolvable base ref exits 2" "$repo" no-such-ref
+
+    # 8. Rename pairing must not hide an added migration: deleting one migration and
+    #    adding a similar destructive one (the regenerate-a-migration flow) would be
+    #    reported as R, not A, without --no-renames.
+    repo="$(new_repo)"
+    rm "$repo/src/App.Persistence/Migrations/20260101000000_LegacyDropColumn.cs"
+    write_migration "$repo" "20260705000008_RegeneratedDrop.cs" \
+        'migrationBuilder.DropColumn(name: "Old", table: "Legacy");' \
+        'migrationBuilder.AddColumn<string>(name: "Old", table: "Legacy");'
+    commit_all "$repo" "regenerated migration"
+    run_case 1 "rename-paired regenerated destructive migration is still caught" "$repo" HEAD^1
+    expect_in_output "20260705000008_RegeneratedDrop.cs"
+
+    # 9. A staged-but-uncommitted destructive migration is caught (the --cached leg).
+    repo="$(new_repo)"
+    write_migration "$repo" "20260705000009_StagedDrop.cs" \
+        'migrationBuilder.DropTable(name: "T");' \
+        'migrationBuilder.CreateTable(name: "T");'
+    git -C "$repo" add -A
+    run_case 1 "staged destructive migration is caught pre-commit" "$repo"
+    expect_in_output "20260705000009_StagedDrop.cs"
+
+    # 10. No base resolvable at all (no origin/main, no main): warn, still scan
+    #     staged + untracked instead of passing silently.
+    repo="$(new_repo)"
+    git -C "$repo" branch -m main trunk
+    write_migration "$repo" "20260705000010_NoBaseDrop.cs" \
+        'migrationBuilder.DropTable(name: "T");' \
+        'migrationBuilder.CreateTable(name: "T");'
+    run_case 1 "without any resolvable base the untracked scan still catches" "$repo"
+    expect_in_output "scanning only staged and untracked migration files"
+    expect_in_output "20260705000010_NoBaseDrop.cs"
+
+    # 11. Nested generic type arguments must not defeat the regex.
+    repo="$(new_repo)"
+    write_migration "$repo" "20260705000011_NestedGeneric.cs" \
+        'migrationBuilder.AlterColumn<Dictionary<string, string>>(name: "Data", table: "T", nullable: false);' \
+        'migrationBuilder.AlterColumn<Dictionary<string, string>>(name: "Data", table: "T", nullable: true);'
+    commit_all "$repo" "nested generic alter"
+    run_case 1 "AlterColumn with nested generic type arguments is caught" "$repo" HEAD^1
+    expect_in_output "20260705000011_NestedGeneric.cs"
+}
+
+CHECKER="$SCRIPTS_DIR/check-migration-safety.sh"
+LABEL="sh"
+run_suite
+
+if command -v pwsh >/dev/null 2>&1; then
+    ps1_runner="$TMP_ROOT/run-ps1.sh"
+    printf '#!/usr/bin/env bash\nexec pwsh -NoProfile -File "%s" "$@"\n' \
+        "$SCRIPTS_DIR/check-migration-safety.ps1" > "$ps1_runner"
+    chmod +x "$ps1_runner"
+    CHECKER="$ps1_runner"
+    LABEL="ps1"
+    run_suite
+else
+    printf 'i pwsh not found — skipped the check-migration-safety.ps1 twin suite.\n'
+fi
+
+printf 'All %d migration-safety guard case(s) passed.\n' "$cases"


### PR DESCRIPTION
Closes #338

## What

The schema analog of the Pure-SSR guard: a CI gate that fails any PR introducing a **destructive** EF Core migration unless it is explicitly acknowledged in-file — enforcing the ADR-0023 forward-only / N-1 backward-compatible contract mechanically, for humans and the autonomous loop alike.

- `scripts/check-migration-safety.sh` (+ `.ps1` twin for local Windows runs) — pure text scan, no SDK, so it sits in the exact pre-`setup-dotnet` slot ssr-purity occupies. Scans migration files **newly added** relative to a base ref (CI passes `HEAD^1`; locally it defaults to the merge-base with `origin/main` and also covers staged + untracked files, so it works pre-commit). Only the `Up()` body is scanned — every `Down()` legitimately contains drops. `*.Designer.cs` / `*ModelSnapshot.cs` excluded; shipped migrations are never re-flagged (11 of 13 existing files contain matrix ops).
- Matrix (ADR-0023 §4): `DropColumn|DropTable|RenameColumn|RenameTable|DropIndex|AlterColumn`. `AlterColumn` always flags — type changes are destructive regardless of nullability (§3); a benign widening costs one acknowledgment line, a trade-off the ADR accepts explicitly.
- Escape hatch: a comment line inside the flagged file containing `MIGRATION-SAFETY: acknowledged — <reason>`.
- Fail-closed hardening (from the code-review gate): `--no-renames` so a deleted+regenerated migration can't hide from `--diff-filter=A` as a rename; each git leg failing exits 2 instead of silently passing; the generic-args group is `(<[^(]*>)?` so `AlterColumn<Dictionary<string, string>>(` can't slip through.
- Wiring: self-test + guard steps in **both** `ci.yml` and `pr-verify.yml` (before `setup-dotnet`; checkout `fetch-depth: 2` for the `HEAD^1` base — the idiom the `changes` job already uses); `force_build` regex extended with the guard, its `.ps1` twin, and the tests file.

## Why

The deploy gate commits the schema **before** traffic moves, and rollback restores code, never schema — so the N-1 revision serves on the N schema in every deploy's smoke window and after any failed rollout. Nothing previously stopped a valid-but-destructive `DropColumn` from passing green (audit 0001 C4). ADR-0023 §4 defines this gate; this PR implements it without re-deciding anything.

## Tests

- `scripts/tests/check-migration-safety.tests.sh` — 11 cases in throwaway git repos: additive passes (with a planted destructive legacy migration proving no re-flagging), destructive fails, acknowledged passes, Down()-only drops ignored, Designer/Snapshot excluded, untracked + staged pre-commit catches, exit-2 on bad base, rename-pairing caught, no-base fallback warns + still scans, nested generics caught. CI runs the suite right before the guard, and it re-runs wholesale against the `.ps1` twin when `pwsh` is present (it is on the ubuntu runners) — so twin drift fails CI.
- Verified on macOS (BSD awk), arm64 Linux (GNU awk), and real pwsh 7 (22/22 including the ps1 legs); two mutation controls (neutered guard, stripped `--no-renames`) each fail the harness, so the self-test can't rot green.
- Real-tree probes: an untracked destructive migration under `src/TranslationSystem/**/Migrations/` → exit 1 with file:line; with the marker → exit 0. This branch itself: guard passes, `dotnet build` zero warnings, 239 unit tests green.
- `code-reviewer` agent: initial REQUEST CHANGES (3 fail-open holes, all empirically confirmed) → fixed + pinned by tests → verification pass **APPROVE**, all acceptance criteria met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)