### PR TITLE
chore(claude): budget agent fan-out + reviews on Opus 4.8 max effort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,11 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 - **Right-size the design — YAGNI by default.** Before proposing an abstraction, cache, config
   knob, queue, or new infra, check it solves a **real, present** need from the current
   spec/ticket — not a hypothetical future. Pick the simple path and note the trade-off in one line.
+- **Agent fan-out is budgeted; reviews always run on Opus 4.8 at max effort.** Hard cap: **max 4
+  subagents in parallel**, no chained waves by default; a small diff gets reviewed **inline, zero
+  agents**. The `code-reviewer` agent, `/code-review` and `/security-review` always run with
+  **model Opus 4.8 + effort max** — never Fable 5 — unless the prompt for that run explicitly
+  says otherwise. Applies to interactive sessions and loop-mode workers alike.
 - **Frontend is Static SSR — enforced, not just documented.** No WebAssembly, no SignalR circuit,
   no per-user server state; forms post via `<form method="post" @formname @onsubmit>` (the SSR
   `@onsubmit` special-case) or `<EditForm OnValidSubmit>` — never interactive `@on*` handlers,


### PR DESCRIPTION
## What & why

Mirror of TheKittySaver koniecdev/TheKittySaver#255 (as amended by the maintainer's review comment).

New house rule in CLAUDE.md:

- hard cap 4 subagents in parallel, no chained waves by default
- small diff => review inline, zero agents
- the code-reviewer agent, /code-review and /security-review always run on **Opus 4.8 at max effort** - never Fable 5 - unless the prompt for that run explicitly says otherwise; applies to interactive sessions and loop-mode workers alike

Background: on 2026-07-03 (in TheKittySaver) a high-effort review fan-out of 10 finder agents burned an entire 5-hour session budget and died before synthesis - findings lost. The cap prevents that; the review model/effort rule is the maintainer's standing decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)