### PR TITLE
Dockerfile: use one form of the non-root user across the app images

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=publish /app/publish .
 # (host-default location), so this directory is unused there.
 USER root
 RUN mkdir -p /keys && chown app:app /keys
-USER app
+USER $APP_UID
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8080/health/live || exit 1

--- a/src/Frontend/LotroKoniecDev.Frontend/Dockerfile
+++ b/src/Frontend/LotroKoniecDev.Frontend/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=publish /app/publish .
 # this directory is unused there.
 USER root
 RUN mkdir -p /keys && chown app:app /keys
-USER app
+USER $APP_UID
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8080/ || exit 1

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Dockerfile
@@ -39,8 +39,6 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 
-USER app
-
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8080/health/live || exit 1
 


### PR DESCRIPTION
The three app Dockerfiles disagreed on how the final stage names the runtime user:

| File | `base` stage | `final` stage (before) |
|---|---|---|
| `TranslationSystem.API` | `USER $APP_UID` | `USER app` |
| `AuthSystem.API` | `USER $APP_UID` | `USER root` → mkdir/chown → `USER app` |
| `Frontend` | `USER $APP_UID` | `USER root` → mkdir/chown → `USER app` |
| `Dockerfile.migrator.prod` | — | `USER $APP_UID` |

Both forms select the same identity. The `mcr.microsoft.com/dotnet/aspnet:10.0` base image sets `ENV APP_UID=1654` and ships user `app` with `uid=gid=1654`, verified against the live image:

```
$ docker run --rm --entrypoint sh mcr.microsoft.com/dotnet/aspnet:10.0 -c "echo $APP_UID; id app"
1654
uid=1654(app) gid=1654(app) groups=1654(app)
```

## What changed

- **Auth + Frontend:** `USER app` → `USER $APP_UID`.
- **TMS:** the `USER app` line is deleted outright. It was dead — `final` derives `FROM base`, which already dropped to `$APP_UID`. Auth and Frontend still need the line because they pass through `USER root` to create `/keys`.

## Why `$APP_UID` and not `app`

It is already the majority form (all three `base` stages plus `Dockerfile.migrator.prod`), it is what the Microsoft project template emits, and `.docker/trust-ca-entrypoint.sh` reads the same variable for its `setpriv --reuid`. A numeric UID also lets an orchestrator verify `runAsNonRoot` without resolving `/etc/passwd`, which a name-form `USER` cannot support.

## Why `chown app:app /keys` stays name-based

Deliberate, not an oversight. `chown` by name resolves uid and gid together, so it avoids baking in an assumption that `gid == uid`. `trust-ca-entrypoint.sh` makes the same hedge explicit in its comment (`APP_GID` defaults to `APP_UID` only as a convenience).

## Verification

No full image build — the diff touches nothing before the `final` stage. Two probe images against the real base instead:

1. `FROM base AS final` with no `USER` restated → runtime user is `uid=1654(app)`, proving the deleted TMS line was a no-op.
2. The Auth/Frontend shape (`USER root` → `mkdir`/`chown` → `USER $APP_UID`) → `/keys` is owned by `app` and writable by `app` at runtime.

No behavior change; consistency and one dead instruction removed.