### PR TITLE
Infra: ACA readiness probes keep the Neon compute awake 24/7 — prod hits the Free-plan 100 CU-h cap around July 10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ scripts/up-prod.sh | up-prod.ps1                       # recommended boot — bo
                                                        #   *.lotro.test vhosts to loopback (idempotent; admin only the
                                                        #   first time), then up. Args pass through (e.g. --build, -d).
 docker compose -f compose.prod.yaml --env-file .env.prod up --build      # raw command (after the bootstraps + a manual hosts entry)
-docker compose -f compose.prod.yaml --env-file .env.prod --profile local-smtp --profile local-otel up  # + mailpit + aspire (all-local; needed for green auth /health/ready)
+docker compose -f compose.prod.yaml --env-file .env.prod --profile local-smtp --profile local-otel up  # + mailpit + aspire (all-local; needed for a green deep auth /health)
 docker compose -f compose.prod.yaml --env-file .env.prod down            # add -v to drop prod volumes (fresh DB/keys)
 # up-prod.{sh,ps1} runs both one-time bootstraps for you: gen-openiddict-keys (3 secrets → .env.prod) +
 #   init-prod-https (local CA → .docker/prod-https/). It also auto-maps the hosts file (cross-platform:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -220,7 +220,7 @@ services:
 
   # --- Optional local infra (NOT started by default — opt in with --profile) ---
   # Real deployments point Email__* / OTEL_EXPORTER_OTLP_ENDPOINT at managed services via .env.prod.
-  # For an all-local parity run, enable these to satisfy the SMTP /health/ready probe + view traces:
+  # For an all-local parity run, enable these to satisfy the SMTP leg of the deep auth /health + view traces:
   #   docker compose -f compose.prod.yaml --env-file .env.prod --profile local-smtp --profile local-otel up
   # (set Email__Host=mailpit, Email__Port=1025, Email__Mode=None, OTEL_EXPORTER_OTLP_ENDPOINT=http://aspire-dashboard:18889)
   mailpit:

--- a/docs/adr/0019-symptom-based-external-slo-probe.md
+++ b/docs/adr/0019-symptom-based-external-slo-probe.md
@@ -54,6 +54,10 @@ origin** (the revision serving 100% of traffic), plus an `azurerm_monitor_metric
 | tms | `${tms_origin}/health/ready` | 200 | 1 |
 | frontend | `${apex_origin}/` | 200–399 (Static-SSR home) | 1 |
 
+> Narrowed by ADR-0025 (2026-07-05): `/health/ready` is DB-free (the probe runs zero checks), so
+> these web tests assert HTTP + TLS liveness of the public origin — not database health. The
+> database is proven by the deploy smoke (legs 2/4) and per-request telemetry.
+
 **This is what makes the fix architectural, not a threshold tweak:** a candidate revision is
 reachable *only* through its private `<app>---cd-candidate.<domain>` label FQDN and takes **0%**
 public traffic during smoke, so an external probe of the public origin **cannot observe it**. The

--- a/docs/adr/0025-db-free-readiness-probes-scale-to-zero-postgres.md
+++ b/docs/adr/0025-db-free-readiness-probes-scale-to-zero-postgres.md
@@ -1,0 +1,101 @@
+# ADR-0025: DB-free readiness probes — health checks must not keep the scale-to-zero database awake
+
+**Status:** Accepted
+**Date:** 2026-07-05
+**Decision-makers:** Solo maintainer
+**Related:** ADR-0012 (health-gated rollout; prod `min_replicas = 1`), ADR-0014 (Neon adoption),
+ADR-0019 (external availability web tests target `/health/ready` — semantics narrowed here),
+ADR-0020 (monitoring cost cadence), ticket #346, MIGR-01 / #336 + PR #344 (the Neon audit that
+surfaced the burn), `iac/azure-container-apps.tf` (probe wiring),
+`TranslationSystem.API/Program.cs` + `AuthSystem.API/Program.cs` (health registrations).
+
+## Context
+
+Live Neon consumption read via the API on 2026-07-05 (billing period started 2026-07-01):
+
+| project | compute used | wall-clock active | verdict |
+|---|---|---|---|
+| prod | **44.80 of 100 CU-h/mo** after 4.65 days | 109.8 h of ~111.6 h possible (**~98% awake**) | **Free-plan cap hit ~2026-07-10** |
+| staging | 10.85 CU-h | 41.8 h | fits (~72 CU-h projected) |
+
+The mechanism: the ACA readiness probes poll `/health/ready` every few seconds on the always-on
+prod replicas (`min_replicas = 1`, ADR-0012 R8). Both APIs tagged their Npgsql health check
+`"ready"`, so every probe pinged Postgres — and the single Neon compute per branch (it serves both
+`lotro_translation` and `lotro_auth`) never saw the 5 idle minutes its autosuspend requires.
+
+The math leaves no middle ground: a permanently-awake compute at the 0.25 CU floor is
+182 CU-h/month against the Free plan's 100. **On a scale-to-zero database, only a database that
+actually sleeps fits the plan** — and when the cap hits, Neon hard-stops the compute until the
+next billing month: 503s on every DB path, availability alerts firing, and every deploy red
+(migrator + smoke against a stopped database).
+
+The deeper point is not the quota: *readiness-pings-the-database is the wrong pattern on
+scale-to-zero Postgres*. A suspended database is normal operation, not unreadiness — and the probe
+itself is what prevents the suspend. The probe defeats the platform feature it shares a box with.
+
+## Decision
+
+1. **The Npgsql health check loses its `"ready"` tag in both APIs.** The ACA-probed
+   `/health/ready` runs zero checks (the tag predicate matches nothing) and returns 200 as soon as
+   the app serves HTTP — exactly what a container probe should assert, and DB-free.
+2. **The full `/health` runs every check on demand** — db (+ smtp on auth). AuthSystem.API gains
+   the endpoint (it only had `/live` + `/ready`), reaching parity with TranslationSystem.API. This
+   is the operator's deep-diagnostics endpoint; none of our infrastructure polls it.
+3. **The database is proven where real proof lives:** the deploy smoke exercises both databases
+   through real endpoints on every rollout (leg 2 — token issuance hits the auth DB; leg 4 — the
+   translation-file GET hits the TMS DB), and at runtime a DB outage surfaces as request 5xx in
+   telemetry. Integration tests pin the new contract in both suites (`/health/ready` carries no db
+   entry; `/health` does).
+4. **The availability web tests keep targeting `/health/ready`** (ADR-0019). Their meaning
+   narrows: they now assert HTTP + TLS liveness of the public origin, not database health.
+   Accepted — with the probes DB-free they also stop waking the database every 15 minutes.
+
+## Consequences
+
+- The Neon compute can finally autosuspend; at today's zero traffic the burn drops from
+  ~9.6 CU-h/day to near zero, and the Free plan holds with a wide margin.
+- Readiness no longer pulls an app with a dead DB out of ingress rotation. With a single replica
+  this loses nothing — out-of-rotation also serves the user a 503, just from the ingress instead
+  of the app — while per-request failures and the Sev alerts carry the actual signal.
+- A candidate revision with a broken connection string now passes readiness during a rollout; the
+  smoke gate (legs 2/4) catches it before promote, and the existing rollback path handles it.
+- The first request after an idle spell pays the Neon cold start (~0.5–1 s). Acceptable at zero
+  users; if that ever violates an SLO, the knob is a paid always-on compute or a scheduled warmer —
+  never re-tagging the probe.
+- `Down()`-style regression risk is pinned by tests: re-tagging the db check `"ready"` fails both
+  integration suites.
+- The full `/health` is public and unthrottled (mapped outside the rate-limited group in both
+  APIs), and each hit pings the DB (+ an SMTP TCP connect on auth) — an external scanner or a
+  deliberate slow poller can keep Neon awake through it. Accepted: the TMS `/health` carried the
+  identical exposure before this ADR, and no rate limit stops a one-request-per-4-minutes
+  keep-awake anyway. If it ever shows in the consumption numbers, the knob is auth on the deep
+  endpoint (or dropping it from the public ingress) — not re-tagging the probe.
+
+## Alternatives Considered
+
+- **TTL-cached DB check inside readiness.** Still wakes the database once per TTL: with the 5-min
+  suspend window, a 10-min TTL keeps it ~50% awake (~90 CU-h/mo), a 30-min TTL ~17% (~31 CU-h) —
+  material burn for a signal that is by then up to 30 min stale, plus custom caching code. Rejected.
+- **Upgrade Neon to Launch and keep the pattern.** Pays real money (~$30/month at the observed
+  burn) for an idle database kept awake by a probe — a bug tax, not a fix. A plan upgrade stays a
+  valid future move for its own reasons (7-day PITR, storage headroom), never as the probe fix.
+- **Azure Database for PostgreSQL Flexible Server.** ~$15–18/month flat, erases the scale-to-zero
+  economics and the entire Neon branch/PITR machinery this repo just built and verified
+  (ADR-0023/0024 proofs, the MIGR-01 runbook, MIGR-04 snapshots). Revisit only with sustained
+  24/7 traffic or hard private-networking needs.
+- **`min_replicas = 0` for the prod apps.** Fixes nothing (probes run whenever a replica exists),
+  adds whole-app cold starts for users, and contradicts ADR-0012 R8. Rejected.
+
+## Implementation Notes
+
+- `TranslationSystem.API/Program.cs`, `AuthSystem.API/Program.cs` — tag change + the why-comment;
+  auth additionally maps the full `/health`.
+- `AuthSystemApiFactory` points SMTP at a deliberately dead port so the full-`/health` test is
+  deterministic (a locally running mailpit on :1025 must not flip it).
+- Verification after the fix reaches prod: a next-day `GET /projects/{id}` must show
+  `active_time_seconds` decoupled from wall-clock (the compute sleeps between requests).
+
+## References
+
+- Neon autosuspend / compute lifecycle: https://neon.com/docs/introduction/auto-suspend
+- Ticket #346; consumption numbers read live via `GET /api/v2/projects/{id}` on 2026-07-05.

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -31,8 +31,8 @@ one TLS-terminating ingress:
 
 | Service | Image (`ghcr.io/koniecdev/…`) | Listens | Health | Persists |
 |---|---|---|---|---|
-| **auth-api** | `lotrokoniecdev-auth-api` | `:8080` (HTTP) | `/health/live`, `/health/ready` (DB + SMTP) | Data Protection keyring → `/keys` |
-| **tms-api** | `lotrokoniecdev-tms-api` | `:8080` (HTTP) | `/health` (anon), `/health/live`, `/health/ready` (DB) | translation artifacts (read-only mount) |
+| **auth-api** | `lotrokoniecdev-auth-api` | `:8080` (HTTP) | `/health` (deep: DB + SMTP), `/health/live`, `/health/ready` (probe — runs no checks, ADR-0025) | Data Protection keyring → `/keys` |
+| **tms-api** | `lotrokoniecdev-tms-api` | `:8080` (HTTP) | `/health` (deep: DB), `/health/live`, `/health/ready` (probe — runs no checks, ADR-0025) | translation artifacts (read-only mount) |
 | **frontend** | `lotrokoniecdev-frontend` | `:8080` (HTTP) | — | Data Protection keyring → `/keys` |
 | **migrator** | `lotrokoniecdev-migrator` | one-shot (exits 0) | exit code | — |
 | _ingress_ | any TLS-terminating reverse proxy | `:443` | — | — |
@@ -301,13 +301,13 @@ It bootstraps `.env.prod` (with freshly generated OpenIddict secrets), the local
 `*.lotro.test` hosts mapping, then runs `docker compose -f compose.prod.yaml up`. Verify:
 
 ```bash
-curl --cacert .docker/prod-https/rootCA.crt https://auth.lotro.test/health/ready
-curl --cacert .docker/prod-https/rootCA.crt https://tms.lotro.test/health/ready
+curl --cacert .docker/prod-https/rootCA.crt https://auth.lotro.test/health
+curl --cacert .docker/prod-https/rootCA.crt https://tms.lotro.test/health
 # browser OIDC login: https://app.lotro.test
 ```
 
-For an all-local run (no external SMTP/OTLP), add the profiles so the auth `/health/ready` SMTP probe
-passes and traces are viewable, and set `Email__Host=mailpit` / `Email__Port=1025` / `Email__Mode=None`
+For an all-local run (no external SMTP/OTLP), add the profiles so the SMTP leg of the deep auth
+`/health` passes and traces are viewable, and set `Email__Host=mailpit` / `Email__Port=1025` / `Email__Mode=None`
 + `OTEL_EXPORTER_OTLP_ENDPOINT=http://aspire-dashboard:18889` in `.env.prod`:
 
 ```bash
@@ -330,7 +330,7 @@ the provider-specific walkthrough is deferred until the provider is chosen):
    ([Database migrations](#database-migrations)). A non-zero exit blocks the rollout.
 4. **Roll out** auth-api, tms-api, frontend on the **same image tag** as the migrator. Mount the DP
    keyring volumes; point the ingress at each app's `:8080`.
-5. **Verify**: `/health/ready` green on both APIs, a full browser OIDC login, and the
+5. **Verify**: the deep `/health` green on both APIs (DB; + SMTP on auth), a full browser OIDC login, and the
    [post-deploy smoke test](#post-deploy-smoke-test) (one command — health + auth token + token
    acceptance + file distribution).
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -188,13 +188,17 @@ try
 
     builder.Services
         .AddHealthChecks()
+        // The db check is deliberately NOT tagged "ready": ACA probes /health/ready every few
+        // seconds, and a DB ping there keeps the scale-to-zero Neon compute awake 24/7 (a suspended
+        // database is normal operation, not unreadiness — ADR-0025). The check stays reachable on
+        // demand via the full /health; deploys prove the DB through the smoke's real endpoints.
         .AddNpgSql(
             connectionStringFactory: sp => sp.GetRequiredService<IOptions<ConnectionStringSettings>>().Value.AuthDatabase,
             name: "authdb",
-            tags: ["db", "postgres", "ready"])
-        // SMTP is intentionally NOT tagged "ready": a Brevo outage must not pull the whole auth
-        // service out of the ingress rotation — login and token issuance work without mail. Only the
-        // database gates readiness; mail failures surface in logs and via "resend confirmation".
+            tags: ["db", "postgres"])
+        // SMTP is likewise NOT tagged "ready": a Brevo outage must not pull the whole auth service
+        // out of the ingress rotation — login and token issuance work without mail. Mail failures
+        // surface in logs, via "resend confirmation", and on the full /health.
         .AddCheck<SmtpHealthCheck>(
             "smtp",
             tags: ["smtp"]);
@@ -316,6 +320,11 @@ try
         app.MapOpenApi();
         app.MapScalarApiReference();
     }
+
+    app.MapHealthChecks("/health", new HealthCheckOptions
+    {
+        ResponseWriter = HealthCheckResponseWriter.WriteResponse
+    });
 
     app.MapHealthChecks("/health/live", new HealthCheckOptions
     {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
@@ -148,10 +148,14 @@ try
 
     builder.Services
         .AddHealthChecks()
+        // The db check is deliberately NOT tagged "ready": ACA probes /health/ready every few
+        // seconds, and a DB ping there keeps the scale-to-zero Neon compute awake 24/7 (a suspended
+        // database is normal operation, not unreadiness — ADR-0025). The check stays reachable on
+        // demand via the full /health; deploys prove the DB through the smoke's real endpoints.
         .AddNpgSql(
             connectionStringFactory: sp => sp.GetRequiredService<IOptions<ConnectionStringSettings>>().Value.TranslationDatabase,
             name: "translationdb",
-            tags: ["db", "postgres", "ready"]);
+            tags: ["db", "postgres"]);
 
     const string rateLimitPolicy = "fixed-by-ip";
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -51,9 +51,12 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
                 // Email identity is no longer baked into base appsettings.json (M6-06); supply it here
                 // so the unconditional EmailOptionsValidator passes at startup (the senders themselves
                 // are replaced with spies below, so these values are never used to send mail).
+                // The port is a deliberately dead one so SmtpHealthCheck is deterministically
+                // Unhealthy — the full /health test must not flip when a local mailpit (:1025) runs.
                 { "Email:SenderEmail", "noreply@lotro-translator.pl" },
                 { "Email:Sender", "lotro-translator.pl" },
                 { "Email:Host", "localhost" },
+                { "Email:Port", "59999" },
             });
         });
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Health/HealthEndpointsTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Health/HealthEndpointsTests.cs
@@ -1,17 +1,17 @@
-namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Health;
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Health;
 
-[Collection("TranslationApi")]
+[Collection("AuthApi")]
 public sealed class HealthEndpointsTests
 {
-    private readonly TranslationSystemApiFactory _factory;
+    private readonly AuthSystemApiFactory _factory;
 
-    public HealthEndpointsTests(TranslationSystemApiFactory factory)
+    public HealthEndpointsTests(AuthSystemApiFactory factory)
     {
         _factory = factory;
     }
 
     [Fact]
-    public async Task GetHealth_WithoutToken_ShouldReturn200AndHealthy()
+    public async Task GetHealth_WithoutToken_ShouldSurfaceDbAndSmtpChecks()
     {
         // Arrange
         using HttpClient client = _factory.CreateClient();
@@ -20,10 +20,11 @@ public sealed class HealthEndpointsTests
         HttpResponseMessage response = await client.GetAsync("/health");
         string body = await response.Content.ReadAsStringAsync();
 
-        // Assert
-        response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        body.ShouldContain("Healthy");
-        body.ShouldContain("translationdb");
+        // Assert — Testing points SMTP at a dead port, so the full report is Unhealthy (503) by
+        // design; what this test pins is that the db + smtp checks stay reachable on demand here.
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+        body.ShouldContain("authdb");
+        body.ShouldContain("smtp");
     }
 
     [Fact]
@@ -52,6 +53,6 @@ public sealed class HealthEndpointsTests
         // Assert — ACA probes this path every few seconds; it must never touch Postgres (ADR-0025).
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         body.ShouldContain("\"status\": \"Healthy\"");
-        body.ShouldNotContain("translationdb");
+        body.ShouldNotContain("authdb");
     }
 }


### PR DESCRIPTION
Closes #346

## What
- Both APIs: the Npgsql health check loses its `"ready"` tag — the ACA-probed `/health/ready` now runs **zero checks** and returns 200 as soon as the app serves HTTP. Why-comments added at the registration; the stale "Only the database gates readiness" SMTP comment rewritten.
- `AuthSystem.API` gains the full `/health` endpoint (parity with TMS): db + smtp checks stay reachable on demand (the operator's deep-diagnostics endpoint — nothing in our infra polls it).
- Integration tests pin the new contract in **both** suites: `/health/ready` → 200 with `"status": "Healthy"` and **no** db entry; deep `/health` still surfaces it. The auth factory points SMTP at a deliberately dead port so a locally running mailpit (`:1025`) can never flip the deep-health test.
- **ADR-0025** records the decision + rejected alternatives (TTL-cached ready check, paid plan as a probe fix, Azure PG, `min_replicas=0`); **ADR-0019** gets a "narrowed by" pointer (the availability web tests now assert HTTP+TLS liveness, not DB health).
- Stale docs aligned: runbook service table + bring-up/verify steps (deep checks moved to `/health`), `CLAUDE.md` compose comment, `compose.prod.yaml` mailpit-profile comment.

## Why
Live Neon consumption (API, 2026-07-05): prod used **44.80 of 100 CU-h** after 4.65 days — awake ~98% of wall-clock (109.8 h of ~111.6 h), burning ~9.6 CU-h/day → **Free-plan hard-stop ~July 10**. Mechanism: ACA readiness probes hit `/health/ready` every few seconds on the always-on prod replicas; the `"ready"`-tagged Npgsql check pinged Postgres on every probe, so the scale-to-zero Neon compute never saw the 5 idle minutes autosuspend needs. Even a permanently-idle 0.25 CU is 182 CU-h/month — on Free, only a database that sleeps survives. Readiness-pings-the-database is the wrong pattern on scale-to-zero Postgres: a suspended DB is normal operation, and the probe itself prevents the suspend.

DB coverage is not lost: the deploy smoke exercises both databases through real endpoints (leg 2 — token issuance; leg 4 — translation-file GET) before promote, and runtime DB outages surface as request 5xx in telemetry.

## Verification
- `dotnet build` — 0 warnings; unit 239/239; **full** integration suites green (auth 226/226, TMS 175/175) including after the rebase onto #345.
- code-reviewer agent: code approve-quality on first pass; its doc findings folded in; its bonus pre-existing finding (empty `/connect` rate-limit group — the brute-force limiter likely never engages on `/connect/token`) cut as #347.
- Post-deploy proof (next day): `GET /api/v2/projects/{id}` must show `active_time_seconds` decoupled from wall-clock — the compute sleeps between requests.

## Urgency
Needs merge + prod promotion before **~July 9–10** to stay under the cap. Interim valve if it slips: upgrade the Neon org to Launch (usage-based) for the rest of the month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)