### PR TITLE
AUDIT-EF-01: add an xmin optimistic-concurrency token to Translation so approve/upsert can't overwrite an import's invalidation

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
@@ -9,9 +9,24 @@ namespace LotroKoniecDev.TranslationSystem.Persistence.Configurations;
 
 internal sealed class TranslationConfiguration : IEntityTypeConfiguration<Translation>
 {
+    private const string ConcurrencyTokenColumn = "xmin";
+    private const string ConcurrencyTokenType = "xid";
+
     public void Configure(EntityTypeBuilder<Translation> builder)
     {
         builder.ToTable("Translations");
+
+        // PostgreSQL's xmin system column is a free optimistic-concurrency token (AUDIT-EF-01),
+        // mapped as a shadow property exactly as TheKittySaver's AuditableEntityConfiguration does:
+        // a stale approve/upsert whose row a concurrent import already changed now fails the version
+        // check instead of silently reversing the invalidation, and DbUpdateConcurrencyExceptionHandler
+        // maps that to 409. xmin already exists on every row, so the migration adds no physical column.
+        // HasColumnType is required here — "xid" is a PostgreSQL system type with no convention mapping.
+        builder.Property<uint>(ConcurrencyTokenColumn)
+            .HasColumnName(ConcurrencyTokenColumn)
+            .HasColumnType(ConcurrencyTokenType)
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
 
         builder.Property(translation => translation.Id)
             .ValueGeneratedNever();

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260706032709_AddTranslationConcurrencyToken.Designer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260706032709_AddTranslationConcurrencyToken.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationWriteDbContext))]
-    partial class ApplicationWriteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706032709_AddTranslationConcurrencyToken")]
+    partial class AddTranslationConcurrencyToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260706032709_AddTranslationConcurrencyToken.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260706032709_AddTranslationConcurrencyToken.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTranslationConcurrencyToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // No-op DDL by design (AUDIT-EF-01): xmin is a PostgreSQL system column that already
+            // exists on every row, so Npgsql emits zero SQL for this AddColumn — the migration only
+            // syncs the model snapshot so the optimistic-concurrency token engages. Trivially N-1-safe
+            // (ADR-0023): nothing physical changes, so the previous app revision keeps serving.
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "translation",
+                table: "Translations",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "translation",
+                table: "Translations");
+        }
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Concurrency/ConcurrencyEndpointsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Concurrency/ConcurrencyEndpointsTests.cs
@@ -23,7 +23,9 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Concurren
 /// identity: parallel upsert of the same fragment, and double-approve of the same row. Both exercise
 /// the lazy-provisioning first-write race (ADR-0004), and approve additionally floods the artifact
 /// rebuild scheduler (PERF-04: the burst coalesces into a debounced background rebuild) — none of
-/// which may surface a 500.
+/// which may surface a 500. With the xmin optimistic-concurrency token (AUDIT-EF-01) the racing
+/// writers no longer silently overwrite each other: at least one commits and the rest resolve as
+/// clean 409 conflicts. The token itself is proven deterministically in TranslationConcurrencyTokenTests.
 /// </summary>
 [Collection("TranslationApi")]
 public sealed class ConcurrencyEndpointsTests : IAsyncLifetime
@@ -58,7 +60,7 @@ public sealed class ConcurrencyEndpointsTests : IAsyncLifetime
     public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
-    public async Task ConcurrentUpsert_SameFragmentByOneNewIdentity_ShouldAllSucceedAndProvisionExactlyOneTranslator()
+    public async Task ConcurrentUpsert_SameFragmentByOneNewIdentity_ShouldSerializeToWinnersAndProvisionExactlyOneTranslator()
     {
         // Arrange — one untranslated row and a single never-before-seen identity firing every write,
         // so the lazy-provisioning insert races with itself.
@@ -71,20 +73,25 @@ public sealed class ConcurrencyEndpointsTests : IAsyncLifetime
             .ToArray();
         HttpResponseMessage[] responses = await Task.WhenAll(tasks);
 
-        // Assert — no request faults; last-write-wins leaves a single coherent Draft row; the unique
-        // identity index plus the first-write-race re-read converge on exactly one Translator.
+        // Assert — the xmin token (AUDIT-EF-01) serializes the racing writers instead of letting them
+        // silently overwrite each other: at least one commits and every loser is a clean 409 (never a
+        // 500). The row settles Draft, and the unique identity index plus the first-write-race re-read
+        // still converge on exactly one Translator.
         foreach (HttpResponseMessage response in responses)
         {
             ((int)response.StatusCode).ShouldBeLessThan(500, $"Unexpected server error: {response.StatusCode}");
         }
 
-        responses.Count(response => response.StatusCode == HttpStatusCode.OK).ShouldBe(ConcurrentRequests);
+        responses.Count(response => response.StatusCode == HttpStatusCode.OK).ShouldBeGreaterThanOrEqualTo(1);
+        responses
+            .Where(response => response.StatusCode != HttpStatusCode.OK)
+            .ShouldAllBe(response => response.StatusCode == HttpStatusCode.Conflict);
         (await GetStatusAsync(gossipId: 1)).ShouldBe(TranslationStatus.Draft);
         (await CountTranslatorsAsync()).ShouldBe(1);
     }
 
     [Fact]
-    public async Task ConcurrentApprove_SameDraftRow_ShouldAllSucceedAndEndApproved()
+    public async Task ConcurrentApprove_SameDraftRow_ShouldSerializeToWinnersAndEndApproved()
     {
         // Arrange — a single draft row, every approve fired by one admin identity in parallel.
         Guid id = await SeedDraftRowAsync(gossipId: 2, polish: "Witaj");
@@ -96,16 +103,19 @@ public sealed class ConcurrencyEndpointsTests : IAsyncLifetime
             .ToArray();
         HttpResponseMessage[] responses = await Task.WhenAll(tasks);
 
-        // Assert — approve is idempotent (no "already approved" guard) and the artifact rebuilds are
-        // scheduled, debounced signals (PERF-04), so every concurrent approve publishes; the row
-        // settles Approved and the admin approver is provisioned once (the seeded submitter is the
-        // only other Translator).
+        // Assert — the xmin token (AUDIT-EF-01) serializes the racing approves rather than letting each
+        // blindly re-stamp the row: at least one publishes and every loser is a clean 409 (never a 500).
+        // The row settles Approved and the admin approver is provisioned once (the seeded submitter is
+        // the only other Translator).
         foreach (HttpResponseMessage response in responses)
         {
             ((int)response.StatusCode).ShouldBeLessThan(500, $"Unexpected server error: {response.StatusCode}");
         }
 
-        responses.Count(response => response.StatusCode == HttpStatusCode.NoContent).ShouldBe(ConcurrentRequests);
+        responses.Count(response => response.StatusCode == HttpStatusCode.NoContent).ShouldBeGreaterThanOrEqualTo(1);
+        responses
+            .Where(response => response.StatusCode != HttpStatusCode.NoContent)
+            .ShouldAllBe(response => response.StatusCode == HttpStatusCode.Conflict);
         (await GetStatusAsync(gossipId: 2)).ShouldBe(TranslationStatus.Approved);
         (await CountTranslatorsAsync()).ShouldBe(2);
     }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Concurrency/TranslationConcurrencyTokenTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Concurrency/TranslationConcurrencyTokenTests.cs
@@ -1,0 +1,176 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Concurrency;
+
+/// <summary>
+/// The xmin optimistic-concurrency token on Translation (AUDIT-EF-01). Both write paths a game
+/// update's import can race — approve and upsert — are proven to LOSE to a concurrent commit rather
+/// than silently overwrite it: EF's version check fails, surfacing <see cref="DbUpdateConcurrencyException"/>
+/// (which the registered <c>DbUpdateConcurrencyExceptionHandler</c> maps to HTTP 409). Deterministic by
+/// construction — load a snapshot, change the row out-of-band, then save the stale snapshot — because a
+/// real HTTP interleave is a race; the endpoint fan-out lives in <c>ConcurrencyEndpointsTests</c>.
+/// </summary>
+[Collection("TranslationApi")]
+public sealed class TranslationConcurrencyTokenTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+    private TranslatorId _seederId;
+
+    public TranslationConcurrencyTokenTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+
+        // Attributed writes (submitter / approver) are local TranslatorId FKs (ADR-0004); the target must exist.
+        Translator seeder = Translator.Create(
+            IdentityId.Create(), DisplayName.Create("Seed Author").Value, email: null, Now).Value;
+        dbContext.Translators.Add(seeder);
+
+        await dbContext.SaveChangesAsync();
+        _versionId = gameVersion.Id;
+        _seederId = seeder.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Approve_WhenAConcurrentImportInvalidatesTheRowFirst_ThrowsConcurrencyAndKeepsTheInvalidation()
+    {
+        // Arrange — a reviewer opens a Draft row to approve it (captures its version token).
+        Guid id = await SeedDraftRowAsync(gossipId: 1, polish: "Witaj");
+
+        using IServiceScope reviewerScope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext reviewerContext =
+            reviewerScope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation reviewerCopy = await LoadTrackedAsync(reviewerContext, id);
+
+        // A concurrent import reworded the English and parked the row for review (bumps xmin).
+        await ApplySourceChangeOutOfBandAsync(id, rewordedSource: "English reworded");
+
+        Result approveResult = reviewerCopy.Approve(_seederId, Now);
+        approveResult.IsSuccess.ShouldBeTrue();
+
+        // Act + Assert — the version check rejects the stale approve, so the import's invalidation
+        // stands, unmasked (spec 0001's core invariant); the handler maps this throw to 409.
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => reviewerContext.SaveChangesAsync());
+
+        Translation persisted = await ReadFreshAsync(id);
+        persisted.Status.ShouldBe(TranslationStatus.NeedsReview);
+        persisted.Source.Text.ShouldBe("English reworded");
+        persisted.PreviousSourceText.ShouldBe("English");
+    }
+
+    [Fact]
+    public async Task Upsert_WhenAnotherTranslatorSavedFirst_ThrowsConcurrencyAndDoesNotOverwrite()
+    {
+        // Arrange — a translator opens an untranslated row to attach Polish (captures its version token).
+        Guid id = await SeedUntranslatedRowAsync(gossipId: 2);
+
+        using IServiceScope editorScope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext editorContext =
+            editorScope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation editorCopy = await LoadTrackedAsync(editorContext, id);
+
+        // Another translator committed their Polish first (bumps xmin).
+        await ProvideTranslationOutOfBandAsync(id, polish: "Pierwszy polski");
+
+        editorCopy.ProvideTranslation("Drugi polski", _seederId, Now);
+
+        // Act + Assert — the version check rejects the stale upsert; the first writer's Polish survives.
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(() => editorContext.SaveChangesAsync());
+
+        Translation persisted = await ReadFreshAsync(id);
+        persisted.TranslatedText.ShouldBe("Pierwszy polski");
+        persisted.Status.ShouldBe(TranslationStatus.Draft);
+    }
+
+    private static Task<Translation> LoadTrackedAsync(ApplicationWriteDbContext dbContext, Guid id)
+    {
+        TranslationId translationId = TranslationId.FromValue(id);
+        return dbContext.Translations.SingleAsync(translation => translation.Id == translationId);
+    }
+
+    private async Task ApplySourceChangeOutOfBandAsync(Guid id, string rewordedSource)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation row = await LoadTrackedAsync(dbContext, id);
+        row.ApplySourceChange(TranslationSource.Create(rewordedSource, null, null).Value, _versionId, Now);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task ProvideTranslationOutOfBandAsync(Guid id, string polish)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation row = await LoadTrackedAsync(dbContext, id);
+        row.ProvideTranslation(polish, _seederId, Now);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task<Translation> ReadFreshAsync(Guid id)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        TranslationId translationId = TranslationId.FromValue(id);
+        return await dbContext.Translations.AsNoTracking().SingleAsync(translation => translation.Id == translationId);
+    }
+
+    private async Task<Guid> SeedDraftRowAsync(int gossipId, string polish)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create("English", null, null).Value,
+            _versionId,
+            Now).Value;
+        row.ProvideTranslation(polish, _seederId, Now);
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+        return row.Id.Value;
+    }
+
+    private async Task<Guid> SeedUntranslatedRowAsync(int gossipId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create("English", null, null).Value,
+            _versionId,
+            Now).Value;
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+        return row.Id.Value;
+    }
+}


### PR DESCRIPTION
Closes #351

## What
Every `Translation` write slice did load → mutate → `SaveChanges` with `WHERE Id` only, so last write wins. During an import's minutes-long apply pass, a reviewer's approve (or a second translator's upsert) could silently reverse the import's invalidation and ship stale Polish against reworded English — breaking spec 0001's core invariant.

## Fix
Map PostgreSQL's `xmin` system column as the optimistic-concurrency token on `Translation` (the same shadow-property mapping TheKittySaver's `EntityConfiguration` uses). A conflicting approve/upsert now throws `DbUpdateConcurrencyException`, which the already-registered handler maps to **409 Conflict**. No handler changes.

Note: the ticket suggested `UseXminAsConcurrencyToken()`, but **Npgsql 10 dropped that helper**, so the manual shadow-property mapping is the current idiom (verified against the installed provider + the KittySaver golden reference).

The migration emits **no DDL** — `xmin` is a system column that already exists on every row, so the generated SQL is only the `__EFMigrationsHistory` insert. Snapshot-only, trivially N-1 safe.

## Tests
- Deterministic token tests: approve and upsert both lose to a concurrent commit → `DbUpdateConcurrencyException`; the import's invalidation stands / the first writer's Polish survives.
- Endpoint concurrency tests now expect racing writers to serialize to one winner + clean 409s (never a 500).
- Full integration suite green (184 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
