### PR TITLE
AUDIT-EF-03: ListTranslations custom sort — append a unique tiebreaker so pages can't repeat or drop rows

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/IQueryableExtensions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Extensions/IQueryableExtensions.cs
@@ -16,15 +16,21 @@ internal static class IQueryableExtensions
             return query;
         }
 
+        /// <summary>
+        /// Orders <paramref name="query"/> by the user's <c>?sort=</c> keys, then always appends the
+        /// unique <paramref name="tiebreaker"/>(s). The final unique key is mandatory: a paginated list
+        /// ordered only by non-unique keys has no defined tie order, so PostgreSQL may hand back a
+        /// different order per page — silently repeating a row on one page and dropping it from another.
+        /// When the sort parses to nothing (empty or malformed), the tiebreaker becomes the primary
+        /// order, so the result is always totally ordered. A unique key's direction is irrelevant, so
+        /// tiebreakers always ascend.
+        /// </summary>
         public IQueryable<TAggregate> ApplyMultipleSorting(
             string sort,
-            Func<string, Expression<Func<TAggregate, object>>> propertySelector)
+            Func<string, Expression<Func<TAggregate, object>>> propertySelector,
+            Expression<Func<TAggregate, object>> tiebreaker,
+            params Expression<Func<TAggregate, object>>[] additionalTiebreakers)
         {
-            if (string.IsNullOrEmpty(sort))
-            {
-                return query;
-            }
-
             List<SortItem> sortItems = SortParser.Parse(sort).ToList();
 
             for (int i = 0; i < sortItems.Count; i++)
@@ -32,17 +38,16 @@ internal static class IQueryableExtensions
                 SortItem sortItem = sortItems[i];
                 Expression<Func<TAggregate, object>> sortExpression = propertySelector(sortItem.PropertyName);
 
-                if (i == 0)
-                {
-                    query = query.ApplySorting(
-                        sortExpression,
-                        sortItem.Operand is SortOperand.Asc);
-                    continue;
-                }
+                query = i == 0
+                    ? query.ApplySorting(sortExpression, sortItem.Operand is SortOperand.Asc)
+                    : query.ApplyThenSorting(sortExpression, sortItem.Operand is SortOperand.Asc);
+            }
 
-                query = query.ApplyThenSorting(
-                    sortExpression,
-                    sortItem.Operand is SortOperand.Asc);
+            foreach (Expression<Func<TAggregate, object>> uniqueKey in additionalTiebreakers.Prepend(tiebreaker))
+            {
+                query = query is IOrderedQueryable<TAggregate> orderedQuery
+                    ? orderedQuery.ThenBy(uniqueKey)
+                    : query.OrderBy(uniqueKey);
             }
 
             return query;

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/ListGameVersions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/ListGameVersions.cs
@@ -41,7 +41,10 @@ internal sealed class ListGameVersions : IEndpoint
         {
             IQueryable<GameVersionReadModel> ordered = string.IsNullOrWhiteSpace(query.Sort)
                 ? _readDbContext.GameVersions.OrderByDescending(gameVersion => gameVersion.DetectedAt)
-                : _readDbContext.GameVersions.ApplyMultipleSorting(query.Sort, GetSortProperty);
+                : _readDbContext.GameVersions.ApplyMultipleSorting(
+                    query.Sort,
+                    GetSortProperty,
+                    gameVersion => gameVersion.Id);
 
             List<GameVersionResponse> items = await ordered
                 .Select(gameVersion => new GameVersionResponse(

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
@@ -97,7 +97,11 @@ internal sealed class ListTranslations : IEndpoint
                 ? filtered
                     .OrderBy(translation => translation.FileId)
                     .ThenBy(translation => translation.GossipId)
-                : filtered.ApplyMultipleSorting(query.Sort, GetSortProperty);
+                : filtered.ApplyMultipleSorting(
+                    query.Sort,
+                    GetSortProperty,
+                    translation => translation.FileId,
+                    translation => translation.GossipId);
 
             List<TranslationListItemResponse> items = await ordered
                 .ApplyPagination(query.Page, query.PageSize)

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/ListTranslationsTests.cs
@@ -234,6 +234,48 @@ public sealed class ListTranslationsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task List_WithTiedSortKey_WalksEveryPageWithoutDuplicatesOrGaps()
+    {
+        // Arrange — five rows sharing one Status (Untranslated) and one UpdatedAt (a baseline import
+        // stamps every row the same timestamp), seeded out of key order. Sorting only by the tied
+        // Status leaves the tie order to PostgreSQL unless a unique final key pins it, so paging can
+        // repeat a row on one page and drop it from another.
+        await SeedAsync(Row(5, "e"), Row(3, "c"), Row(1, "a"), Row(4, "d"), Row(2, "b"));
+
+        // Act — walk every page of the tied sort.
+        List<long> walked = [];
+        PaginationResponse<TranslationListItemResponse> pageResult;
+        int page = 0;
+        do
+        {
+            pageResult = await ListAsync($"?sort=status&page={++page}&pageSize=2");
+            walked.AddRange(pageResult.Items.Select(item => item.GossipId));
+        }
+        while (pageResult.HasNextPage);
+
+        // Assert — the union of pages is the full set with no repeats, in the unique tiebreaker order.
+        walked.ShouldBe([1L, 2L, 3L, 4L, 5L]);
+    }
+
+    [Fact]
+    public async Task List_WithTiedSortKey_EndsWithTheUniqueTiebreaker()
+    {
+        // Arrange — every row shares one UpdatedAt (a baseline import's single timestamp), seeded out
+        // of (FileId, GossipId) order. Sorting by the tied submittedAt alone leaves no defined order.
+        await SeedAsync(
+            Row(1, "x", fileId: 200),
+            Row(2, "y", fileId: 100),
+            Row(1, "z", fileId: 100));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> resultPage = await ListAsync("?sort=submittedAt");
+
+        // Assert — the tie resolves to the unique (FileId, GossipId) key, ascending.
+        resultPage.Items.Select(item => (item.FileId, item.GossipId))
+            .ShouldBe([(100, 1L), (100, 2L), (200, 1L)]);
+    }
+
+    [Fact]
     public async Task List_WithUnsupportedLanguage_ShouldReturn400()
     {
         // Act


### PR DESCRIPTION
Closes #353

## What
The custom-sort branch of `ListTranslations` ordered only by the user's `?sort=` keys and paginated with `Skip`/`Take` — no unique tiebreaker. With non-unique keys (`status` has 4 values; a baseline import stamps one `UpdatedAt` on ~792k rows) PostgreSQL gives no stable tie order, so paging can show a row twice and drop others — invisible lost work for a translator walking the NeedsReview backlog page by page.

## Fix
`ApplyMultipleSorting` now takes a **mandatory** tiebreaker (plus optional extra keys) and always appends it after the user's sort, so every paginated list is totally ordered. Making it a required parameter stops future list slices repeating the mistake. Both call sites pass their unique key:
- `ListTranslations` → `(FileId, GossipId)`
- `ListGameVersions` → `Id`

## Tests
- Walk every page of `?sort=status` over rows sharing one status → union equals the full set, no repeats.
- `?sort=submittedAt` over rows sharing one `UpdatedAt` → resolves to the unique `(FileId, GossipId)` order.
- Full integration suite green (184 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
