### PR TITLE
Loop: default the headless ticket loop to the account1 Claude config

### DIFF
--- a/scripts/claude/backlog-loop.sh
+++ b/scripts/claude/backlog-loop.sh
@@ -12,6 +12,7 @@
 #   caffeinate -is scripts/claude/backlog-loop.sh   # overnight on macOS (blocks sleep)
 #
 # Env (all forwarded to work-ticket.sh): LOOP_EFFORT (default max), LOOP_MODEL (default opus),
+#   LOOP_CONFIG_DIR (default ~/.claude-account1 — which account runs the loop),
 #   LOOP_PERMISSION_MODE (default auto), LOOP_UNSAFE, LOOP_MAX_BUDGET_USD,
 #   LOOP_TICKET_TIMEOUT_MIN, LOOP_CHECKS_TIMEOUT_MIN, LOOP_SKIP_LABELS. Loop-only:
 #   LOOP_LIMIT_SLEEP_MIN (default 60), LOOP_LIMIT_RETRIES (default 4),

--- a/scripts/claude/work-ticket.sh
+++ b/scripts/claude/work-ticket.sh
@@ -11,6 +11,8 @@
 #   LOOP_EFFORT             claude effort level (default: max)
 #   LOOP_MODEL              model (default: opus — Opus 4.8; its 1M-token context window is
 #                           native/standard, no [1m] variant or long-context premium involved)
+#   LOOP_CONFIG_DIR         Claude config dir = which account runs the loop
+#                           (default: ~/.claude-account1)
 #   LOOP_PERMISSION_MODE    default: auto, plus a loop-scoped --allowedTools Bash allowlist
 #                           (git/gh/dotnet/scripts — see LOOP_ALLOWED_TOOLS below); this does NOT
 #                           widen permissions of your interactive sessions
@@ -33,6 +35,7 @@ mkdir -p "$RUN_DIR"
 
 EFFORT="${LOOP_EFFORT:-max}"
 MODEL="${LOOP_MODEL:-opus}"
+export CLAUDE_CONFIG_DIR="${LOOP_CONFIG_DIR:-$HOME/.claude-account1}"
 PERMISSION_MODE="${LOOP_PERMISSION_MODE:-auto}"
 TIMEOUT_MIN="${LOOP_TICKET_TIMEOUT_MIN:-90}"
 CHECKS_TIMEOUT_MIN="${LOOP_CHECKS_TIMEOUT_MIN:-30}"


### PR DESCRIPTION
## What
`work-ticket.sh` now exports `CLAUDE_CONFIG_DIR` with a default of `~/.claude-account1`; override per run with `LOOP_CONFIG_DIR`. Env docs updated in both loop scripts.

## Why
The loop used whatever account the shell defaulted to, so overnight runs silently ran (and burned limits) on the main account. This encodes the intended default instead of relying on remembering to set it per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)