### PR TITLE
MIGR-05: CI test — N-1 backward compatibility (previous release's code against the new schema)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,6 +8,13 @@
         "dotnet-stryker"
       ],
       "rollForward": true
+    },
+    "dotnet-ef": {
+      "version": "10.0.9",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": true
     }
   }
 }

--- a/.github/workflows/n1-compat.yml
+++ b/.github/workflows/n1-compat.yml
@@ -1,0 +1,59 @@
+name: N-1 Backward Compatibility
+
+# Executable proof of the ADR-0023 contract (MIGR-05 / ADR-0024): the PREVIOUS release's
+# integration suites must pass against the NEW (HEAD) schema, because that is exactly what
+# serves production during every deploy's smoke window and after any failed rollout
+# (rollback moves traffic, never schema). scripts/n1-compat.sh generates idempotent schema
+# scripts from the PR merge commit, checks out HEAD^1 (= the main tip being merged into =
+# the deployed release; the repo has no version tags) into a worktree, and runs the old
+# checkout's own *.Tests.Integration.csproj suites with the seam env var set.
+#
+# Deliberately NOT a required check: path-filtered required checks deadlock every PR the
+# filter skips (the pr-verify docs-only lesson). Schema can only change through
+# src/**/Migrations/ (the migrator is the sole schema writer, ADR-0008 §6), so the paths
+# below cover every PR that can break the invariant; everything else is trivially green.
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'src/**/Migrations/**'
+      - 'scripts/n1-compat.sh'
+      - '.github/workflows/n1-compat.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: n1-compat-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  n1-compat:
+    name: Previous release on HEAD schema
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      # Full history: the script resolves HEAD^1 and materializes it as a git worktree.
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: '10.0.100'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Run previous release's integration suites against the HEAD schema
+        run: ./scripts/n1-compat.sh

--- a/.github/workflows/n1-compat.yml
+++ b/.github/workflows/n1-compat.yml
@@ -19,6 +19,12 @@ on:
       - 'src/**/Migrations/**'
       - 'scripts/n1-compat.sh'
       - '.github/workflows/n1-compat.yml'
+      # The proof's own load-bearing parts: a PR touching the seam or its factory call sites
+      # must run the job so a removed/renamed seam reds on THAT PR (the script's step 0
+      # asserts both), not one migration-PR later.
+      - 'tests/**/N1CompatSchemaSeam.cs'
+      - 'tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs'
+      - 'tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs'
   workflow_dispatch:
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,10 @@ scripts/claude/work-ticket.sh 123                      # one ticket, one fresh h
 # LOOP_EFFORT / LOOP_PERMISSION_MODE / LOOP_UNSAFE=1 · full manual: docs/claude-loop.md
 
 # TMS — EF Core migrations (write context owns them; --connection makes it work without appsettings/live DB)
+# dotnet-ef is a pinned local tool (dotnet tool restore). No --startup-project: it would equal
+# --project, and dotnet-ef 10.0.9 mis-parses the pair when both carry the identical value.
 dotnet ef migrations add <Name> \
   --project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
-  --startup-project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
   --context ApplicationWriteDbContext \
   -- --connection "Host=localhost;Database=lotro_translation;Username=postgres;Password=changeme"
 
@@ -341,7 +342,10 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
   (drop/rename a column or table, change a type, add `NOT NULL`, tighten a constraint / unique
   index over existing data) ship as **expand → backfill → contract across ≥ 2 deploys**; a
   deliberate destructive step carries an in-file `MIGRATION-SAFETY: acknowledged — <reason>`
-  comment (CI gate: #338 / MIGR-03).
+  comment (CI gate: #338 / MIGR-03). Migration-touching PRs additionally run the executable
+  N-1 proof: the previous release's integration suites against the HEAD schema
+  (`n1-compat.yml` / `scripts/n1-compat.sh` — ADR-0024; the factories' seam is
+  `N1_COMPAT_SCHEMA_SCRIPTS_DIR`, inert in normal test runs).
 - **Right-size the design — YAGNI by default.** Before proposing an abstraction, cache, config
   knob, queue, or new infra, check it solves a **real, present** need from the current
   spec/ticket — not a hypothetical future. Pick the simple path and note the trade-off in one line.

--- a/docs/adr/0023-forward-only-n-1-backward-compatible-migrations.md
+++ b/docs/adr/0023-forward-only-n-1-backward-compatible-migrations.md
@@ -170,7 +170,9 @@ with the recovery procedure, not here.
 - `Down()` methods become permanently dead code for shared environments (still generated, never
   executed there).
 - Until MIGR-05 lands, N-1 compatibility is asserted by rule + lint, not proven by a test.
-  Accepted: post-mvp, proportional to zero users.
+  Accepted: post-mvp, proportional to zero users. *(Closed 2026-07-05: ADR-0024 / #340 adds the
+  executable proof — the previous release's integration suites against the HEAD schema, on every
+  migration-touching PR.)*
 - Nothing restores data automatically — the net is a documented manual procedure. Accepted at
   this scale.
 

--- a/docs/adr/0024-n1-backward-compat-ci-proof.md
+++ b/docs/adr/0024-n1-backward-compat-ci-proof.md
@@ -1,0 +1,211 @@
+# ADR-0024: N-1 backward-compatibility proof — the previous release's integration suite against the HEAD schema
+
+**Status:** Accepted
+**Date:** 2026-07-05
+**Decision-makers:** Solo maintainer
+**Related:** ADR-0023 (the N-1 contract this job proves; its "asserted by rule + lint, not proven
+by a test" trade-off closes here), ADR-0012 (CD — every `main` commit deploys; §5 shared-schema
+window), MIGR-03 / #338 (the text gate this job backs with an executable proof), epic #335,
+ticket #340 (MIGR-05), `.github/workflows/pr-verify.yml` (required-check + path-filter lesson),
+`tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration`,
+`tests/LotroKoniecDev.AuthSystem.API.Tests.Integration`.
+
+## Context
+
+ADR-0023 makes every migration N-1 backward-compatible: the currently-deployed app revision must
+keep working against the schema as it stands after the migration. Enforcement today is a rule
+plus a text gate (MIGR-03) — nothing *executes* old code against a new schema. The integration
+suites can't do it as they stand: each factory boots its own throwaway PostgreSQL and migrates it
+itself to the schema of its own commit —
+`TranslationSystemApiFactory.InitializeAsync` calls `Database.MigrateAsync()`
+(`TranslationSystemApiFactory.cs:184`), and the Auth factory reaches the same call through
+`DatabaseSeederExtensions.SeedAuthDatabaseAsync` (`DatabaseSeederExtensions.cs:26`). New code ×
+new schema, always; the N-1 window is never exercised (ADR-0023 Context, last bullet).
+
+Facts that constrain the design:
+
+- **There are no `v*` tags.** `git tag` is empty. Releases are `main` commits: `deploy.yml`
+  deploys every push to `main` (ADR-0012), so "the previous release" can only be defined in git
+  terms, not tag terms.
+- **`MigrateAsync` is idempotent via `__EFMigrationsHistory`.** If a database already carries a
+  *newer* schema (more history rows than the running assembly knows), the old assembly's
+  `MigrateAsync()` finds all of its own migrations recorded and applies nothing. Old test
+  fixtures therefore tolerate a pre-migrated HEAD database without modification — the only
+  missing piece is getting that HEAD schema *into* the container the old fixture creates.
+- **Schema can only change through `src/**/Migrations/`.** The migrator (dev and prod) is the
+  sole schema writer (ADR-0008 §6); app code never issues DDL. A PR that adds no migration
+  cannot change the schema, so old-code-on-new-schema is trivially green for it.
+- **A required check with a path filter deadlocks.** The repo already learned this with
+  docs-only PRs (`pr-verify.yml` header): a required status that never reports blocks the merge.
+  A path-filtered N-1 job must therefore stay a non-required check.
+- **The integration suites already reset state with `TRUNCATE … CASCADE`** (e.g.
+  `CoreLoopTests.cs:41`, `CleanerService.cs`), so rows in HEAD-added child tables referencing
+  old parents are cascaded away rather than failing the old suite's resets — additive FK
+  migrations stay green without touching old tests.
+- **Idempotent scripts are generatable offline.** `dotnet ef migrations script --idempotent`
+  needs only a build plus the design-time factory's `-- --connection` argument (the same
+  mechanism `Dockerfile.migrator` and `scripts/apply-migrations.sh` rely on); it never connects.
+  Testcontainers' `PostgreSqlContainer.ExecScriptAsync` (Testcontainers.PostgreSql 4.12.0) can
+  apply such a script inside the container via psql.
+
+## Decision
+
+### 1. "Previous release" := `HEAD^1` of the checked-out commit
+
+On a PR run, actions/checkout checks out the merge commit, whose first parent is the tip of
+`main` the PR would merge into — under continuous deployment that *is* the running release (every
+older revision was already proven by its own PR's run, transitively). On a `workflow_dispatch`
+run from `main`, `HEAD^1` is the previous squash commit — the release before the current one.
+One expression, correct in both contexts, no tag infrastructure invented for the purpose. If the
+repo ever adopts release tags, this definition is the single line to revisit.
+
+### 2. The vehicle is the old checkout's own integration suites, discovered by the old checkout's own convention
+
+The job checks out `HEAD^1` into a git worktree and runs **every** `*.Tests.Integration.csproj`
+that `find tests -name '*.Tests.Integration.csproj'` discovers **in that worktree** — the exact
+discovery loop `pr-verify.yml`/`ci.yml` gate on. Whatever the previous release proved about
+itself is what this job re-proves against the new schema: no curated subset, no silent narrowing;
+suites added or removed on `main` change the proof automatically. The `*.E2E.Tests` projects stay
+excluded exactly as they are excluded from the PR gate (they build Docker images; disproportionate
+here for the same reason). Unit suites touch no database and prove nothing about schema — skipped.
+
+### 3. The seam: `N1_COMPAT_SCHEMA_SCRIPTS_DIR`, applied before the fixture's own migrate
+
+Both API factories gain one opt-in branch, immediately after their PostgreSQL container starts:
+when the environment variable `N1_COMPAT_SCHEMA_SCRIPTS_DIR` is set, the factory applies
+`<dir>/translation.sql` (TMS) / `<dir>/auth.sql` (Auth) — idempotent EF scripts generated from
+HEAD — to the fresh container via `ExecScriptAsync`, then proceeds exactly as before. Its own
+`MigrateAsync()` becomes a no-op (all its migrations are already in the applied history) and
+stays in place as a safety net: it would loudly fail if HEAD ever *removed* a shipped migration.
+When the variable is unset — every normal test run — behavior is byte-identical to today.
+
+The seam refuses to false-green. A configured-but-missing script file throws; the script content
+is prefixed with `\set ON_ERROR_STOP on` and a non-zero psql exit throws with stderr; the seam
+parses the migration ids the script inserts into `__EFMigrationsHistory`, throws if it finds none
+(a generation bug would otherwise silently hand the old fixture an empty database to migrate
+old-style), and after applying verifies every parsed id is actually present in the history table.
+Each failure mode is a thrown exception — a seam misconfiguration reads as a red job, never as a
+quietly-vacuous green one.
+
+Bootstrap and regression are told apart by *which side* lacks the seam: the job fails if the
+marker is missing from the **HEAD** checkout (the seam is a contract; removing it silences the
+proof — that must be red), and reports-and-passes if it is missing from the **previous release**
+(genuine pre-seam history; a one-time window that closes at the first post-seam merge, loudly
+noted in the run summary).
+
+### 4. Scope the trigger to what can break the invariant: migration-touching PRs, plus manual dispatch
+
+A separate workflow (`n1-compat.yml`), triggered by `pull_request` path-filtered to
+`src/**/Migrations/**` plus the job's own definition files, and by `workflow_dispatch`. It is
+deliberately **not** a required check (Context: the path-filter deadlock) and deliberately absent
+from the push-to-`main` backstop — the heaviest guard in the migration family runs only where a
+schema change can actually enter (main is PR-only), keeping its cost at zero for the overwhelming
+majority of PRs. `workflow_dispatch` covers assurance runs and re-verification after the fact.
+
+### 5. Schema source: `dotnet ef migrations script --idempotent`, pinned tooling, one runnable script
+
+The HEAD schema ships to the old suite as two idempotent scripts generated with the same
+project/startup/context pairs the migrator uses (`ApplicationWriteDbContext` via
+`TranslationSystem.Persistence`; `AuthDbContext` via `AuthSystem.Persistence` +
+`AuthSystem.API` startup). `dotnet-ef` joins `.config/dotnet-tools.json` (pinned, like
+`dotnet-stryker`) instead of the migrator image's floating global install. The whole job lives in
+`scripts/n1-compat.sh` — generate, worktree, detect, build, run — so the CI workflow is a thin
+caller and the identical proof (including the deliberate-red experiment) runs on a laptop. No
+`.ps1` twin: the script's consumer is CI; local runs are maintainer verification of the guard
+itself, and the twins exist for developer-workflow gates (`check-ssr-purity`,
+`check-migration-safety`), not CI conductors (`apply-migrations.sh` has none).
+
+## Consequences
+
+### Positive
+
+- The invariant the rollout depends on is now *executed*, not just linted: a backward-incompatible
+  migration turns a PR job red before the merge, with the old suite's failing tests naming exactly
+  what breaks.
+- ADR-0023's accepted gap ("asserted by rule + lint, not proven by a test") closes.
+- Zero steady-state cost: the job triggers only on migration-touching PRs and adds no step to
+  `pr-verify`/`ci`.
+- The proof is reproducible locally with the same script CI runs, including the red path
+  (add a destructive migration locally, run `scripts/n1-compat.sh HEAD`, watch it fail).
+- The seam is inert by default — normal test runs are untouched — and self-guarding: every
+  misconfiguration throws.
+
+### Negative / Accepted Trade-offs
+
+- The proof is one release deep (N-1, not N-k) — exactly the window ADR-0023 §2 contracts;
+  anything older was proven transitively by earlier runs.
+- ~10–15 min of CI on migration PRs (full old build + two integration suites against
+  Testcontainers). Accepted: migration PRs are rare and the repo is public (free runners).
+- Old-suite flakiness reads as a red N-1 job. Accepted: the suites are the same ones the PR gate
+  already trusts; re-run on flake.
+- A non-required check can be ignored at merge time. Accepted deliberately (deadlock avoidance);
+  the merge gate for migrations remains MIGR-03 + review, with this job as the loud alarm.
+- The seam code (~one small class) is twin-copied into both integration test projects — the
+  repo's test projects stay self-contained (no shared test library exists to host it). Marked as
+  twins; drift is caught by the HEAD-side marker assert only if renamed, by review otherwise.
+- New integration suites with their own DbContext must adopt the seam (a new script file name +
+  the same apply call) to be covered — recorded here as the extension point.
+
+## Alternatives Considered
+
+### A. Seam in the fixtures + idempotent HEAD scripts + old suite from a worktree (this ADR)
+
+Chosen. Minimal, explicit, locally reproducible; false-green paths all throw.
+
+### B. Run the previous release's suite unmodified
+
+Rejected. Vacuous: each old fixture migrates its own container to the *old* schema
+(`TranslationSystemApiFactory.cs:184`) and the job would green-light every migration ever
+written. This is precisely why the seam must exist in the fixture.
+
+### C. Shadow the `postgres:17-alpine` tag with an image whose initdb bakes the HEAD schema
+
+Rejected. Works day-one with zero old-code cooperation (Testcontainers uses a local image when
+the tag resolves), but silently redefines an upstream tag for everything on the runner, keys the
+whole proof on an implementation detail of image resolution, and offers no honest failure mode —
+the exact quiet-vacuity Decision 3 is built to refuse.
+
+### D. A curated N-1 contract test subset
+
+Rejected. The ticket allows it, but curation is a second backlog (every new slice needs a
+decision), and the full old integration suites are already fast enough for a rare, path-filtered
+job. "No silent narrowing" is cheapest when the scope is *everything the old release gated on*.
+
+### E. Make the job a required check on every PR
+
+Rejected. Required + path-filtered deadlocks non-migration PRs (the docs-only lesson); required
+without a path filter taxes every PR with the heaviest job in the family. Non-required +
+path-filtered keeps the signal where it matters.
+
+### F. Define "previous release" by `v*` tag
+
+Rejected for now. No tags exist and CD ships every `main` commit; a tag scheme would be invented
+solely to serve this job. Decision 1 names the single line to revisit if tags ever arrive.
+
+## Implementation Notes
+
+- `tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/N1CompatSchemaSeam.cs` +
+  `tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/N1CompatSchemaSeam.cs` — twin copies
+  (env-var read, `ExecScriptAsync` apply, migration-id parse, history verification); called from
+  `TranslationSystemApiFactory.InitializeAsync` / `AuthSystemApiFactory.InitializeAsync` right
+  after `StartAsync()`.
+- Pure unit tests for the script parser live beside the TMS seam copy (no container needed).
+- `scripts/n1-compat.sh` — generate scripts → assert HEAD seam → worktree `HEAD^1` (or the
+  argument ref) → bootstrap detect → build + run the old integration suites with
+  `N1_COMPAT_SCHEMA_SCRIPTS_DIR` set.
+- `.github/workflows/n1-compat.yml` — thin caller; `pull_request` paths
+  `src/**/Migrations/**`, `scripts/n1-compat.sh`, itself; `workflow_dispatch`.
+- `.config/dotnet-tools.json` — pinned `dotnet-ef`.
+- ADR-0023 — dated note on the closed trade-off; `CLAUDE.md` migrations rule + `tests/CLAUDE.md`
+  gain one-line pointers.
+
+## References
+
+- Ticket #340 (MIGR-05), epic #335 (MIGR-00)
+- ADR-0023 — the N-1 contract (Decision 2), the delegated proof (Decision 5)
+- ADR-0012 — CD from `main`; §5 shared-schema smoke window (why N-1 is the contract)
+- ADR-0008 §6 — the migrator is the sole schema writer
+- `.github/workflows/pr-verify.yml` — discovery loop + the required-check/path-filter lesson
+- `Dockerfile.migrator`, `scripts/apply-migrations.sh` — project/startup/context pairs and the
+  `-- --connection` design-time mechanism
+- EF Core docs — idempotent migration scripts; `__EFMigrationsHistory` semantics

--- a/docs/adr/0024-n1-backward-compat-ci-proof.md
+++ b/docs/adr/0024-n1-backward-compat-ci-proof.md
@@ -87,16 +87,19 @@ old-style), and after applying verifies every parsed id is actually present in t
 Each failure mode is a thrown exception — a seam misconfiguration reads as a red job, never as a
 quietly-vacuous green one.
 
-Bootstrap and regression are told apart by *which side* lacks the seam: the job fails if the
-marker is missing from the **HEAD** checkout (the seam is a contract; removing it silences the
-proof — that must be red), and reports-and-passes if it is missing from the **previous release**
-(genuine pre-seam history; a one-time window that closes at the first post-seam merge, loudly
-noted in the run summary).
+Bootstrap and regression are told apart by *which side* lacks the seam: the job fails (exit 2)
+if the **HEAD** checkout is missing either the marker in the seam files or the
+`ApplyIfConfiguredAsync` call in the factories (the seam is a contract; removing the file *or*
+orphaning it as dead code silences the proof — both must be red), and reports-and-passes if the
+marker is missing from the **previous release** (genuine pre-seam history; a one-time window
+that closes at the first post-seam merge, loudly noted in the run summary).
 
 ### 4. Scope the trigger to what can break the invariant: migration-touching PRs, plus manual dispatch
 
 A separate workflow (`n1-compat.yml`), triggered by `pull_request` path-filtered to
-`src/**/Migrations/**` plus the job's own definition files, and by `workflow_dispatch`. It is
+`src/**/Migrations/**` plus the proof's own load-bearing files (the workflow, the script, the
+seam twins and their factory call sites — so a seam regression reds on the PR that introduces
+it, not one migration-PR later), and by `workflow_dispatch`. It is
 deliberately **not** a required check (Context: the path-filter deadlock) and deliberately absent
 from the push-to-`main` backstop — the heaviest guard in the migration family runs only where a
 schema change can actually enter (main is PR-only), keeping its cost at zero for the overwhelming
@@ -142,7 +145,9 @@ itself, and the twins exist for developer-workflow gates (`check-ssr-purity`,
   the merge gate for migrations remains MIGR-03 + review, with this job as the loud alarm.
 - The seam code (~one small class) is twin-copied into both integration test projects — the
   repo's test projects stay self-contained (no shared test library exists to host it). Marked as
-  twins; drift is caught by the HEAD-side marker assert only if renamed, by review otherwise.
+  twins; removal of a seam file or a factory call site is red (the script asserts both on every
+  run, and the workflow triggers on changes to any of them); subtler drift between the twins is
+  caught by review.
 - New integration suites with their own DbContext must adopt the seam (a new script file name +
   the same apply call) to be covered — recorded here as the extension point.
 
@@ -194,7 +199,8 @@ solely to serve this job. Decision 1 names the single line to revisit if tags ev
   argument ref) → bootstrap detect → build + run the old integration suites with
   `N1_COMPAT_SCHEMA_SCRIPTS_DIR` set.
 - `.github/workflows/n1-compat.yml` — thin caller; `pull_request` paths
-  `src/**/Migrations/**`, `scripts/n1-compat.sh`, itself; `workflow_dispatch`.
+  `src/**/Migrations/**`, `scripts/n1-compat.sh`, itself, the seam twins and the two factory
+  files; `workflow_dispatch`.
 - `.config/dotnet-tools.json` — pinned `dotnet-ef`.
 - ADR-0023 — dated note on the closed trade-off; `CLAUDE.md` migrations rule + `tests/CLAUDE.md`
   gain one-line pointers.

--- a/scripts/n1-compat.sh
+++ b/scripts/n1-compat.sh
@@ -120,6 +120,12 @@ echo "== Generating idempotent schema scripts from the current tree =="
 # is "cannot run", never the exit-1 "backward-incompatible migration" verdict.
 dotnet tool restore >/dev/null || exit 2
 
+# Explicit restore first: dotnet-ef's project-metadata query (msbuild /t:ResolvePackageAssets)
+# does NOT implicit-restore, so on a fresh checkout (CI, clean clone) it dies with NETSDK1004
+# "Assets file ... project.assets.json not found". Same two startup projects as Dockerfile.migrator.
+dotnet restore src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/LotroKoniecDev.TranslationSystem.Persistence.csproj || exit 2
+dotnet restore src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj || exit 2
+
 # No --startup-project here: it equals --project, and dotnet-ef 10.0.9's parser mis-reads the
 # pair when both carry the identical value ("Unable to retrieve project metadata"); omitting it
 # makes the startup project default to --project, which is exactly what we want.

--- a/scripts/n1-compat.sh
+++ b/scripts/n1-compat.sh
@@ -38,9 +38,16 @@ set -euo pipefail
 
 CODE_REF="${1:-HEAD^1}"
 SEAM_MARKER='N1_COMPAT_SCHEMA_SCRIPTS_DIR'
+SEAM_CALL='N1CompatSchemaSeam.ApplyIfConfiguredAsync'
 SEAM_FILES=(
   "tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/N1CompatSchemaSeam.cs"
   "tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/N1CompatSchemaSeam.cs"
+)
+# The factories must keep CALLING the seam — a removed call site (seam file intact) would make
+# every future run silently vacuous: the old suite would migrate its own old schema and pass.
+SEAM_CALL_SITES=(
+  "tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs"
+  "tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs"
 )
 # Never used to connect: script generation is offline, but the design-time factories require a
 # syntactically valid connection string (same mechanism as Dockerfile.migrator / apply-migrations.sh).
@@ -83,11 +90,20 @@ canonical_tmp_dir() {
   (cd "$dir" && pwd -P)
 }
 
-# --- 0. The seam must exist in the CURRENT tree — losing it silences the proof forever. -------
+# --- 0. The seam must exist AND be called in the CURRENT tree — losing either silences the ----
+# --- proof forever (the old suite would just migrate its own old schema and pass). ------------
 for seam_file in "${SEAM_FILES[@]}"; do
   if ! grep -q "$SEAM_MARKER" "$seam_file" 2>/dev/null; then
     echo "ERROR: '$seam_file' no longer carries the $SEAM_MARKER seam." >&2
     echo "The N-1 job cannot prove anything without it (ADR-0024 §3). Restore the seam or update this script." >&2
+    exit 2
+  fi
+done
+
+for factory_file in "${SEAM_CALL_SITES[@]}"; do
+  if ! grep -qF "$SEAM_CALL" "$factory_file" 2>/dev/null; then
+    echo "ERROR: '$factory_file' no longer calls $SEAM_CALL." >&2
+    echo "Without the call the seam is dead code and every N-1 run is vacuous green (ADR-0024 §3). Restore the call or update this script." >&2
     exit 2
   fi
 done
@@ -100,7 +116,9 @@ prev_sha="$(git rev-parse --verify --quiet "${CODE_REF}^{commit}")" || {
 # --- 1. Generate the HEAD schema as idempotent scripts, one per context. ----------------------
 schema_dir="$(canonical_tmp_dir)"
 echo "== Generating idempotent schema scripts from the current tree =="
-dotnet tool restore >/dev/null
+# `|| exit 2` on the generation phase keeps the exit-code contract honest: an infra failure here
+# is "cannot run", never the exit-1 "backward-incompatible migration" verdict.
+dotnet tool restore >/dev/null || exit 2
 
 # No --startup-project here: it equals --project, and dotnet-ef 10.0.9's parser mis-reads the
 # pair when both carry the identical value ("Unable to retrieve project metadata"); omitting it
@@ -108,13 +126,13 @@ dotnet tool restore >/dev/null
 dotnet ef migrations script --idempotent --output "$schema_dir/translation.sql" \
   --project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
   --context ApplicationWriteDbContext \
-  -- --connection "$DESIGN_TIME_CONNECTION"
+  -- --connection "$DESIGN_TIME_CONNECTION" || exit 2
 
 dotnet ef migrations script --idempotent --output "$schema_dir/auth.sql" \
   --project src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence \
   --startup-project src/AuthSystem/LotroKoniecDev.AuthSystem.API \
   --context AuthDbContext \
-  -- --connection "$DESIGN_TIME_CONNECTION"
+  -- --connection "$DESIGN_TIME_CONNECTION" || exit 2
 
 for script in translation auth; do
   migration_count="$(grep -c "INSERT INTO.*\"__EFMigrationsHistory\"" "$schema_dir/$script.sql" || true)"
@@ -129,7 +147,7 @@ done
 worktree_parent="$(canonical_tmp_dir)"
 worktree_dir="$worktree_parent/n1-prev"
 echo "== Previous release: $prev_sha ($(git log -1 --format=%s "$prev_sha")) =="
-git worktree add --detach --quiet "$worktree_dir" "$prev_sha"
+git worktree add --detach --quiet "$worktree_dir" "$prev_sha" || exit 2
 
 if ! grep -rq "$SEAM_MARKER" "$worktree_dir/tests" --include="*.cs" 2>/dev/null; then
   say "N-1 compat: BOOTSTRAP — previous release $prev_sha predates the $SEAM_MARKER seam (ADR-0024); nothing it can prove yet. The window closes at the first post-seam merge."
@@ -156,7 +174,7 @@ if [ "$suites" -eq 0 ]; then
 fi
 
 if [ "$status" -ne 0 ]; then
-  say "N-1 compat: RED — the previous release ($prev_sha) fails on the current schema. A migration in this change is backward-incompatible (ADR-0023): ship it as expand → backfill → contract, or fix the breaking DDL."
+  say "N-1 compat: RED — the previous release ($prev_sha) fails on the current schema. A migration in this change is backward-incompatible (ADR-0023): ship it as expand → backfill → contract, or fix the breaking DDL. (If the old suite failed to build or start rather than failing tests, it's an infra problem — check the log above.)"
   exit 1
 fi
 

--- a/scripts/n1-compat.sh
+++ b/scripts/n1-compat.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# N-1 backward-compatibility proof (MIGR-05 / ADR-0024) — the executable counterpart of the
+# check-migration-safety.sh text gate.
+#
+# ADR-0023: every migration must be N-1 backward-compatible — during each deploy's smoke window
+# (and after any failed rollout) the PREVIOUS app revision serves on the NEW schema. This script
+# executes that exact combination: it migrates throwaway PostgreSQL containers to the schema of
+# the CURRENT tree and runs the PREVIOUS release's own integration suites against them.
+#
+# Mechanics:
+#   1. Generate idempotent schema scripts from the current tree (dotnet ef migrations script
+#      --idempotent) for both contexts — ApplicationWriteDbContext and AuthDbContext — using the
+#      same project/startup pairs as Dockerfile.migrator.
+#   2. Check out the previous release (default: HEAD^1 — on a PR merge commit that is the main
+#      tip being merged into, i.e. the deployed release; the repo has no version tags and CD
+#      ships every main commit) into a temporary git worktree.
+#   3. Run every *.Tests.Integration.csproj the OLD checkout discovers (the same convention
+#      pr-verify.yml gates on — no silent narrowing) with N1_COMPAT_SCHEMA_SCRIPTS_DIR pointing
+#      at the generated scripts. Each old test fixture applies the HEAD schema to its container
+#      before its own MigrateAsync (which then no-ops). Red = the old release cannot live on the
+#      new schema = a backward-incompatible migration.
+#
+# Bootstrap: if the previous release predates the seam (no N1_COMPAT_SCHEMA_SCRIPTS_DIR marker in
+# its tests/), there is nothing it can prove — report loudly and pass. The window closes at the
+# first post-seam merge. The seam missing from the CURRENT tree is a hard error instead: that
+# would silence the proof for every future run.
+#
+# Local usage:
+#   ./scripts/n1-compat.sh                  # previous release := HEAD^1
+#   ./scripts/n1-compat.sh origin/main      # previous release := main tip
+#   ./scripts/n1-compat.sh HEAD             # self-check; with an uncommitted destructive
+#                                           # migration in the tree this MUST go red (the
+#                                           # deliberate-red experiment from #340's AC)
+#
+# Requires: Docker (Testcontainers), the pinned dotnet-ef tool (dotnet tool restore runs here).
+# Exit codes: 0 = compatible (or bootstrap), 1 = N-1 incompatibility (old suite red), 2 = cannot run.
+set -euo pipefail
+
+CODE_REF="${1:-HEAD^1}"
+SEAM_MARKER='N1_COMPAT_SCHEMA_SCRIPTS_DIR'
+SEAM_FILES=(
+  "tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/N1CompatSchemaSeam.cs"
+  "tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/N1CompatSchemaSeam.cs"
+)
+# Never used to connect: script generation is offline, but the design-time factories require a
+# syntactically valid connection string (same mechanism as Dockerfile.migrator / apply-migrations.sh).
+DESIGN_TIME_CONNECTION='Host=localhost;Database=design_time_only;Username=postgres;Password=unused'
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+say() {
+  echo "$1"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "$1" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+schema_dir=""
+worktree_parent=""
+worktree_dir=""
+cleanup() {
+  if [ -n "$worktree_dir" ] && [ -d "$worktree_dir" ]; then
+    git worktree remove --force "$worktree_dir" >/dev/null 2>&1 || true
+    git worktree prune >/dev/null 2>&1 || true
+  fi
+  if [ -n "$worktree_parent" ] && [ -d "$worktree_parent" ]; then
+    rm -rf "$worktree_parent"
+  fi
+  if [ -n "$schema_dir" ] && [ -d "$schema_dir" ]; then
+    rm -rf "$schema_dir"
+  fi
+}
+trap cleanup EXIT
+
+# mktemp output must be canonicalized (pwd -P): on macOS it lives under /var → /private/var, and
+# feeding the symlinked form to dotnet as an absolute project path makes restore and build
+# disagree about project identity — the compile then silently resolves ZERO references
+# (empirically: 646 CS errors via /var/..., a clean build via /private/var/...).
+canonical_tmp_dir() {
+  local dir
+  dir="$(mktemp -d)"
+  (cd "$dir" && pwd -P)
+}
+
+# --- 0. The seam must exist in the CURRENT tree — losing it silences the proof forever. -------
+for seam_file in "${SEAM_FILES[@]}"; do
+  if ! grep -q "$SEAM_MARKER" "$seam_file" 2>/dev/null; then
+    echo "ERROR: '$seam_file' no longer carries the $SEAM_MARKER seam." >&2
+    echo "The N-1 job cannot prove anything without it (ADR-0024 §3). Restore the seam or update this script." >&2
+    exit 2
+  fi
+done
+
+prev_sha="$(git rev-parse --verify --quiet "${CODE_REF}^{commit}")" || {
+  echo "ERROR: cannot resolve '$CODE_REF' to a commit." >&2
+  exit 2
+}
+
+# --- 1. Generate the HEAD schema as idempotent scripts, one per context. ----------------------
+schema_dir="$(canonical_tmp_dir)"
+echo "== Generating idempotent schema scripts from the current tree =="
+dotnet tool restore >/dev/null
+
+# No --startup-project here: it equals --project, and dotnet-ef 10.0.9's parser mis-reads the
+# pair when both carry the identical value ("Unable to retrieve project metadata"); omitting it
+# makes the startup project default to --project, which is exactly what we want.
+dotnet ef migrations script --idempotent --output "$schema_dir/translation.sql" \
+  --project src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence \
+  --context ApplicationWriteDbContext \
+  -- --connection "$DESIGN_TIME_CONNECTION"
+
+dotnet ef migrations script --idempotent --output "$schema_dir/auth.sql" \
+  --project src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence \
+  --startup-project src/AuthSystem/LotroKoniecDev.AuthSystem.API \
+  --context AuthDbContext \
+  -- --connection "$DESIGN_TIME_CONNECTION"
+
+for script in translation auth; do
+  migration_count="$(grep -c "INSERT INTO.*\"__EFMigrationsHistory\"" "$schema_dir/$script.sql" || true)"
+  if [ "$migration_count" -eq 0 ]; then
+    echo "ERROR: '$script.sql' contains no migration-history inserts — generation produced an unusable script." >&2
+    exit 2
+  fi
+  echo "   $script.sql: $migration_count migration(s)"
+done
+
+# --- 2. Check out the previous release into a worktree. ---------------------------------------
+worktree_parent="$(canonical_tmp_dir)"
+worktree_dir="$worktree_parent/n1-prev"
+echo "== Previous release: $prev_sha ($(git log -1 --format=%s "$prev_sha")) =="
+git worktree add --detach --quiet "$worktree_dir" "$prev_sha"
+
+if ! grep -rq "$SEAM_MARKER" "$worktree_dir/tests" --include="*.cs" 2>/dev/null; then
+  say "N-1 compat: BOOTSTRAP — previous release $prev_sha predates the $SEAM_MARKER seam (ADR-0024); nothing it can prove yet. The window closes at the first post-seam merge."
+  exit 0
+fi
+
+# --- 3. Run the OLD release's integration suites against the NEW schema. ----------------------
+status=0
+suites=0
+while IFS= read -r proj; do
+  suites=$((suites + 1))
+  echo "::group::$(basename "$proj") (previous release, HEAD schema)"
+  if ! (cd "$worktree_dir" && \
+        N1_COMPAT_SCHEMA_SCRIPTS_DIR="$schema_dir" \
+        dotnet test "$proj" --configuration Release --logger "console;verbosity=minimal"); then
+    status=1
+  fi
+  echo "::endgroup::"
+done < <(find "$worktree_dir/tests" -name '*.Tests.Integration.csproj' | sort)
+
+if [ "$suites" -eq 0 ]; then
+  echo "ERROR: no *.Tests.Integration.csproj found in the previous release — refusing to report a false green." >&2
+  exit 2
+fi
+
+if [ "$status" -ne 0 ]; then
+  say "N-1 compat: RED — the previous release ($prev_sha) fails on the current schema. A migration in this change is backward-incompatible (ADR-0023): ship it as expand → backfill → contract, or fix the breaking DDL."
+  exit 1
+fi
+
+say "N-1 compat: GREEN — previous release $prev_sha passes all $suites integration suite(s) on the current schema."

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -137,6 +137,18 @@ checkboxes + state panels (`register-success`, `confirm-email-success`). **Requi
 name** (`...E2E.Tests`) — runs via `e2e.yml` (the `e2e-frontend` job) or a local `dotnet test`. Compiled by the
 solution build, so the zero-warning gate covers it.
 
+## N-1 schema seam (integration factories — ADR-0024)
+
+Both API integration factories carry `N1CompatSchemaSeam` (twin copies — keep in sync): when
+`N1_COMPAT_SCHEMA_SCRIPTS_DIR` is set, the factory applies a pre-generated idempotent HEAD schema
+script (`translation.sql` / `auth.sql`) to its fresh PostgreSQL container before its own
+`MigrateAsync()` (which then no-ops), so the suite exercises **its** code against a **newer**
+schema. Only `scripts/n1-compat.sh` (the MIGR-05 N-1 proof, `n1-compat.yml`) sets the variable —
+normal test runs are untouched. Every misconfiguration throws; keep `TRUNCATE … CASCADE` in test
+resets (a plain TRUNCATE breaks once a newer schema adds a referencing child table). A new
+integration suite with its own DbContext must adopt the seam (new script file name + the same
+apply call) to be covered.
+
 ## Conventions
 
 - Test class naming: `{ClassUnderTest}Tests`

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -120,6 +120,10 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
         await _postgresContainer.StartAsync();
         _connectionString = _postgresContainer.GetConnectionString();
 
+        // N-1 compat runs (ADR-0024) pre-apply the HEAD schema here; the seeder's MigrateAsync
+        // then no-ops and this suite exercises its (older) code against the newer schema.
+        await N1CompatSchemaSeam.ApplyIfConfiguredAsync(_postgresContainer, "auth.sql");
+
         // Accessing Services triggers host startup.
         // The seeder is skipped in Testing environment, so we seed explicitly
         // using the test host's services (which have the correct connection string).

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/N1CompatSchemaSeam.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/N1CompatSchemaSeam.cs
@@ -1,0 +1,107 @@
+using System.Text.RegularExpressions;
+using DotNet.Testcontainers.Containers;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration;
+
+/// <summary>
+/// N-1 backward-compatibility seam (ADR-0024 / #340). When <see cref="SchemaScriptsDirEnvVar"/>
+/// is set — only ever by <c>scripts/n1-compat.sh</c> — the factory applies a pre-generated
+/// idempotent HEAD schema script to its fresh PostgreSQL container before its own
+/// <c>MigrateAsync()</c>, which then no-ops against the already-filled
+/// <c>__EFMigrationsHistory</c>. This (older) suite then runs against the newer schema.
+/// Unset, every code path here is skipped and normal test runs are unchanged.
+/// Every misconfiguration throws: a vacuous N-1 check must read as red, never as green.
+/// Twin copy: <c>tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/N1CompatSchemaSeam.cs</c>
+/// — keep in sync (its copy also carries the pure parser unit tests).
+/// </summary>
+internal static partial class N1CompatSchemaSeam
+{
+    public const string SchemaScriptsDirEnvVar = "N1_COMPAT_SCHEMA_SCRIPTS_DIR";
+
+    public static async Task ApplyIfConfiguredAsync(PostgreSqlContainer postgresContainer, string scriptFileName)
+    {
+        string? scriptsDirectory = Environment.GetEnvironmentVariable(SchemaScriptsDirEnvVar);
+        if (string.IsNullOrWhiteSpace(scriptsDirectory))
+        {
+            return;
+        }
+
+        string scriptPath = Path.Combine(scriptsDirectory, scriptFileName);
+        if (!File.Exists(scriptPath))
+        {
+            throw new InvalidOperationException(
+                $"{SchemaScriptsDirEnvVar} is set but '{scriptPath}' does not exist — refusing to run a vacuous N-1 check.");
+        }
+
+        string script = await File.ReadAllTextAsync(scriptPath);
+
+        IReadOnlyCollection<HistoryInsert> expectedInserts = ParseHistoryInserts(script);
+        if (expectedInserts.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"'{scriptPath}' inserts no __EFMigrationsHistory rows — an empty or malformed schema script would leave this suite migrating its own (old) schema.");
+        }
+
+        ExecResult execResult = await postgresContainer.ExecScriptAsync("\\set ON_ERROR_STOP on\n" + script);
+        if (execResult.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Applying '{scriptPath}' failed (psql exit code {execResult.ExitCode}). Stderr: {execResult.Stderr}");
+        }
+
+        await VerifyHistoryContainsAsync(postgresContainer.GetConnectionString(), expectedInserts);
+    }
+
+    internal static IReadOnlyCollection<HistoryInsert> ParseHistoryInserts(string script)
+    {
+        return HistoryInsertRegex()
+            .Matches(script)
+            .Select(match => new HistoryInsert(match.Groups["table"].Value, match.Groups["id"].Value))
+            .Distinct()
+            .ToArray();
+    }
+
+    private static async Task VerifyHistoryContainsAsync(
+        string connectionString,
+        IReadOnlyCollection<HistoryInsert> expectedInserts)
+    {
+        await using NpgsqlConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        foreach (IGrouping<string, HistoryInsert> tableGroup in expectedInserts.GroupBy(insert => insert.HistoryTable))
+        {
+            HashSet<string> appliedIds = [];
+
+            // The identifier is not parameterizable; it is safe to interpolate because the regex
+            // only ever captures an optional plain-identifier schema plus the fixed quoted table name.
+            await using NpgsqlCommand command = new($"SELECT \"MigrationId\" FROM {tableGroup.Key}", connection);
+            await using (NpgsqlDataReader reader = await command.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    appliedIds.Add(reader.GetString(0));
+                }
+            }
+
+            string[] missingIds = tableGroup
+                .Select(insert => insert.MigrationId)
+                .Where(migrationId => !appliedIds.Contains(migrationId))
+                .ToArray();
+
+            if (missingIds.Length > 0)
+            {
+                throw new InvalidOperationException(
+                    $"The schema script ran, but {tableGroup.Key} is missing migration(s): {string.Join(", ", missingIds)} — the script did not apply fully.");
+            }
+        }
+    }
+
+    [GeneratedRegex(
+        @"INSERT INTO (?<table>(?:[A-Za-z_][A-Za-z0-9_]*\.)?""__EFMigrationsHistory"")\s*\(\s*""MigrationId"",\s*""ProductVersion""\s*\)\s*VALUES\s*\('(?<id>[^']+)'",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex HistoryInsertRegex();
+}
+
+internal sealed record HistoryInsert(string HistoryTable, string MigrationId);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/N1CompatSchemaSeam.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/N1CompatSchemaSeam.cs
@@ -1,0 +1,107 @@
+using System.Text.RegularExpressions;
+using DotNet.Testcontainers.Containers;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration;
+
+/// <summary>
+/// N-1 backward-compatibility seam (ADR-0024 / #340). When <see cref="SchemaScriptsDirEnvVar"/>
+/// is set — only ever by <c>scripts/n1-compat.sh</c> — the factory applies a pre-generated
+/// idempotent HEAD schema script to its fresh PostgreSQL container before its own
+/// <c>MigrateAsync()</c>, which then no-ops against the already-filled
+/// <c>__EFMigrationsHistory</c>. This (older) suite then runs against the newer schema.
+/// Unset, every code path here is skipped and normal test runs are unchanged.
+/// Every misconfiguration throws: a vacuous N-1 check must read as red, never as green.
+/// Twin copy: <c>tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/N1CompatSchemaSeam.cs</c>
+/// — keep in sync.
+/// </summary>
+internal static partial class N1CompatSchemaSeam
+{
+    public const string SchemaScriptsDirEnvVar = "N1_COMPAT_SCHEMA_SCRIPTS_DIR";
+
+    public static async Task ApplyIfConfiguredAsync(PostgreSqlContainer postgresContainer, string scriptFileName)
+    {
+        string? scriptsDirectory = Environment.GetEnvironmentVariable(SchemaScriptsDirEnvVar);
+        if (string.IsNullOrWhiteSpace(scriptsDirectory))
+        {
+            return;
+        }
+
+        string scriptPath = Path.Combine(scriptsDirectory, scriptFileName);
+        if (!File.Exists(scriptPath))
+        {
+            throw new InvalidOperationException(
+                $"{SchemaScriptsDirEnvVar} is set but '{scriptPath}' does not exist — refusing to run a vacuous N-1 check.");
+        }
+
+        string script = await File.ReadAllTextAsync(scriptPath);
+
+        IReadOnlyCollection<HistoryInsert> expectedInserts = ParseHistoryInserts(script);
+        if (expectedInserts.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"'{scriptPath}' inserts no __EFMigrationsHistory rows — an empty or malformed schema script would leave this suite migrating its own (old) schema.");
+        }
+
+        ExecResult execResult = await postgresContainer.ExecScriptAsync("\\set ON_ERROR_STOP on\n" + script);
+        if (execResult.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Applying '{scriptPath}' failed (psql exit code {execResult.ExitCode}). Stderr: {execResult.Stderr}");
+        }
+
+        await VerifyHistoryContainsAsync(postgresContainer.GetConnectionString(), expectedInserts);
+    }
+
+    internal static IReadOnlyCollection<HistoryInsert> ParseHistoryInserts(string script)
+    {
+        return HistoryInsertRegex()
+            .Matches(script)
+            .Select(match => new HistoryInsert(match.Groups["table"].Value, match.Groups["id"].Value))
+            .Distinct()
+            .ToArray();
+    }
+
+    private static async Task VerifyHistoryContainsAsync(
+        string connectionString,
+        IReadOnlyCollection<HistoryInsert> expectedInserts)
+    {
+        await using NpgsqlConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        foreach (IGrouping<string, HistoryInsert> tableGroup in expectedInserts.GroupBy(insert => insert.HistoryTable))
+        {
+            HashSet<string> appliedIds = [];
+
+            // The identifier is not parameterizable; it is safe to interpolate because the regex
+            // only ever captures an optional plain-identifier schema plus the fixed quoted table name.
+            await using NpgsqlCommand command = new($"SELECT \"MigrationId\" FROM {tableGroup.Key}", connection);
+            await using (NpgsqlDataReader reader = await command.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    appliedIds.Add(reader.GetString(0));
+                }
+            }
+
+            string[] missingIds = tableGroup
+                .Select(insert => insert.MigrationId)
+                .Where(migrationId => !appliedIds.Contains(migrationId))
+                .ToArray();
+
+            if (missingIds.Length > 0)
+            {
+                throw new InvalidOperationException(
+                    $"The schema script ran, but {tableGroup.Key} is missing migration(s): {string.Join(", ", missingIds)} — the script did not apply fully.");
+            }
+        }
+    }
+
+    [GeneratedRegex(
+        @"INSERT INTO (?<table>(?:[A-Za-z_][A-Za-z0-9_]*\.)?""__EFMigrationsHistory"")\s*\(\s*""MigrationId"",\s*""ProductVersion""\s*\)\s*VALUES\s*\('(?<id>[^']+)'",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex HistoryInsertRegex();
+}
+
+internal sealed record HistoryInsert(string HistoryTable, string MigrationId);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/N1Compat/N1CompatSchemaSeamTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/N1Compat/N1CompatSchemaSeamTests.cs
@@ -1,0 +1,139 @@
+using Shouldly;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.N1Compat;
+
+/// <summary>
+/// Pure unit coverage for the N-1 seam's schema-script parser (ADR-0024 / #340). It lives in the
+/// integration project because the seam is internal to it; it instantiates no factory and starts
+/// no container. The parser is the seam's vacuity guard: if it finds no history inserts in a
+/// generated script, the seam throws instead of letting the suite silently migrate its own
+/// (old) schema.
+/// </summary>
+public sealed class N1CompatSchemaSeamTests
+{
+    private const string IdempotentScriptWithTwoMigrations =
+        """
+        CREATE TABLE IF NOT EXISTS translation."__EFMigrationsHistory" (
+            "MigrationId" character varying(150) NOT NULL,
+            "ProductVersion" character varying(32) NOT NULL,
+            CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY ("MigrationId")
+        );
+
+        DO $EF$
+        BEGIN
+            IF NOT EXISTS(SELECT 1 FROM translation."__EFMigrationsHistory" WHERE "MigrationId" = '20260612201021_InitialCreate') THEN
+            CREATE TABLE translation."GameVersions" ("Id" uuid NOT NULL);
+            END IF;
+        END $EF$;
+
+        DO $EF$
+        BEGIN
+            IF NOT EXISTS(SELECT 1 FROM translation."__EFMigrationsHistory" WHERE "MigrationId" = '20260612201021_InitialCreate') THEN
+            INSERT INTO translation."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+            VALUES ('20260612201021_InitialCreate', '10.0.0');
+            END IF;
+        END $EF$;
+
+        DO $EF$
+        BEGIN
+            IF NOT EXISTS(SELECT 1 FROM translation."__EFMigrationsHistory" WHERE "MigrationId" = '20260613090456_AddTranslationAggregate') THEN
+            INSERT INTO translation."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+            VALUES ('20260613090456_AddTranslationAggregate', '10.0.0');
+            END IF;
+        END $EF$;
+        """;
+
+    [Fact]
+    public void ParseHistoryInserts_IdempotentScriptWithTwoMigrations_ReturnsBothIdsWithTheirTable()
+    {
+        IReadOnlyCollection<HistoryInsert> inserts = N1CompatSchemaSeam.ParseHistoryInserts(IdempotentScriptWithTwoMigrations);
+
+        inserts.Count.ShouldBe(2);
+        inserts.ShouldContain(new HistoryInsert("translation.\"__EFMigrationsHistory\"", "20260612201021_InitialCreate"));
+        inserts.ShouldContain(new HistoryInsert("translation.\"__EFMigrationsHistory\"", "20260613090456_AddTranslationAggregate"));
+    }
+
+    [Fact]
+    public void ParseHistoryInserts_IdempotencyGuardConditionsOnly_ReturnsEmpty()
+    {
+        string script =
+            """
+            DO $EF$
+            BEGIN
+                IF NOT EXISTS(SELECT 1 FROM translation."__EFMigrationsHistory" WHERE "MigrationId" = '20260612201021_InitialCreate') THEN
+                CREATE TABLE translation."GameVersions" ("Id" uuid NOT NULL);
+                END IF;
+            END $EF$;
+            """;
+
+        IReadOnlyCollection<HistoryInsert> inserts = N1CompatSchemaSeam.ParseHistoryInserts(script);
+
+        inserts.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("-- an entirely unrelated script\nSELECT 1;")]
+    public void ParseHistoryInserts_NoHistoryInserts_ReturnsEmpty(string script)
+    {
+        IReadOnlyCollection<HistoryInsert> inserts = N1CompatSchemaSeam.ParseHistoryInserts(script);
+
+        inserts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ParseHistoryInserts_UnqualifiedHistoryTable_CapturesTheBareTableName()
+    {
+        string script =
+            """
+            INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+            VALUES ('20260101000000_Init', '10.0.0');
+            """;
+
+        IReadOnlyCollection<HistoryInsert> inserts = N1CompatSchemaSeam.ParseHistoryInserts(script);
+
+        inserts.ShouldHaveSingleItem();
+        inserts.ShouldContain(new HistoryInsert("\"__EFMigrationsHistory\"", "20260101000000_Init"));
+    }
+
+    [Fact]
+    public void ParseHistoryInserts_SingleLineInsert_IsParsed()
+    {
+        string script =
+            """INSERT INTO auth."__EFMigrationsHistory" ("MigrationId", "ProductVersion") VALUES ('20260627145210_InitialAuthSchema', '10.0.0');""";
+
+        IReadOnlyCollection<HistoryInsert> inserts = N1CompatSchemaSeam.ParseHistoryInserts(script);
+
+        inserts.ShouldHaveSingleItem();
+        inserts.ShouldContain(new HistoryInsert("auth.\"__EFMigrationsHistory\"", "20260627145210_InitialAuthSchema"));
+    }
+
+    [Fact]
+    public void ParseHistoryInserts_DuplicatedInsertStatements_AreDeduplicated()
+    {
+        string insert =
+            """
+            INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+            VALUES ('20260101000000_Init', '10.0.0');
+            """;
+        string script = insert + "\n" + insert;
+
+        IReadOnlyCollection<HistoryInsert> inserts = N1CompatSchemaSeam.ParseHistoryInserts(script);
+
+        inserts.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void ParseHistoryInserts_InsertIntoAnotherTable_IsIgnored()
+    {
+        string script =
+            """
+            INSERT INTO translation."Translations" ("MigrationId", "ProductVersion")
+            VALUES ('not-a-migration', '10.0.0');
+            """;
+
+        IReadOnlyCollection<HistoryInsert> inserts = N1CompatSchemaSeam.ParseHistoryInserts(script);
+
+        inserts.ShouldBeEmpty();
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
@@ -177,6 +177,10 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
         await _postgresContainer.StartAsync();
         _connectionString = _postgresContainer.GetConnectionString();
 
+        // N-1 compat runs (ADR-0024) pre-apply the HEAD schema here; MigrateAsync below then
+        // no-ops and this suite exercises its (older) code against the newer schema.
+        await N1CompatSchemaSeam.ApplyIfConfiguredAsync(_postgresContainer, "translation.sql");
+
         // Accessing Services triggers host startup; the compose migrator owns migrations in
         // deployed environments, so tests apply them explicitly against the container.
         using IServiceScope scope = Services.CreateScope();


### PR DESCRIPTION
Closes #340

## What

The executable proof of the ADR-0023 N-1 contract (designed in **ADR-0024**, added here):

- **Seam** — both API integration-test factories call `N1CompatSchemaSeam.ApplyIfConfiguredAsync` after their PostgreSQL Testcontainer starts. When `N1_COMPAT_SCHEMA_SCRIPTS_DIR` is set (only ever by the script below), the factory applies a pre-generated idempotent HEAD schema script (`translation.sql` / `auth.sql`) via `ExecScriptAsync`; its own `MigrateAsync()` then no-ops via `__EFMigrationsHistory`, so the (older) suite runs against the (newer) schema. Unset — every normal test run — behavior is byte-identical. Every misconfiguration throws: missing file, psql error (`ON_ERROR_STOP` + exit code), a script with no history inserts, history rows missing after apply.
- **`scripts/n1-compat.sh`** — generates the two idempotent scripts from the current tree (pinned `dotnet-ef`), worktrees the previous release, and runs every `*.Tests.Integration.csproj` discovered **in the old checkout** (the same convention `pr-verify.yml` gates on — no silent narrowing) with the env var set. Asserts HEAD still carries the seam **and** its factory call sites (exit 2); bootstrap (old side predates the seam) reports loudly and passes.
- **`.github/workflows/n1-compat.yml`** — thin caller; `pull_request` path-filtered to `src/**/Migrations/**` + the proof's own load-bearing files, plus `workflow_dispatch`. Deliberately **not** a required check (required + path-filter = the docs-only deadlock).

## Ticket decisions (documented in ADR-0024)

- **"Previous release"** := `HEAD^1` of the checked-out commit — on a PR merge commit that is the `main` tip being merged into, i.e. the deployed release (no `v*` tags exist; CD ships every main commit).
- **Scope**: the full old integration suites, not a curated subset — zero curation to maintain, coverage = everything the old release gated on; `*.E2E.Tests` stay excluded exactly as they are excluded from the PR gate.

## Acceptance criteria — verified empirically

| AC | Result |
|---|---|
| Deliberately backward-incompatible migration → red | ✅ Local `RenameColumn` migration: exit 1, old TMS suite failed 86/175 with `42703: column "ApprovedById" does not exist`, Auth unaffected (also proves the seam really applies the schema) |
| Additive migrations → green | ✅ Local nullable `AddColumn` migration: exit 0, 398/398 old tests green |
| Previous-release selection + test scope documented | ✅ ADR-0024 Decisions 1–2 |
| Zero warnings | ✅ Full solution Release build clean |

Also: schema-identical green-proof (exit 0 end-to-end), negative test of the call-site guard (exit 2), both integration suites + all 6 unit suites green with the seam inert.

## Notable

- `code-reviewer` gate ran; its Major finding (a removed factory call site would make future runs permanently vacuous-green) is fixed: the script asserts the call sites and the workflow triggers on the seam/factory files.
- Two latent tooling traps found and handled: dotnet-ef 10.0.9 mis-parses `--startup-project` when equal to `--project` (CLAUDE.md's documented migration command carried it — fixed), and macOS's `/var → /private/var` symlink makes `dotnet` silently resolve **zero** references for absolute temp paths (`canonical_tmp_dir` in the script).
- No `.ps1` twin for `n1-compat.sh`: it's a CI conductor like `apply-migrations.sh`, not a dev-workflow gate (reasoning in ADR-0024 §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)