### PR TITLE
Auth: /connect rate-limit group is empty — the brute-force limiter never engages on /connect/token

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -116,8 +116,12 @@ Content-Type: multipart/form-data          # the import upload only
 ### 2.4 Rate limiting
 
 In non-dev/test, `tms-api` applies a **fixed-window 100 requests/minute per IP** policy across the
-endpoint group; over-limit returns **429** (`Program.cs:119`). `auth-api`'s `auth/register` carries
-its own `auth-endpoint-limit` policy.
+endpoint group; over-limit returns **429** (`Program.cs:119`). `auth-api` rate-limits per IP: the
+OpenIddict `/connect/*` endpoints and the sensitive account endpoints (`auth/register`,
+confirm/reset/change-password, delete/export) carry the `auth-endpoint-limit` policy (10/min),
+forgot-password and resend-confirmation carry stricter 3/15 min policies, and the remaining API
+endpoints fall under the generic 20/min policy (health probes and the OpenIddict discovery/JWKS
+documents are deliberately unlimited).
 
 ---
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/EndpointExtensions.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/EndpointExtensions.cs
@@ -48,16 +48,19 @@ internal static class EndpointExtensions
         /// <summary>
         /// Maps endpoints that live at the application root — everything that is a plain
         /// <see cref="IEndpoint"/> but not an <see cref="IApiEndpoint"/>. This covers OpenIddict's
-        /// <c>/connect/*</c> surface.
+        /// <c>/connect/*</c> surface. Mounted directly at the root; grouped only so the brute-force
+        /// rate-limit policy genuinely binds to these endpoints — a group convention reaches only
+        /// endpoints mapped through it.
         /// </summary>
+        /// <param name="routeGroupBuilder">Rate-limited root <see cref="RouteGroupBuilder"/>.</param>
         /// <returns>The <see cref="IApplicationBuilder"/> for further configuration.</returns>
-        public IApplicationBuilder MapRootEndpoints()
+        public IApplicationBuilder MapRootEndpoints(RouteGroupBuilder routeGroupBuilder)
         {
             IEnumerable<IEndpoint> endpoints = app.Services.GetRequiredService<IEnumerable<IEndpoint>>();
 
             foreach (IEndpoint endpoint in endpoints.Where(endpoint => endpoint is not IApiEndpoint))
             {
-                endpoint.MapEndpoint(app);
+                endpoint.MapEndpoint(routeGroupBuilder);
             }
 
             return app;

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -305,15 +305,22 @@ try
         : productionCorsPolicy;
     app.UseCors(corsPolicy);
 
+    // BEFORE authentication: OpenIddict validates /connect/* requests inside the authentication
+    // stage and short-circuits invalid ones (e.g. unknown client_id floods) — a limiter placed
+    // after it would never count exactly the junk traffic it exists to stop. Routing has already
+    // selected the endpoint here, so the per-endpoint policy metadata is visible to the limiter.
+    // Off in Development/Testing so local flows and the test suites never trip the limits;
+    // RateLimiting:ForceEnable lets a test host arm the middleware to observe real 429 rejection.
+    bool rateLimiterOffByEnvironment = app.Environment.IsDevelopment() || app.Environment.IsTesting();
+    if (!rateLimiterOffByEnvironment || app.Configuration.GetValue<bool>("RateLimiting:ForceEnable"))
+    {
+        app.UseRateLimiter();
+    }
+
     app.UseAuthentication();
     app.UseAuthorization();
 
     app.UseAuthorizationLogging();
-
-    if (!app.Environment.IsDevelopment() && !app.Environment.IsTesting())
-    {
-        app.UseRateLimiter();
-    }
 
     if (app.Environment.IsDevelopment())
     {
@@ -338,24 +345,20 @@ try
         ResponseWriter = HealthCheckResponseWriter.WriteResponse
     });
 
-    RouteGroupBuilder endpointsGroup = app.MapGroup("");
-
-    if (!app.Environment.IsDevelopment() && !app.Environment.IsTesting())
-    {
-        endpointsGroup.RequireRateLimiting(rateLimitPolicy);
-    }
+    // Policy metadata is attached unconditionally (matching the per-endpoint RequireRateLimiting
+    // calls in the feature slices); UseRateLimiter above is the single switch deciding enforcement.
+    RouteGroupBuilder endpointsGroup = app.MapGroup("")
+        .RequireRateLimiting(rateLimitPolicy);
 
     app.MapApiEndpoints(endpointsGroup);
 
-    // OpenIddict endpoints are mapped directly at the root (e.g. /connect/token).
-    // Apply rate limiting to auth endpoints to prevent brute force attacks.
-    if (!app.Environment.IsDevelopment() && !app.Environment.IsTesting())
-    {
-        app.MapGroup("/connect")
-            .RequireRateLimiting(authEndpointRateLimitPolicy);
-    }
+    // OpenIddict's /connect/* endpoints live at the root and are mapped THROUGH this group — a
+    // group convention binds only to endpoints mapped through it, so this is what actually arms
+    // the brute-force limiter on /connect/token (a bare MapGroup("/connect") never engaged it).
+    RouteGroupBuilder rootEndpointsGroup = app.MapGroup("")
+        .RequireRateLimiting(authEndpointRateLimitPolicy);
 
-    app.MapRootEndpoints();
+    app.MapRootEndpoints(rootEndpointsGroup);
 
     app.MapRazorPages();
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/RateLimiting/ConnectRateLimitingTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/RateLimiting/ConnectRateLimitingTests.cs
@@ -1,0 +1,168 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.RateLimiting;
+
+/// <summary>
+/// Proves the brute-force limiter genuinely binds to the OpenIddict <c>/connect/*</c> endpoints
+/// (#347): they are mapped at the root, so the policy must ride the group they are actually mapped
+/// through — a bare <c>MapGroup("/connect")</c> convention never reaches them. Enforcement order
+/// matters too: the limiter middleware must run BEFORE authentication, because OpenIddict validates
+/// protocol requests inside the authentication stage and short-circuits invalid ones — a limiter
+/// placed after it would never count exactly the junk traffic it exists to stop. The suite's
+/// Testing host keeps the limiter middleware off; the burst tests force-arm it on a derived host to
+/// observe real 429 rejection, which a Staging-environment factory cannot do in-suite (outside
+/// Dev/Testing the settings validators demand production key material at startup).
+/// </summary>
+public sealed class ConnectRateLimitingTests : EndpointsTestBase
+{
+    private const string AuthEndpointRateLimitPolicy = "auth-endpoint-limit";
+
+    /// <summary>Mirrors the auth-endpoint-limit policy: 10 permits per minute per client IP.</summary>
+    private const int AuthEndpointPermitLimit = 10;
+
+    public ConnectRateLimitingTests(AuthSystemApiFactory appFactory) : base(appFactory)
+    {
+    }
+
+    [Theory]
+    [InlineData("connect/token")]
+    [InlineData("connect/authorize")]
+    [InlineData("connect/logout")]
+    [InlineData("connect/revoke")]
+    [InlineData("connect/userinfo")]
+    public void ConnectEndpoint_Always_CarriesAuthEndpointRateLimitPolicy(string route)
+    {
+        // Arrange
+        EndpointDataSource endpointDataSource = Factory.Services.GetRequiredService<EndpointDataSource>();
+
+        // Act
+        RouteEndpoint endpoint = endpointDataSource.Endpoints
+            .OfType<RouteEndpoint>()
+            .Single(routeEndpoint => routeEndpoint.RoutePattern.RawText?.TrimStart('/') == route);
+
+        // Assert
+        EnableRateLimitingAttribute? rateLimiting = endpoint.Metadata.GetMetadata<EnableRateLimitingAttribute>();
+        rateLimiting.ShouldNotBeNull($"'{route}' must carry the brute-force rate-limit policy");
+        rateLimiting.PolicyName.ShouldBe(AuthEndpointRateLimitPolicy);
+    }
+
+    [Theory]
+    [InlineData("auth/forgot-password", "forgot-password-limit")]
+    [InlineData("auth/resend-email-confirmation", "resend-confirmation-limit")]
+    public void ApiEndpointWithOwnPolicy_Always_OverridesTheGroupPolicy(string route, string expectedPolicy)
+    {
+        // Arrange — group metadata is attached in every environment now, so the endpoint-level
+        // policy must keep winning (GetMetadata returns the last match: group first, endpoint last).
+        EndpointDataSource endpointDataSource = Factory.Services.GetRequiredService<EndpointDataSource>();
+
+        // Act
+        RouteEndpoint endpoint = endpointDataSource.Endpoints
+            .OfType<RouteEndpoint>()
+            .Single(routeEndpoint => routeEndpoint.RoutePattern.RawText?.TrimStart('/') == route);
+
+        // Assert
+        EnableRateLimitingAttribute? rateLimiting = endpoint.Metadata.GetMetadata<EnableRateLimitingAttribute>();
+        rateLimiting.ShouldNotBeNull();
+        rateLimiting.PolicyName.ShouldBe(expectedPolicy);
+    }
+
+    [Theory]
+    [InlineData("health")]
+    [InlineData("health/live")]
+    [InlineData("health/ready")]
+    public void HealthEndpoint_Always_CarriesNoRateLimitPolicy(string route)
+    {
+        // Arrange — ACA readiness probes poll these continuously (ADR-0025); a limiter here would
+        // 429 the probe and pull the app out of the ingress rotation.
+        EndpointDataSource endpointDataSource = Factory.Services.GetRequiredService<EndpointDataSource>();
+
+        // Act
+        RouteEndpoint endpoint = endpointDataSource.Endpoints
+            .OfType<RouteEndpoint>()
+            .Single(routeEndpoint => routeEndpoint.RoutePattern.RawText?.TrimStart('/') == route);
+
+        // Assert
+        endpoint.Metadata.GetMetadata<EnableRateLimitingAttribute>().ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ConnectToken_BurstWithSeededClient_RejectsRequestBeyondPermitLimit()
+    {
+        // Arrange — the seeded public client with a wrong password: admitted requests travel the
+        // full OpenIddict validation + passthrough endpoint path before failing with 400.
+        using WebApplicationFactory<Program> limitedHost = CreateRateLimitedHost();
+        using HttpClient client = limitedHost.CreateClient();
+
+        HttpStatusCode[] statusCodes = new HttpStatusCode[AuthEndpointPermitLimit + 1];
+
+        // Act
+        for (int i = 0; i < statusCodes.Length; i++)
+        {
+            using FormUrlEncodedContent tokenRequest = CreateTokenRequest(clientId: "lotrokoniecdev-test");
+            using HttpResponseMessage response = await client.PostAsync(
+                new Uri("connect/token", UriKind.Relative), tokenRequest);
+            statusCodes[i] = response.StatusCode;
+        }
+
+        // Assert — the first requests pass through to OpenIddict (fresh partition), the one past
+        // the permit limit is cut off by the limiter.
+        statusCodes.Take(AuthEndpointPermitLimit).ShouldAllBe(statusCode => statusCode != HttpStatusCode.TooManyRequests);
+        statusCodes[AuthEndpointPermitLimit].ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    [Fact]
+    public async Task ConnectToken_BurstWithUnknownClient_RejectsRequestBeyondPermitLimit()
+    {
+        // Arrange — an unknown client_id is the cheapest externally craftable junk: OpenIddict
+        // rejects it during the authentication stage, so this burst proves the limiter counts
+        // requests BEFORE OpenIddict sees them — the exact ordering a post-authentication limiter
+        // silently loses.
+        using WebApplicationFactory<Program> limitedHost = CreateRateLimitedHost();
+        using HttpClient client = limitedHost.CreateClient();
+
+        HttpStatusCode[] statusCodes = new HttpStatusCode[AuthEndpointPermitLimit + 1];
+
+        // Act
+        for (int i = 0; i < statusCodes.Length; i++)
+        {
+            using FormUrlEncodedContent tokenRequest = CreateTokenRequest(clientId: "unknown-brute-force-client");
+            using HttpResponseMessage response = await client.PostAsync(
+                new Uri("connect/token", UriKind.Relative), tokenRequest);
+            statusCodes[i] = response.StatusCode;
+        }
+
+        // Assert
+        statusCodes.Take(AuthEndpointPermitLimit).ShouldAllBe(statusCode => statusCode != HttpStatusCode.TooManyRequests);
+        statusCodes[AuthEndpointPermitLimit].ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    private WebApplicationFactory<Program> CreateRateLimitedHost()
+    {
+        return Factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "RateLimiting:ForceEnable", "true" }
+                });
+            });
+        });
+    }
+
+    private static FormUrlEncodedContent CreateTokenRequest(string clientId)
+    {
+        return new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = "burst@lotro-translator.pl",
+            ["password"] = "DefinitelyWrong1!",
+            ["client_id"] = clientId
+        });
+    }
+}


### PR DESCRIPTION
Closes #347

## What
- The five root-mapped OpenIddict endpoints (`/connect/token|authorize|logout|revoke|userinfo`) are now mapped **through** a group that carries the `auth-endpoint-limit` policy (10/min per IP); the dead `MapGroup("/connect")` is deleted. `MapRootEndpoints` takes the `RouteGroupBuilder`, mirroring `MapApiEndpoints`.
- `UseRateLimiter` moved **before** `UseAuthentication`: OpenIddict validates `/connect/*` requests inside the authentication stage and short-circuits invalid ones, so the old position never counted exactly the junk traffic (unknown `client_id` floods) the limiter exists to stop. This also genuinely arms `/connect/revoke`, which OpenIddict serves middleware-side (no passthrough).
- Rate-limit policy metadata is attached in every environment; enforcement stays off in Development/Testing unless a test host sets `RateLimiting:ForceEnable` (enable-only seam, set nowhere in deployed config).
- `docs/API.md` rate-limiting section updated to match reality.

## Why
Runtime-verified pre-fix: 11 bursts to `/connect/token` never produced a 429 — no limiter engaged at all (a group's conventions bind only to endpoints mapped through it, and no `GlobalLimiter` exists). Password/client-credential grants were fully brute-forceable.

## Tests (red-first)
- Metadata theories: every `/connect/*` endpoint carries `auth-endpoint-limit`; per-endpoint stricter policies (forgot-password, resend-confirmation) still override the group default; health probes carry no policy (ADR-0025 — probes must never 429).
- Runtime bursts on a `ForceEnable` derived host: 11th request is 429 with the seeded client AND with an unknown client (the ordering regression guard; it failed while the limiter sat after authentication).
- Build zero warnings; auth integration suite 238/238; patcher unit suite 239/239. `code-reviewer` agent: APPROVE; `/security-review`: no findings (flag is enable-only, no authz/CORS metadata cross-talk).

## Notes
- Deployed-behavior deltas: `/connect/*` goes from unlimited to 10/min/IP, and requests that authentication/authorization would reject now consume permits first (correct direction for an anti-abuse device). The Frontend's back-channel token exchanges share one egress IP partition — fine at current scale; revisit if legit 429s appear.
- Watch the first staging deploy smoke for 429s (it stays well under 10 auth calls/min today).
- Follow-up #349: `/connect/introspect` is middleware-served and structurally outside metadata-based limiting; the routed `RevokeEndpoint` handler is pre-existing dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)