### PR TITLE
Raise the LAW daily ingestion cap to 0.5 GB

### DIFF
--- a/iac/azure-law.tf
+++ b/iac/azure-law.tf
@@ -5,7 +5,20 @@ resource "azurerm_log_analytics_workspace" "law" {
   resource_group_name = azurerm_resource_group.main.name
   sku                 = "PerGB2018"
   retention_in_days   = 30
-  daily_quota_gb      = 0.16
+
+  # This one workspace ingests BOTH projects (lotrotms + tks, prod + staging) — they share the
+  # `lotrotmsenvprod` Container Apps environment, so there is exactly one LAW in the subscription.
+  #
+  # 0.16 pinned ingestion to the 5 GB/month free grant (5 / 31 = 0.161) and was hit EVERY day around
+  # 20:00 UTC, leaving the workspace blind from then until the 12:00 UTC reset — 16 h/day, and the
+  # hole covers the 05:00 UTC cron warm-window scale-up (ADR-0027), which is precisely when the
+  # cold-start replica restarts we need to diagnose happen. Raised to 0.5 to reopen that window.
+  #
+  # Raising the cap does not by itself cost anything: billing is per GB ingested, and the cap only
+  # truncates. Measured burn is ~0.168 GB/day at 24/7 uptime and ~0.105 GB/day (~3.3 GB/month) since
+  # scale-to-zero — still inside the free grant. ~65% of it is /health/live + /health/ready probe
+  # telemetry; filtering those out of OpenTelemetry is the durable fix, after which this drops back.
+  daily_quota_gb = 0.5
 
   lifecycle {
     # Audit 0001 / H11 (ADR-0017): losing this workspace drops all log history. Guard against a stray


### PR DESCRIPTION
## Why

The prod Log Analytics workspace `lotrotmslawprod` had `daily_quota_gb = 0.16`, which pins ingestion to the 5 GB/month free grant (5 / 31 = 0.161). It was reached **every day**, and ingestion then stopped until the next 12:00 UTC reset:

```
2026-07-08 20:11:52  Data collection stopped due to daily limit ... OverQuota
2026-07-09 12:00:02  Data collection started due to new day starting - daily limit reset
```

Same on 6 and 7 July. The workspace is blind roughly 16 hours a day, and the blind window covers **05:00 UTC** — the moment the KEDA cron warm window (ADR-0027) scales the apps up from zero.

That matters right now: on the first cron cold start (today, 05:00 UTC) both auth apps restarted a replica once — `lotrotms-auth-api-prod` and `tks-auth-api-prod` reported `RestartCount = 1`, while the four non-auth apps that scaled up in the same minute reported 0. `lotrotms-alert-replica-restart-auth-api-prod` fired at 05:04 and auto-resolved at 05:10. There are no container logs for that window, so the cause cannot be diagnosed until the cap is lifted.

Audit 0001, finding M9, already asked for this: "Zostaw cap dla kosztu, ale dodaj alert 'daily cap reached'; rozważ ~0.5 GB przed staging." The alert was implemented; the bump was not.

## Cost

Raising the cap does not by itself cost anything — billing is per GB ingested, and the cap only truncates. Measured burn:

| Uptime | Ingestion |
|---|---|
| 24/7 (until 2026-07-08) | 0.168 GB/day |
| warm window, 15 h/day | ~0.105 GB/day (~3.3 GB/month) |

Both sit inside the free grant. About 65% of it is `GET /health/live` + `GET /health/ready` probe telemetry (45,306 of 69,799 `AppRequests` over two days), which cascades into `postgresql` dependency spans and, on the frontends, a full page render per probe. Filtering `/health/*` out of OpenTelemetry is the durable fix, after which the cap can drop back down — follow-up ticket.

The `lotrotms-alert-law-daily-cap-prod` alert still guards the new value.

## Scope

- One workspace serves **both** projects: `lotrotms` and `tks`, prod and staging, all share the `lotrotmsenvprod` Container Apps environment. TheKittySaver's `iac/` declares no workspace of its own, so this single change covers both.
- The live workspace was already raised to 0.5 GB so tonight's ingestion survives to tomorrow's 05:00 UTC cold start. **Merge and apply this before approving any pending prod deploy** — otherwise `terraform apply` reverts the cap to 0.16 and the debug window closes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)