### PR TITLE
AUDIT-TEST-02: wrong-role 403 tests per translator-gated endpoint (#357)

### DIFF
--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Auth/AuthorizationDefaultsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Auth/AuthorizationDefaultsTests.cs
@@ -150,4 +150,27 @@ public sealed class AuthorizationDefaultsTests
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
     }
+
+    [Theory]
+    [InlineData("PUT", "/api/v1/translations")]
+    [InlineData("GET", "/api/v1/translations/11111111-1111-1111-1111-111111111111")]
+    [InlineData("GET", "/api/v1/translations/stats")]
+    [InlineData("GET", "/api/v1/game-versions/11111111-1111-1111-1111-111111111111")]
+    public async Task TranslatorGatedEndpoint_WithUnrecognizedRole_ShouldReturn403(string method, string route)
+    {
+        // Arrange — the same unrecognized-role token as above, sent at each translator-gated
+        // route so every endpoint's own RequireTranslatorRole binding is proven, not just the
+        // policy definition. Authorization short-circuits before the endpoint runs, so the write
+        // route needs no request body.
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", TranslationSystemApiFactory.CreateAccessToken("Reviewer"));
+        using HttpRequestMessage request = new(new HttpMethod(method), route);
+
+        // Act
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
 }


### PR DESCRIPTION
Closes #357

## What
Adds one `[Theory]` in `AuthorizationDefaultsTests` (next to the existing unrecognized-role `Fact`) that sends a `Reviewer` token — authenticated but neither `Admin` nor `Translator` — to each translator-gated route the audit flagged, asserting `403`:

- `PUT  /api/v1/translations`
- `GET  /api/v1/translations/{id}`
- `GET  /api/v1/translations/stats`
- `GET  /api/v1/game-versions/{id}`

The fifth translator-gated route (`GET /api/v1/game-versions` list) was already covered by the existing `GetTranslatorResource_WithUnrecognizedRole_ShouldReturn403` Fact.

## Why
Each of these endpoints is bound to `RequireAuthorization(RequireTranslatorRole)`, but only the list route had a wrong-role test. Removing the policy from any of the others silently drops it to the fallback policy (any authenticated identity) and every existing test still passes — a real gap for the write endpoint (`PUT /translations`), which stamps user attribution.

## Acceptance criteria
- [x] Each translator-gated endpoint has a test proving an authenticated token with an unrecognized role gets 403.
- [x] Removing `RequireAuthorization(RequireTranslatorRole)` from an endpoint makes a test fail — verified empirically: temporarily swapping Upsert's policy to `RequireAuthenticatedUser` made the `PUT` row fail (BadRequest instead of Forbidden) while the other three stayed green; endpoint then restored.

## Verification
- Full solution build: green, 0 warnings.
- `AuthorizationDefaultsTests`: 13/13 pass.
- `code-reviewer`: APPROVE (no Critical/Major/Minor findings).

Test-only change; `git diff src/` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)