### PR TITLE
M7-00: spec 0008 (agreed) + Companion knowledge base + roadmap — game-content catalog docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -536,9 +536,13 @@ runs, env knobs, triage, troubleshooting): **`docs/claude-loop.md`**.
   entry bulk approve → artifact contains the rows (E2E).
 - **Post-MVP backlog (deliberately cut from MVP):** glossary, `TranslationHistory`, bulk
   operations, keyboard shortcuts, AI review, Discord notifications, public API versioning,
-  crowdsourced game-version reports, per-language roles, Companion data auto-fetch from GitHub,
-  TMS→Companion `labels/pl` reverse export. (The former "LOTRO Companion XML context import +
-  quest browser" items were promoted to M7.)
+  crowdsourced game-version reports, per-language roles, Companion data auto-fetch from GitHub.
+  (The former "LOTRO Companion XML context import + quest browser" items were promoted to M7.)
+  **Epic TP-00 (#377)** parks the post-M7 productivity/ecosystem pack with its evidence:
+  TM-lite duplicate propagation (45% of corpus measured), Companion reference labels (named
+  `${PLAYER}` placeholders + RU/DE/FR reference panel), per-patch worklist, launch sentinel
+  (DAT-repair gap), lotro-data version watcher, glossary seed, quest arcs, `labels/pl` reverse
+  export — promotion order on the epic; TP-01/TP-10 are `/spec`-first.
 
 ## Proactive command use
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ A KittySaver slice is one file: `internal sealed class <Action> : IEndpoint` con
 | Make a non-trivial architectural/modeling decision | skim `docs/adr/`, then **write a new ADR** (`/adr`); anchors: 0001 (no mediator), 0002 (TMS pivot + freeze/unfreeze amendments), 0008 (cloud-agnostic deployment + env strategy — M6), 0009 (browser E2E via Testcontainers + Playwright) |
 | Deploy/operate the stack, or set env vars per environment | `docs/deployment/runbook.md` — env-var matrix (service × environment), secret generation, the issuer/redirect/authority/CORS gotchas, bring-up sequence + DB migrations |
 | Touch the update lifecycle (GameVersion, import diff, invalidation, distribution, CLI sync) | `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md` — the agreed domain spec |
+| Touch the game-content catalog (CatalogEntry/TextSlot, Companion zip import, catalog browser, memberships) | `docs/specs/0008-game-content-catalog-layer.md` (agreed) + `docs/knowledge-base/lotro-companion-data-model.md` (the verified `key:<FileId>:<GossipId>` join — never join on text). Naming rule: **never "entity"** in this layer (DDD-Entity misconception) |
 | Implement a feature whose business rules are fuzzy | **`/spec`** first (seed → questions → agreed spec in `docs/specs/`) |
 | Review a finished change | the **`code-reviewer`** agent |
 | Understand the backlog / milestones | `gh issue list` (being re-cut post-pivot) + Roadmap digest below |
@@ -522,9 +523,22 @@ runs, env knobs, triage, troubleshooting): **`docs/claude-loop.md`**.
   browser, authenticated.
 - **M4 — WPF player app** (later): GUI over the patcher handlers + the same TMS auto-download
   the CLI ships in M2-20.
-- **Post-MVP backlog (deliberately cut from MVP):** LOTRO Companion XML context import, glossary,
-  quest browser, `TranslationHistory`, bulk operations, keyboard shortcuts, AI review, Discord
-  notifications, public API versioning, crowdsourced game-version reports, per-language roles.
+- **M7 — Game-content catalog (spec 0008, agreed 2026-07-06; epic #362).** LOTRO Companion's
+  lore XML imported as a catalog lens over the flat rows: catalog entries (quest/deed +
+  registry-driven long tail incl. items) with role-tagged text slots joined **by
+  `(FileId, GossipId)` keys, never text** (verified —
+  `docs/knowledge-base/lotro-companion-data-model.md`); admin zip import (replace-per-kind, COPY
+  idiom), catalog browser + per-entry/per-category Approved-based progress, atomic quest
+  translation UX (entry page + editor context + entry bulk approve), translation→entry
+  memberships. The lens never mutates translations and never triggers the artifact. Naming rule:
+  **CatalogEntry, never "entity"** (DDD-Entity misconception — user decision 2026-07-06).
+  **DoD:** import fixture → browse `/catalog` → translate a whole quest via editor context →
+  entry bulk approve → artifact contains the rows (E2E).
+- **Post-MVP backlog (deliberately cut from MVP):** glossary, `TranslationHistory`, bulk
+  operations, keyboard shortcuts, AI review, Discord notifications, public API versioning,
+  crowdsourced game-version reports, per-language roles, Companion data auto-fetch from GitHub,
+  TMS→Companion `labels/pl` reverse export. (The former "LOTRO Companion XML context import +
+  quest browser" items were promoted to M7.)
 
 ## Proactive command use
 

--- a/docs/knowledge-base/README.md
+++ b/docs/knowledge-base/README.md
@@ -22,6 +22,13 @@ Detailed analysis: [russian-project.md](russian-project.md)
 - Desktop launcher (Elanor, C# WPF) uses `-disablePatch -nosplash -skiprawdownload` flags on TurbineLauncher.exe
 - NinjaMark: metadata in DAT subfile `620750000`, format `Ru&{version}&{date}&{subscribed}`, detects if official launcher overwrote translations
 
+### LOTRO Companion Data Model — the `(FileId, GossipId)` join (feeds spec 0008)
+Detailed analysis: [lotro-companion-data-model.md](lotro-companion-data-model.md)
+- Their published XML stores every translatable game-object field as the literal token `key:<FileId>:<GossipId>` — **deterministic, zero-heuristic join** with our `Translations` identity, proven three ways (their labels ⇔ our export; structural tokens ⇔ live 48.7 export; locale-stable keys)
+- Records keyed by DID (`1879xxxxxx`); quests (14,974) + deeds (5,394) ≈ 215k token refs with semantic roles (name/description/objective N/dialog/progress); our TMS layer is named **Catalog** (never "entity")
+- `lotro-data` GitHub repo **is** the live dataset (updated within days of each patch); labels not needed — our English comes from our own export
+- Caveats: subset coverage, join on keys never text (`${PLAYER}` vs `<--DO_NOT_TOUCH!-->`), version skew tolerated as dangling refs, no LICENSE (attribution = courtesy decision)
+
 ### DAT Protection: NOT NEEDED — Translations Survive Updates (incl. MAJOR)
 Detailed analysis: [dat-protection.md](dat-protection.md)
 - **PROVEN by 7 independent tests** including updates 47.2→48.0 (2026-04-23) and 48.0→48.7 (2026-06-25)

--- a/docs/knowledge-base/lotro-companion-data-model.md
+++ b/docs/knowledge-base/lotro-companion-data-model.md
@@ -1,0 +1,174 @@
+# LOTRO Companion data model — game-object records & the `(FileId, GossipId)` join
+
+**Date:** 2026-07-06 · **Status:** empirically verified (code + published data + live local export)
+**Sources:** LotroCompanion GitHub org (local shallow clones: `~/RiderProjects/LotroCompanionOrg/`),
+downloaded app `~/Downloads/lotro-companion-24.9.0.48.5/` (data = Update 48.5),
+downloaded legacy dataset `~/Downloads/lotro-lore-database-SoABook11-4.0.1/` (same toolchain,
+Echoes-of-Angmar Book 11 content), our live `data/exported.txt` (792,509 rows, game 48.7).
+**Feeds:** spec 0008 (game-content catalog layer), supersedes the research premise of old ticket #30.
+
+## TL;DR — the verdict
+
+**LOTRO Companion's published data preserves our exact translation-row identity.** Every
+translatable field of every game object (quest, deed, item, NPC, …) is stored as the literal string
+token **`key:<tableId>:<tokenId>`**, where `tableId` **is our `FileId`** (0x25-band DAT text-table
+id, decimal) and `tokenId` **is our `GossipId`**. A deterministic, zero-heuristic join between
+their per-object structure and our flat `Translations` table exists in both directions. No string
+matching, no running their Java pipeline — parsing their XML is enough.
+
+## Who they are, which repos matter
+
+LOTRO Companion is a mature Java desktop app ("apka-wiki": character planner + lore compendium)
+by Damien Morcellet (`dmorcellet`), org `github.com/LotroCompanion` (19 repos). Relevant:
+
+| Repo | Role | Relevance |
+|---|---|---|
+| **`lotro-data`** | **The published dataset itself** — `lore/*.xml` + `lore/labels/{de,en,es,fr,ru}/` + `lore/enums/`. Git history shows updates **within days of every LOTRO patch** (e.g. "Updated for Update 48.8" extracted 2026-07-01; Russian labels v335 2026-07-04). | **Primary data source for us** |
+| **`lotro-tools`** | The DAT→XML extraction pipeline (quest/deed loaders, the i18n label writer — the code that generates the `key:T:K` tokens). | Evidence + role taxonomy |
+| **`lotro-core`** | Data-access library (XML schema constants, runtime label resolution). | Schema reference |
+| `lotro-items-db`, `lotro-maps-db` | Items and maps live in separate repos (per `lotro-data/README.txt`). | Only if we extend beyond quests/deeds |
+| `lotro-dat-utils` | **Closed-source** (`com.dam.delta4j:delta-lotro-dat-utils`, not on GitHub/Maven Central) — their DAT parser. API reconstructable from call sites; irrelevant to us (we have our own DAT layer). | None |
+
+**No repo carries a LICENSE file.** The underlying texts are SSG's game content; the community
+convention is goodwill + attribution (RU/ES communities contribute label drops back upstream).
+
+## The data model (verified on Update 48.5 app data + lotro-data master)
+
+Two parallel trees, both language-neutral keyed:
+
+1. **Structural game-object XML** — `lore/quests.xml`, `deeds.xml`, `items.xml`, … One record per
+   game object, identified by its **DID** (`id="1879048195"`, 0x70-band). Human-readable English is
+   inlined for convenience (`name=`, `npcName=`, `itemName=`); every translatable field is a
+   **`key:<FileId>:<GossipId>` token** in attributes such as `rawName`, `description`, bestower
+   `text`, `objective[@index]/text`, `dialog/text`, `progressOverride`, `billboardOverride`,
+   `questArc`, `pluralName`, `loreInfo`, NPC `title`, emote `description`.
+2. **Label files** — `lore/labels/<locale>/<set>.xml` (`de,en,es,fr,ru` — **no `pl`**): flat
+   `<label key="…" value="…"/>` lists resolving those tokens per locale. **Identical key sets in
+   every locale** (216,563 labels in each `labels/*/quests.xml`). Two key forms coexist: the raw
+   object DID (object *names* only — a convenience alias) and the verbatim `key:T:K` string
+   (everything, including names via `rawName`).
+
+Canonical example (`lore/quests.xml`, trimmed):
+
+```xml
+<quest id="1879048195" name="The Bird and Baby" rawName="key:620767095:228870261"
+       category="22" level="7" description="key:620767095:54354734">
+  <bestower npcId="1879048194" npcName="Carlo Blagrove" text="key:620767095:218649169"/>
+  <objectives>
+    <objective index="1" text="key:620767095:94621393">
+      <dialog npcId="1879048194" npcName="Carlo Blagrove" text="key:620767095:218649170"/>
+      <compoundEvent>
+        <npcTalk progressOverride="key:620767095:22075073" npcId="1879048194" …/>
+        <externalInventoryItem progressOverride="key:620767095:22075074"
+                               itemId="1879062158" itemName="Yellowed Recipe" …/>
+      </compoundEvent>
+    </objective>
+  </objectives>
+  <rewards><money copper="90"/><XP quantity="118"/><object id="1879051637" …/></rewards>
+</quest>
+```
+
+A third indirection exists for **enum-coded metadata**: `category="22"` →
+`lore/enums/QuestCategory.xml` maps code 22 to `name="key:620757000:…"` → resolved in
+`labels/en/enum-QuestCategory.xml`. Region/territory/area names in `geoAreas.xml` are inline
+strings (not tokens).
+
+## Code evidence — where the token comes from
+
+Their DAT reader hands every string-valued game-object property to the loaders as a
+`TableEntryStringInfo { int getTableId(); int getTokenId(); }` (the raw reference is **never
+discarded**). The label key writer is `lotro-tools`
+`…/tools/extraction/utils/i18n/I18nUtils.java:295-300`:
+
+```java
+private String getKey(TableEntryStringInfo stringInfo)
+{
+  int tableId=stringInfo.getTableId();
+  int tokenId=stringInfo.getTokenId();
+  return "key:"+tableId+":"+tokenId;
+}
+```
+
+`QuestsLoader.java:112-118` wires it: `Quest_Name` → DID-keyed label **plus** `rawName` =
+`key:T:K`; `Quest_Description` → `key:T:K`; `DatObjectivesLoader.java:145-154` does objectives
+(`Quest_ObjectiveDescription`, `Quest_ObjectiveProgressOverride`, …). One label XML per locale per
+set is written by `LabelsStorage.saveLabels`. Missing per-locale strings fall back to the English
+value under the same key — which is why key sets are byte-identical across locales.
+
+## Empirical join proof (three independent probes)
+
+1. **Their labels ⇔ our export, same coordinates:** `labels/en/quests.xml`
+   `key:620757029:218649169` ("'While both you and I have seen five Nazgûl…") and
+   `key:620757029:228870261` ("Book 1, Chapter 5: The Other Riders") match our `exported.txt`
+   rows `620757029||218649169||…` / `620757029||228870261||…` **character-for-character**
+   (their `&#10;` ≡ our `\n` escape). `620757029 = 0x25000025`.
+2. **Their structural tokens ⇔ our live export (48.5 data vs 48.7 game):**
+   `key:620767095:228870261` → `The Bird and Baby` (quest name), `key:620767095:54354734` →
+   `Carlo Blagrove, innkeeper of The Bird and Baby…` (description), `key:620767095:94621393` →
+   objective 1 text, `key:620767446:54354734` → deed "Lore of the Blade" description — all found
+   at exactly those `(FileId, GossipId)` pairs in our 792,509-row export.
+3. **Locale stability:** the same key resolves to RU/FR/DE text in the respective label files —
+   keys derive from DAT tokens, not from English content, so they survive rewordings.
+
+## Record inventory per kind (app data, Update 48.5)
+
+| File | Size | Elements | Token-bearing fields (counts where sampled) |
+|---|---|---|---|
+| `items.xml` | 72.5 MB | 149,710 `<item>` | `description` (41,502), `pluralName`, `descriptionOverride` (3,246) |
+| `quests.xml` | 34.1 MB | 14,974 `<quest>` | `text` (93,996), `progressOverride` (50,001), `rawName` (14,974), `description` (14,643), `questArc` (1,580), `billboardOverride` (644) |
+| `deeds.xml` | 5.6 MB | 5,394 `<deed>` | `rawName`, `description`, `progressOverride`, `loreInfo` (~39k token labels) |
+| `skills.xml` | 6.3 MB | 11,486 | descriptions |
+| `mobs.xml` | 5.3 MB | 20,017 | names/titles |
+| `NPCs.xml` | 1.06 MB | 16,274 | `title` tokens |
+| `traits.xml` | 1.2 MB | 3,847 | descriptions |
+| `titles.xml` | 0.52 MB | 3,056 | 6,112 token labels |
+| `factions.xml` | 0.12 MB | 105 | descriptions |
+| `dungeons.xml` | 0.19 MB | 1,295 | names/descriptions |
+| `geoAreas.xml` | 66 KB | 7 regions / 86 territories / 674 areas | **inline names, no tokens** |
+| `emotes.xml` | 29 KB | 270 | `description` tokens |
+| + ~75 more | | | recipes 7,753, effects 6,733, sets 2,173, vendors 1,437, landmarks 2,733, … |
+
+Quests + deeds alone ≈ **215k token references** over ~20k records. Our export has ~792k rows —
+Companion's lore files cover the *object-anchored* subset (quest/deed/item/… texts); pure UI/
+system strings remain uncovered by design.
+
+## Data acquisition for the TMS
+
+- **Primary: the `lotro-data` GitHub repo** — raw fetch
+  `https://raw.githubusercontent.com/LotroCompanion/lotro-data/master/lore/quests.xml` (+
+  `deeds.xml`, `enums/…`, `labels/en/enum-*.xml`), updated within days of each game update.
+  Items would come from `lotro-items-db` if ever needed.
+- Alternative: the packaged app data (`app/data/lore/`) or the SourceForge package chain
+  (`software.xml` descriptor) — both lag the repo slightly. Version metadata:
+  `data/config/params.txt` (`current.version.name=24.9 Update 48.5`).
+
+## Caveats for the join implementation
+
+1. **Coverage is a subset** — join direction that always works: their `key:T:K` → our row. Many
+   of our rows (UI strings, system messages) will belong to no game object; expected and fine.
+2. **Join on keys, never on text.** Their label *values* render arguments as named variables
+   (`${PLAYER}`, `${NUMBER}`) where our export uses positional `<--DO_NOT_TOUCH!-->` markers.
+   Text equality holds only for argless strings. We don't need their label values at all — our
+   English source comes from our own export.
+3. **Token width:** their `getTokenId()` is a Java `int` (max observed 266,424,533); our
+   `GossipId` is stored as `long`. If an id > 2^31 ever appears, verify their decimal rendering —
+   non-issue today.
+4. **Names:** prefer `rawName` (`key:T:K`) as the name slot; the plain-DID label key is their
+   convenience alias. Don't confuse deeds' legacy `key="Lore_of_the_Blade"` slug with i18n keys.
+5. **Version skew is normal** in both directions (their 48.5/48.8 vs our 48.7): tokens referencing
+   rows we don't have yet (or that we soft-removed) must be tolerated as dangling, not errors.
+6. **No LICENSE anywhere** — attribution/contact is a courtesy decision, not a legal gate we can
+   resolve from the repos.
+
+## Strategic side-note (post-MVP)
+
+Companion merges **community translation drops** (Russian v335, Spanish beta) as
+`labels/<locale>/` files keyed by the same DAT tokens. Since our DB is keyed identically, a future
+`labels/pl/` export from the TMS would give the Polish community a translated LOTRO Companion app
+essentially for free — the reverse of the import this research enables.
+
+## Local artifacts
+
+- Shallow clones: `C:\Users\halin\RiderProjects\LotroCompanionOrg\{lotro-core,lotro-tools,lotro-data,lotro-data-extractor,lotro-companion,delta-common-l10n}`
+- App with full 48.5 dataset: `C:\Users\halin\Downloads\lotro-companion-24.9.0.48.5\LotRO Companion\app\data\lore\`
+- Legacy (EoA Book 11) dataset, same toolchain: `C:\Users\halin\Downloads\lotro-lore-database-SoABook11-4.0.1\`

--- a/docs/specs/0008-game-content-catalog-layer.md
+++ b/docs/specs/0008-game-content-catalog-layer.md
@@ -1,0 +1,321 @@
+# Spec 0008: Game-content catalog — catalog entries as translation units (LOTRO Companion import)
+
+- **Status:** Agreed (drafted and agreed same day — all five extracted decisions resolved by the user;
+  naming amended same day: **CatalogEntry, never "entity"** — the term collides with DDD's Entity
+  and this layer is deliberately *not* domain-modeled)
+- **Date:** 2026-07-06
+- **Author:** Artur Koniec (vision) — researched & structured by Claude
+- **Ticket:** epic **#362** (M7-00) + #363–#375 (M7-01…M7-13), milestone "M7: Game-content
+  catalog (LOTRO Companion)"; supersedes #30 (M2-08 — closed) and the quest-browser half of #38
+  (M3-07 — re-scoped to glossary)
+- **Related:** `docs/knowledge-base/lotro-companion-data-model.md` (the empirical foundation —
+  read it first), spec 0001 (update lifecycle — untouched by this spec), ADR-0002 (bounded
+  contexts), ADR-0007 (projections are not aggregates), ADR-0011 + spec 0006 (COPY/streaming
+  import idiom), ADR-0021 (artifact rebuild — explicitly NOT triggered here), ADR-0023
+  (forward-only migrations)
+
+## Business context
+
+The TMS holds ~792k flat translation rows keyed `(FileId, GossipId)` — spec 0001 §Identity is
+explicit that the DAT is "one undifferentiated bag of texts" with no category or grouping. A
+translator therefore cannot work the way translation actually happens: pick *a quest*, translate
+its name, description, objectives, dialogs and progress texts as one coherent unit, and move to
+the next. Both prior-art projects solved this the same way — LOTRO Companion (and the Russian
+platform built on its data) organizes game texts per game object. Companion's published XML
+preserves our exact row identity as literal `key:<FileId>:<GossipId>` tokens on every
+translatable field, with semantic roles derivable from XML structure — a **deterministic,
+zero-heuristic join** (verified in code, in their published data, and against our live 48.7
+export; see the knowledge-base doc). This spec imports that structure as a **catalog** over the
+flat rows.
+
+## Goal
+
+A translator (or anonymous visitor) can browse the game-content catalog (quests, deeds, …), see
+per-entry and per-category translation progress, open one entry, and translate/approve **all of
+its texts as a unit** — while the flat `/translations` list keeps serving search and the rows no
+catalog entry covers.
+
+## Ubiquitous language
+
+| Term | Meaning |
+|---|---|
+| **CatalogEntry** | One game object a player recognizes: a quest, deed, item, NPC, skill, trait, title, emote, faction, dungeon, mob, … Identified by its game **DID** (`1879xxxxxx`, 0x70-band int). Imported reference data — never user-edited. **Named deliberately: not "entity"** (collides with DDD's Entity; this layer is not domain-modeled — see the M7-01 ADR). |
+| **Kind** | The entry's type (`CatalogKind`, string-backed, registry-driven). **Every Companion lore file that carries `key:` tokens is a kind** (decided Q1); quests + deeds ship first, the rest follow via the harvester registry within the same epic. |
+| **TextSlot** | One translatable position within an entry: `(Role, ObjectiveIndex?, SortOrder)` → `(FileId, GossipId)`. The join to the Translation row is **logical by key**, never an FK — the row may not exist (dangling). |
+| **Role** | The slot's semantic function. **Curated taxonomy for quests/deeds** (derived from XML structure): `Name`, `Description`, `Bestowal`, `Objective`, `ObjectiveDialog`, `ObjectiveProgress`, `Billboard`, `LoreInfo`; **attribute-derived for registry kinds** (e.g. `description`, `pluralName`, `title`). Stored as a bounded string. |
+| **Harvester registry** | Code-side (static) per-file config for the long-tail kinds: file name → kind, record element, id/name/category attributes. One registry row + one fixture per kind — no per-kind parser code. |
+| **Companion dataset** | One uploaded snapshot of LOTRO Companion's `lore/*.xml` files (e.g. "Update 48.5"). Replace-per-kind on import; carries a freeform label + import stats. |
+| **Dangling slot** | A slot whose `(FileId, GossipId)` matches no live Translation row (version skew or our soft-removal). Kept, counted, hidden from progress denominators. |
+| **Membership** | The reverse view: the catalog entries (+roles) a given translation row belongs to. One row can belong to many entries; most rows belong to none ("uncategorized"). |
+| **Entry progress** | Per-entry counters over its non-dangling slots: `Total / Approved / Draft / NeedsReview / Untranslated`. "Complete" = all Approved. |
+
+## In scope
+
+- **Reference-data model** (new tables, additive migration): `CatalogEntries` (DID PK, Kind, Name,
+  Category, Level) + `CatalogTextSlots` (EntryDid, Role, ObjectiveIndex?, SortOrder, FileId,
+  GossipId) + `CompanionDatasets` (import audit: label, counts, ImportedAt, ImportedById).
+  Modeled as **imported reference data, not a DDD aggregate** (no behavior, no user mutation;
+  ADR-0007's spirit) — the modeling decision gets its own ADR at implementation start (M7-01).
+- **Import slice** `POST /api/v1/catalog-entries/import` (Admin): multipart **zip** upload
+  containing any subset of Companion's `lore/*.xml` files (+ optional `enums/*.xml`,
+  `labels/en/enum-*.xml` for category names). Streaming parse (`XmlReader`), all-or-nothing
+  **replace per imported kind** in one transaction, bulk write via a COPY port (ADR-0011 idiom),
+  summary with dangling/matched counts per kind.
+- **Two-tier parsing (decided Q1 — "everything with tokens"):** tier 1 = curated mappers for
+  `quests.xml` and `deeds.xml` (rich role taxonomy, objective structure); tier 2 = the
+  **harvester registry** for every other token-bearing lore file (items, NPCs, skills, traits,
+  titles, emotes, factions, dungeons, mobs, effects, recipes, sets, …): entry = the registry's
+  record element (DID + inline name), slots = its `key:` token attributes with attribute-derived
+  roles. Files with no tokens (e.g. `geoAreas.xml` — inline names) are not kinds.
+- **Read surface** (anonymous read, mirroring `/translations` browsability):
+  `GET /api/v1/catalog-entries` (kind/category/search/progress filters, paged, per-entry progress
+  counters), `GET /api/v1/catalog-entries/{did}` (ordered slots joined to translation rows),
+  `GET /api/v1/catalog-entries/categories?kind=`, entry **memberships on
+  `GET /api/v1/translations/{id}`**, and `GET /api/v1/catalog-entries/stats` (coverage by
+  kind+category — dashboard food).
+- **Frontend (Blazor SSR, purity-gated):** catalog browser page (`/catalog` — kind dropdown, not
+  tabs: the kind list is registry-sized), catalog entry page (`/catalog/{did}`: slots grouped by
+  role with status badges, links into the existing editor, **entry-scoped bulk approve** posting
+  to the existing bulk endpoint), editor gains catalog context (breadcrumb + prev/next slot +
+  "next untranslated in this entry").
+- **Attribution (decided Q4):** a visible credit in the frontend footer/about — "catalog
+  structure data: LOTRO Companion" with a link; reaching out to the maintainer (Discord/forum) is
+  an epic-level human checklist item for Artur, not a code ticket.
+- **Tests:** golden Companion XML fixtures (trimmed real quests/deeds incl. an argful text and a
+  multi-objective quest), parser unit tests, import/list/detail/membership integration tests
+  against real PostgreSQL, one E2E browser scenario (import → browse → translate a quest
+  atomically → bulk approve → artifact contains the rows).
+
+## Out of scope
+
+- **Name slots for kinds whose XML carries no name token.** Quests/deeds emit `rawName`
+  (`key:T:K`); some kinds (observed: items) expose the name only as an inline string + DID-keyed
+  label, which carries no `(FileId, GossipId)`. Those kinds get description/pluralName/… slots
+  but **no Name slot** — and there is **no text-matching fallback** (join on keys, never text).
+  Honest per-kind coverage; revisit only if a deterministic name source appears.
+- **Auto-fetch from the `lotro-data` GitHub repo** — decided (Q2): the epic ships
+  admin-uploads-a-zip, same trust and offline model as `exported.txt`. A "fetch latest from
+  GitHub" button is a named fast-follow after the epic.
+- **Wiki features** — rewards, prerequisites, quest chains/arcs, maps, icons, NPC pages.
+  We import *text structure*, not the game encyclopedia.
+- **Glossary** (#31) — unchanged, separate backlog item. The old #38 bundled it; this spec
+  supersedes only the quest-browser half of #38.
+- **`labels/pl` reverse export to Companion** — strategically sweet (their RU/ES precedent shows
+  the mechanism), explicitly post-MVP; noted in the knowledge-base doc.
+- **Per-game-version catalog history** — one current dataset, replace-per-kind; no snapshots
+  (anti-bloat, mirrors spec 0001 §Storage).
+- **No change** to the `||` contract, the patcher, the import/diff of `exported.txt`, statuses,
+  approve/upsert semantics, or the distribution artifact. The catalog is a **lens**: it never
+  mutates translations. Catalog import does **not** trigger an artifact rebuild (ADR-0021's
+  triggers are unchanged — the distributed set is untouched).
+
+## Business rules & edge cases
+
+### Import & dataset lifecycle
+
+- Upload is a zip; the importer locates known file names at any depth (`quests.xml`, `deeds.xml`,
+  every registered harvester file, enum/category files). Unknown zip entries are ignored. A zip
+  containing **no** known token-bearing file → 422 (nothing to import). Present kinds are
+  imported; absent kinds keep their current data (**replace-per-kind**, so a quests+deeds-only
+  zip never wipes items and vice versa).
+- All-or-nothing: any XML parse failure, malformed token (`key:<int>:<int>` regex), or DID
+  outside the positive-int range rejects the whole upload (422, ProblemDetails with collected
+  errors capped like the text import). No partial datasets.
+- Re-upload of the same zip is idempotent (replace-per-kind is inherently so). Concurrent import
+  requests: last-commit-wins inside the transaction; imports are admin-only and rare (per game
+  update) — no extra locking beyond the transaction.
+- Unknown *attributes/elements inside known files* are skipped silently (their schema evolves —
+  e.g. new reward types must not break us); only the whitelisted role-bearing attributes are
+  read. A file yielding **zero** entries is treated as malformed (422), not as "delete all".
+- Entry fields: `Name` = inline English `name=` attribute (display convenience; its *translation*
+  lives in the `Name` slot via `rawName`'s token). `Category` = resolved English enum label when
+  the enum files are present in the zip, else the raw code as string. `Level` = `level=` when
+  present.
+- The dataset row records: freeform label (admin-entered, e.g. "24.9 / U48.5"), counts
+  (entries, slots, matched, dangling, per kind), `ImportedAt`, `ImportedById`. History appends;
+  the newest row is "current" (display-only metadata — slots/entries themselves are the truth).
+- **No GameVersion coupling.** Companion data lags or leads our export by design (their 48.5/48.8
+  vs our 48.7 — both observed). Version skew materializes as dangling slots, which is normal
+  operation, not an error. The dangling fraction in the summary is the admin's health signal.
+
+### The join & the lens invariant
+
+- Slot → row join is **by `(FileId, GossipId)`** against the existing unique index — never by
+  text (their argument rendering differs: `${PLAYER}` vs `<--DO_NOT_TOUCH!-->`), never by FK.
+- Dangling slots (no live row, or the row is soft-removed `RemovedInVersion != null`): rendered
+  greyed-out in the entry view, **excluded from progress denominators**, counted in the import
+  summary and the entry payload (`MissingSlots`).
+- One row may appear in many entries (shared strings) — memberships are a list. Rows with no
+  membership remain exactly where they are today: the flat list. **Nothing about the flat
+  workflow regresses.**
+- The layer never writes to `Translations`. Upsert/approve/bulk-approve flows are reused as-is
+  (entry bulk approve posts translation ids to the existing endpoint; quests average ~12 slots,
+  and if an outlier ever exceeds the endpoint's 100-id cap, the frontend loader posts in batches —
+  no endpoint change).
+
+### Browsing & progress
+
+- Catalog list default sort: `Category, Level, Name` with `Did` tiebreaker (total order — the
+  AUDIT-EF-03 lesson); sortable by name/level/category/progress; offset pagination mirroring
+  `ListTranslations` (`PageSize` clamp 1..100).
+- Filters: `kind` (single-select dropdown, default `Quest` — the kind list is registry-sized, so
+  no tabs), `category`, `search` (entry **name**, trigram ILIKE), `progress`
+  (`untouched | inProgress | complete`).
+- **Progress bar = Approved / total live slots (decided Q3)** — "done" means shippable in the
+  distributed artifact. Draft and NeedsReview appear as secondary counters, never in the bar.
+- Progress counters are computed on read (GROUP BY join over the page's entries — bounded by
+  page size × slots/entry); the coverage **stats** endpoint aggregates by kind+category. If the
+  landing/stats query ever proves hot, caching follows the #354 pattern — not built now (YAGNI).
+- Anonymous visitors get the same read-only browse the flat list already gives (decided Q5);
+  HATEOAS action links appear per role exactly like `ListTranslations` does today.
+
+### Editor integration
+
+- Editor called with `?entry=<did>` renders the catalog breadcrumb ("Quest: The Bird and Baby →
+  Objective 1 dialog"), prev/next slot links in `SortOrder`, and "next untranslated slot in this
+  entry". Without the param, the editor is byte-for-byte today's editor (deep links and the flat
+  list keep working).
+- Translation detail (API + editor page) lists memberships: kind, name, role, link back to the
+  catalog entry page.
+
+## Contract
+
+- **Import:** `POST /api/v1/catalog-entries/import` — multipart zip + form field `datasetLabel`
+  (Admin; `DisableAntiforgery` like the text import; size cap via settings, default 100 MB
+  compressed). Response `CatalogImportSummary { DatasetLabel, PerKind: [{ Kind, Entries, Slots,
+  MatchedSlots, DanglingSlots }], Warnings }`. Errors: 400 validation / 401 / 403 / 422
+  malformed-or-empty (ProblemDetails).
+- **List:** `GET /api/v1/catalog-entries?kind=Quest&category=&search=&progress=&sort=&page=&pageSize=`
+  → `PaginationResponse<CatalogEntryListItemResponse>` where the item =
+  `{ Did, Kind, Name, Category, Level, Progress { TotalSlots, Approved, Draft, NeedsReview,
+  Untranslated, MissingSlots } }` + HATEOAS links.
+- **Detail:** `GET /api/v1/catalog-entries/{did:int}` → `CatalogEntryDetailResponse { Did, Kind,
+  Name, Category, Level, Progress, Slots: [ { SortOrder, Role, ObjectiveIndex?, FileId, GossipId,
+  Translation?: { Id, Status, SourceText, TranslatedText } } ] }` (`Translation: null` =
+  dangling). 404 unknown DID.
+- **Categories:** `GET /api/v1/catalog-entries/categories?kind=Quest` → distinct category strings.
+- **Stats:** `GET /api/v1/catalog-entries/stats` → coverage rows by kind+category (counts as in
+  Progress).
+- **Membership:** `GetTranslation` response gains
+  `Memberships: [{ Did, Kind, Name, Role, ObjectiveIndex? }]` (empty list for uncategorized).
+- **Frontend routes:** `/catalog` (browser), `/catalog/{did}` (entry incl. the bulk-approve
+  form), editor `?entry=` context. All SSR-pure (forms + GET links only).
+- **Files touched:** none outside the TMS. No `||` format change, no patcher change, no artifact
+  schema change. New EF migration is **additive only** (three new tables + indexes) — trivially
+  N-1 compatible (ADR-0023).
+
+## Acceptance criteria
+
+- [ ] Importing the golden fixture zip creates the expected entries + slots with correct roles,
+      objective indexes, document order, and category names; the summary's matched/dangling
+      counts equal the fixture's designed truth.
+- [ ] The Bird & Baby fixture quest's slots resolve — via pure key join — to seeded translation
+      rows (name, description, bestowal, objective, dialog, progress), proving the end-to-end
+      join in an integration test.
+- [ ] Re-importing the identical zip is a no-op state-wise (idempotent); importing a
+      quests-only zip leaves deeds untouched (replace-per-kind).
+- [ ] Malformed XML, malformed token, or zero-entry file → 422, database state intact
+      (all-or-nothing).
+- [ ] Catalog list: filters (kind/category/search/progress) and sorts return correct, totally
+      ordered pages; progress counters match the seeded row statuses; a dangling slot never
+      inflates a denominator.
+- [ ] Catalog entry detail: slots in document order, dangling slots flagged, translation snippets
+      and statuses correct; unknown DID → 404.
+- [ ] Translation detail lists correct memberships; an uncategorized row returns an empty list.
+- [ ] Entry-scoped bulk approve approves exactly the entry's approvable slots (existing endpoint
+      semantics: skips report as skipped) and the artifact converges to include them
+      (poll-with-timeout per ADR-0021 test idiom).
+- [ ] Catalog import alone never schedules an artifact rebuild and never mutates any
+      `Translations` row (byte-identical rows incl. timestamps).
+- [ ] A registry-kind fixture (items) harvests exactly its token-bearing attributes as slots
+      (description/pluralName), invents **no** Name slot, and lands under its own kind without
+      touching quest/deed data (replace-per-kind proof across tiers).
+- [ ] The frontend shows the LOTRO Companion credit (footer/about) once catalog pages ship.
+- [ ] Authorization: import is Admin-only (403 for translator — the wrong-role matrix extends per
+      AUDIT-TEST-02); reads are anonymous; SSR purity gate stays green with the new pages.
+- [ ] E2E: upload fixture → browse `/catalog` → open the quest → translate two slots via the
+      editor (with breadcrumb/next-slot nav) → bulk approve on the entry page → downloaded
+      artifact contains the rows.
+
+## Open questions
+
+### Empirical — answered (sources: `docs/knowledge-base/lotro-companion-data-model.md`)
+
+- *Can our rows be deterministically grouped into game objects?* **Yes.** Companion's XML
+  carries `key:<FileId>:<GossipId>` on every translatable field; verified in their generator code
+  (`I18nUtils.getKey`), in published data, and against our live 792,509-row export (Bird & Baby
+  probe). Roles derive from XML structure.
+- *Do we need their label files / their DAT parser?* **No.** English source comes from our own
+  export; structure comes from the lore XML alone; their `lotro-dat-utils` is closed-source and
+  irrelevant to us.
+- *How fresh is their data and how do we get it?* The `lotro-data` GitHub repo is the live
+  dataset, updated within days of each LOTRO patch (48.8 on 2026-07-01); raw-file fetch or repo
+  zip. Items live in `lotro-items-db`.
+- *What breaks on version skew?* Nothing — skew manifests as dangling slots (both directions),
+  tolerated by design. `[needs live test]` only in the mild sense that each future game update
+  re-confirms the dangling fraction stays small; the import summary surfaces it.
+- *Token width?* Their tokens are Java `int`; our `GossipId` is `long` — superset, safe.
+
+### Business decisions — resolved by the user, 2026-07-06
+
+- **Q1 — Kinds: everything with tokens.** Every token-bearing Companion lore file becomes a
+  kind. Realized as two tiers: curated quest/deed mappers first (the epic's core loop + DoD),
+  then the harvester-registry long tail (items, NPCs, skills, traits, titles, emotes, factions,
+  dungeons, mobs, effects, recipes, sets, …) as dedicated tickets **inside the same epic**.
+  Schema and API are kind-generic from day 1; adding a kind is a registry row + fixture.
+- **Q2 — Acquisition: admin uploads a zip** (same trust/offline model as `exported.txt`).
+  "Fetch latest from GitHub `lotro-data`" = named fast-follow after the epic.
+- **Q3 — Progress: the bar counts Approved only** ("done" = shippable in the artifact);
+  Draft/NeedsReview are secondary counters.
+- **Q4 — Attribution: visible UI credit + contact the maintainer.** Footer/about credit ships
+  with the frontend tickets; reaching out (Discord/forum — also seeding the future `labels/pl`
+  contribution) is Artur's checklist item on the epic issue.
+- **Q5 — Anonymous browsing: yes** — catalog browser/detail/stats are public read-only, exactly
+  like `/translations`; writes stay role-gated.
+- **Naming (amendment, same day):** the layer's concept is **CatalogEntry** (tables
+  `CatalogEntries`/`CatalogTextSlots`, routes `/api/v1/catalog-entries` + `/catalog`) — the word
+  "entity" is banned in this layer to avoid the DDD-Entity misconception (this data is
+  deliberately *not* domain-modeled; see the M7-01 ADR).
+
+## Assumptions
+
+- One current Companion dataset at a time (per kind); no per-version catalog snapshots.
+- Import cadence ≈ once per game update, admin-driven, single-flight; volumes (≈20k entries /
+  ≈220k slots for quests+deeds; estimated ≈250k entries / ≈300–500k slots at full registry
+  coverage) sit comfortably in the COPY-import envelope proven at 792k rows.
+- Companion's XML schema evolves additively in practice; the importer whitelists what it reads
+  and warns rather than breaks on novelty inside known files.
+- The existing editor, upsert, approve, bulk-approve, artifact and distribution slices remain the
+  single write path for translation content.
+- DIDs fit positive `int` by construction (0x70-band ends at `int.MaxValue`).
+
+## Impact on existing docs & backlog (applied 2026-07-06)
+
+- **Tickets:** epic **M7** cut (#362 tracking + #363–#375, dependency-ordered); #30 closed as
+  superseded-by-M7 (its `key:{file_id}:{gossip_id}` premise is now proven and absorbed); #38
+  re-scoped to its glossary half (quest browser moved to M7).
+- **CLAUDE.md:** Roadmap gains M7 (game-content catalog); read-first routing points at spec 0008
+  + the knowledge-base doc for anything touching the catalog layer.
+- **ADR:** new ADR at M7-01 start — "Game-content catalog is imported reference data (persistence
+  models + read models + COPY port; no domain aggregate)" with the per-kind-replace decision and
+  the no-"entity" naming rule.
+- **Knowledge base:** `lotro-companion-data-model.md` committed (2026-07-06).
+
+## Epic cut (M7 — GitHub issues #362–#375)
+
+| # | Issue | Ticket | Depends on | Scope |
+|---|---|---|---|---|
+| M7-00 | #362 | [Epic] tracking issue | — | DoD = the E2E criterion of this spec |
+| M7-01 | #363 | ADR + reference-data model: tables, migration, read models, indexes | — | `CatalogEntries`, `CatalogTextSlots` (+ `(FileId, GossipId)` index), `CompanionDatasets` |
+| M7-02 | #364 | Companion parsing core + quest mapper + golden fixtures | #363 | token parser, streaming `XmlReader` walker, role taxonomy, Bird & Baby + argful + multi-objective fixtures |
+| M7-03 | #365 | Deed mapper + enum/category resolution | #364 | deeds.xml, `QuestCategory`/`DeedCategory` enum + label files, category fallback |
+| M7-04 | #366 | Import slice: zip intake → replace-per-kind → COPY → summary | #364, #365 | guards (422s), idempotence, dangling stats, integration tests, wrong-role 403 |
+| M7-05 | #367 | Catalog list + categories endpoints (filters, paging, progress) | #363 | read models, aggregation, HATEOAS, integration tests |
+| M7-06 | #368 | Catalog entry detail + translation memberships | #363 | ordered slots, dangling flags, `GetTranslation.Memberships`, tests |
+| M7-07 | #369 | FE: catalog browser `/catalog` + Companion credit | #367 | SSR list, filters, progress bars |
+| M7-08 | #370 | FE: catalog entry `/catalog/{did}` + entry bulk approve | #368 | slots by role, status badges, editor links, bulk-approve form |
+| M7-09 | #371 | FE: editor catalog context | #368 | breadcrumb, prev/next, next-untranslated |
+| M7-10 | #372 | Coverage stats endpoint + dashboard widget | #367 | by kind+category |
+| M7-11 | #373 | E2E: atomic quest translation loop | #366, #369–#371 | Playwright scenario per the E2E acceptance criterion |
+| M7-12 | #374 | Harvester registry + items kind | #366 | generic token harvester over registry config; `items.xml` (149,710 records — descriptions/pluralName, **no Name slot**); fixture + integration tests |
+| M7-13 | #375 | Long-tail kinds via registry | #374 | NPCs, skills, traits, titles, emotes, factions, dungeons, mobs, effects, recipes, sets, … — one registry row + fixture each; kind dropdown fed from data |


### PR DESCRIPTION
## What

Docs-only groundwork for the **M7 epic #362** (game-content catalog):

- **`docs/specs/0008-game-content-catalog-layer.md`** — the agreed spec (all five business decisions resolved 2026-07-06): catalog entries over the flat translation rows, two-tier Companion import (curated quest/deed mappers + harvester registry for everything with tokens), admin zip acquisition, Approved-based progress, translation memberships, the epic cut #363–#375. Naming rule: **CatalogEntry, never "entity"** (DDD-Entity misconception).
- **`docs/knowledge-base/lotro-companion-data-model.md`** — the empirical foundation: the `key:<FileId>:<GossipId>` join verified three ways (their generator code, their published data, our live 792,509-row 48.7 export), record inventory per kind, acquisition paths, caveats (join on keys never text, dangling tolerance, no-Name-slot kinds).
- Knowledge-base README index entry; CLAUDE.md roadmap M7 + read-first routing row.

## Why

The epic's constitution must live on `main` before sprint work starts (the backlog loop reads specs/CLAUDE.md from a fresh clone of main).

Part of #362 (does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)