### PR TITLE
Fix the frontend image: --no-restore silently drops blazor.web.js and every static asset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,14 +357,24 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
   `@rendermode`, `StateHasChanged`, or `AddInteractive*`. `scripts/check-ssr-purity.sh` (with a
   `.ps1` twin for local Windows devs) gates this in **both** `pr-verify` and `ci`, before
   `setup-dotnet`. Genuinely need interactivity? That's an ADR-first architecture change.
-- **Docker restore layers are loud and gated (ADR-0028).** Every Dockerfile that lists `.csproj`
-  files must COPY the **full transitive closure** of the projects it restores. `dotnet restore`
-  treats a missing project file as `Skipping project … because it was not found` and still
-  **exits 0**, so a stale list silently caches an incomplete restore layer. Two defenses, both
-  required: image builds run `dotnet build`/`publish` with **`--no-restore`**, turning the gap into
-  a hard `NETSDK1004`; and `scripts/check-dockerfile-restore-graph.sh` (with a `.ps1` twin) gates
-  it in **both** `pr-verify` and `ci`, because those workflows build no images and `cd` runs only
-  after the merge. A new project must join every Dockerfile whose restore graph reaches it.
+- **Docker restore layers are loud and gated (ADR-0028, amended).** Every Dockerfile that lists
+  `.csproj` files must COPY the **full transitive closure** of the projects it restores.
+  `dotnet restore` treats a missing project file as `Skipping project … because it was not found`
+  and still **exits 0**, so a stale list silently caches an incomplete restore layer. Two defenses:
+  image builds run `dotnet build`/`publish` with **`--no-restore`**, turning the gap into a hard
+  `NETSDK1004`; and `scripts/check-dockerfile-restore-graph.sh` (with a `.ps1` twin) gates it in
+  **both** `pr-verify` and `ci`, because those workflows build no images and `cd` runs only after
+  the merge. A new project must join every Dockerfile whose restore graph reaches it.
+  **The Blazor exception (#414):** the frontend image's `dotnet build` runs **without**
+  `--no-restore`. `blazor.web.js` ships in `Microsoft.AspNetCore.App.Internal.Assets`, which the SDK
+  references only once it sees `.razor` files — never during the `.csproj`-only restore — so
+  `--no-restore` there silently emits a static-web-assets manifest with no `_framework/*` and every
+  asset 404s at runtime. Never add the flag back to that `dotnet build`; `publish` keeps it.
+- **`GET / -> 200` never proves the Blazor frontend works.** A `[StreamRendering]` page returns 200
+  with its spinner frame before it fetches anything. The signature of a healthy image is the
+  **fingerprint**: `@Assets[]` renders `_framework/blazor.web.<hash>.js` only when `MapStaticAssets`
+  resolved its manifest. `scripts/smoke.{sh,ps1}` leg 2 asserts exactly that, and CD smokes the
+  0%-traffic candidate before any traffic shift.
 - **Git is rebase-based, and branches are never deleted.** Integrate a feature branch off `main`
   with `git rebase main` — never `git merge main`; no merge commits in feature branches (remote
   `main` is squash-only, so history stays linear). After a PR's squash commit lands on `main`,

--- a/docs/adr/0028-docker-restore-graph-loud-and-gated.md
+++ b/docs/adr/0028-docker-restore-graph-loud-and-gated.md
@@ -1,6 +1,6 @@
 # ADR-0028: Make an incomplete Docker restore graph loud, and gate it before merge
 
-**Status:** Accepted
+**Status:** Accepted (amended 2026-07-09 — see "Amendment: the Blazor exception")
 **Date:** 2026-07-09
 **Decision-makers:** Solo maintainer
 **Related:** ADR-0008 (cloud-agnostic deployment; the four images this governs), ADR-0012 (CD —
@@ -86,7 +86,69 @@ deliberate trade, made affordable by the two layers above.
   keeps this cost bounded: if the guard's static model ever misjudges, the real toolchain still
   fails the build.
 
+## Amendment: the Blazor exception (2026-07-09, same day — #414)
+
+Layer 1 is wrong for the frontend image, and shipped a broken staging deploy within hours of this
+ADR landing. `dotnet build --no-restore` is now removed from
+`src/Frontend/LotroKoniecDev.Frontend/Dockerfile`. `dotnet publish --no-restore` stays there, and
+both flags stay on the three non-Blazor images.
+
+`blazor.web.js` is not part of the SDK image. It ships in the NuGet package
+`Microsoft.AspNetCore.App.Internal.Assets`, which the Razor SDK references **only once it can see
+`.razor` files**. The `.csproj`-only restore layer runs before `COPY . .`, so at that moment the
+project does not look like a Blazor app and the package never enters the NuGet cache. With
+`--no-restore`, `dotnet build` cannot fetch it, and — this is the part that matters — **does not
+fail**. It emits a static-web-assets publish manifest with 10 endpoints instead of 30 and no
+`_framework/*`, and exits 0. At runtime `MapStaticAssets()` maps nothing: every static file 404s,
+and pages carrying `[StreamRendering]` return HTTP 200 with their spinner frame that the missing
+`blazor.web.js` never replaces.
+
+Isolated by building the same Dockerfile four ways:
+
+| `dotnet build` | `dotnet publish` | restore scope | endpoints | `blazor.web.js` |
+|---|---|---|---|---|
+| `--no-restore` | `--no-restore` | `.csproj` only | 10 | missing |
+| restore | restore | `.csproj` only | 30 | present |
+| restore | `--no-restore` | `.csproj` only | 30 | present |
+| `--no-restore` | `--no-restore` | full tree | 30 | present |
+
+The original Decision claimed layer 1 "needs no model of the toolchain and cannot drift from it."
+That is true of the `ProjectReference` graph and false of the package graph: the `.csproj`-first
+layer is not merely an *incomplete* restore, it is a restore of a *different project* — one with no
+Razor components. The `.dockerignore` argument above (`**/obj` is excluded, so `COPY . .` cannot
+clobber the restore layer) is sound and irrelevant; the missing artifact is a package, not `obj/`.
+
+**Consequences.** The frontend keeps its `.csproj` COPY list and its restore layer for cache
+warmth; `dotnet build` re-restores, which is fast because packages are cached and is the only step
+that can discover the Blazor ones. The frontend therefore loses layer 1's `NETSDK1004` backstop.
+Layer 2 — `scripts/check-dockerfile-restore-graph.sh` in `pr-verify` and `ci` — is untouched and
+remains the pre-merge gate this ADR was written for; it is unaffected by this class of bug either
+way, because the restore *graph* was always complete.
+
+Loudness is restored where it protects a user rather than a build: `scripts/smoke.{sh,ps1}` gain a
+leg asserting that the rendered home page carries a fingerprinted
+`_framework/blazor.web.<hash>.js` and that the URL returns 200. `@Assets[]` emits the fingerprint
+only when it resolved the manifest, so an unfingerprinted `src` is an exact, cheap signature of
+this failure. The candidate is smoked before any traffic shift (ADR-0012), so an image built this
+way can no longer reach a user. Verified red against the broken image and green against the fixed
+one, both run as containers.
+
+The wider lesson, now a house rule: `GET / -> 200` never proves a Blazor SSR frontend works. The
+old smoke leg passed on a completely broken deploy.
+
 ## Alternatives Considered
+
+**Restore after `COPY . .`, keeping `--no-restore` — rejected.** It also produces a correct image
+(row 4 above) and keeps layer 1 loud. It costs the frontend's restore layer: every C# edit
+re-downloads the package graph, which is exactly the regression `Dockerfile.migrator` was moved
+*away* from in this same ADR. Trading a warm cache for a backstop that layer 2 already covers is
+the wrong side of the trade.
+
+**Pin `Microsoft.AspNetCore.App.Internal.Assets` as an explicit `PackageReference` — rejected.**
+It would let the `.csproj`-only restore fetch it and keep `--no-restore` everywhere. The package is
+an SDK implementation detail with no compatibility contract, and its version must track the SDK's;
+pinning it under CPM invites a silent version skew on every SDK bump, in the exact place where a
+skew is invisible. Revisit only if the SDK ever documents it.
 
 **`COPY --parents src/**/*.csproj ./` — rejected.** One line per Dockerfile, no list, no guard.
 It requires a `# syntax=docker/dockerfile:1.7-labs` frontend directive, which pulls an unpinned,
@@ -124,3 +186,4 @@ today. This is the alternative to revisit first if the guard ever becomes a main
 - CLAUDE.md → house rule "Docker restore layers are gated"
 - ADR-0024 (twin-script precedent), ADR-0023 (rule + pre-merge gate precedent)
 - #136 (added `TranslationSystem.Projections`; the TMS API image never learned about it)
+- #414 (the Blazor exception; `scripts/smoke.sh` / `scripts/smoke.ps1` leg 2)

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -6,23 +6,29 @@
 .DESCRIPTION
     One command that gives a green/red signal that a deployed environment came up correctly, without
     manual clicking. Run it after every deploy (staging or production), or against the local
-    prod-parity / dev stack. It exercises the four legs that actually break on a deploy:
+    prod-parity / dev stack. It exercises the five legs that actually break on a deploy:
 
       1. Health      auth-api + tms-api /health/ready return 200; the frontend root responds (it has
                      no /health endpoint — it is a Static-SSR app, so "the page serves" is liveness).
-      2. Auth token  a client-credentials token round-trip against auth-api's /connect/token — the
+      2. FE assets   the frontend image actually shipped its static web assets. "The page serves" is
+                     NOT enough: a [StreamRendering] page returns 200 with its spinner frame before it
+                     fetches anything, so an image whose static-web-assets manifest lost _framework/*
+                     passes leg 1 while every asset 404s and the browser spins forever (#414). The
+                     fingerprint in blazor.web.<hash>.js is the tell — @Assets[] emits it only when it
+                     resolved the manifest, so an unfingerprinted src means the manifest is empty.
+      3. Auth token  a client-credentials token round-trip against auth-api's /connect/token — the
                      only non-interactive OIDC grant available in staging/production (the web client
                      needs a browser; the password-flow client is seeded only in Testing).
-      3. Token accept tms-api ACCEPTS that token: an anonymous call to a protected read is 401, and
+      4. Token accept tms-api ACCEPTS that token: an anonymous call to a protected read is 401, and
                      the same call WITH the bearer token is NOT 401 (it is 403 — the service account
                      has no role; every TMS endpoint is role-gated). 401-with-a-valid-token is the
                      classic "works locally, breaks on staging" issuer/audience/JWKS mismatch
                      (runbook -> "Consistency rules that bite"), so 403-vs-401 is the high-value check.
-      4. Distribution the public translation-file endpoint serves the artifact with an ETag and
+      5. Distribution the public translation-file endpoint serves the artifact with an ETag and
                      honours If-None-Match with a 304 (the CLI/player relies on this; spec 0001).
 
     Clear pass/fail per check; NON-ZERO exit on any failure (exit 1). Usage/config problems exit 2.
-    A not-yet-seeded environment (no artifact built) WARNS on leg 4 rather than failing. Keep in
+    A not-yet-seeded environment (no artifact built) WARNS on leg 5 rather than failing. Keep in
     sync with smoke.sh. Requires PowerShell 7+ (for -SkipHttpErrorCheck).
 
 .EXAMPLE
@@ -122,7 +128,7 @@ Write-Host "  frontend = $FrontendUrl"
 if ($Insecure) { Write-Host "  (TLS verification disabled: -Insecure)" }
 Write-Host ""
 
-Write-Host "[1/4] Health"
+Write-Host "[1/5] Health"
 $code = Get-Status "$AuthUrl/health/ready"
 if ($code -eq 200) { Add-Pass "auth /health/ready -> 200" } else { Add-Fail "auth /health/ready -> $code (expected 200)" }
 $code = Get-Status "$TmsUrl/health/ready"
@@ -132,7 +138,24 @@ $code = Get-Status "$FrontendUrl/"
 if ($code -ge 200 -and $code -lt 400) { Add-Pass "frontend / -> $code (serving)" } else { Add-Fail "frontend / -> $code (expected 2xx/3xx)" }
 Write-Host ""
 
-Write-Host "[2/4] OIDC token round-trip (client_credentials)"
+Write-Host "[2/5] Frontend static web assets (#414)"
+$homeHtml = ''
+try { $homeHtml = (Invoke-Smoke -Url "$FrontendUrl/").Content } catch { $homeHtml = '' }
+if ($null -eq $homeHtml) { $homeHtml = '' }
+# @Assets["_framework/blazor.web.js"] renders a fingerprinted src ONLY when MapStaticAssets resolved
+# the publish manifest. A bare `blazor.web.js` means the manifest shipped empty.
+$assetMatch = [regex]::Match($homeHtml, '_framework/blazor\.web\.[A-Za-z0-9]+\.js')
+if (-not $assetMatch.Success) {
+    Add-Fail "frontend / has no fingerprinted _framework/blazor.web.<hash>.js (image built without its static web assets)"
+} else {
+    $assetPath = $assetMatch.Value
+    Add-Pass "frontend / references $assetPath (manifest resolved)"
+    $code = Get-Status "$FrontendUrl/$assetPath"
+    if ($code -eq 200) { Add-Pass "frontend /$assetPath -> 200" } else { Add-Fail "frontend /$assetPath -> $code (expected 200)" }
+}
+Write-Host ""
+
+Write-Host "[3/5] OIDC token round-trip (client_credentials)"
 $token = $null
 $tokenCode = 0
 try {
@@ -152,7 +175,7 @@ if ($tokenCode -eq 200 -and $token) {
 }
 Write-Host ""
 
-Write-Host "[3/4] Token accepted by tms-api (authenticated read)"
+Write-Host "[4/5] Token accepted by tms-api (authenticated read)"
 $anonCode = Get-Status "$TmsUrl/api/v1/game-versions"
 if ($anonCode -eq 401) { Add-Pass "GET tms/api/v1/game-versions (no token) -> 401 (protected)" }
 else { Add-Fail "GET tms/api/v1/game-versions (no token) -> $anonCode (expected 401)" }
@@ -168,7 +191,7 @@ if ($token) {
 }
 Write-Host ""
 
-Write-Host "[4/4] Translation-file distribution (ETag / 304)"
+Write-Host "[5/5] Translation-file distribution (ETag / 304)"
 $fileCode = 0
 $etag = $null
 try {

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -3,23 +3,29 @@
 # environment came up correctly, without manual clicking — run it after every deploy (staging or
 # production), or against the local prod-parity / dev stack.
 #
-# It exercises the four legs that actually break on a deploy:
+# It exercises the five legs that actually break on a deploy:
 #   1. Health      — auth-api + tms-api /health/ready return 200; the frontend root responds (it has
 #                    no /health endpoint — it is a Static-SSR app, so "the page serves" is liveness).
-#   2. Auth token  — a client-credentials token round-trip against auth-api's /connect/token. This is
+#   2. FE assets   — the frontend image actually shipped its static web assets. "The page serves" is
+#                    NOT enough: a [StreamRendering] page returns 200 with its spinner frame before it
+#                    fetches anything, so an image whose static-web-assets manifest lost `_framework/*`
+#                    passes leg 1 while every asset 404s and the browser spins forever (#414). The
+#                    fingerprint in `blazor.web.<hash>.js` is the tell — `@Assets[]` emits it only when
+#                    it resolved the manifest, so an unfingerprinted src means the manifest is empty.
+#   3. Auth token  — a client-credentials token round-trip against auth-api's /connect/token. This is
 #                    the only non-interactive OIDC grant available in staging/production (the web
 #                    client needs a browser; the password-flow client is seeded only in Testing).
-#   3. Token accept — tms-api ACCEPTS that token: an anonymous call to a protected read is 401, and
+#   4. Token accept — tms-api ACCEPTS that token: an anonymous call to a protected read is 401, and
 #                    the same call WITH the bearer token is NOT 401 (it is 403 — the service account
 #                    has no role; every TMS endpoint is role-gated). 401-with-a-valid-token is the
 #                    classic "works locally, breaks on staging" issuer/audience/JWKS mismatch
 #                    (runbook → "Consistency rules that bite", rule #1), so distinguishing 403 from
 #                    401 is the high-value check, not reading any particular row.
-#   4. Distribution — the public translation-file endpoint serves the artifact with an ETag and
+#   5. Distribution — the public translation-file endpoint serves the artifact with an ETag and
 #                    honours If-None-Match with a 304 (the CLI/player relies on this; spec 0001).
 #
 # Clear pass/fail per check; NON-ZERO exit on any failure (exit 1). Usage / configuration problems
-# exit 2. A not-yet-seeded environment (no translation artifact built) WARNS on leg 4 rather than
+# exit 2. A not-yet-seeded environment (no translation artifact built) WARNS on leg 5 rather than
 # failing — a correctly deployed but empty environment is still "up". Keep in sync with smoke.ps1.
 
 set -euo pipefail
@@ -150,7 +156,7 @@ echo "  frontend = $FRONTEND_URL"
 [ "$INSECURE" = "1" ] && echo "  (TLS verification disabled: --insecure)"
 echo
 
-echo "[1/4] Health"
+echo "[1/5] Health"
 code="$(get_status "$AUTH_URL/health/ready")"
 [ "$code" = "200" ] && pass "auth /health/ready -> 200" || fail "auth /health/ready -> $code (expected 200)"
 code="$(get_status "$TMS_URL/health/ready")"
@@ -165,7 +171,21 @@ else
 fi
 echo
 
-echo "[2/4] OIDC token round-trip (client_credentials)"
+echo "[2/5] Frontend static web assets (#414)"
+home_html="$(curl -s --max-time "$TIMEOUT" $TLS_FLAG "$FRONTEND_URL/" 2>/dev/null || true)"
+# `@Assets["_framework/blazor.web.js"]` renders a fingerprinted src ONLY when MapStaticAssets
+# resolved the publish manifest. A bare `blazor.web.js` means the manifest shipped empty.
+asset_path="$(printf '%s' "$home_html" | grep -oE '_framework/blazor\.web\.[A-Za-z0-9]+\.js' | head -n 1 || true)"
+if [ -z "$asset_path" ]; then
+    fail "frontend / has no fingerprinted _framework/blazor.web.<hash>.js (image built without its static web assets)"
+else
+    pass "frontend / references $asset_path (manifest resolved)"
+    code="$(get_status "$FRONTEND_URL/$asset_path")"
+    [ "$code" = "200" ] && pass "frontend /$asset_path -> 200" || fail "frontend /$asset_path -> $code (expected 200)"
+fi
+echo
+
+echo "[3/5] OIDC token round-trip (client_credentials)"
 TOKEN=""
 token_out="$(curl -s --max-time "$TIMEOUT" $TLS_FLAG \
     -X POST "$AUTH_URL/connect/token" \
@@ -186,7 +206,7 @@ else
 fi
 echo
 
-echo "[3/4] Token accepted by tms-api (authenticated read)"
+echo "[4/5] Token accepted by tms-api (authenticated read)"
 # Reads are role-gated; a client-credentials token has no role, so the value here is proving the
 # token is VALIDATED (403), not that it is rejected (401). Pair with an anonymous call (must 401)
 # so the check also proves the endpoint is genuinely protected.
@@ -205,7 +225,7 @@ else
 fi
 echo
 
-echo "[4/4] Translation-file distribution (ETag / 304)"
+echo "[5/5] Translation-file distribution (ETag / 304)"
 : > "$HDR_FILE"
 file_code="$(curl -s -o /dev/null -D "$HDR_FILE" -w '%{http_code}' --max-time "$TIMEOUT" $TLS_FLAG "$TMS_URL/api/v1/translation-files/$LANG_CODE" 2>/dev/null)" || file_code="000"
 if [ "$file_code" = "200" ]; then

--- a/src/Frontend/LotroKoniecDev.Frontend/Dockerfile
+++ b/src/Frontend/LotroKoniecDev.Frontend/Dockerfile
@@ -24,7 +24,14 @@ RUN dotnet restore "src/Frontend/LotroKoniecDev.Frontend/LotroKoniecDev.Frontend
 ARG CACHEBUST=0
 COPY . .
 WORKDIR "/src/src/Frontend/LotroKoniecDev.Frontend"
-RUN dotnet build "./LotroKoniecDev.Frontend.csproj" -c $BUILD_CONFIGURATION -o /app/build --no-restore
+
+# No `--no-restore` here, unlike the API images (ADR-0028, amended). `blazor.web.js` lives in the
+# implicit `Microsoft.AspNetCore.App.Internal.Assets` package, which the SDK references only once it
+# sees `.razor` files — that is, after `COPY . .`, never during the `.csproj`-only restore above. With
+# `--no-restore` the build cannot fetch it and still exits 0, emitting a static-web-assets manifest
+# with no `_framework/*`; `MapStaticAssets()` then 404s every asset at runtime. `publish` below keeps
+# `--no-restore`: by then this build has restored the full graph.
+RUN dotnet build "./LotroKoniecDev.Frontend.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release


### PR DESCRIPTION
Closes #414.

Staging has been serving a broken frontend since the CD deploy at 2026-07-09 16:11 UTC: every page
with `[StreamRendering]` returns HTTP 200 with its loading spinner and never resolves. Prod is
unaffected — it still runs the pre-#412 image, and its promotion is gated behind a reviewer.

## Root cause

`blazor.web.js` is not in the SDK image. It ships in the NuGet package
`Microsoft.AspNetCore.App.Internal.Assets`, which the Razor SDK references **only once it can see
`.razor` files**. The image restores from the `.csproj` files alone, before `COPY . .`, so at that
moment the project does not look like a Blazor app and the package never enters the NuGet cache.
`dotnet build --no-restore` (added by #412 / ADR-0028) then cannot fetch it and **still exits 0**,
emitting a static-web-assets manifest with 10 endpoints instead of 30 and no `_framework/*`. At
runtime `MapStaticAssets()` maps nothing: css, favicon and `blazor.web.js` all 404, and the streamed
DOM patch that would replace the spinner is never applied.

Isolated by building the same Dockerfile four ways:

| `dotnet build` | `dotnet publish` | restore scope | endpoints | `blazor.web.js` |
|---|---|---|---|---|
| `--no-restore` | `--no-restore` | `.csproj` only | 10 | missing |
| restore | restore | `.csproj` only | 30 | present |
| restore | `--no-restore` | `.csproj` only | 30 | present |
| `--no-restore` | `--no-restore` | full tree | 30 | present |

`--no-restore` on `dotnet build` is the sole trigger. The `.csproj`-first restore layer stays sound
for the three non-Blazor images, which keep the flag on both steps.

## Why nothing caught it

- `scripts/check-dockerfile-restore-graph.sh` cannot: the restore *graph* is complete. The missing
  thing is a package the restore never learns about.
- `pr-verify` and `ci` build no images.
- The smoke gate asserted `GET / -> 2xx/3xx` and passed, because a `[StreamRendering]` page returns
  200 before it fetches anything.

## Changes

1. **Fix.** Drop `--no-restore` from `dotnet build` in the frontend Dockerfile only.
2. **Guard.** New smoke leg (`smoke.sh` + `smoke.ps1` twin): the rendered home page must carry a
   fingerprinted `_framework/blazor.web.<hash>.js`, and that URL must return 200. `@Assets[]` emits
   the fingerprint only when `MapStaticAssets` resolved its manifest, so a bare `blazor.web.js` is an
   exact signature of this failure. CD smokes the 0%-traffic candidate before shifting traffic, so
   such an image can no longer reach a user.
3. **Docs.** ADR-0028 amended with the Blazor exception, the isolation matrix and two rejected
   alternatives (full-tree restore; pinning the internal package). CLAUDE.md house rules updated.

## Verification

Both images built locally and run as containers against the real staging tms-api:

```
ZEPSUTY (current staging image)      NAPRAWIONY (this PR)
[1/5] frontend / -> 200 (serving) ✓  [1/5] frontend / -> 200 (serving) ✓
[2/5] no fingerprinted ...js      ✗  [2/5] references blazor.web.ne14ti1q68.js ✓
                                     [2/5] /_framework/blazor.web.ne14ti1q68.js -> 200 ✓
```

The fixed image's fingerprint (`ne14ti1q68`) matches the one prod serves today. Its rendered home
page contains the real progress numbers instead of the spinner. `check-dockerfile-restore-graph.sh`
still passes on all 4 Dockerfiles.

`smoke.ps1` was edited as the required twin but not executed: no `pwsh` on the authoring machine.

## After merge

CD will rebuild and redeploy staging with the fix. The stale run 29032112454 still holds a pending
`Deploy to prod` job carrying the broken image — reject that deployment rather than approving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
