### PR TITLE
FINOPS: run prod on a scheduled warm window and replace the Azure availability tests with a daily health ping

### DIFF
--- a/.github/workflows/health-ping.yml
+++ b/.github/workflows/health-ping.yml
@@ -56,14 +56,15 @@ jobs:
             code=000
             echo "::group::${name} → ${url}"
             for attempt in $(seq 1 20); do
-              code=$(curl -sS -o /tmp/probe-body.txt -w '%{http_code}' --max-time 30 "$url" || echo 000)
+              code=$(curl -sS -o /tmp/probe-body.txt -w '%{http_code}' --max-time 60 "$url" || echo 000)
               echo "  attempt ${attempt}: HTTP ${code}"
               if [ "$code" -ge "$lo" ] 2>/dev/null && [ "$code" -le "$hi" ] 2>/dev/null; then
                 echo "::endgroup::"
                 printf -- '- OK **%s** — HTTP %s (after %s attempt(s))\n' "$name" "$code" "$attempt" >> "$GITHUB_STEP_SUMMARY"
                 return 0
               fi
-              # A cold start from zero replicas takes ~10-30 s; 20 x 10 s is a generous budget for it.
+              # A measured cold start from zero replicas is ~45-60 s (auth's own is ~31 s and dominates
+              # the chain), so a single attempt must out-wait it: --max-time 60 above, 20 x 10 s here.
               sleep 10
             done
             echo "  last response body:"

--- a/.github/workflows/health-ping.yml
+++ b/.github/workflows/health-ping.yml
@@ -1,0 +1,92 @@
+name: Health ping (prod)
+
+# The daily availability check for production (ADR-0027). It replaces the three Application Insights
+# standard web tests, which billed per execution AND — probing every 15 minutes from three regions —
+# would have kept the scale-to-zero apps awake all night, cancelling the warm window's whole saving.
+#
+# This runs on free GitHub-hosted minutes once a day, a little before the warm window opens, and it
+# deliberately hits the apps while they are still asleep: the run therefore proves BOTH that the
+# platform is healthy and that a cold start from zero replicas actually serves traffic — the exact
+# path a visitor takes outside the warm window.
+#
+# Failure notification is GitHub's own: a failed scheduled run emails the user whose commit last
+# touched this file. No Azure action group, no cost.
+#
+# Cron is UTC. 03:00 UTC = 05:00 Europe/Warsaw in summer (CEST), 04:00 in winter (CET) — close enough
+# for a "tell me in the morning if it died overnight" signal, and it lands before the 07:00 warm window
+# so the probe, not a visitor, pays the first cold start of the day.
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: health-ping
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    name: probe the public origins
+    # Never run on a fork: the origins below belong to this deployment only.
+    if: github.repository == 'koniecdev/LotroKoniecDev'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Probe auth, tms and the frontend
+        run: |
+          set -uo pipefail
+
+          # The public origins of the prod environment (iac/locals.tf derives these from
+          # var.public_base_domain = "lotro-translator.pl").
+          #
+          # The APIs are probed on /health, not /health/ready: ADR-0025 deliberately leaves the
+          # Postgres check OUT of the readiness tag so the ACA probes cannot keep the scale-to-zero
+          # Neon compute awake, and names the full /health as the on-demand deep check. Once a day is
+          # exactly that occasion — this is the only probe that proves the database is reachable.
+          # auth's /health also covers SMTP, so a red run here can legitimately mean "Brevo is down",
+          # not "the site is down"; the response body below says which check failed.
+          #
+          # The Static-SSR frontend exposes /health/live but nothing deep, so '/' is its liveness.
+          probe() {
+            name="$1"; url="$2"; lo="$3"; hi="$4"
+            code=000
+            echo "::group::${name} → ${url}"
+            for attempt in $(seq 1 20); do
+              code=$(curl -sS -o /tmp/probe-body.txt -w '%{http_code}' --max-time 30 "$url" || echo 000)
+              echo "  attempt ${attempt}: HTTP ${code}"
+              if [ "$code" -ge "$lo" ] 2>/dev/null && [ "$code" -le "$hi" ] 2>/dev/null; then
+                echo "::endgroup::"
+                printf -- '- OK **%s** — HTTP %s (after %s attempt(s))\n' "$name" "$code" "$attempt" >> "$GITHUB_STEP_SUMMARY"
+                return 0
+              fi
+              # A cold start from zero replicas takes ~10-30 s; 20 x 10 s is a generous budget for it.
+              sleep 10
+            done
+            echo "  last response body:"
+            head -c 2000 /tmp/probe-body.txt || true
+            echo
+            echo "::endgroup::"
+            echo "::error::${name} is unhealthy (last HTTP ${code}): ${url}"
+            {
+              printf -- '- FAIL **%s** — HTTP %s at `%s`\n\n' "$name" "$code" "$url"
+              printf -- '```\n%s\n```\n' "$(head -c 1000 /tmp/probe-body.txt)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            return 1
+          }
+
+          echo '## Prod health ping' >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          probe auth     "https://auth.lotro-translator.pl/health" 200 200 || failed=1
+          probe tms      "https://tms.lotro-translator.pl/health"  200 200 || failed=1
+          probe frontend "https://lotro-translator.pl/"            200 399 || failed=1
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::Production health ping failed — see the job summary."
+            exit 1
+          fi
+          echo "All three origins are healthy."

--- a/docs/adr/0012-continuous-deployment-pipeline.md
+++ b/docs/adr/0012-continuous-deployment-pipeline.md
@@ -148,6 +148,11 @@ fixed here:
    > **Scoped by ADR-0020 (2026-07-01):** R8's `min_replicas = 1` stands for **prod**; staging runs
    > `min_replicas = 0` (`var.app_min_replicas`) — there the readiness warm-up above is the
    > load-bearing mechanism, not insurance.
+   >
+   > **Reversed by ADR-0027 (2026-07-09):** prod also runs `min_replicas = 0`. Its warm replica is now
+   > a **schedule** (`var.app_warm_window`, a KEDA cron rule) rather than a floor, so the readiness
+   > warm-up above is load-bearing in every environment. R8's serving argument was premised on real
+   > users; with none, an always-warm prod only burned the student credit.
 
 ### 6. Infra is also CI-managed, behind the same gate
 

--- a/docs/adr/0019-symptom-based-external-slo-probe.md
+++ b/docs/adr/0019-symptom-based-external-slo-probe.md
@@ -1,5 +1,10 @@
 # ADR-0019: Symptom-based alerting — external synthetic SLO probe replaces the log-based auth check
 
+> **Superseded in part by ADR-0027 (2026-07-09):** the three standard web tests and their availability
+> alerts are removed. An external probe of the public origin wakes a scaled-to-zero app, so it cannot
+> coexist with the warm window. The symptom-based *principle* stands; the instrument is now a daily
+> GitHub Actions cron (`.github/workflows/health-ping.yml`).
+
 **Status:** Accepted
 **Date:** 2026-07-01
 **Decision-makers:** Solo maintainer

--- a/docs/adr/0020-finops-right-sizing-staging-scale-to-zero-and-probe-cadence.md
+++ b/docs/adr/0020-finops-right-sizing-staging-scale-to-zero-and-probe-cadence.md
@@ -1,5 +1,11 @@
 # ADR-0020: FinOps right-sizing — staging scales to zero, SLO probe cadence drops to 15 min
 
+> **Superseded in part by ADR-0027 (2026-07-09):** §1 (staging scale-to-zero) stands and is extended to
+> prod. §2 (probe cadence) is void — the web tests are gone. This ADR's rejection of a "free
+> GitHub-Actions cron probe" is **overturned**: it was argued against an always-warm prod, where a
+> probe costs only money. Against a scale-to-zero prod a 15-minute external probe holds the apps awake
+> and destroys the saving, which makes the cheap probe the only coherent one.
+
 **Status:** Accepted
 **Date:** 2026-07-01
 **Decision-makers:** Solo maintainer

--- a/docs/adr/0027-scheduled-warm-window-and-daily-health-ping.md
+++ b/docs/adr/0027-scheduled-warm-window-and-daily-health-ping.md
@@ -1,0 +1,162 @@
+# ADR-0027: Prod buys its warm replica from a schedule, not a floor — and the availability probe moves out of Azure
+
+**Status:** Accepted
+**Date:** 2026-07-09
+**Decision-makers:** Solo maintainer
+**Related:** ADR-0012 §5 R8 (**reversed** — prod `min_replicas = 1`), ADR-0019 (external synthetic
+SLO probe — **web tests removed**), ADR-0020 (FinOps right-sizing — its "GitHub-Actions cron probe"
+rejection is **overturned**; its staging scale-to-zero stands), ADR-0018 (staging shares the prod
+ACA environment), ADR-0025 (DB-free readiness probes), ticket #409, TheKittySaver ADR-0015 (the
+mirror decision on the other project sharing this subscription).
+
+## Context
+
+The subscription is an **Azure for Students** plan (~$100 for the year, one Container Apps
+Environment). It carries **two** projects — LotroKoniecDev and TheKittySaver — each with a prod and
+a staging environment. Both prods are links in the maintainer's CV while he is job-hunting.
+
+Cost Management (`ActualCost`, MonthToDate), read on 2026-07-09 for **1–9 July 2026**:
+
+| Meter | EUR (9 days) |
+|---|---|
+| Standard vCPU Active Usage | 25.06 |
+| Standard Memory Active Usage | 6.28 |
+| Standard Memory Idle Usage | 5.34 |
+| Standard Web Test Execution | 3.42 |
+| Standard vCPU Idle Usage | 2.66 |
+| Alerts | 0.48 |
+| **Total** | **43.35** |
+
+| Resource group | EUR (9 days) |
+|---|---|
+| `rg-lotrotms-prod` | 19.29 |
+| `rg-tks-prod` | 14.03 |
+| `rg-tks-staging` | 8.04 |
+| `rg-lotrotms-staging` | 1.98 |
+
+That is **EUR 4.82/day** against roughly EUR 49 of remaining credit: about **ten days**. June's total
+was EUR 0.23 — the whole platform came up on 1 July, so this is the first real bill, not a regression.
+
+Three facts drive the decision:
+
+1. **Six always-on prod replicas serve zero users.** `min_replicas = 1` × 3 apps × 2 projects. The
+   product is pre-release; the only human who opens prod is a recruiter, and only during waking hours.
+2. **The compute bills at the *active* rate, not the idle rate.** EUR 25.06 vCPU-active against EUR
+   2.66 vCPU-idle. A replica with no users is still running health probes every 10–30 s and an OTel
+   exporter, so it never sinks into ACA's cheaper idle billing. **Reducing replica-hours is the only
+   lever we can rely on** — hoping for the idle rate is not a plan.
+3. **The synthetic probes are self-defeating against scale-to-zero.** ADR-0019's three standard web
+   tests hit the *public origins* every 15 minutes from three regions. A probe is a request; a request
+   wakes a scaled-to-zero app. Keeping them would hold every app warm around the clock and cancel the
+   entire saving, on top of their own EUR 3.42/9 days.
+
+ADR-0012 R8 made prod always-warm for a real reason (a cold auth mid-smoke broke a rollout, and users
+should not pay a cold start). ADR-0020 then explicitly rejected a GitHub-Actions cron probe in favour
+of the web tests. **What has changed is that prod has no users and the credit has a deadline.** R8's
+premise — "the warm replica removes cold starts for real users" — is currently vacuous, and ADR-0020's
+rejection was reasoned against an always-warm prod, where a probe costs nothing but money.
+
+## Decision
+
+### 1. `min_replicas = 0` everywhere; prod's warm replica comes from a KEDA cron rule
+
+`var.app_min_replicas` defaults to **0** (staging already was). A new nullable
+`var.app_warm_window` object (`timezone` / `start` / `end`) renders a `custom_scale_rule` of type
+`cron` on each app, with `desiredReplicas = "1"`. Prod's default window is
+**07:00–22:00 Europe/Warsaw, daily** — the hours a recruiter opens the link. KEDA takes `max()` over
+all scalers, so inside the window the cron rule is a *dynamic minimum* of one replica; outside it the
+app returns to `min_replicas` after the platform's 300 s cool-down. Staging sets `app_warm_window = null`
+and stays pure scale-to-zero (ADR-0020).
+
+The window is one variable. Widen it, narrow it, or make it weekday-only (`0 8 * * 1-5`) in one line.
+
+### 2. Every app declares an explicit `http_scale_rule`
+
+Azure applies its implicit HTTP scale rule **only while no scale rule is declared** ("If you don't
+create a scale rule, the default scale rule is applied"). Declaring the cron rule *replaces* it. An
+app at zero replicas with only a cron rule would have no trigger to start on, and a request outside
+the warm window would reach nothing — a silent nightly outage instead of a cold start. The explicit
+`http_scale_rule` (`concurrent_requests = 10`) is the 0→1 activation; `max_replicas = 1` caps it.
+
+**Off-hours is therefore a cold start (~10–30 s, including the Neon wake), never an outage.**
+
+### 3. The Azure web tests are deleted; a daily GitHub Actions cron replaces them
+
+`.github/workflows/health-ping.yml` probes the three public origins once a day at 03:00 UTC (05:00
+Warsaw in summer), on free GitHub-hosted minutes, and fails the run when any origin is unhealthy —
+GitHub emails the last committer of the workflow file. Running *before* the warm window opens is
+deliberate: the probe pays the day's first cold start, and a green run proves both platform health and
+that scale-from-zero actually serves traffic.
+
+The APIs are probed on **`/health`**, not `/health/ready`. ADR-0025 keeps the Postgres check out of the
+readiness tag so ACA's probes cannot hold Neon awake, and names the full `/health` as the on-demand deep
+check; once a day is precisely that occasion, and it is the only probe that proves the database is
+reachable.
+
+## Consequences
+
+### Positive
+
+- Projected run rate **EUR 4.82/day → ~EUR 2.4/day** (~EUR 145 → ~EUR 72 per month), roughly half:
+  prod compute −37.5% (15 warm hours of 24), TheKittySaver staging to zero, web tests to zero.
+  The remaining credit stretches from ~10 days to the end of the month.
+- Prod is fast exactly when it is looked at, and reachable — slowly — when it is not.
+- The daily probe is strictly *more* honest than the web tests it replaces: it exercises the deep
+  `/health` (database included), which `/health/ready` deliberately does not.
+- The cost knob is a Terraform variable, not a code change.
+
+### Negative / Accepted Trade-offs
+
+- **Outage detection latency goes from ~20 minutes to ~24 hours.** Accepted: zero users, and the
+  5xx / restart / log-spike metric alerts still fire on their own cadences for serving-path failures.
+- **A visitor outside 07:00–22:00 pays a cold start**, and the chain compounds (frontend cold → auth
+  cold on OIDC discovery). This is the explicit price of the credit lasting the month.
+- **The SSL-expiry guard and the App Insights availability record are lost** with the web tests. The
+  ACA managed certificate auto-renews; losing the guard is a real, accepted reduction in cover.
+- **A red morning run can mean "Brevo is down", not "the site is down"** — auth's deep `/health`
+  includes SMTP. The failing check's name is printed in the job summary.
+- **The daily deep probe wakes Neon once**, against ADR-0025's spirit. One wake per day is noise next
+  to the compute cap.
+- **GitHub disables scheduled workflows in repositories with 60 days of no activity.** Both repos are
+  active; if that ever changes, the probe silently stops.
+
+### Operational note — a Terraform apply alone does NOT take effect
+
+The apps run `revision_mode = "Multiple"` with `ingress[0].traffic_weight` under
+`lifecycle.ignore_changes` (ADR-0012 §5). Scale rules live in `template`, so changing them mints a
+**new revision that receives 0% of traffic**, while the old revision keeps serving *and keeps its old
+`min_replicas`*. Terraform will not move traffic. Every change to this file therefore only lands once
+the rollout shifts traffic to the new revision and deactivates the previous one — which `deploy.yml`
+does on a normal deploy, and which must be done by hand after an out-of-band `terraform apply`.
+
+## Alternatives Considered
+
+- **Keep prod always warm (status quo, R8).** Rejected: EUR ~145/month against ~EUR 49 of credit — the
+  sites would go dark mid-month, which is worse for a CV link than a nightly cold start.
+- **Keep the web tests at a lower cadence.** Rejected as *incoherent*, not merely expensive: any
+  external probe of the public origin wakes the app it is watching. A probe and a scale-to-zero app
+  cannot coexist. This is what ADR-0020 could not have foreseen while prod was always warm.
+- **Weekday-only window (`0 8 * * 1-5`).** Rejected for now: a recruiter clicking on Sunday evening is
+  plausible, and the extra saving (~EUR 15/month) does not buy that risk. It is the next knob if the
+  credit runs short — a one-line change to `app_warm_window`.
+- **Take one prod down (it is two portfolio projects).** Rejected: both are CV links.
+- **Scale prod to zero with no window at all.** Rejected: it makes every recruiter visit a cold start,
+  the one outcome the maintainer explicitly ruled out.
+- **Lengthen the health-probe intervals so replicas fall into ACA's idle billing.** Rejected as
+  unverified: the active/idle split above suggests it would not work, and it would slow crash detection.
+  Fewer replica-hours is the lever we can prove.
+
+## Implementation Notes
+
+- `iac/vars.tf` — `app_min_replicas` default 1 → 0; new nullable `app_warm_window` object with cron
+  shape validation.
+- `iac/azure-container-apps.tf` — all three apps gain an explicit `http_scale_rule` plus a
+  `dynamic "custom_scale_rule"` (type `cron`) rendered only when `app_warm_window != null`.
+- `iac/env/staging.tfvars` — `app_warm_window = null`.
+- `iac/monitoring.tf` — `azurerm_application_insights_standard_web_test.availability` and
+  `azurerm_monitor_metric_alert.availability` deleted, with their locals; the App Insights component,
+  the auth-latency alert and every metric/log alert stay.
+- `.github/workflows/health-ping.yml` — new.
+- `docs/deployment/runbook.md` — warm window + the new probe documented.
+- TheKittySaver receives the mirror change (its ADR-0015 / issue #281); the two projects share this
+  subscription, and fixing only one of them fixes nothing.

--- a/docs/adr/0027-scheduled-warm-window-and-daily-health-ping.md
+++ b/docs/adr/0027-scheduled-warm-window-and-daily-health-ping.md
@@ -78,7 +78,19 @@ app at zero replicas with only a cron rule would have no trigger to start on, an
 the warm window would reach nothing — a silent nightly outage instead of a cold start. The explicit
 `http_scale_rule` (`concurrent_requests = 10`) is the 0→1 activation; `max_replicas = 1` caps it.
 
-**Off-hours is therefore a cold start (~10–30 s, including the Neon wake), never an outage.**
+**Off-hours is therefore a cold start, never an outage.** Measured on the live stack at 04:15 Warsaw,
+all three apps at zero replicas:
+
+| request | result |
+|---|---|
+| first hit on `https://lotro-translator.pl/` | **200 in 42.8 s** (TTFB 11.9 s) |
+| same page while everything is warm | **200 in 0.21 s** |
+| `auth` cold start alone | **31.4 s** |
+| `tms` / frontend cold start alone | ~11 s |
+
+The chain compounds: the frontend cold-starts, then blocks on OIDC discovery against a still-cold auth.
+**Auth's ~31 s dominates**, so it — not the frontend — is what to optimise if this ever needs to be
+faster. Warming only the frontend would buy nothing, which is why the cron rule covers all three apps.
 
 ### 3. The Azure web tests are deleted; a daily GitHub Actions cron replaces them
 
@@ -109,8 +121,10 @@ reachable.
 
 - **Outage detection latency goes from ~20 minutes to ~24 hours.** Accepted: zero users, and the
   5xx / restart / log-spike metric alerts still fire on their own cadences for serving-path failures.
-- **A visitor outside 07:00–22:00 pays a cold start**, and the chain compounds (frontend cold → auth
-  cold on OIDC discovery). This is the explicit price of the credit lasting the month.
+- **A visitor outside 07:00–22:00 waits ~43 s for the first page** (measured, above) — noticeably worse
+  than the 10–30 s this ADR first assumed before the stack was measured. This is the explicit price of
+  the credit lasting the month. If it ever costs a real opportunity, the window is one line, and auth's
+  31 s cold start is the thing to attack.
 - **The SSL-expiry guard and the App Insights availability record are lost** with the web tests. The
   ACA managed certificate auto-renews; losing the guard is a real, accepted reduction in cover.
 - **A red morning run can mean "Brevo is down", not "the site is down"** — auth's deep `/health`

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -985,19 +985,22 @@ the traces**. Adding a metrics destination is deferred until there is a real nee
 
 ## Monitoring & alerting
 
-Defined as code in [`iac/monitoring.tf`](../../iac/monitoring.tf) (audit 0001 §C3; the availability
-SLO reworked in [ADR-0019](../adr/0019-symptom-based-external-slo-probe.md)). Every alert
+Defined as code in [`iac/monitoring.tf`](../../iac/monitoring.tf) (audit 0001 §C3). Every alert
 **fires by email** to `var.admin_email` through a single Azure Monitor action group
 (`lotrotmsag<env_id>`) — **email only, no SMS**. Most alerts stand on signals that already exist (ACA
-platform metrics + the Log Analytics workspace the apps stream console logs to); the availability SLO
-and the auth latency alert additionally read **Application Insights** (synthetic web tests + the
-OTel-reconstructed request metrics). Everything is parametrized by `var.env_id`, so a future staging
-inherits the same alerting.
+platform metrics + the Log Analytics workspace the apps stream console logs to); the auth latency
+alert additionally reads **Application Insights** (the OTel-reconstructed request metrics).
+Everything is parametrized by `var.env_id`, so a future staging inherits the same alerting.
+
+> **The external availability SLO of [ADR-0019](../adr/0019-symptom-based-external-slo-probe.md) is
+> gone** ([ADR-0027](../adr/0027-scheduled-warm-window-and-daily-health-ping.md)). Prod now scales to
+> zero outside its warm window, and an Application Insights web test hitting the public origin every
+> 15 minutes would wake the apps around the clock. Availability is checked once a day instead, by
+> [`.github/workflows/health-ping.yml`](../../.github/workflows/health-ping.yml) — see
+> "Warm window & the daily health ping" below.
 
 | Alert | Source | Fires when | Severity |
 |---|---|---|---|
-| **Availability SLO — auth** | AI standard web test (public origin) | `https://auth.<domain>/health/ready` is unreachable from **≥2 of 3 regions** — auth is the token-issuance SPOF, so this is the platform's SLO | 0 Critical |
-| **Availability — tms / frontend** | AI standard web tests | `tms/health/ready` or the frontend home is unreachable from **≥2 of 3 regions** | 1 Error |
 | **Replica restart** | metric `RestartCount` | any of the three apps restarts a replica (crash-loop signal: OOM, failed readiness, unhandled crash). Sensitive by design (`> 0`); stays active for the affected revision and auto-mitigates on a clean revision | 1 Error |
 | **HTTP 5xx spike** | metric `Requests` (`statusCodeCategory = 5xx`) | an app returns more than 5 server errors in 5 minutes. 4xx is intentionally not alerted (auth 401/400 are normal control flow) | 1 Error |
 | **Key Vault availability** | metric `Microsoft.KeyVault/vaults` `Availability` | the vault's availability drops below 99% over 15 minutes — KV is the secret-resolution SPOF (every revision resolves its secrets at start) | 1 Error |
@@ -1005,17 +1008,10 @@ inherits the same alerting.
 | **Memory saturation** | metric `WorkingSetBytes` | an app sustains >80% of its 0.5 GiB limit for 15 minutes (OOM precursor) | 2 Warning |
 | **Auth latency** | AI `requests/duration` (auth role) | auth server response time averages **>2 s over 15 minutes** — a leading indicator before readiness fails | 2 Warning |
 | **LAW daily cap reached** | LAW `Operation` table | the workspace's daily ingestion cap (`daily_quota_gb` in `azure-law.tf`) is hit and **log collection has stopped** — a blind spot exactly during an error storm | 2 Warning |
-| **CPU saturation** | metric `UsageNanoCores` | an app sustains >80% of its 0.25 vCPU limit for 15 minutes (capacity signal; no horizontal headroom at min=max=1 replica) | 3 Informational |
+| **CPU saturation** | metric `UsageNanoCores` | an app sustains >80% of its 0.25 vCPU limit for 15 minutes (capacity signal; no horizontal headroom at `max_replicas = 1`) | 3 Informational |
 
 Notes for the operator:
 
-- **The availability SLO is deploy-safe by construction.** The standard web tests probe each app's
-  **public origin** — which only ever resolves to the revision serving 100% of traffic. A health-gated
-  rollout's candidate revision takes 0% traffic and is reachable only via its private
-  `<app>---cd-candidate` label FQDN, so **a deploy cannot trip these**. This is the fix for the old
-  log-based `auth_availability`, which paged Sev0 on every release (it matched the app name, not the
-  serving revision). Durability is geographic — **≥2 of 3 locations** (West Europe, North Europe,
-  France Central) must fail — so a single-region blip is rejected without delaying a real outage.
 - The metric alerts are fanned out **per app** (a `for_each` over auth-api / tms-api / frontend),
   one single-scope rule each — the universally-supported shape (Azure does not allow multi-resource
   metric alerts for Container Apps). The alert name carries the app key, e.g.
@@ -1023,25 +1019,67 @@ Notes for the operator:
 - The two log (scheduled-query) alerts set `skip_query_validation = true`, because the
   `*_CL` tables only exist once the apps have emitted those records — a fresh environment can
   provision the alerts before any logs flow.
-- **Confirm-at-apply, not at plan.** The web-test geo codes, the auth alert's `cloud/roleName`
-  (= the app's OTel `service.name` = its entry-assembly name `LotroKoniecDev.AuthSystem.API`), and
-  the App Insights / KV metric names are only validated server-side. If an availability or latency
+- **Confirm-at-apply, not at plan.** The auth alert's `cloud/roleName`
+  (= the app's OTel `service.name` = its entry-assembly name `LotroKoniecDev.AuthSystem.API`) and
+  the App Insights / KV metric names are only validated server-side. If the latency
   alert shows **no data**, verify those against live App Insights after the first apply.
 
 **Responding to an alert:**
 
 | Alert | First moves |
 |---|---|
-| Availability SLO (auth/tms/frontend) | Hit the public origin yourself: `curl -sS -o /dev/null -w '%{http_code}' https://auth.<domain>/health/ready`. If it's down, check ACA revision health + the traffic split (`az containerapp ingress traffic show`) — a bad revision live means the rollout's auto-rollback (`deploy.yml`) did not fire; steer traffic back with `az containerapp ingress traffic set --revision-weight <prev>=100`. If the origin is up, suspect DNS/cert/regional network. |
+| Health ping failed (GitHub Actions) | Read the run's job summary — it names the failing origin and prints the `/health` response body, so an unhealthy `authdb` / `smtp` check is distinguishable from a dead site. Then hit it yourself: `curl -sS -o /dev/null -w '%{http_code}' https://auth.<domain>/health` (allow ~30 s: outside the warm window this is a cold start). If it stays down, check ACA revision health + the traffic split (`az containerapp ingress traffic show`) — a bad revision live means the rollout's auto-rollback (`deploy.yml`) did not fire; steer traffic back with `az containerapp ingress traffic set --revision-weight <prev>=100`. If the origin is up, suspect DNS/cert. |
 | Key Vault availability | Portal → the vault → check for throttling / an Azure KV incident; confirm the `lotrotms-aca-<env_id>` identity still has *Key Vault Secrets User*; new revisions cannot boot without secret resolution. |
 | Auth latency | App Insights → Performance for the auth role; check the DB (Neon) latency and the sibling CPU/memory saturation alerts. Leading indicator — investigate before it becomes a 5xx / readiness failure. |
 | Replica restart / 5xx / log error spike | App Insights logs + `az containerapp logs show` for the named app; correlate with a recent deploy. |
-| CPU / memory saturation | Capacity signal at min=max=1 replica: inspect the workload, then raise the request or replica ceiling in `azure-container-apps.tf`. |
+| CPU / memory saturation | Capacity signal at `max_replicas = 1`: inspect the workload, then raise the request or replica ceiling in `azure-container-apps.tf`. |
 
-**Silencing during planned disruptive work.** Routine deploys need **no** suppression (the availability
-SLO is deploy-safe by construction). For genuinely disruptive planned work (e.g. a migration with
-downtime), add a temporary **alert processing rule** rather than editing Terraform — scope it to the
-resource group for the maintenance window, then delete it:
+### Warm window & the daily health ping
+
+Prod runs `min_replicas = 0` and buys its warm replica from a **schedule**
+([ADR-0027](../adr/0027-scheduled-warm-window-and-daily-health-ping.md)): a KEDA `cron` scale rule
+holds one replica per app during `var.app_warm_window` (default **07:00–22:00 Europe/Warsaw, daily**;
+KEDA handles DST from the IANA name). Outside it the apps scale to zero and the explicit
+`http_scale_rule` wakes them on the first request — **off-hours is a cold start (~10–30 s incl. the
+Neon wake), never an outage.** Staging sets `app_warm_window = null` and never schedules a replica.
+
+Change the window in **one place**, `iac/vars.tf`:
+
+```hcl
+# widen it (recruiter season)          # or make it weekday-only (cheapest)
+start = "0 6 * * *"                    start = "0 8 * * 1-5"
+end   = "0 23 * * *"                   end   = "0 20 * * 1-5"
+```
+
+Verify the live scale config and the current replica count:
+
+```bash
+az containerapp show -n lotrotms-frontend-prod -g rg-lotrotms-prod-polc-001 \
+  --query 'properties.template.scale' -o json          # minReplicas 0 + the http + cron rules
+az containerapp replica list -n lotrotms-frontend-prod -g rg-lotrotms-prod-polc-001 -o table
+```
+
+> **A `terraform apply` alone does not take effect.** Scale rules live in `template`, the apps run
+> `revision_mode = "Multiple"`, and `ingress[0].traffic_weight` is under `lifecycle.ignore_changes`.
+> Changing a scale rule therefore mints a **new revision at 0% traffic** while the old one keeps
+> serving with its old scale config. Either deploy normally (`deploy.yml` promotes and deactivates), or
+> promote by hand:
+>
+> ```bash
+> az containerapp ingress traffic set -n <app> -g <rg> --revision-weight <new>=100 <old>=0
+> az containerapp revision deactivate -n <app> -g <rg> --revision <old>
+> ```
+
+Availability is checked once a day by [`.github/workflows/health-ping.yml`](../../.github/workflows/health-ping.yml)
+(03:00 UTC — just before the window opens, so the probe pays the day's first cold start, not a visitor).
+It probes `auth`/`tms` on the **deep** `/health` (database included — `/health/ready` is DB-free by
+ADR-0025) and the frontend on `/`. A failed run emails the last committer of the workflow file. Trigger
+it on demand with `gh workflow run health-ping.yml`.
+
+**Silencing during planned disruptive work.** Routine deploys need **no** suppression (every alert is
+scoped to a serving signal, and the candidate revision takes 0% traffic). For genuinely disruptive
+planned work (e.g. a migration with downtime), add a temporary **alert processing rule** rather than
+editing Terraform — scope it to the resource group for the maintenance window, then delete it:
 
 ```bash
 az monitor alert-processing-rule create \

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -1040,8 +1040,10 @@ Prod runs `min_replicas = 0` and buys its warm replica from a **schedule**
 ([ADR-0027](../adr/0027-scheduled-warm-window-and-daily-health-ping.md)): a KEDA `cron` scale rule
 holds one replica per app during `var.app_warm_window` (default **07:00–22:00 Europe/Warsaw, daily**;
 KEDA handles DST from the IANA name). Outside it the apps scale to zero and the explicit
-`http_scale_rule` wakes them on the first request — **off-hours is a cold start (~10–30 s incl. the
-Neon wake), never an outage.** Staging sets `app_warm_window = null` and never schedules a replica.
+`http_scale_rule` wakes them on the first request — **off-hours is a cold start, never an outage.**
+Measured on the live stack with every app at zero: the first page load takes **~43 s** (auth's own cold
+start is ~31 s of it and dominates the chain, because the frontend blocks on OIDC discovery); once warm
+the same page serves in **0.21 s**. Staging sets `app_warm_window = null` and never schedules a replica.
 
 Change the window in **one place**, `iac/vars.tf`:
 

--- a/iac/azure-container-apps.tf
+++ b/iac/azure-container-apps.tf
@@ -63,14 +63,44 @@ resource "azurerm_container_app" "auth_api" {
   }
 
   template {
-    # Prod keeps one warm replica per revision (audit 0001 M3 / ADR-0012 R8): no cold starts, and the
-    # health-gated rollout's 0%-traffic candidate stays smokeable while the previous revision stays
-    # warm for cross-revision token validation. Staging runs 0 (ADR-0020 FinOps): scale-to-zero
-    # between rollouts/QA — deploy.yml's readiness polls wake the candidates and warm the public auth
-    # origin before smoke, so the rollout holds at min 0. The CD rollout still deactivates superseded
-    # revisions so a warm minimum never accumulates idle replicas.
+    # ADR-0027 replaces the always-warm floor of ADR-0012 R8 with a SCHEDULE. min_replicas is 0 in
+    # every environment; prod's warm replica now comes from the cron rule below, so the apps hold a
+    # replica only during the hours a recruiter opens the CV link and cost nothing overnight. The
+    # health-gated rollout stays valid at 0: deploy.yml's readiness polls (60×10s) wake the
+    # 0%-traffic candidate and warm the public auth origin before smoke, and the rollout still
+    # deactivates superseded revisions so no idle replica accumulates.
     min_replicas = var.app_min_replicas
     max_replicas = 1
+
+    # The platform's implicit HTTP scale rule exists ONLY while no rule is declared ("If you don't
+    # create a scale rule, the default scale rule is applied" — Azure "Scaling in Container Apps").
+    # Declaring the cron rule below therefore REPLACES it, and an app sitting at zero replicas would
+    # be left with no trigger to start on: a request outside the warm window would reach nothing.
+    # This rule is the 0→1 activation that keeps off-hours a cold start, never an outage.
+    http_scale_rule {
+      name                = "http"
+      concurrent_requests = "10"
+    }
+
+    # Warm window (ADR-0027). KEDA evaluates every scaler and takes max(metrics), so inside the
+    # window this rule acts as a dynamic minimum of one replica; outside it the app returns to
+    # min_replicas after the platform's 300 s cool-down. Staging passes null and runs pure
+    # scale-to-zero (ADR-0020), which is why the rule is a dynamic block rather than a literal.
+    dynamic "custom_scale_rule" {
+      for_each = var.app_warm_window == null ? [] : [var.app_warm_window]
+
+      content {
+        name             = "warm-window"
+        custom_rule_type = "cron"
+
+        metadata = {
+          timezone        = custom_scale_rule.value.timezone
+          start           = custom_scale_rule.value.start
+          end             = custom_scale_rule.value.end
+          desiredReplicas = "1"
+        }
+      }
+    }
 
     container {
       name   = "auth-api"
@@ -261,14 +291,44 @@ resource "azurerm_container_app" "tms_api" {
   }
 
   template {
-    # Prod keeps one warm replica per revision (audit 0001 M3 / ADR-0012 R8): no cold starts, and the
-    # health-gated rollout's 0%-traffic candidate stays smokeable while the previous revision stays
-    # warm for cross-revision token validation. Staging runs 0 (ADR-0020 FinOps): scale-to-zero
-    # between rollouts/QA — deploy.yml's readiness polls wake the candidates and warm the public auth
-    # origin before smoke, so the rollout holds at min 0. The CD rollout still deactivates superseded
-    # revisions so a warm minimum never accumulates idle replicas.
+    # ADR-0027 replaces the always-warm floor of ADR-0012 R8 with a SCHEDULE. min_replicas is 0 in
+    # every environment; prod's warm replica now comes from the cron rule below, so the apps hold a
+    # replica only during the hours a recruiter opens the CV link and cost nothing overnight. The
+    # health-gated rollout stays valid at 0: deploy.yml's readiness polls (60×10s) wake the
+    # 0%-traffic candidate and warm the public auth origin before smoke, and the rollout still
+    # deactivates superseded revisions so no idle replica accumulates.
     min_replicas = var.app_min_replicas
     max_replicas = 1
+
+    # The platform's implicit HTTP scale rule exists ONLY while no rule is declared ("If you don't
+    # create a scale rule, the default scale rule is applied" — Azure "Scaling in Container Apps").
+    # Declaring the cron rule below therefore REPLACES it, and an app sitting at zero replicas would
+    # be left with no trigger to start on: a request outside the warm window would reach nothing.
+    # This rule is the 0→1 activation that keeps off-hours a cold start, never an outage.
+    http_scale_rule {
+      name                = "http"
+      concurrent_requests = "10"
+    }
+
+    # Warm window (ADR-0027). KEDA evaluates every scaler and takes max(metrics), so inside the
+    # window this rule acts as a dynamic minimum of one replica; outside it the app returns to
+    # min_replicas after the platform's 300 s cool-down. Staging passes null and runs pure
+    # scale-to-zero (ADR-0020), which is why the rule is a dynamic block rather than a literal.
+    dynamic "custom_scale_rule" {
+      for_each = var.app_warm_window == null ? [] : [var.app_warm_window]
+
+      content {
+        name             = "warm-window"
+        custom_rule_type = "cron"
+
+        metadata = {
+          timezone        = custom_scale_rule.value.timezone
+          start           = custom_scale_rule.value.start
+          end             = custom_scale_rule.value.end
+          desiredReplicas = "1"
+        }
+      }
+    }
 
     container {
       name  = "tms-api"
@@ -389,14 +449,44 @@ resource "azurerm_container_app" "frontend" {
   }
 
   template {
-    # Prod keeps one warm replica per revision (audit 0001 M3 / ADR-0012 R8): no cold starts, and the
-    # health-gated rollout's 0%-traffic candidate stays smokeable while the previous revision stays
-    # warm for cross-revision token validation. Staging runs 0 (ADR-0020 FinOps): scale-to-zero
-    # between rollouts/QA — deploy.yml's readiness polls wake the candidates and warm the public auth
-    # origin before smoke, so the rollout holds at min 0. The CD rollout still deactivates superseded
-    # revisions so a warm minimum never accumulates idle replicas.
+    # ADR-0027 replaces the always-warm floor of ADR-0012 R8 with a SCHEDULE. min_replicas is 0 in
+    # every environment; prod's warm replica now comes from the cron rule below, so the apps hold a
+    # replica only during the hours a recruiter opens the CV link and cost nothing overnight. The
+    # health-gated rollout stays valid at 0: deploy.yml's readiness polls (60×10s) wake the
+    # 0%-traffic candidate and warm the public auth origin before smoke, and the rollout still
+    # deactivates superseded revisions so no idle replica accumulates.
     min_replicas = var.app_min_replicas
     max_replicas = 1
+
+    # The platform's implicit HTTP scale rule exists ONLY while no rule is declared ("If you don't
+    # create a scale rule, the default scale rule is applied" — Azure "Scaling in Container Apps").
+    # Declaring the cron rule below therefore REPLACES it, and an app sitting at zero replicas would
+    # be left with no trigger to start on: a request outside the warm window would reach nothing.
+    # This rule is the 0→1 activation that keeps off-hours a cold start, never an outage.
+    http_scale_rule {
+      name                = "http"
+      concurrent_requests = "10"
+    }
+
+    # Warm window (ADR-0027). KEDA evaluates every scaler and takes max(metrics), so inside the
+    # window this rule acts as a dynamic minimum of one replica; outside it the app returns to
+    # min_replicas after the platform's 300 s cool-down. Staging passes null and runs pure
+    # scale-to-zero (ADR-0020), which is why the rule is a dynamic block rather than a literal.
+    dynamic "custom_scale_rule" {
+      for_each = var.app_warm_window == null ? [] : [var.app_warm_window]
+
+      content {
+        name             = "warm-window"
+        custom_rule_type = "cron"
+
+        metadata = {
+          timezone        = custom_scale_rule.value.timezone
+          start           = custom_scale_rule.value.start
+          end             = custom_scale_rule.value.end
+          desiredReplicas = "1"
+        }
+      }
+    }
 
     container {
       name   = "frontend"

--- a/iac/env/staging.tfvars
+++ b/iac/env/staging.tfvars
@@ -21,5 +21,10 @@ aca_environment_resource_group = "rg-lotrotms-prod-polc-001"
 # Scale-to-zero (ADR-0020 FinOps): staging serves no steady traffic — no synthetic probes (staging
 # creates no monitoring, ADR-0018/M6-22) and no users between rollouts/QA — so three always-on
 # 0.25 vCPU / 0.5 GiB replicas were pure idle spend (~$15-18/month). First request after idle pays a
-# cold start (~10-20 s incl. Neon wake); accepted for QA. Prod stays at 1 (ADR-0012 R8).
+# cold start (~10-20 s incl. Neon wake); accepted for QA. Prod is now 0 too (ADR-0027) — it buys its
+# warm replica from a schedule instead of a floor.
 app_min_replicas = 0
+
+# No warm window on staging (ADR-0027): nobody is looking at it outside a rollout or a QA session,
+# and both wake it through the http_scale_rule. Prod keeps the default schedule.
+app_warm_window = null

--- a/iac/monitoring.tf
+++ b/iac/monitoring.tf
@@ -4,15 +4,16 @@
 #
 # Most alerts deliberately stand on signals that ALREADY exist — ACA platform metrics
 # (Microsoft.App/containerApps) and the Log Analytics workspace the apps already stream console logs
-# to. The availability SLO + auth latency added in ADR-0019 additionally read Application Insights
-# (the synthetic web tests + the OTel-reconstructed request metrics, observability.tf). Everything is
-# parametrized by var.env_id so a future staging inherits alerting for free.
+# to. The auth latency alert additionally reads Application Insights (the OTel-reconstructed request
+# metrics, observability.tf). The external availability SLO that used to live here was retired by
+# ADR-0027 — see the comment above the auth_role_name local. Everything is parametrized by var.env_id
+# so a future staging inherits alerting for free.
 #
 # Delivery is EMAIL ONLY (owner decision): one action group with a single email receiver
 # (var.admin_email). No SMS, no webhook. Every alert below references that action group.
 #
-# Plan-on-PR caveat: Terraform `plan` does not validate metric names, log-table schemas, KQL, the
-# web-test geo codes, or the auth cloud_RoleName against the live Azure catalog — those are checked
+# Plan-on-PR caveat: Terraform `plan` does not validate metric names, log-table schemas, KQL, or the
+# auth cloud_RoleName against the live Azure catalog — those are checked
 # server-side at `apply` (or observed only once telemetry flows). The metric names used here
 # (RestartCount / Requests / UsageNanoCores / WorkingSetBytes / KeyVault Availability / requests-
 # duration) and the log tables (ContainerAppConsoleLogs_CL / Operation) are the documented
@@ -156,7 +157,7 @@ resource "azurerm_monitor_metric_alert" "http_server_errors" {
 }
 
 # Sustained CPU saturation (>80% of the 0.25-vCPU limit over 15 minutes). Informational: at
-# min=max=1 replica there is no horizontal headroom, so this is a capacity signal — investigate or
+# max_replicas = 1 there is no horizontal headroom, so this is a capacity signal — investigate or
 # raise the CPU request before it throttles.
 resource "azurerm_monitor_metric_alert" "cpu_saturation" {
   for_each            = local.create_env ? local.monitored_container_apps : {}
@@ -335,117 +336,24 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "law_daily_cap" {
 }
 
 # ---------------------------------------------------------------------------------------------------
-# External synthetic availability — the platform's real SLO (ADR-0019). This REPLACES the former
-# log-based auth_availability, which fired on EVERY deploy: that rule matched ContainerAppSystemLogs_CL
-# by app NAME (not revision), so a health-gated candidate revision (0% traffic, still starting → a few
-# transient /health/ready misses until its Npgsql pool connects) tripped a Sev0 while users were served
-# the whole time by the previous, healthy revision.
+# The synthetic availability probes of ADR-0019 (three azurerm_application_insights_standard_web_test +
+# their location-availability alerts) were REMOVED here by ADR-0027, and the removal is not a cost tweak
+# but a correctness one: an external probe hitting the public origin every 15 minutes from three regions
+# is itself a request, so it would wake a scaled-to-zero app around the clock and cancel the very saving
+# the warm window exists to make. A probe cannot both watch an app and let it sleep.
 #
-# A standard web test probes each app's PUBLIC origin from multiple regions. The public origin only
-# ever resolves to the revision serving 100% of traffic — a 0%-traffic candidate is reachable solely via
-# its private <app>---cd-candidate label FQDN — so a deploy CANNOT trip these. The false-positive class
-# is eliminated by construction, not by threshold tuning. This is exactly the synthetic probe audit 0001
-# §C3 named as the correct instrument, deferred only for want of an App Insights resource + a public-
-# origin variable; both now exist (ADR-0016 / ADR-0017).
+# The replacement lives outside Azure: .github/workflows/health-ping.yml probes the same three public
+# origins once a day, just before the warm window opens, on free GitHub-hosted minutes. It costs nothing,
+# wakes the apps once, and a failed run emails the owner. The trade is deliberate — detection latency
+# goes from ~20 minutes to ~24 hours, which is the right shape for a pre-release platform with zero users
+# whose real requirement is "tell me in the morning if it died overnight". Restore the web tests (git
+# history) the day real users arrive: at that point an always-warm prod is justified anyway, and the
+# probe/warm-window conflict dissolves.
 locals {
   # cloud_RoleName as the apps tag it via OTel (service.name = IHostEnvironment.ApplicationName = the
   # entry-assembly name; each Program.cs ConfigureResource). Scopes the auth latency alert below.
   # Confirm against live App Insights on first apply (managed OTel agent → AI role-name mapping).
   auth_role_name = "LotroKoniecDev.AuthSystem.API"
-
-  # Probe locations (Azure Monitor availability population tags): West Europe (Amsterdam), North Europe
-  # (Dublin), France Central (Paris) — EU-centric, closest to the Poland Central deployment.
-  availability_test_geo_locations = ["emea-nl-ams-azr", "emea-gb-db3-azr", "emea-fr-pra-edge"]
-
-  # One entry per user-facing app: its public origin, the status it must return, and the alert severity.
-  # auth is Sev0 (token-issuance SPOF = platform outage); tms + frontend are Sev1 (degraded, not a total
-  # outage). expected_status_code 0 = "any code < 400" — the Static-SSR frontend has no /health endpoint,
-  # so a 2xx/3xx on '/' is its liveness.
-  availability_web_tests = {
-    "auth"     = { url = "${local.auth_origin}/health/ready", expected_status_code = 200, severity = 0 }
-    "tms"      = { url = "${local.tms_origin}/health/ready", expected_status_code = 200, severity = 1 }
-    "frontend" = { url = "${local.apex_origin}/", expected_status_code = 0, severity = 1 }
-  }
-}
-
-# The web tests. Standard tests (classic ping tests are Microsoft-retired) run from the geo locations
-# above every 15 minutes, validating the status code + the SSL certificate's remaining lifetime. The
-# 7-day SSL threshold is a free, low-noise cert-expiry guard: the ACA managed cert auto-renews well
-# before 7 days, so a trip means auto-renew has failed — a real imminent outage, correctly escalated.
-#
-# Cadence is a cost knob (ADR-0020): standard tests bill $0.0006 PER EXECUTION, so 3 tests × 3
-# locations × every 300 s ≈ 77.8k executions ≈ $47/month — the single largest line item on the
-# student subscription, dwarfing the apps' compute. 900 s cuts that to ≈ $15.6/month (and cuts the
-# probes' own request-telemetry ingestion 3×) at the price of ~15-20 min worst-case detection —
-# acceptable pre-release with zero users. When real users arrive, drop auth (the Sev0 SPOF) back to
-# 300 (+$10/month) and leave tms/frontend at 900.
-resource "azurerm_application_insights_standard_web_test" "availability" {
-  for_each                = local.create_env ? local.availability_web_tests : {}
-  name                    = "lotrotms-webtest-${each.key}-${var.env_id}"
-  resource_group_name     = azurerm_resource_group.main.name
-  location                = azurerm_resource_group.main.location
-  application_insights_id = azurerm_application_insights.app_insights[0].id
-  geo_locations           = local.availability_test_geo_locations
-  frequency               = 900
-  timeout                 = 30
-  enabled                 = true
-  retry_enabled           = true
-  description             = "External synthetic availability probe of ${each.key} at its public origin (ADR-0019)."
-
-  request {
-    url                      = each.value.url
-    follow_redirects_enabled = true
-  }
-
-  validation_rules {
-    expected_status_code        = each.value.expected_status_code
-    ssl_check_enabled           = true
-    ssl_cert_remaining_lifetime = 7
-  }
-
-  tags = {
-    environment = var.env_id
-    src         = var.src_key
-    project     = "lotrotms"
-  }
-}
-
-# Availability alert per web test. Durability is GEOGRAPHIC, not temporal: the alert fires only when at
-# least 2 of the 3 locations fail in the window — rejecting a single-location network blip WITHOUT the
-# detection delay a "wait N consecutive windows" debounce would add to a real Sev0. A
-# location-availability criterion needs BOTH the web test id and the App Insights component id in scopes.
-# The window must be wide enough to hold results from ≥2 locations at the 900 s cadence (ADR-0020):
-# PT30M holds ~2 results per location; the former PT5M would often hold ≤1 result TOTAL, so the
-# 2-location quorum could never be reached and the alert would go silent — widening it is correctness,
-# not tuning.
-resource "azurerm_monitor_metric_alert" "availability" {
-  for_each            = local.create_env ? local.availability_web_tests : {}
-  name                = "lotrotms-slo-availability-${each.key}-${var.env_id}"
-  resource_group_name = azurerm_resource_group.main.name
-  scopes = [
-    azurerm_application_insights_standard_web_test.availability[each.key].id,
-    azurerm_application_insights.app_insights[0].id,
-  ]
-  description = "SLO: ${each.key} unreachable at its public origin from multiple regions. Fires by email."
-  severity    = each.value.severity
-  frequency   = "PT1M"
-  window_size = "PT30M"
-
-  application_insights_web_test_location_availability_criteria {
-    web_test_id           = azurerm_application_insights_standard_web_test.availability[each.key].id
-    component_id          = azurerm_application_insights.app_insights[0].id
-    failed_location_count = 2
-  }
-
-  action {
-    action_group_id = azurerm_monitor_action_group.alerts[0].id
-  }
-
-  tags = {
-    environment = var.env_id
-    src         = var.src_key
-    project     = "lotrotms"
-  }
 }
 
 # Key Vault availability (audit 0001 §M14). KV is the secret-resolution SPOF — every app + the migrator

--- a/iac/vars.tf
+++ b/iac/vars.tf
@@ -73,12 +73,38 @@ variable "aca_environment_resource_group" {
 
 variable "app_min_replicas" {
   type        = number
-  description = "min_replicas for the three container apps. Prod keeps the default 1 (ADR-0012 R8 — a warm replica per revision, no cold starts). Staging sets 0 (ADR-0020 FinOps): scale-to-zero between rollouts/QA — the health-gated rollout stays valid because deploy.yml's readiness polls wake the candidates and warm the public auth origin before smoke."
-  default     = 1
+  description = "min_replicas for the three container apps. Every environment now defaults to 0 (ADR-0027): prod's warm replica is no longer a floor but a SCHEDULE (var.app_warm_window), and staging has run at 0 since ADR-0020. The health-gated rollout stays valid at 0 because deploy.yml's readiness polls wake the candidates and warm the public auth origin before smoke."
+  default     = 0
 
   validation {
     condition     = var.app_min_replicas >= 0 && var.app_min_replicas <= 1
     error_message = "app_min_replicas must be 0 or 1 (max_replicas is fixed at 1)."
+  }
+}
+
+variable "app_warm_window" {
+  type = object({
+    timezone = string
+    start    = string
+    end      = string
+  })
+  nullable    = true
+  description = "Daily window during which a KEDA cron scale rule holds one warm replica per app (ADR-0027). Outside it the apps fall back to app_min_replicas and an explicit http_scale_rule wakes them on the first request. `timezone` is an IANA name (KEDA handles DST); `start`/`end` are 5-field cron expressions. Prod keeps the default — the hours a recruiter opens the CV link. Set to null (staging) for pure scale-to-zero with no schedule."
+
+  default = {
+    timezone = "Europe/Warsaw"
+    start    = "0 7 * * *"
+    end      = "0 22 * * *"
+  }
+
+  validation {
+    condition     = var.app_warm_window == null || try(trimspace(var.app_warm_window.start) != trimspace(var.app_warm_window.end), false)
+    error_message = "app_warm_window.start and app_warm_window.end must differ — KEDA's cron scaler rejects an identical start/end."
+  }
+
+  validation {
+    condition     = var.app_warm_window == null || try(length(split(" ", trimspace(var.app_warm_window.start))) == 5 && length(split(" ", trimspace(var.app_warm_window.end))) == 5, false)
+    error_message = "app_warm_window.start and app_warm_window.end must be 5-field cron expressions (minute hour day-of-month month day-of-week)."
   }
 }
 


### PR DESCRIPTION
Closes #409

## What and why

The subscription was burning **EUR 4.82/day** (EUR 43.35 over 1-9 July) with about EUR 49 of student credit left — roughly ten days. Six always-on prod replicas across two projects served **zero users**.

Prod now holds a warm replica **only during `07:00-22:00 Europe/Warsaw`** (a KEDA cron scale rule), and scales to zero outside it. `min_replicas` is 0 in every environment.

## The two traps this had to solve

1. **Declaring a scale rule removes the platform's implicit HTTP one.** Azure applies the default HTTP rule *only while no rule is declared*. A cron rule alone would leave a zero-replica app with no trigger to start on, so a request at 23:30 would reach nothing — a silent nightly outage instead of a cold start. Every app therefore declares `http_scale_rule` explicitly. Verified live: a zero-replica candidate revision answered 200 on the first request.

2. **A `terraform apply` alone changes nothing.** Scale rules live in the revision `template`, the apps run `revision_mode = "Multiple"`, and `traffic_weight` is under `lifecycle.ignore_changes`. The apply mints a **new revision at 0% traffic** while the old one keeps serving with its old `min_replicas`. Documented in ADR-0027 and the runbook; the rollout (or a manual promote) is what lands it.

## Why the web tests had to go

They are not merely expensive (EUR 3.42 in 9 days) — they are **incoherent with scale-to-zero**. An Application Insights web test hits the public origin every 15 minutes from three regions. A probe is a request; a request wakes a scaled-to-zero app. They would have held prod warm around the clock and cancelled the entire saving.

`.github/workflows/health-ping.yml` replaces them: one probe a day at 03:00 UTC, on free GitHub minutes, just before the window opens — so the probe pays the day's first cold start, not a visitor. It hits the **deep** `/health` (database included; `/health/ready` is DB-free by ADR-0025), and a failed run emails the workflow file's last committer.

This overturns ADR-0020's rejection of a cron probe. That rejection was argued against an always-warm prod, where a probe costs only money.

## Verification (already applied to live prod)

`terraform fmt -check` + `terraform validate` green. The plan was checked for image drift before applying: images stayed pinned to their current digests.

```
lotrotms-auth-api-prod    --0000017   0 replicas   100% traffic   ScaledToZero
lotrotms-tms-api-prod     --0000017   0 replicas   100% traffic   ScaledToZero
lotrotms-frontend-prod    --0000017   0 replicas   100% traffic   ScaledToZero
```

All three public origins returned 200 after promotion, including the deep `/health` on auth and tms.

Projected run rate: **EUR 4.82/day -> ~EUR 2.4/day**, with TheKittySaver's mirror change (koniecdev/TheKittySaver#281).

## Trade-offs accepted

- A visitor outside 07:00-22:00 pays a cold start (~10-30 s incl. the Neon wake).
- Outage detection latency goes from ~20 minutes to ~24 hours.
- The SSL-expiry guard the web tests provided is lost.
- Widening, narrowing or making the window weekday-only is a one-line change to `var.app_warm_window`.