### PR TITLE
Stop dependabot from offering Microsoft.OpenApi 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,16 @@ updates:
       nuget-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # Microsoft.OpenApi 3.x cannot build on ASP.NET Core 10. Microsoft.AspNetCore.OpenApi 10.0.9
+      # (the whole 10.x line) depends on Microsoft.OpenApi 2.0.0, and its bundled XmlCommentGenerator
+      # emits `mediaType.Example = …` — a property 3.x turned read-only on IOpenApiMediaType, so the
+      # generated file fails with CS0200 in both API projects (PR #390). The only reason dependabot
+      # sees Microsoft.OpenApi at all is the direct 2.x pin that forces the GHSA-v5pm-xwqc-g5wc fix
+      # into the graph. Drop this ignore when the apps move to .NET 11 (its preview OpenApi packages
+      # are the first built against 3.x). Minor/patch 2.x updates still flow through the group above.
+      - dependency-name: "Microsoft.OpenApi"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions referenced across every workflow.
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## What

Adds a dependabot `ignore` for **major** updates of `Microsoft.OpenApi`. Minor/patch updates inside 2.x keep flowing through the existing `nuget-minor-patch` group.

## Why

Dependabot opened #390 (`Microsoft.OpenApi` 2.7.5 → 3.8.0). It cannot ever go green on .NET 10:

`Microsoft.AspNetCore.OpenApi` 10.0.9 — and every 10.x — declares `<dependency id="Microsoft.OpenApi" version="2.0.0" />`. The `XmlCommentGenerator` source generator it bundles emits `mediaType.Example = …`, and 3.x turned `Example` into a read-only property on `IOpenApiMediaType`. Overriding the transitive version to 3.8.0 therefore breaks the *generated* file, in both API projects:

```
OpenApiXmlCommentSupport.generated.cs(399,41): error CS0200: Property or indexer
'IOpenApiMediaType.Example' cannot be assigned to -- it is read only
```

4 errors, 0 warnings, no first-party code involved. Nothing in this repo can fix that.

The only reason dependabot sees the package at all is the direct 2.x pin in `Directory.Packages.props`, which exists to force the `GHSA-v5pm-xwqc-g5wc` fix into the graph. Without this ignore the same unbuildable PR returns every week.

## When to remove it

When the apps move to .NET 11. `Microsoft.AspNetCore.OpenApi` 11.0.0-preview.5 is the first release built against `Microsoft.OpenApi` 3.3.1 — verified against the published nuspec.

Supersedes #390, which is closed as unbuildable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)