### PR TITLE
AUDIT-SEC-08: gate the autonomous loop on issue provenance — only maintainer-written tickets may drive it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
       - name: Migration-safety guard
         run: ./scripts/check-migration-safety.sh HEAD^1
 
+      # Same provenance-gate self-test as pr-verify (ADR-0026) — backstops direct pushes to main.
+      - name: Backlog-loop provenance gate self-test
+        run: ./scripts/tests/claude-loop-provenance.tests.sh
+
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -57,13 +57,15 @@ jobs:
           # the SSR guard. NEVER add a build input here (.editorconfig, Directory.*.props/.targets,
           # global.json, nuget.config, test fixtures) — that would be a false green.
           inert='\.md$|^docs/|^LICENSE$|^\.gitignore$|^\.gitattributes$|\.sh$|\.ps1$|^iac/|(^|/)Dockerfile(\.migrator(\.prod)?|\.tests)?$|^compose[^/]*\.ya?ml$|^\.docker/|^\.github/|^\.run/|^\.vscode/|^\.idea/|(^|/)\.env[^/]*\.example$'
-          # Build-relevant despite matching `inert`: check-ssr-purity.sh and the migration-safety
-          # guard + its self-test are EXECUTED by the build job (the .ps1 twin runs through the
-          # self-test's pwsh leg), and pr-verify/ci define the .NET gate itself — a change to any
-          # of them must run the gate so it validates its own new definition. Dockerfiles join them
-          # because the restore-graph guard now reads them: a Dockerfile-only PR that drops a
-          # COPY ["…csproj"] line must still face the gate that catches it.
-          force_build='^scripts/check-ssr-purity\.sh$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|(^|/)Dockerfile(\.migrator(\.prod)?|\.tests)?$|^\.github/workflows/pr-verify\.yml$|^\.github/workflows/ci\.yml$'
+          # Build-relevant despite matching `inert`: check-ssr-purity.sh, the migration-safety
+          # guard + its self-test, the Docker restore-graph guard, and the backlog loop's
+          # provenance gate + its self-test are EXECUTED by the build job (the .ps1 twins run
+          # through the migration self-test's pwsh leg), and pr-verify/ci define the .NET gate
+          # itself — a change to any of them must run the gate so it validates its own new
+          # definition. Dockerfiles join them because the restore-graph guard now reads them: a
+          # Dockerfile-only PR that drops a COPY ["…csproj"] line must still face the gate that
+          # catches it.
+          force_build='^scripts/check-ssr-purity\.sh$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|^scripts/claude/(issue-trust|next-ticket|work-ticket)\.sh$|^scripts/tests/claude-loop-provenance\.tests\.sh$|(^|/)Dockerfile(\.migrator(\.prod)?|\.tests)?$|^\.github/workflows/pr-verify\.yml$|^\.github/workflows/ci\.yml$'
           code=true
           if files="$(git diff --name-only HEAD^1 HEAD)"; then
             build_relevant="$(printf '%s\n' "$files" | grep -vE "$inert" || true)"
@@ -118,6 +120,13 @@ jobs:
 
       - name: Migration-safety guard
         run: ./scripts/check-migration-safety.sh HEAD^1
+
+      # The backlog loop's issue-provenance gate (ADR-0026) is what keeps attacker-authored text
+      # on this public repo from becoming the task of an agent that auto-merges to main. It runs
+      # on the maintainer's machine, never in CI — this offline self-test is the only thing that
+      # stops it rotting green.
+      - name: Backlog-loop provenance gate self-test
+        run: ./scripts/tests/claude-loop-provenance.tests.sh
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,8 +484,11 @@ hygiene), and one ticket = one fresh context (cost + quality).** Different rules
 
 **The loop is a SCRIPT, not a session — `scripts/claude/backlog-loop.sh` (the conductor).**
 Deterministic bash picks the next ready ticket (`next-ticket.sh`: priority labels + the
-`Depends on #X` gate + skip rules for qa/post-mvp/Windows-only work) and runs it to completion in
-a **fresh headless process** (`work-ticket.sh` → `claude -p "/work-ticket <n>"`). The per-ticket
+`Depends on #X` gate + skip rules for qa/post-mvp/audit/Windows-only work) and runs it to completion in
+a **fresh headless process** (`work-ticket.sh` → `claude -p "/work-ticket <n>"`). This repo is
+public, so **only maintainer-written tickets may drive the loop**: `issue-trust.sh` refuses any
+issue whose author *or any commenter* lacks write access, fails closed, and is enforced in front of
+the session — naming a ticket explicitly cannot bypass it (ADR-0026). The per-ticket
 session does the whole slice — spec weight, branch, implement, tests, `code-reviewer` gate,
 commit → push → PR — then **dies**; the runner judges only its final `STATUS: DONE|BLOCKED` block,
 waits for pr-verify, squash-merges (**never `--delete-branch`** — branches are kept), syncs main,

--- a/docs/adr/0026-issue-provenance-gate-for-the-autonomous-loop.md
+++ b/docs/adr/0026-issue-provenance-gate-for-the-autonomous-loop.md
@@ -1,0 +1,187 @@
+# ADR-0026: Issue provenance gate — only maintainer-written text may drive the autonomous loop
+
+**Status:** Accepted
+**Date:** 2026-07-09
+**Decision-makers:** Solo maintainer
+**Related:** ticket #398 (AUDIT-SEC-08), `docs/claude-loop.md` (the loop manual — Safety model),
+`scripts/claude/issue-trust.sh` (the gate), `scripts/claude/next-ticket.sh` (picker),
+`scripts/claude/work-ticket.sh` (per-ticket runner), `.claude/commands/work-ticket.md` (the worker
+prompt whose contract makes comments authoritative), CLAUDE.md ("Loop mode" — the standing
+commit/push/PR/merge authorization this ADR bounds).
+
+## Context
+
+`koniecdev/LotroKoniecDev` is a **public** repository: anyone with a GitHub account can open an
+issue on it and comment on any existing one. The autonomous backlog loop turns issues into merged
+commits on `main` with no human step in between:
+
+- `next-ticket.sh` picks the next ready issue. Before this ADR it excluded only the labels
+  `loop-blocked,qa,post-mvp`, `[Epic]`/`[Tracking]` titles, and issues with an open
+  `Depends on #X`. It never looked at **who wrote the issue**, and it required no label at all —
+  an unlabeled issue simply sorted last (`else 4`) and was still eligible.
+- `work-ticket.sh` feeds `/work-ticket <n>` to a fresh headless Claude whose Bash allowlist
+  already contains `git`, `gh`, `dotnet` and `scripts/*`; `LOOP_UNSAFE=1` grants everything.
+- Once `pr-verify` is green the same script **auto-squash-merges the PR into `main`** with no
+  human review.
+
+`/work-ticket` reads the issue title, body **and comments** as its task, and its own contract says
+*"later comments override the body"*. Two facts follow:
+
+- **Attacker-authored text is one hop from `main`.** An outsider's issue is a prompt-injection
+  channel into an agent that has write access and merges itself. `gitleaks` blocks committed
+  secrets and CodeQL catches some patterns, but a logic backdoor or a data-exfil step is not
+  guaranteed to be caught by CI.
+- **The author is not the only writer.** Even if every issue were maintainer-authored, anyone can
+  append a comment to a maintainer's ticket — and the worker is told to prefer it over the body.
+
+Constraints that shape the fix:
+
+- **GitHub already computes the trust signal.** The REST issue and issue-comment payloads carry
+  `author_association` (`OWNER` / `MEMBER` / `COLLABORATOR` = write access; `CONTRIBUTOR`,
+  `FIRST_TIME_CONTRIBUTOR`, `MANNEQUIN`, `NONE` = no write access). It is evaluated per read, so
+  it tracks permission changes with no state of our own.
+  `gh issue list --json` does **not** expose it — only `gh api` does.
+- **Labels are already a maintainer-only signal** (applying one needs triage/write access), so
+  "carries label X" is a usable second gate — but it is a weaker, indirect statement of the same
+  fact the association states directly.
+- **The picker is not the trust boundary.** `backlog-loop.sh 123 130` (explicit ticket list) and a
+  bare `work-ticket.sh 123` never call `next-ticket.sh`. Gating only the picker would be cosmetic.
+- **The `audit` label already claims a human gate it never had.** Its description reads
+  *"Finding from an autonomous audit session — triage before /backlog"*, yet it was absent from
+  `LOOP_SKIP_LABELS`.
+
+## Decision
+
+### 1. Trust is a property of every writer, checked against `author_association`
+
+An issue is **trusted** when its author *and every one of its comment authors* has an
+`author_association` in `LOOP_TRUSTED_ASSOCIATIONS` (default `OWNER,MEMBER,COLLABORATOR`) or a
+login in `LOOP_TRUSTED_LOGINS` (default empty — the hook for a second maintainer account or a bot).
+Checking comments is not defense-in-depth padding: the worker's own contract makes the last comment
+the most authoritative text in the ticket, so an unchecked comment channel would leave the gate
+decorative on exactly the tickets an attacker would target.
+
+### 2. The check is one script, `scripts/claude/issue-trust.sh`, and it fails closed
+
+One source of truth for the policy, callable from anywhere: exit `0` trusted, `1` untrusted writer,
+`2` error. A missing association, an unknown association, a malformed argument, or **any** GitHub
+API failure exits non-zero. A rate-limited or offline `gh` therefore means "refuse", never
+"proceed". All diagnostics go to stderr so callers keep their own stdout contract (the picker's
+stdout is still exactly one issue number).
+
+### 3. The gate is enforced where untrusted text meets the LLM — `work-ticket.sh` — and mirrored in the picker
+
+`work-ticket.sh` calls the gate **before it spawns the session** and exits `11` on an untrusted
+writer, so an explicitly-named ticket cannot bypass it. `next-ticket.sh` calls the same script per
+candidate so untrusted work is never even selected (and priority cannot outrank provenance: an
+attacker's `critical` ticket loses to a maintainer's `low` one). `backlog-loop.sh` counts an `11` as
+*untrusted*, skips it, and does not charge it against the systemic-failure circuit breaker.
+
+An **unreachable API is not a refusal** — it is systemic. `work-ticket.sh` maps a gate error (exit
+`2`: unauthenticated, rate-limited, offline) to its own exit `3`, so the conductor's
+consecutive-failure breaker stops the run instead of cheerfully "skipping" the whole backlog as
+untrusted. Fail-closed must not become fail-silent.
+
+### 4. `audit` joins the default skip labels; explicit naming is the triage step
+
+`LOOP_SKIP_LABELS` defaults to `loop-blocked,qa,post-mvp,audit`, making the `audit` label's stated
+intent enforceable. This is a *selection* rule, not a security rule: naming an audit ticket
+explicitly (`backlog-loop.sh 391`) still works, and that act of naming **is** the human triage. The
+provenance gate keeps firing on explicitly-named tickets — the two rules are deliberately separate.
+
+### 5. The gate is self-tested offline, in CI
+
+`scripts/tests/claude-loop-provenance.tests.sh` stubs `gh` from fixtures (applying the caller's own
+`--jq` filter with real `jq`, so the scripts' filters are under test too) and asserts the policy,
+the picker's refusal, and that **no `claude` session is spawned** for an untrusted ticket. It runs
+in `pr-verify` and `ci` alongside the migration-safety self-test, so the gate cannot rot green.
+
+## Consequences
+
+### Positive
+
+- Attacker-authored issue text can no longer become the task of an agent that pushes and merges.
+  The blast radius that led this audit sweep is closed at its narrowest point.
+- The rule is one script and one grep-able exit code; every caller (present and future) inherits it.
+- Fail-closed means a degraded GitHub API pauses the loop instead of widening it.
+- The `audit` label finally means what it says.
+
+### Negative / Accepted Trade-offs
+
+- **A single benign outsider comment (a "+1") strands a ticket** for the loop until a human acts.
+  That is the fail-closed behavior we want; the escape hatch is `LOOP_TRUST_GATE=0` (after reading
+  the issue *and* its comments yourself), or `LOOP_TRUSTED_LOGINS`. Note the hatch is **run-wide**,
+  not per-ticket: set it only on an explicitly-named single ticket, never on a drain.
+- **Check-then-use is racy by construction.** The gate reads the comments at T; the worker re-reads
+  the issue at T+Δ (Δ = seconds, the session spawn). A comment appended inside that window on an
+  already-cleared ticket reaches the worker unchecked. Closing it would require GitHub to hand us
+  the text we validated, which the API does not offer. The window is small and the attacker cannot
+  observe when it opens; a wider fix (locking the conversation while the loop runs) is not worth it.
+- **Two extra API calls per candidate ticket** (issue + comments). The picker returns on the first
+  ready ticket, so this is a handful of calls per loop iteration — irrelevant against the rate limit.
+- **`author_association` is a permission proxy, not an identity proof.** A compromised collaborator
+  account still passes. That risk is out of scope here and is not new.
+- The gate protects the *loop*. A human running `/ticket <n>` interactively on a hostile issue is
+  still reading attacker text — but a human is in the loop, which is the whole distinction.
+
+## Alternatives Considered
+
+### A. Author + comment association gate at both the picker and the runner (this ADR)
+
+Direct, uses GitHub's own signal, closes the explicit-naming bypass and the comment channel.
+
+### B. Gate only `next-ticket.sh` (as ticket #398 originally proposed)
+
+Rejected: `backlog-loop.sh 123` and `work-ticket.sh 123` skip the picker entirely, so the gate
+would not hold on the very path a maintainer uses most. The picker check is kept, but as an
+optimization (don't select what would be refused), not as the boundary.
+
+### C. Require a maintainer-only label instead of an author check
+
+Rejected as the primary gate: it works (labels need write access) but states the fact indirectly
+and silently couples the security model to labeling hygiene — an unlabeled maintainer ticket would
+be refused, and a labeled ticket with a hostile comment would pass. Kept as the *selection* rule
+(§4) where that is exactly what is wanted.
+
+### D. Require human approval before every loop merge
+
+Rejected: CLAUDE.md's Loop mode makes commit → push → PR → merge the standing authorization, and
+that is the point of an overnight loop. With the input provenance fixed, the agent is acting on
+maintainer-written instructions again — which is the trust assumption the merge authorization was
+granted under in the first place. If the loop ever runs on tickets from a wider circle, revisit
+this line first.
+
+### E. Sanitize/strip untrusted issue text and run anyway
+
+Rejected: there is no reliable sanitizer for natural-language instructions, and a partial one
+invites trusting it. Refusing is correct and cheap.
+
+## Implementation Notes
+
+- `gh api repos/{owner}/{repo}/issues/<n>` → `.author_association`;
+  `…/issues/<n>/comments --paginate` → `.[].author_association`. `gh issue view --json` has no
+  `authorAssociation` field, which is why the gate uses `gh api` rather than the porcelain.
+- **`--paginate` is load-bearing**: without it only the first 30 comments are checked and a hostile
+  comment posted after 30 benign ones would be invisible. The stub in the self-test models
+  pagination, so deleting the flag turns a test red rather than turning the gate off silently.
+- A deleted author leaves `user: null`. An unidentifiable writer is refused outright — the
+  association alone is never enough. (Splitting the `@tsv` row uses parameter expansion, not
+  `IFS=$'\t' read`, which collapses a leading empty field and would shift the association into the
+  login.)
+- The argument shape-check sits **above** the `LOOP_TRUST_GATE` escape hatch: a guard an env var
+  can switch off is not a guard. `work-ticket.sh` validates the issue number independently.
+- Both the gate and the picker `cd` to their own checkout before calling `gh`, so
+  `repos/{owner}/{repo}` resolves from the repository the scripts live in, not the caller's cwd.
+- Allowlists are normalized (whitespace stripped, upper-cased, empty entries dropped) so a trailing
+  comma in `LOOP_TRUSTED_ASSOCIATIONS` can never admit an empty association. There is a test for it.
+- Exit `11` is new in `work-ticket.sh` and means *untrusted writer*; `backlog-loop.sh` treats it as
+  a skip, not a failure. A gate that cannot reach the API surfaces as the ordinary error exit `3`,
+  and the picker warns loudly rather than reporting the backlog as drained.
+- Every guard above is pinned by a mutation-checked case: removing `--paginate`, the picker gate,
+  the worker's refusal, the ghost-account guard, or the comment loop each turns the suite red.
+
+## References
+
+- Ticket #398 — AUDIT-SEC-08 (the finding, from the `security` audit lens, 2026-07-07).
+- GitHub REST: `author_association` on issues and issue comments.
+- `docs/claude-loop.md` — Safety model, Knobs, Troubleshooting.

--- a/docs/claude-loop.md
+++ b/docs/claude-loop.md
@@ -27,7 +27,8 @@ The only LLM context that ever exists is one sharp per-ticket session.
 |---|---|
 | `scripts/claude/backlog-loop.sh` | the conductor — serial loop, lock, stop conditions, console totals |
 | `scripts/claude/next-ticket.sh` | deterministic picker: priority labels + `Depends on #X` gate + skip rules |
-| `scripts/claude/work-ticket.sh` | one ticket: fresh headless session → judge `STATUS:` → wait for pr-verify → squash-merge → sync main |
+| `scripts/claude/issue-trust.sh` | the provenance gate: refuses an issue written by anyone without write access (ADR-0026) |
+| `scripts/claude/work-ticket.sh` | one ticket: provenance gate → fresh headless session → judge `STATUS:` → wait for pr-verify → squash-merge → sync main |
 | `.claude/commands/work-ticket.md` | the per-ticket discipline prompt (the old `ticket-worker` agent, promoted to a slash command) |
 | `.claude/commands/backlog.md` | `/backlog` in an interactive session = launch the script in background + report the roll-up |
 
@@ -60,15 +61,35 @@ to the loop.
 
 ## What "ready" means (the picker)
 
-Open issue, not `[Epic]`/`[Tracking]`, none of the skip labels, and every `Depends on #X` in the
-body already CLOSED (a ticket is closed by its merged PR, so closed = merged). Order: `critical` >
-`high` > `medium` > `low` > unlabeled, then lowest number first.
+Open issue, not `[Epic]`/`[Tracking]`, none of the skip labels, **written only by trusted
+maintainers** (see the provenance gate below), and every `Depends on #X` in the body already CLOSED
+(a ticket is closed by its merged PR, so closed = merged). Order: `critical` > `high` > `medium` >
+`low` > unlabeled, then lowest number first — but priority never outranks provenance.
 
 Default exclusions (all overridable via env):
 
 - labels `loop-blocked`, `qa` (manual/human passes), `post-mvp` (deliberately cut from MVP),
+  `audit` (audit findings are triaged by a human — name one explicitly to work it),
 - titles matching `^M4-` (the WPF milestone is Windows-only — it cannot build on the macOS host),
 - issue `#85` (M2-18 forum watcher — deferred post-MVP; work it only by naming it explicitly).
+
+## The provenance gate (ADR-0026)
+
+This repo is **public**: anyone can open an issue or comment on one, and `/work-ticket` reads the
+title, body *and comments* as its instructions before the loop auto-merges the result. So every
+path into the worker asks `issue-trust.sh` first:
+
+> An issue is trusted only when its author **and every one of its commenters** has an
+> `author_association` of `OWNER` / `MEMBER` / `COLLABORATOR` (i.e. write access), or a login
+> listed in `LOOP_TRUSTED_LOGINS`.
+
+It **fails closed** — a missing association or any GitHub API failure refuses the ticket. The gate
+runs inside `work-ticket.sh`, not just the picker, so `backlog-loop.sh 123` and a bare
+`work-ticket.sh 123` are gated too; a refused ticket exits `11` and no session is ever spawned.
+A gate that cannot *reach* the API is systemic rather than a property of the ticket, so it surfaces
+as the ordinary error exit `3` and the conductor's circuit breaker stops the run.
+A stranger's harmless "+1" comment will therefore park a ticket: read it yourself, then run that
+one ticket with `LOOP_TRUST_GATE=0`, or add the commenter to `LOOP_TRUSTED_LOGINS`.
 
 ## Knobs (env vars)
 
@@ -82,9 +103,12 @@ Default exclusions (all overridable via env):
 | `LOOP_MAX_BUDGET_USD` | (none) | optional per-ticket API budget cap |
 | `LOOP_TICKET_TIMEOUT_MIN` | `90` | wall-clock kill switch per ticket; leftovers are stashed |
 | `LOOP_CHECKS_TIMEOUT_MIN` | `30` | wait for pr-verify before falling back to `--auto` merge |
-| `LOOP_SKIP_LABELS` | `loop-blocked,qa,post-mvp` | picker label exclusions |
+| `LOOP_SKIP_LABELS` | `loop-blocked,qa,post-mvp,audit` | picker label exclusions |
 | `LOOP_SKIP_TITLES` | `^M4-` | picker title-regex exclusion |
 | `LOOP_SKIP_ISSUES` | `85` | picker number exclusions |
+| `LOOP_TRUSTED_ASSOCIATIONS` | `OWNER,MEMBER,COLLABORATOR` | provenance gate: associations that carry write access |
+| `LOOP_TRUSTED_LOGINS` | (none) | provenance gate: extra logins (a second maintainer account, a bot) |
+| `LOOP_TRUST_GATE` | `1` | `0` = skip the provenance gate **for the whole run** (you read the issue *and* its comments yourself) — use it only on a single explicitly-named ticket |
 | `LOOP_LIMIT_SLEEP_MIN` | `60` | nap length when the usage limit is hit |
 | `LOOP_LIMIT_RETRIES` | `4` | max naps before giving up |
 | `LOOP_MAX_CONSECUTIVE_FAILURES` | `2` | systemic-failure circuit breaker |
@@ -114,9 +138,14 @@ Per-ticket outcomes:
   `claude-loop salvage #<n>` (`git stash list`), main is restored. Two consecutive failures stop
   the whole loop (something systemic).
 - **usage limit** — the loop naps (`LOOP_LIMIT_SLEEP_MIN`) and retries the same ticket.
+- **untrusted** — the ticket failed the provenance gate; it is skipped without spawning a session
+  and without counting toward the failure circuit breaker (drain mode never selects one anyway).
 
 ## Safety model
 
+- **Only maintainer-written text becomes a task** — the provenance gate above, enforced in front of
+  the session so no invocation path bypasses it. Self-tested by
+  `scripts/tests/claude-loop-provenance.tests.sh`, which runs in `pr-verify` and `ci`.
 - The runner **refuses a dirty working copy** and never deletes work — anything left behind is
   stashed, never reset.
 - The worker session may commit/push/PR (that authorization is the point of loop mode) but **never
@@ -135,6 +164,11 @@ Per-ticket outcomes:
   mid-run crash.
 - **Checks keep timing out** — raise `LOOP_CHECKS_TIMEOUT_MIN`; pr-verify runs the integration
   suite and can be slow on cold runners.
-- **The picker returns nothing but issues exist** — they're excluded (labels/titles/deps); run
-  `LOOP_SKIP_LABELS= LOOP_SKIP_TITLES= LOOP_SKIP_ISSUES= scripts/claude/next-ticket.sh` to see the
-  unfiltered choice, then fix labels/deps on GitHub.
+- **The picker returns nothing but issues exist** — they're excluded (labels/titles/deps/provenance);
+  run `LOOP_SKIP_LABELS= LOOP_SKIP_TITLES= LOOP_SKIP_ISSUES= scripts/claude/next-ticket.sh` to see the
+  unfiltered choice (its stderr names every ticket the provenance gate refused), then fix
+  labels/deps on GitHub.
+- **`REFUSED … has author_association …`** — the provenance gate did its job. Read the issue and its
+  comments; then either run that ticket once with `LOOP_TRUST_GATE=0`, add the writer to
+  `LOOP_TRUSTED_LOGINS`, or leave it for a human. `cannot read … (fail-closed)` instead means `gh`
+  is unauthenticated or rate-limited — fix the API access, don't disable the gate.

--- a/scripts/claude/backlog-loop.sh
+++ b/scripts/claude/backlog-loop.sh
@@ -14,8 +14,10 @@
 # Env (all forwarded to work-ticket.sh): LOOP_EFFORT (default max), LOOP_MODEL (default opus),
 #   LOOP_CONFIG_DIR (default ~/.claude-account1 — which account runs the loop),
 #   LOOP_PERMISSION_MODE (default auto), LOOP_UNSAFE, LOOP_MAX_BUDGET_USD,
-#   LOOP_TICKET_TIMEOUT_MIN, LOOP_CHECKS_TIMEOUT_MIN, LOOP_SKIP_LABELS. Loop-only:
-#   LOOP_LIMIT_SLEEP_MIN (default 60), LOOP_LIMIT_RETRIES (default 4),
+#   LOOP_TICKET_TIMEOUT_MIN, LOOP_CHECKS_TIMEOUT_MIN, LOOP_SKIP_LABELS,
+#   LOOP_TRUSTED_ASSOCIATIONS / LOOP_TRUSTED_LOGINS / LOOP_TRUST_GATE (the provenance gate —
+#   ADR-0026; it also fires on explicitly-named tickets, which never touch the picker).
+#   Loop-only: LOOP_LIMIT_SLEEP_MIN (default 60), LOOP_LIMIT_RETRIES (default 4),
 #   LOOP_MAX_CONSECUTIVE_FAILURES (default 2).
 #
 # Raw per-ticket session logs land in logs/claude-loop/<timestamp>/ (debugging only);
@@ -62,7 +64,7 @@ gh label create loop-blocked --color D93F0B \
     --description "claude-loop: needs human input" --force >/dev/null 2>&1 || true
 
 attempted=""
-merged=0 blocked=0 failed=0 queued=0 count=0
+merged=0 blocked=0 failed=0 queued=0 untrusted=0 count=0
 consecutive_failures=0
 limit_naps=0
 
@@ -111,6 +113,12 @@ while :; do
         0) merged=$((merged + 1)); consecutive_failures=0 ;;
         7) queued=$((queued + 1)); consecutive_failures=0 ;;
         2) blocked=$((blocked + 1)); consecutive_failures=0 ;;
+        11)
+            # Refused before any session started: the ticket carries untrusted text. Not a
+            # systemic failure — skip it and keep draining (drain mode never selects one anyway).
+            untrusted=$((untrusted + 1)); consecutive_failures=0
+            echo "[conductor] #$next refused by the provenance gate — skipping"
+            ;;
         10)
             echo "[conductor] dirty working copy — stopping (nothing was touched)"
             exit 10
@@ -136,7 +144,7 @@ else
 fi
 
 echo
-echo "[conductor] done: $merged merged · $queued auto-merge queued · $blocked blocked · $failed failed · \$$total_cost"
+echo "[conductor] done: $merged merged · $queued auto-merge queued · $blocked blocked · $failed failed · $untrusted untrusted · \$$total_cost"
 [ "$blocked" -gt 0 ] && echo "[conductor] blocked tickets carry your questions as issue comments: gh issue list --label loop-blocked"
 echo "[conductor] raw session logs: $RUN_DIR"
 

--- a/scripts/claude/issue-trust.sh
+++ b/scripts/claude/issue-trust.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Issue-provenance gate for the autonomous backlog loop (AUDIT-SEC-08 / ADR-0026).
+#
+# This repository is PUBLIC: anyone on GitHub can open an issue or comment on one. The loop feeds
+# an issue to `/work-ticket <n>`, which reads its title, body AND comments as instructions, then
+# auto-squash-merges the resulting PR into `main` once pr-verify is green. Untrusted issue text
+# reaching that agent is therefore a prompt-injection channel straight to `main`, so every path
+# that hands an issue to the worker asks this script first.
+#
+# Trusted == the writer's GitHub `author_association` is in $LOOP_TRUSTED_ASSOCIATIONS
+# (OWNER / MEMBER / COLLABORATOR — the associations that carry write access), or the writer's
+# login is in $LOOP_TRUSTED_LOGINS. It is evaluated for the issue author AND for every comment
+# author, because "later comments override the body" is part of the worker's contract — gating
+# only the author would leave the comment channel wide open on a maintainer-authored ticket.
+#
+# FAIL-CLOSED: an API error, a missing association, or an unknown association refuses the ticket.
+#
+# Usage: issue-trust.sh <issue-number>
+# Exit:  0 trusted · 1 untrusted writer · 2 error (bad input / missing dependency / API failure)
+#        Callers MUST refuse the ticket on any non-zero exit. All diagnostics go to stderr;
+#        stdout stays empty so callers can keep their own stdout contract.
+# Env:
+#   LOOP_TRUSTED_ASSOCIATIONS  comma-separated allowlist (default: OWNER,MEMBER,COLLABORATOR)
+#   LOOP_TRUSTED_LOGINS        comma-separated extra logins, e.g. a second maintainer account or
+#                              a bot that comments on tickets (default: empty)
+#   LOOP_TRUST_GATE=0          human escape hatch: accept the ticket unchecked for this run. Use it
+#                              only after reading the issue AND its comments yourself.
+set -euo pipefail
+
+ISSUE="${1:?usage: issue-trust.sh <issue-number>}"
+
+# Shape-check the argument BEFORE the escape hatch: a cheap guard that a human's env var can
+# switch off is not a guard at all.
+case "$ISSUE" in
+    ''|*[!0-9]*) echo "issue-trust: not an issue number: '$ISSUE'" >&2; exit 2 ;;
+esac
+
+if [ "${LOOP_TRUST_GATE:-1}" = "0" ]; then
+    echo "issue-trust: GATE DISABLED (LOOP_TRUST_GATE=0) — #$ISSUE accepted unchecked" >&2
+    exit 0
+fi
+
+for tool in gh jq; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "issue-trust: missing dependency: $tool" >&2; exit 2; }
+done
+
+# Resolve the repository from the checkout this script lives in, never from the caller's cwd —
+# `gh api repos/{owner}/{repo}` otherwise picks up whatever remote the current directory happens
+# to have, and a security gate must not depend on where it was invoked from.
+cd "$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Normalize both allowlists once: strip whitespace, upper-case the associations (GitHub returns
+# them upper-case), and drop empty entries so a trailing comma can never match an empty value.
+normalize_list() {
+    printf '%s' "$1" | tr -d '[:space:]' | tr ',' '\n' | grep -v '^$' | paste -sd, - || true
+}
+
+TRUSTED_ASSOCIATIONS="$(normalize_list "$(printf '%s' "${LOOP_TRUSTED_ASSOCIATIONS:-OWNER,MEMBER,COLLABORATOR}" | tr '[:lower:]' '[:upper:]')")"
+TRUSTED_LOGINS="$(normalize_list "${LOOP_TRUSTED_LOGINS:-}")"
+
+in_list() {
+    # $1 needle, $2 comma-separated haystack. An empty needle never matches.
+    [ -n "$1" ] || return 1
+    case ",$2," in
+        *",$1,"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Split one `[login, association] | @tsv` row. Done with parameter expansion rather than
+# `IFS=$'\t' read`, which — tab being IFS whitespace — silently collapses a leading empty login
+# and shifts the association into it.
+row_login() { printf '%s' "${1%%$'\t'*}"; }
+row_association() { printf '%s' "${1#*$'\t'}"; }
+
+# $1 login, $2 author_association, $3 role (for the refusal message)
+check_writer() {
+    local login="$1" association="$2" role="$3"
+    if [ -z "$login" ]; then
+        echo "issue-trust: REFUSED #$ISSUE — $role has no identifiable author (deleted/ghost account)" >&2
+        return 1
+    fi
+    in_list "$login" "$TRUSTED_LOGINS" && return 0
+    in_list "$(printf '%s' "$association" | tr '[:lower:]' '[:upper:]')" "$TRUSTED_ASSOCIATIONS" && return 0
+    echo "issue-trust: REFUSED #$ISSUE — $role by '$login' has author_association" \
+         "'${association:-<none>}'; trusted: $TRUSTED_ASSOCIATIONS${TRUSTED_LOGINS:+ + logins $TRUSTED_LOGINS}" >&2
+    return 1
+}
+
+api_failed() {
+    echo "issue-trust: REFUSED #$ISSUE — cannot read $1 from the GitHub API; refusing (fail-closed)" >&2
+    exit 2
+}
+
+issue_writer="$(gh api "repos/{owner}/{repo}/issues/$ISSUE" \
+    --jq '[.user.login // "", .author_association // ""] | @tsv' 2>/dev/null)" \
+    || api_failed "issue #$ISSUE"
+
+issue_login="$(row_login "$issue_writer")"
+issue_association="$(row_association "$issue_writer")"
+check_writer "$issue_login" "$issue_association" "issue" || exit 1
+
+# --paginate is load-bearing: without it only the first page of comments is checked, and a
+# hostile comment posted after 30 benign ones would never be seen. The self-test pins it.
+comment_writers="$(gh api "repos/{owner}/{repo}/issues/$ISSUE/comments" --paginate \
+    --jq '.[] | [.user.login // "", .author_association // ""] | @tsv' 2>/dev/null)" \
+    || api_failed "the comments of issue #$ISSUE"
+
+comments=0
+while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    comments=$((comments + 1))
+    check_writer "$(row_login "$row")" "$(row_association "$row")" "comment #$comments" || exit 1
+done <<< "$comment_writers"
+
+echo "issue-trust: #$ISSUE trusted — issue by $issue_login ($issue_association), $comments comment(s), all writers trusted" >&2
+exit 0

--- a/scripts/claude/next-ticket.sh
+++ b/scripts/claude/next-ticket.sh
@@ -2,20 +2,27 @@
 # Deterministic READY-ticket picker for the claude backlog loop — no LLM, no tokens.
 # Prints the number of the next ready ticket and exits 0; exits 1 when none is ready.
 #
-# "Ready" = open, not skip-labeled, not an [Epic]/[Tracking] title, and every
-# "Depends on #X" reference in the body points at a CLOSED issue (a ticket is closed
-# by its merged PR, so closed == merged in this repo's workflow).
-# Order: priority label (critical > high > medium > low > none), then issue number.
+# "Ready" = open, not skip-labeled, not an [Epic]/[Tracking] title, written only by trusted
+# maintainers (issue-trust.sh — ADR-0026), and every "Depends on #X" reference in the body points
+# at a CLOSED issue (a ticket is closed by its merged PR, so closed == merged in this repo's
+# workflow). Order: priority label (critical > high > medium > low > none), then issue number.
 #
 # Usage: next-ticket.sh [--exclude "296 293"]     # numbers already attempted this run
 # Env:   LOOP_SKIP_LABELS   comma-separated labels that exclude a ticket
-#                           (default: loop-blocked,qa,post-mvp — qa passes are manual/human,
-#                           post-mvp is deliberately cut from MVP per CLAUDE.md)
+#                           (default: loop-blocked,qa,post-mvp,audit — qa passes are manual/human,
+#                           post-mvp is deliberately cut from MVP per CLAUDE.md, and audit findings
+#                           are triaged by a human first: name one explicitly to work it)
 #        LOOP_SKIP_TITLES   regex over titles to exclude (default: ^M4- — the WPF milestone is
 #                           Windows-only and can't build on the macOS loop host)
 #        LOOP_SKIP_ISSUES   space-separated numbers to exclude (default: 85 — the M2-18 forum
 #                           watcher is deferred post-MVP; work it only by naming it explicitly)
+#        see issue-trust.sh for the provenance knobs (LOOP_TRUSTED_ASSOCIATIONS / _LOGINS,
+#        LOOP_TRUST_GATE)
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve `gh`'s repository from this checkout, not from the caller's cwd (see issue-trust.sh).
+cd "$SCRIPT_DIR/../.."
 
 EXCLUDE=""
 if [ "${1:-}" = "--exclude" ]; then
@@ -23,7 +30,7 @@ if [ "${1:-}" = "--exclude" ]; then
 fi
 EXCLUDE="$EXCLUDE ${LOOP_SKIP_ISSUES-85}"
 
-SKIP_LABELS="${LOOP_SKIP_LABELS:-loop-blocked,qa,post-mvp}"
+SKIP_LABELS="${LOOP_SKIP_LABELS:-loop-blocked,qa,post-mvp,audit}"
 SKIP_TITLES="${LOOP_SKIP_TITLES:-^M4-}"
 
 for tool in gh jq; do
@@ -50,6 +57,17 @@ for n in $candidates; do
     case " $EXCLUDE " in
         *" $n "*) continue ;;
     esac
+
+    # Provenance gate (ADR-0026): on a public repo anyone can write the text the worker reads as
+    # its task. An issue whose author — or any of whose commenters — lacks write access is never
+    # ready. work-ticket.sh re-checks this, so naming a ticket explicitly cannot bypass it.
+    trust_rc=0
+    "$SCRIPT_DIR/issue-trust.sh" "$n" || trust_rc=$?
+    if [ "$trust_rc" -eq 2 ]; then
+        # Say so loudly: an unreachable API skipping every candidate must not read as "backlog drained".
+        echo "next-ticket: WARNING — could not verify #$n (GitHub API); skipping it (fail-closed)" >&2
+    fi
+    [ "$trust_rc" -eq 0 ] || continue
 
     # Dependency gate: every "Depends on #X" must be CLOSED (i.e. merged).
     deps="$(gh issue view "$n" --json body --jq '.body // ""' \

--- a/scripts/claude/work-ticket.sh
+++ b/scripts/claude/work-ticket.sh
@@ -21,15 +21,21 @@
 #   LOOP_MAX_BUDGET_USD     optional per-ticket API budget cap
 #   LOOP_TICKET_TIMEOUT_MIN wall-clock kill switch per ticket (default: 90)
 #   LOOP_CHECKS_TIMEOUT_MIN how long to wait for pr-verify before queueing auto-merge (default: 30)
+#   LOOP_TRUSTED_ASSOCIATIONS / LOOP_TRUSTED_LOGINS / LOOP_TRUST_GATE — see issue-trust.sh
 #
-# Exit codes: 0 merged · 2 blocked · 3 error · 4 timeout · 5 checks failed / merge failed
-#             6 usage limit hit · 7 auto-merge queued (checks still running) · 10 dirty working copy
+# Exit codes: 0 merged · 2 blocked · 3 error (incl. a provenance gate that could not reach the API)
+#             4 timeout · 5 checks failed / merge failed · 6 usage limit hit
+#             7 auto-merge queued (checks still running) · 10 dirty working copy
+#             11 issue refused by the provenance gate (untrusted author or commenter)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 ISSUE="${1:?usage: work-ticket.sh <issue-number> [run-dir]}"
+case "$ISSUE" in
+    ''|*[!0-9]*) echo "work-ticket: not an issue number: '$ISSUE'" >&2; exit 3 ;;
+esac
 RUN_DIR="${2:-$REPO_ROOT/logs/claude-loop/adhoc-$(date +%Y%m%d-%H%M%S)}"
 mkdir -p "$RUN_DIR"
 
@@ -51,6 +57,23 @@ done
 log() { echo "[loop] #$ISSUE $(date +%H:%M:%S) $*"; }
 
 meta() { echo "$1=$2" >> "$META"; }
+
+# ── Provenance gate: only maintainer-written issue text may become the worker's task ───────────
+# This is the enforcement point, not next-ticket.sh: the picker merely *selects*, whereas the
+# untrusted text reaches the LLM here. Explicit ticket numbers (backlog-loop.sh 123) and direct
+# invocations skip the picker entirely, so the gate has to live in front of the session (ADR-0026).
+trust_rc=0
+"$REPO_ROOT/scripts/claude/issue-trust.sh" "$ISSUE" || trust_rc=$?
+if [ "$trust_rc" -eq 1 ]; then
+    log "REFUSED by the provenance gate — untrusted writer (see above); no session spawned"
+    exit 11
+fi
+if [ "$trust_rc" -ne 0 ]; then
+    # An unreadable API is systemic, not a property of this ticket: report it as a session error
+    # so the conductor's circuit breaker stops the run instead of "skipping" the whole backlog.
+    log "provenance gate could not verify #$ISSUE (rc=$trust_rc) — treating as an error"
+    exit 3
+fi
 
 # Stash (never delete) anything a failed/blocked session left behind, and return to main.
 salvage() {

--- a/scripts/tests/claude-loop-provenance.tests.sh
+++ b/scripts/tests/claude-loop-provenance.tests.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# Test suite for the backlog loop's issue-provenance gate (AUDIT-SEC-08, ADR-0026).
+#
+# The gate is what stops attacker-authored text on this PUBLIC repo from becoming the task of an
+# agent that pushes and auto-merges. It is enforced in two places and both are covered here:
+#   * issue-trust.sh  — the policy (author + every commenter must carry write access)
+#   * next-ticket.sh  — the picker never returns an untrusted ticket
+#   * work-ticket.sh  — an explicitly-named untrusted ticket never spawns a claude session
+#
+# `gh` is stubbed from fixtures, so the suite is offline and hermetic. The stub applies the
+# caller's own `--jq` filter with real jq, which keeps the scripts' jq filters under test too.
+# CI runs this before anything else that could rot the gate silently.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TRUST="$SCRIPTS_DIR/claude/issue-trust.sh"
+NEXT="$SCRIPTS_DIR/claude/next-ticket.sh"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+export GH_FIXTURES="$TMP_ROOT/fixtures"
+CLAUDE_MARKER="$TMP_ROOT/claude-was-spawned"
+mkdir -p "$GH_FIXTURES" "$TMP_ROOT/bin"
+
+# work-ticket.sh checks out branches and stashes; exercise it against a throwaway clone of the
+# two scripts, never the developer's own working copy — a regression in the gate must not be able
+# to `git checkout main` under someone's feet just because they ran the tests.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+export GIT_AUTHOR_NAME=provenance-tests GIT_AUTHOR_EMAIL=tests@localhost
+export GIT_COMMITTER_NAME=provenance-tests GIT_COMMITTER_EMAIL=tests@localhost
+FAKE_REPO="$TMP_ROOT/fake-repo"
+WORK="$FAKE_REPO/scripts/claude/work-ticket.sh"
+mkdir -p "$FAKE_REPO/scripts/claude"
+cp "$SCRIPTS_DIR/claude/work-ticket.sh" "$SCRIPTS_DIR/claude/issue-trust.sh" "$FAKE_REPO/scripts/claude/"
+chmod +x "$FAKE_REPO/scripts/claude/work-ticket.sh" "$FAKE_REPO/scripts/claude/issue-trust.sh"
+git -C "$FAKE_REPO" init -q -b main
+git -C "$FAKE_REPO" add -A
+git -C "$FAKE_REPO" commit -qm "provenance-gate fixture repo"
+
+LAST_OUTPUT=""
+LAST_STDOUT=""
+cases=0
+
+fail() {
+    printf '✗ %s\n' "$1"
+    if [ -n "${2:-}" ]; then
+        printf '%s\n' "$2" | sed 's/^/    /'
+    fi
+    exit 1
+}
+
+# ── Offline `gh` + `claude` stubs ──────────────────────────────────────────────────────────────
+cat > "$TMP_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+# Minimal offline `gh`: serves $GH_FIXTURES and applies the caller's --jq filter with real jq.
+#
+# It models `--paginate` faithfully — comments live in `comments-<n>.json` (page 1) plus optional
+# `comments-<n>-p2.json` … , and only a caller that passes --paginate sees past page 1, exactly as
+# real `gh` only follows Link headers when asked. That is what makes "a hostile comment on page 2"
+# a test the gate can fail: drop --paginate from issue-trust.sh and the case goes red.
+set -o pipefail
+
+filter=""
+paginate=0
+args=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --jq) filter="${2:-}"; shift 2 ;;
+        --paginate) paginate=1; shift ;;
+        *) args+=("$1"); shift ;;
+    esac
+done
+
+emit_file() {
+    if [ -n "$filter" ]; then jq -r "$filter" < "$1"; else cat "$1"; fi
+}
+
+emit() {
+    if [ ! -f "$1" ]; then
+        echo "gh: Not Found (HTTP 404)" >&2
+        exit 1
+    fi
+    emit_file "$1"
+}
+
+case "${args[0]:-}" in
+    api)
+        path="${args[1]:-}"
+        case "$path" in
+            */comments)
+                number="${path%/comments}"
+                number="${number##*/}"
+                emit "$GH_FIXTURES/comments-$number.json"
+                if [ "$paginate" = "1" ]; then
+                    for page in "$GH_FIXTURES/comments-$number-p"*.json; do
+                        if [ -f "$page" ]; then emit_file "$page"; fi
+                    done
+                fi
+                ;;
+            *)
+                emit "$GH_FIXTURES/issue-${path##*/}.json"
+                ;;
+        esac
+        ;;
+    issue)
+        case "${args[1]:-}" in
+            list) emit "$GH_FIXTURES/issue-list.json" ;;
+            view) emit "$GH_FIXTURES/issue-${args[2]:-}.json" ;;
+            *) echo "gh stub: unsupported issue subcommand" >&2; exit 1 ;;
+        esac
+        ;;
+    *) echo "gh stub: unsupported command" >&2; exit 1 ;;
+esac
+exit 0
+STUB
+
+cat > "$TMP_ROOT/bin/claude" <<STUB
+#!/usr/bin/env bash
+# The worker session must never start for an untrusted ticket — leave proof if it does.
+touch "$CLAUDE_MARKER"
+echo '{"result":"STATUS: DONE","is_error":false}'
+STUB
+
+chmod +x "$TMP_ROOT/bin/gh" "$TMP_ROOT/bin/claude"
+export PATH="$TMP_ROOT/bin:$PATH"
+
+command -v jq >/dev/null 2>&1 || fail "this suite needs jq on PATH"
+
+# ── Fixture helpers ────────────────────────────────────────────────────────────────────────────
+# fixture_issue <number> <login> <association> [state] [body]
+# `association` may be the literal `null` to model a missing association; `login` may be the
+# literal `null` to model a deleted (ghost) account.
+fixture_issue() {
+    local number="$1" login="$2" association="$3" state="${4:-OPEN}" body="${5:-}"
+    local association_json="\"$association\"" user_json="{ \"login\": \"$login\" }"
+    [ "$association" = "null" ] && association_json="null"
+    [ "$login" = "null" ] && user_json="null"
+    cat > "$GH_FIXTURES/issue-$number.json" <<EOF
+{
+  "number": $number,
+  "state": "$state",
+  "user": $user_json,
+  "author_association": $association_json,
+  "body": "$body"
+}
+EOF
+    printf '[]' > "$GH_FIXTURES/comments-$number.json"
+}
+
+# write_comments <file> <login:association> ...
+write_comments() {
+    local file="$1"
+    shift
+    local json="[" separator=""
+    for writer in "$@"; do
+        json="$json$separator{\"user\":{\"login\":\"${writer%%:*}\"},\"author_association\":\"${writer##*:}\"}"
+        separator=","
+    done
+    printf '%s]' "$json" > "$file"
+}
+
+# fixture_comments <number> <login:association> ...              — page 1
+fixture_comments() {
+    local number="$1"
+    shift
+    write_comments "$GH_FIXTURES/comments-$number.json" "$@"
+}
+
+# fixture_comments_page2 <number> <login:association> ...        — only a --paginate caller sees it
+fixture_comments_page2() {
+    local number="$1"
+    shift
+    write_comments "$GH_FIXTURES/comments-$number-p2.json" "$@"
+}
+
+# fixture_list <number:label,label> ... — builds the `gh issue list` payload, lowest number first.
+fixture_list() {
+    local json="[" separator=""
+    for entry in "$@"; do
+        local number="${entry%%:*}" labels="${entry#*:}" labels_json="" label_separator=""
+        [ "$labels" = "$number" ] && labels=""
+        local IFS=,
+        for label in $labels; do
+            labels_json="$labels_json$label_separator{\"name\":\"$label\"}"
+            label_separator=","
+        done
+        unset IFS
+        json="$json$separator{\"number\":$number,\"title\":\"T$number: fixture\",\"labels\":[$labels_json]}"
+        separator=","
+    done
+    printf '%s]' "$json" > "$GH_FIXTURES/issue-list.json"
+}
+
+reset_fixtures() {
+    rm -f "$GH_FIXTURES"/*.json "$CLAUDE_MARKER"
+}
+
+# ── Assertions ─────────────────────────────────────────────────────────────────────────────────
+# run_case <expected-exit> <description> <command...>
+run_case() {
+    local expected="$1" description="$2"
+    shift 2
+    local rc=0
+    LAST_STDOUT="$("$@" 2>"$TMP_ROOT/stderr.txt")" || rc=$?
+    LAST_OUTPUT="$LAST_STDOUT$(printf '\n')$(cat "$TMP_ROOT/stderr.txt")"
+    if [ "$rc" -ne "$expected" ]; then
+        fail "$description — expected exit $expected, got $rc" "$LAST_OUTPUT"
+    fi
+    cases=$((cases + 1))
+    printf '✓ %s\n' "$description"
+}
+
+expect_in_output() {
+    printf '%s' "$LAST_OUTPUT" | grep -qF "$1" \
+        || fail "output should contain '$1'" "$LAST_OUTPUT"
+}
+
+expect_stdout() {
+    [ "$LAST_STDOUT" = "$1" ] \
+        || fail "stdout should be '$1' but was '$LAST_STDOUT'" "$LAST_OUTPUT"
+}
+
+# ── issue-trust.sh: the policy ─────────────────────────────────────────────────────────────────
+for association in OWNER MEMBER COLLABORATOR; do
+    reset_fixtures
+    fixture_issue 10 maintainer "$association"
+    run_case 0 "issue-trust: $association author is trusted" "$TRUST" 10
+    expect_in_output "trusted"
+done
+
+for association in CONTRIBUTOR FIRST_TIME_CONTRIBUTOR MANNEQUIN NONE; do
+    reset_fixtures
+    fixture_issue 11 outsider "$association"
+    run_case 1 "issue-trust: $association author is refused" "$TRUST" 11
+    expect_in_output "REFUSED #11"
+    expect_in_output "$association"
+done
+
+reset_fixtures
+fixture_issue 12 ghost null
+run_case 1 "issue-trust: a missing author_association is refused (fail-closed)" "$TRUST" 12
+expect_in_output "<none>"
+
+# The comment channel: `/work-ticket` treats later comments as overriding the body, and on a
+# public repo anyone may comment on a maintainer's issue.
+reset_fixtures
+fixture_issue 13 maintainer OWNER
+fixture_comments 13 maintainer:OWNER outsider:NONE
+run_case 1 "issue-trust: an outsider comment on a maintainer issue is refused" "$TRUST" 13
+expect_in_output "comment #2"
+expect_in_output "outsider"
+
+reset_fixtures
+fixture_issue 14 maintainer OWNER
+fixture_comments 14 maintainer:OWNER teammate:COLLABORATOR
+run_case 0 "issue-trust: comments by trusted writers keep the ticket trusted" "$TRUST" 14
+expect_in_output "2 comment(s)"
+
+# The attack the finding named: bury the hostile comment past the first page. The gate must
+# paginate; drop `--paginate` from issue-trust.sh and this case goes red (that is its whole job).
+reset_fixtures
+fixture_issue 22 maintainer OWNER
+fixture_comments 22 maintainer:OWNER teammate:COLLABORATOR
+fixture_comments_page2 22 outsider:NONE
+run_case 1 "issue-trust: a hostile comment on page 2 is still caught (--paginate is pinned)" "$TRUST" 22
+expect_in_output "comment #3"
+expect_in_output "outsider"
+
+reset_fixtures
+fixture_issue 23 maintainer OWNER
+fixture_comments 23 maintainer:OWNER
+fixture_comments_page2 23 teammate:MEMBER
+run_case 0 "issue-trust: trusted writers across both comment pages stay trusted" "$TRUST" 23
+expect_in_output "2 comment(s)"
+
+# A deleted account leaves `user: null`. Its association must never be read as the login.
+reset_fixtures
+fixture_issue 24 null MEMBER
+run_case 1 "issue-trust: an issue by a ghost account is refused" "$TRUST" 24
+expect_in_output "no identifiable author"
+
+# Fail-closed on every API failure — a rate-limited or offline `gh` must never mean "trusted".
+reset_fixtures
+run_case 2 "issue-trust: an unreadable issue is refused (fail-closed)" "$TRUST" 15
+expect_in_output "fail-closed"
+
+reset_fixtures
+fixture_issue 16 maintainer OWNER
+rm -f "$GH_FIXTURES/comments-16.json"
+run_case 2 "issue-trust: unreadable comments are refused (fail-closed)" "$TRUST" 16
+expect_in_output "comments of issue #16"
+
+# Knobs.
+reset_fixtures
+fixture_issue 17 outsider NONE
+run_case 0 "issue-trust: LOOP_TRUST_GATE=0 is the human escape hatch" \
+    env LOOP_TRUST_GATE=0 "$TRUST" 17
+expect_in_output "GATE DISABLED"
+
+reset_fixtures
+fixture_issue 18 teammate MEMBER
+run_case 1 "issue-trust: LOOP_TRUSTED_ASSOCIATIONS can narrow the allowlist" \
+    env LOOP_TRUSTED_ASSOCIATIONS=OWNER "$TRUST" 18
+
+reset_fixtures
+fixture_issue 19 maintainer OWNER
+run_case 0 "issue-trust: a lower-case allowlist is normalized" \
+    env LOOP_TRUSTED_ASSOCIATIONS=owner,member "$TRUST" 19
+
+reset_fixtures
+fixture_issue 20 release-bot NONE
+run_case 0 "issue-trust: LOOP_TRUSTED_LOGINS admits a named bot/second account" \
+    env LOOP_TRUSTED_LOGINS=release-bot "$TRUST" 20
+
+# A trailing comma must not turn the empty association into a trusted one.
+reset_fixtures
+fixture_issue 21 ghost null
+run_case 1 "issue-trust: a trailing comma in the allowlist admits no empty association" \
+    env LOOP_TRUSTED_ASSOCIATIONS=OWNER, "$TRUST" 21
+
+run_case 2 "issue-trust: a non-numeric issue argument is a usage error" "$TRUST" "42; rm -rf /"
+
+# The shape guard must sit above the escape hatch — an env var must not be able to switch it off.
+run_case 2 "issue-trust: LOOP_TRUST_GATE=0 does not disable the argument guard" \
+    env LOOP_TRUST_GATE=0 "$TRUST" "42; rm -rf /"
+
+run_case 3 "work-ticket: a non-numeric issue argument is rejected" "$WORK" "1 2" "$TMP_ROOT/run"
+
+# ── next-ticket.sh: the picker never selects untrusted work ────────────────────────────────────
+picker() { env LOOP_SKIP_ISSUES= LOOP_SKIP_TITLES= "$NEXT" "$@"; }
+
+reset_fixtures
+fixture_list 30:high
+fixture_issue 30 outsider NONE
+run_case 1 "next-ticket: an externally-authored issue is never returned" picker
+expect_stdout ""
+
+reset_fixtures
+fixture_list 31:high
+fixture_issue 31 maintainer OWNER
+run_case 0 "next-ticket: a maintainer-authored issue is still returned" picker
+expect_stdout "31"
+
+# Priority must not outrank provenance: the attacker's `critical` ticket sorts first and loses.
+reset_fixtures
+fixture_list 32:critical 33:low
+fixture_issue 32 outsider NONE
+fixture_issue 33 maintainer OWNER
+run_case 0 "next-ticket: a critical untrusted issue never outranks a low trusted one" picker
+expect_stdout "33"
+
+reset_fixtures
+fixture_list 34:high
+fixture_issue 34 maintainer OWNER
+fixture_comments 34 outsider:NONE
+run_case 1 "next-ticket: an outsider comment disqualifies a maintainer ticket" picker
+expect_stdout ""
+
+# `audit` findings are triaged by a human before the loop may touch them.
+reset_fixtures
+fixture_list 35:medium,audit
+fixture_issue 35 maintainer OWNER
+run_case 1 "next-ticket: audit findings are skipped by default" picker
+expect_stdout ""
+
+run_case 0 "next-ticket: the audit skip is a default, not a hard block" \
+    env LOOP_SKIP_ISSUES= LOOP_SKIP_TITLES= LOOP_SKIP_LABELS=loop-blocked "$NEXT"
+expect_stdout "35"
+
+# The dependency gate still works behind the provenance gate.
+reset_fixtures
+fixture_list 36:high
+fixture_issue 36 maintainer OWNER OPEN "Depends on #37"
+fixture_issue 37 maintainer OWNER OPEN
+run_case 1 "next-ticket: an open dependency still blocks a trusted ticket" picker
+expect_stdout ""
+
+reset_fixtures
+fixture_list 38:high
+fixture_issue 38 maintainer OWNER OPEN "Depends on #39"
+fixture_issue 39 maintainer OWNER CLOSED
+run_case 0 "next-ticket: a closed dependency releases a trusted ticket" picker
+expect_stdout "38"
+
+# ── work-ticket.sh: naming a ticket explicitly cannot bypass the gate ──────────────────────────
+reset_fixtures
+fixture_issue 40 outsider NONE
+run_case 11 "work-ticket: an explicitly-named untrusted ticket exits 11" "$WORK" 40 "$TMP_ROOT/run"
+expect_in_output "REFUSED"
+[ ! -f "$CLAUDE_MARKER" ] || fail "work-ticket spawned a claude session for an untrusted ticket"
+cases=$((cases + 1))
+printf '✓ work-ticket: no claude session is spawned for an untrusted ticket\n'
+
+# An unreadable API is systemic, not a property of the ticket: exit 3 so the conductor's
+# circuit breaker stops the run rather than "skipping" every remaining ticket as untrusted.
+reset_fixtures
+run_case 3 "work-ticket: an unverifiable ticket is an error, not a skip" "$WORK" 41 "$TMP_ROOT/run"
+expect_in_output "could not verify"
+[ ! -f "$CLAUDE_MARKER" ] || fail "work-ticket spawned a claude session for an unverifiable ticket"
+
+printf 'All %d provenance-gate case(s) passed.\n' "$cases"


### PR DESCRIPTION
Closes #398

## What

This repo is public, so anyone can open an issue or comment on one. The loop reads that text as its task (`/work-ticket` treats title, body **and comments** as instructions, with later comments overriding the body) and auto-squash-merges the resulting PR into `main`. Attacker-written text was one hop from the default branch.

New `scripts/claude/issue-trust.sh` is the single source of truth: an issue is trusted only when its author **and every one of its comment authors** carries write access (`author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, or a login in `LOOP_TRUSTED_LOGINS`). It fails closed — a missing association, a ghost account, or any GitHub API failure refuses the ticket.

## Why it is placed where it is

Two deliberate departures from the ticket's proposed fix, both because the fix would otherwise be cosmetic:

1. **The gate lives in `work-ticket.sh`, not only `next-ticket.sh`.** The picker merely *selects*; the untrusted text reaches the LLM when the session spawns. `backlog-loop.sh 123` and a bare `work-ticket.sh 123` never call the picker. The picker check is kept as an optimization, not as the boundary.
2. **Comment authors are checked, not just the issue author.** Anyone can comment on a maintainer's issue, and the worker is told to prefer the latest comment over the body.

An unreachable API is systemic, not a property of the ticket: the gate's error maps to `work-ticket.sh`'s ordinary exit `3` so the conductor's circuit breaker stops the run, rather than "skipping" the whole backlog as untrusted. `audit` also joins the default skip labels, making that label's stated "triage before /backlog" intent real — naming an audit ticket explicitly still works, and that act of naming *is* the triage.

Decision, rejected alternatives and residual risks (TOCTOU, compromised-collaborator) are in **ADR-0026**.

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| `next-ticket.sh` never returns an externally-authored issue | Per-candidate gate; tested, incl. that an attacker's `critical` ticket loses to a maintainer's `low` one |
| `audit` in the default skip labels | `LOOP_SKIP_LABELS=loop-blocked,qa,post-mvp,audit`; tested as a default, not a hard block |
| A test/doc note records the rule; maintainer behavior unchanged | 34-case offline suite + ADR-0026 + `docs/claude-loop.md` + CLAUDE.md; "trusted issue still returned" and "closed dependency releases a ticket" pin the unchanged path |

## Tests

`scripts/tests/claude-loop-provenance.tests.sh` — 34 hermetic cases, no network. The `gh` stub applies the caller's own `--jq` filter with real `jq` (so the scripts' filters are under test) and **models `--paginate`**: comments span two pages and only a `--paginate` caller sees page 2.

That last part is the point. `--paginate` is load-bearing — without it only the first 30 comments are checked and a hostile comment posted after 30 benign ones is invisible. The first version of this suite ignored the flag, so removing it would have been a silent fail-open; `code-reviewer` caught that.

Every guard is mutation-checked — removing `--paginate`, the picker gate, the worker's refusal, the ghost-account guard, or the comment loop each turns the suite red:

```
M1: --paginate removed              -> ✗ a hostile comment on page 2 is still caught
M2: picker gate removed             -> ✗ an externally-authored issue is never returned
M3: worker exit-11 refusal removed  -> ✗ an explicitly-named untrusted ticket exits 11
M4: ghost-account guard removed     -> ✗ an issue by a ghost account is refused
M5: comment-author checking removed -> ✗ an outsider comment on a maintainer issue is refused
```

The `work-ticket` cases run against a throwaway git repo, so a future regression cannot `git checkout main` under a developer's working copy. Green on bash 3.2 (macOS) and 5.x (CI). Wired into `pr-verify` and `ci`, and the four scripts join `force_build` so a `.sh`-only change still runs the gate.

Also verified against the live API: an owner-authored issue passes, a narrowed allowlist refuses it, the check is unaffected by the caller's cwd, and `--paginate` really follows Link headers (1 → 73 items on a paged endpoint).

No .NET code is touched.

## Deferred

- A conductor-level test for `backlog-loop.sh`'s exit-11 skip branch (not a security boundary — the worker already refused to spawn).
- `LOOP_TRUST_GATE=0` remains run-wide rather than per-ticket; documented as "use it only on a single explicitly-named ticket".

🤖 Generated with [Claude Code](https://claude.com/claude-code)