### PR TITLE
Import: supersede older unprocessed versions so the stale-export guard engages (#352)

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
@@ -179,8 +179,9 @@ internal sealed class ImportExportedTexts : IEndpoint
             // execution strategy and is re-entrant: every pass re-seeks the buffered upload and
             // reloads its chunks, and no tracked state survives into a retry.
             passStopwatch.Restart();
+            int supersededVersions = 0;
             await _unitOfWork.ExecuteInTransactionAsync(
-                transactionToken => ApplyPlanAsync(plan, command, now, transactionToken),
+                async transactionToken => supersededVersions = await ApplyPlanAsync(plan, command, now, transactionToken),
                 cancellationToken);
             long applyPassMilliseconds = passStopwatch.ElapsedMilliseconds;
 
@@ -199,7 +200,7 @@ internal sealed class ImportExportedTexts : IEndpoint
             // (PERF-04): the O(N) rebuild runs debounced in the background on the host lifetime.
             _rebuildScheduler.Schedule(SupportedLanguages.Polish);
 
-            return Result.Success(BuildSummary(plan));
+            return Result.Success(BuildSummary(plan, supersededVersions));
         }
 
         private async Task<Result<Dictionary<FragmentKeyValue, SourceHash>>> BuildIncomingMapAsync(
@@ -264,7 +265,7 @@ internal sealed class ImportExportedTexts : IEndpoint
             return Result.Success(incomingByKey);
         }
 
-        private async Task ApplyPlanAsync(
+        private async Task<int> ApplyPlanAsync(
             TranslationDiffPlan plan,
             Command command,
             DateTimeOffset now,
@@ -304,12 +305,34 @@ internal sealed class ImportExportedTexts : IEndpoint
             // now is an invariant break, not a business outcome.
             Maybe<GameVersion> gameVersionMaybe =
                 await _gameVersionRepository.GetByIdAsync(command.GameVersionId, cancellationToken);
-            Result markProcessedResult = gameVersionMaybe.Value.MarkAsProcessed();
+            GameVersion processedVersion = gameVersionMaybe.Value;
+            Result markProcessedResult = processedVersion.MarkAsProcessed();
             if (markProcessedResult.IsFailure)
             {
                 throw new InvalidOperationException(
                     $"The game version refused MarkAsProcessed inside the apply transaction after passing the pre-check: {markProcessedResult.Error.Message}");
             }
+
+            // Stacked older versions never get their own upload (spec 0001): processing the newest
+            // supersedes every still-unprocessed version detected before it, committed with the same
+            // final save (all-or-nothing with the diff). This is what arms the stale-export guard — a
+            // later import against one of them then fails MarkAsProcessed with
+            // SupersededCannotBeProcessed instead of rewinding the catalog backwards. The rows are all
+            // Unprocessed (repository filter), so MarkSuperseded can only fail on an invariant break,
+            // handled like the flip above.
+            IReadOnlyList<GameVersion> olderUnprocessedVersions =
+                await _gameVersionRepository.GetUnprocessedDetectedBeforeAsync(processedVersion.DetectedAt, cancellationToken);
+            foreach (GameVersion olderVersion in olderUnprocessedVersions)
+            {
+                Result markSupersededResult = olderVersion.MarkSuperseded();
+                if (markSupersededResult.IsFailure)
+                {
+                    throw new InvalidOperationException(
+                        $"An unprocessed game version refused MarkSuperseded inside the apply transaction: {markSupersededResult.Error.Message}");
+                }
+            }
+
+            return olderUnprocessedVersions.Count;
         }
 
         private async IAsyncEnumerable<Translation> StreamAddedRowsAsync(
@@ -426,12 +449,17 @@ internal sealed class ImportExportedTexts : IEndpoint
             }
         }
 
-        private static ImportSummary BuildSummary(TranslationDiffPlan plan)
+        private static ImportSummary BuildSummary(TranslationDiffPlan plan, int supersededVersions)
         {
             List<string> warnings = [];
             if (plan.RestoredIds.Count > 0)
             {
                 warnings.Add($"{plan.RestoredIds.Count} previously-removed row(s) re-added with an unchanged source and restored.");
+            }
+
+            if (supersededVersions > 0)
+            {
+                warnings.Add($"{supersededVersions} older unprocessed version(s) marked superseded — they will never receive their own upload.");
             }
 
             return new ImportSummary(

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Repositories/IGameVersionRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Repositories/IGameVersionRepository.cs
@@ -2,10 +2,21 @@ using LotroKoniecDev.SharedKernel.BuildingBlocks;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
 
 namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Repositories;
 
 public interface IGameVersionRepository : IRepository<GameVersion, GameVersionId>
 {
     Task<bool> ExistsByVersionAsync(LotroNotationVersion version, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Loads the tracked, still-<see cref="GameVersionStatus.Unprocessed"/> versions detected before
+    /// <paramref name="detectedAt"/> — the stacked older versions an import supersedes when a newer one
+    /// is processed (spec 0001). A handful of rows at most, so it returns the aggregates for the handler
+    /// to mass-mark; the version being processed is excluded by the strict "detected before" bound.
+    /// </summary>
+    Task<IReadOnlyList<GameVersion>> GetUnprocessedDetectedBeforeAsync(
+        DateTimeOffset detectedAt,
+        CancellationToken cancellationToken);
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/GameVersionRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/GameVersionRepository.cs
@@ -3,6 +3,7 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Re
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
 using Microsoft.EntityFrameworkCore;
 
 namespace LotroKoniecDev.TranslationSystem.Persistence.DomainRepositories;
@@ -21,5 +22,17 @@ internal sealed class GameVersionRepository : GenericRepository<GameVersion, Gam
             .AnyAsync(gameVersion => gameVersion.LotroNotationVersion.Value == version.Value, cancellationToken);
 
         return exists;
+    }
+
+    public async Task<IReadOnlyList<GameVersion>> GetUnprocessedDetectedBeforeAsync(
+        DateTimeOffset detectedAt,
+        CancellationToken cancellationToken)
+    {
+        List<GameVersion> versions = await DbContext.GameVersions
+            .Where(gameVersion =>
+                gameVersion.Status == GameVersionStatus.Unprocessed && gameVersion.DetectedAt < detectedAt)
+            .ToListAsync(cancellationToken);
+
+        return versions;
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
@@ -154,6 +154,74 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Import_WhileOlderVersionUnprocessed_ShouldSupersedeItInTheSameTransaction()
+    {
+        // Arrange — the admin skips the older still-unprocessed version and uploads only the newer one
+        // (spec 0001, stacked versions). Detected-at is set explicitly so "older" is unambiguous.
+        GameVersionId olderVersion = await SeedVersionAsync("48.0", new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        GameVersionId newerVersion = await SeedVersionAsync("48.1", new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero));
+        using HttpClient client = AdminClient();
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            ImportRoute(newerVersion), ExportContent(Line(1, "Alpha"), Line(2, "Beta")));
+        ImportSummary? summary = await response.Content.ReadFromJsonAsync<ImportSummary>();
+
+        // Assert — the newer version processed, the older one superseded in the same commit, and the
+        // admin is told what was skipped.
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        summary.ShouldNotBeNull();
+        (await GetVersionStatusAsync(newerVersion)).ShouldBe(GameVersionStatus.Processed);
+        (await GetVersionStatusAsync(olderVersion)).ShouldBe(GameVersionStatus.Superseded);
+        summary.Warnings.ShouldContain(warning => warning.Contains("1 older unprocessed version"));
+    }
+
+    [Fact]
+    public async Task Import_AgainstASupersededVersion_ShouldReturn422AndPersistNothing()
+    {
+        // Arrange — process the newer version, which supersedes the older one. Then attempt a fresh
+        // (stale) import against that now-superseded older version. The upload is identical to the
+        // catalog so the mass-removal guard cannot fire first — the supersede guard is what rejects it.
+        GameVersionId olderVersion = await SeedVersionAsync("48.0", new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        GameVersionId newerVersion = await SeedVersionAsync("48.1", new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero));
+        using HttpClient client = AdminClient();
+        await client.PostAsync(ImportRoute(newerVersion), ExportContent(Line(1, "Alpha"), Line(2, "Beta")));
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            ImportRoute(olderVersion), ExportContent(Line(1, "Alpha"), Line(2, "Beta")));
+
+        // Assert — rejected with the supersede error and nothing changed: the older version stays
+        // superseded, the newer stays processed, and the catalog is untouched.
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        (await ReadErrorCodeAsync(response)).ShouldBe("GameVersionEntity.SupersededCannotBeProcessed");
+        (await GetVersionStatusAsync(olderVersion)).ShouldBe(GameVersionStatus.Superseded);
+        (await GetVersionStatusAsync(newerVersion)).ShouldBe(GameVersionStatus.Processed);
+        (await CountTranslationsAsync()).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Import_WhileANewerVersionIsUnprocessed_ShouldLeaveTheNewerVersionUnprocessed()
+    {
+        // Arrange — three stacked unprocessed versions; the admin uploads only the middle one. Only
+        // versions detected before it are superseded; a version detected after it stays pending.
+        GameVersionId olderVersion = await SeedVersionAsync("48.0", new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        GameVersionId targetVersion = await SeedVersionAsync("48.1", new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero));
+        GameVersionId newerVersion = await SeedVersionAsync("48.2", new DateTimeOffset(2026, 6, 15, 0, 0, 0, TimeSpan.Zero));
+        using HttpClient client = AdminClient();
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            ImportRoute(targetVersion), ExportContent(Line(1, "Alpha")));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await GetVersionStatusAsync(targetVersion)).ShouldBe(GameVersionStatus.Processed);
+        (await GetVersionStatusAsync(olderVersion)).ShouldBe(GameVersionStatus.Superseded);
+        (await GetVersionStatusAsync(newerVersion)).ShouldBe(GameVersionStatus.Unprocessed);
+    }
+
+    [Fact]
     public async Task Import_TruncatedFile_ShouldReturn422()
     {
         // Arrange
@@ -602,11 +670,13 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         return client;
     }
 
-    private async Task<GameVersionId> SeedVersionAsync(string version)
+    private Task<GameVersionId> SeedVersionAsync(string version) => SeedVersionAsync(version, DateTimeOffset.UtcNow);
+
+    private async Task<GameVersionId> SeedVersionAsync(string version, DateTimeOffset detectedAt)
     {
         using IServiceScope scope = _factory.Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
-        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, DateTimeOffset.UtcNow).Value;
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, detectedAt).Value;
         dbContext.GameVersions.Add(gameVersion);
         await dbContext.SaveChangesAsync();
         return gameVersion.Id;

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
@@ -38,6 +38,10 @@ public sealed class ImportExportedTextsHandlerTests
         _translationRepository.GetByIdsAsync(Arg.Any<IReadOnlyList<TranslationId>>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
+        // No stacked older versions by default; the supersede tests override this per case.
+        _gameVersionRepository.GetUnprocessedDetectedBeforeAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
         // The transaction seam runs its operation for real against the stubbed boundaries, so the
         // success path still exercises the COPY + SaveChanges orchestration the handler wraps.
         _unitOfWork.ExecuteInTransactionAsync(Arg.Any<Func<CancellationToken, Task>>(), Arg.Any<CancellationToken>())
@@ -76,6 +80,9 @@ public sealed class ImportExportedTextsHandlerTests
 
     private static GameVersion UnprocessedVersion()
         => GameVersion.Create(LotroNotationVersion.Create("48.0").Value, new DateTimeOffset(2026, 6, 13, 0, 0, 0, TimeSpan.Zero)).Value;
+
+    private static GameVersion OlderUnprocessedVersion(string version, DateTimeOffset detectedAt)
+        => GameVersion.Create(LotroNotationVersion.Create(version).Value, detectedAt).Value;
 
     private static Translation ExistingRow(int gossipId, string text)
         => Translation.CreateUntranslated(
@@ -300,5 +307,45 @@ public sealed class ImportExportedTextsHandlerTests
         result.IsSuccess.ShouldBeTrue();
         result.Value.Added.ShouldBe(2);
         gameVersion.Status.ShouldBe(GameVersionStatus.Processed);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOlderUnprocessedVersionsExist_ShouldMarkThemSupersededAndWarn()
+    {
+        // Arrange — the target is processed while two older versions are still unprocessed. The
+        // stub keys on the target's DetectedAt, so this also pins that the handler queries with the
+        // processed version's timestamp (a wrong argument falls through to the default empty stub).
+        GameVersion target = UnprocessedVersion();
+        GivenVersion(target);
+        GameVersion olderA = OlderUnprocessedVersion("47.2", new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        GameVersion olderB = OlderUnprocessedVersion("47.3", new DateTimeOffset(2026, 6, 5, 0, 0, 0, TimeSpan.Zero));
+        _gameVersionRepository.GetUnprocessedDetectedBeforeAsync(target.DetectedAt, Arg.Any<CancellationToken>())
+            .Returns([olderA, olderB]);
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(
+            Command(VersionId, Export(Line(1, "A"))), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        target.Status.ShouldBe(GameVersionStatus.Processed);
+        olderA.Status.ShouldBe(GameVersionStatus.Superseded);
+        olderB.Status.ShouldBe(GameVersionStatus.Superseded);
+        result.Value.Warnings.ShouldContain(warning => warning.Contains("2 older unprocessed version"));
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoOlderUnprocessedVersions_ShouldNotEmitSupersedeWarning()
+    {
+        // Arrange — the default stub returns no older versions, so a plain baseline import warns nothing.
+        GivenVersion(UnprocessedVersion());
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(
+            Command(VersionId, Export(Line(1, "A"))), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Warnings.ShouldNotContain(warning => warning.Contains("superseded"));
     }
 }


### PR DESCRIPTION
Closes #352

## Problem
The import handler marked the target `GameVersion` `Processed` but never touched other still-`Unprocessed` versions, so `GameVersion.MarkSuperseded()` was dead code. Two consequences:
1. Stacked older versions stayed `Unprocessed` forever — the admin's pending list never cleared.
2. The stale-export guard never engaged: importing an old export against an older still-`Unprocessed` version after a newer one was processed succeeded and rewound the whole catalog (mass-invalidating current work).

## Fix
In the import apply transaction (the same commit that flips the target to `Processed`), load every `Unprocessed` version detected before the target via the new repository method `IGameVersionRepository.GetUnprocessedDetectedBeforeAsync` and mark each `Superseded` with the existing domain method. All-or-nothing with the diff. The strict "detected before" bound leaves newer versions `Unprocessed`. The skipped count surfaces in `ImportSummary.Warnings`.

## Acceptance criteria
- [x] Importing B while older A is `Unprocessed` marks A `Superseded` in the same transaction.
- [x] A later import against A returns 422 `SupersededCannotBeProcessed` with nothing persisted (the pre-existing pre-check is now armed).
- [x] Versions detected after the processed one stay `Unprocessed`.
- [x] Re-upload to an already-`Processed` version stays idempotent (existing test untouched).
- [x] Unit + integration coverage for the mass-mark.

## Tests
Green: 164 API unit, 145 domain unit, 23 import integration (3 new). Full solution builds with zero warnings. `code-reviewer` verdict: APPROVE (only Note-level findings; the optional one was folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)