### PR TITLE
CD-01: Health-gated rollout never deactivates superseded revisions — on prod they keep a warm replica and probe forever

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,8 @@ name: CD
 #                    staging→prod promotion of the artifact that just passed staging. The full
 #                    health-gated rollout lives in deploy.yml: verify provenance → migrate → deploy
 #                    candidates at 0% traffic → readiness (incl. frontend) + warm the auth origin →
-#                    smoke the candidate → promote to 100% → smoke → roll back on any failure.
+#                    smoke the candidate → promote to 100% + sweep superseded revisions → smoke →
+#                    roll back on any failure → assert exactly one active revision per app.
 #
 # The deployment unit is an immutable per-commit image (`sha-<short>`); the rolling tag is owned by
 # THIS pipeline (`az containerapp update`), not Terraform — the ACA resources ignore image + traffic
@@ -26,8 +27,14 @@ name: CD
 # Health-gated rollout (audit 0001 H7): traffic NEVER jumps onto an unverified revision. Each app is
 # deployed as a candidate revision receiving 0% production traffic, reachable only through a private
 # `<app>---cd-candidate.<env-domain>` label FQDN. The candidate is smoked first; only then is 100% of
-# traffic shifted onto it. The previous revision is kept (0% traffic, scales to zero) so any failure
-# rolls straight back to it — no window where users hit a bad revision.
+# traffic shifted onto it. During the rollout the previous revision keeps serving, and any failure
+# steers traffic straight back to it (the in-job rollback re-activates it first) — no window where
+# users hit a bad revision. After a green promotion EVERY other active revision is deactivated and
+# the rollout ends by asserting exactly one active revision per app (#407 / ADR-0029): an active
+# superseded revision is a paid warm replica inside the ADR-0027 warm window, and one such orphan
+# once probed Postgres for 8 days from a 0%-traffic replica, holding Neon awake while a deployed fix
+# ran dark behind it. Rolling back AFTER the job is `az containerapp revision activate` + a traffic
+# shift — one cold start (runbook: "Roll back a completed deploy").
 #
 # Why ONE job per environment (not a job per phase): the Azure OIDC federated credential trusts only a
 # specific environment subject (gh-env-production / gh-env-staging), so a job WITHOUT that `environment:`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -334,13 +334,12 @@ jobs:
           deploy_candidate tms "$TMS_APP" "$TMS_API_IMAGE"
           deploy_candidate frontend "$FRONTEND_APP" "$FRONTEND_IMAGE"
 
-      # Readiness against the CANDIDATE revisions before the gated smoke. With prod's min_replicas=1
-      # every revision (incl. the 0%-traffic candidate) keeps a live replica, so this is a short wait
-      # for the new replica to pass its probes. On staging (min_replicas=0, ADR-0020) these polls ARE
+      # Readiness against the CANDIDATE revisions before the gated smoke. With min_replicas=0
+      # everywhere (ADR-0027 — prod's warm replica is a cron schedule, not a floor) these polls ARE
       # the scale-from-zero warm-up — the 60×10s budget absorbs the cold start — and the final poll
       # wakes the previous auth revision serving the public origin (which the candidate tms validates
-      # tokens against); on prod that revision is already warm and the poll is cheap insurance.
-      # Frontend: Static-SSR, no /health → 2xx/3xx on '/'.
+      # tokens against); inside prod's warm window the replicas are already up and the polls are
+      # cheap insurance. Frontend: Static-SSR, no /health → 2xx/3xx on '/'.
       - name: Wait for candidate readiness (incl. frontend) + warm the auth origin
         run: |
           set -euo pipefail
@@ -382,8 +381,14 @@ jobs:
             --timeout 30
 
       # The "→ 100%" leg: a green candidate smoke shifts production traffic onto the candidate, then
-      # deactivates the previous revision (with min_replicas=1 it would otherwise hold an idle replica).
-      # A failed post-promotion smoke re-activates it and steers traffic back (the rollback step).
+      # deactivates EVERY other active revision — not just prev (#407 / ADR-0029). Terraform applies
+      # mint their own revisions (auto-numbered, 0% traffic, never in the traffic config), and a
+      # previously-leaked revision may still be active; each active revision buys a warm replica
+      # inside the ADR-0027 warm window, and one such orphan held a DB-probing replica for 8 days
+      # (#407). The match is BY EXCLUSION against the promoted candidate, never a name pattern.
+      # Each deactivation is best-effort (a cleanup hiccup must not fail a healthy deploy here) —
+      # the post-rollout assertion below is the loud gate. A failed post-promotion smoke
+      # re-activates prev and steers traffic back (the rollback step).
       - name: Promote the candidate to 100% traffic
         run: |
           set -euo pipefail
@@ -396,9 +401,16 @@ jobs:
             # candidate; the next rollout recreates it on the next candidate.
             az containerapp revision label remove -n "$app" -g "$RESOURCE_GROUP" \
               --label "$CANDIDATE_LABEL" -o none || true
-            # With min_replicas=1 a kept-active prev would hold a replica forever; deactivate it to
-            # reclaim it. The failure-rollback step re-activates prev before sending traffic back.
-            az containerapp revision deactivate -n "$app" -g "$RESOURCE_GROUP" --revision "$prev" -o none || true
+            # Sweep: deactivate every active revision that is not the promoted candidate. Revision
+            # names are DNS labels (no whitespace), so plain word-splitting is safe here.
+            superseded="$(az containerapp revision list -n "$app" -g "$RESOURCE_GROUP" --all \
+              --query "[?properties.active && name != '${candidate}'].name" -o tsv | tr -d '\r' \
+              || echo '')"
+            for rev in $superseded; do
+              echo "  deactivating superseded revision: ${rev}"
+              az containerapp revision deactivate -n "$app" -g "$RESOURCE_GROUP" --revision "$rev" -o none \
+                || echo "::warning::${app}: could not deactivate ${rev} — the post-rollout assertion will fail if it is still active"
+            done
             echo "::endgroup::"
           }
           promote "$AUTH_APP" "$AUTH_PREV" "$AUTH_CANDIDATE"
@@ -431,7 +443,7 @@ jobs:
             if [ -z "$candidate" ]; then echo "  ${app}: no candidate created — nothing to roll back"; return 0; fi
             echo "::group::Roll back ${app} → ${prev}"
             if [ -n "$prev" ]; then
-              # Promote may have deactivated prev (min_replicas=1 reclaim) — re-activate before traffic.
+              # Promote's sweep may have deactivated prev (ADR-0029) — re-activate before traffic.
               az containerapp revision activate -n "$app" -g "$RESOURCE_GROUP" --revision "$prev" -o none || true
               az containerapp ingress traffic set -n "$app" -g "$RESOURCE_GROUP" \
                 --revision-weight "${prev}=100" "${candidate}=0" -o none || true
@@ -444,3 +456,37 @@ jobs:
           roll_back "$TMS_APP" "${TMS_PREV:-}" "${TMS_CANDIDATE:-}"
           roll_back "$FRONTEND_APP" "${FRONTEND_PREV:-}" "${FRONTEND_CANDIDATE:-}"
           echo "::error::Rollout failed — production traffic restored to the previous revisions; candidates deactivated."
+
+      # Post-rollout invariant (#407 / ADR-0029): exactly ONE active revision per app — the promoted
+      # candidate, at 100% traffic. This is the loud gate behind the best-effort sweep above: a
+      # leaked active revision buys a warm replica inside the ADR-0027 warm window, and once kept a
+      # DB-probing replica alive for 8 days while a deployed fix ran dark behind it (#346/#407).
+      # Deliberately placed AFTER the failure-rollback step: when this step runs, that step was
+      # already evaluated (and skipped), so a red assertion fails the pipeline WITHOUT reverting
+      # traffic — a leftover revision is a cost defect, not a serving defect, and the promoted
+      # revision has already passed both smokes.
+      - name: Assert exactly one active revision per app (post-rollout invariant)
+        run: |
+          set -euo pipefail
+          assert_single() {
+            app="$1"; candidate="$2"
+            active="$(az containerapp revision list -n "$app" -g "$RESOURCE_GROUP" --all \
+                        --query "[?properties.active].name" -o tsv | tr -d '\r')"
+            count="$(printf '%s\n' "$active" | grep -c . || true)"
+            if [ "$count" -ne 1 ] || [ "$active" != "$candidate" ]; then
+              echo "::error::${app}: expected exactly one active revision (${candidate}); active now: $(printf '%s' "$active" | tr '\n' ' ')"
+              return 1
+            fi
+            weight="$(az containerapp ingress traffic show -n "$app" -g "$RESOURCE_GROUP" \
+                        --query "[?revisionName == '${candidate}'].weight | [0]" -o tsv | tr -d '\r')"
+            if [ "$weight" != "100" ]; then
+              echo "::error::${app}: promoted revision ${candidate} holds ${weight:-0}% of traffic, expected 100."
+              return 1
+            fi
+            echo "${app}: single active revision ${candidate} at 100% traffic — OK"
+          }
+          fail=0
+          assert_single "$AUTH_APP" "$AUTH_CANDIDATE" || fail=1
+          assert_single "$TMS_APP" "$TMS_CANDIDATE" || fail=1
+          assert_single "$FRONTEND_APP" "$FRONTEND_CANDIDATE" || fail=1
+          exit "$fail"

--- a/docs/adr/0012-continuous-deployment-pipeline.md
+++ b/docs/adr/0012-continuous-deployment-pipeline.md
@@ -153,6 +153,13 @@ fixed here:
    > a **schedule** (`var.app_warm_window`, a KEDA cron rule) rather than a floor, so the readiness
    > warm-up above is load-bearing in every environment. R8's serving argument was premised on real
    > users; with none, an always-warm prod only burned the student credit.
+   >
+   > **Extended by ADR-0029 / #407 (2026-07-09):** deactivating only *the* superseded revision proved
+   > insufficient — Terraform applies mint revisions the traffic config never names, and a silently
+   > failed deactivation went unnoticed for 8 days while a leaked 0%-traffic replica held Neon awake.
+   > Promote now sweeps **every** active non-promoted revision, and the rollout ends with a hard
+   > assertion: exactly one active revision per app, at 100% traffic. Rolling back a *completed*
+   > deploy is `revision activate` + a traffic shift — one cold start.
 
 ### 6. Infra is also CI-managed, behind the same gate
 

--- a/docs/adr/0029-single-active-revision-sweep-and-cold-start-rollback.md
+++ b/docs/adr/0029-single-active-revision-sweep-and-cold-start-rollback.md
@@ -1,0 +1,158 @@
+# ADR-0029: Exactly one active revision per app — the rollout sweeps superseded revisions, rollback pays a cold start
+
+**Status:** Accepted
+**Date:** 2026-07-09
+**Decision-makers:** Solo maintainer
+**Related:** deployment pipeline (`.github/workflows/deploy.yml`, `cd.yml`, `infra.yml`), ticket #407 (CD-01),
+ADR-0012 §5 (amended — the H7 "previous revision is kept" clause), ADR-0025 (DB-free readiness probes),
+ADR-0027 (scheduled warm window)
+
+## Context
+
+On 2026-07-09 the prod Neon project stood at 86.03 of its 100 CU-hour monthly allowance, 9 days into
+the period, having never suspended once. The compute was held awake by a revision serving **0% of
+traffic**: `lotrotms-tms-api-prod--0000016`, created by `terraform apply` on 2026-06-30, whose
+template still carried `min_replicas = 1` and whose image (built at `cd498a2`) still tagged the
+Postgres health check `ready` — so ACA's readiness probe queried Postgres every 30 s for 8 days and
+13 hours from a replica no user could reach. The ADR-0025 fix (untag the DB check) deployed to prod
+on 2026-07-05 and changed nothing for four days, because the old revision kept probing alongside the
+new one. "Is the fix on prod?" answered *yes* while the defect ran on.
+
+Code facts that constrain the choice:
+
+- The rollout **already deactivates a previous revision** — since #258,
+  `deploy.yml`'s promote step runs `az containerapp revision deactivate --revision "$prev"`. But it
+  targets exactly **one** revision, resolved from the highest traffic weight, and the call is
+  `|| true`. Two failure modes follow: revisions that never enter the traffic config are never
+  matched (Terraform creates its revisions with 0% traffic — `--0000016` was invisible to it), and a
+  failed deactivation is silently swallowed (the 2026-07-05 deploy left `--ccd498a2…` active despite
+  the deactivate line, and nothing noticed).
+- **Two independent mechanisms mint revisions** and neither cleans up the other's: `deploy.yml`
+  (image by digest, suffix `c<sha>-<run>-<attempt>`) and `terraform apply` (image by tag,
+  auto-numbered). Any durable fix must match on *"not the promoted revision"*, never on a name
+  pattern.
+- `cd.yml:29` states the design assumption: *"The previous revision is kept (0% traffic, scales to
+  zero) so any failure rolls straight back to it."* Both halves are false — promote deactivates it,
+  and on prod nothing at 0% traffic reliably scaled to zero. This comment is what hid the defect.
+- **ADR-0027 changed the price, not the leak.** `min_replicas` is now 0 everywhere, but the prod
+  warm window is a KEDA cron rule with `desiredReplicas = 1` — and scale rules apply **per active
+  revision**, so every leaked active revision still buys a warm replica 15 hours a day. ADR-0025
+  closed the Neon-burn leg (probes no longer touch Postgres); the ACA replica-hours leg stays open
+  until leaked revisions stop existing.
+- The in-job auto-rollback already handles a deactivated `prev`: it runs
+  `revision activate` before steering traffic back (`deploy.yml`, the `Roll back on failure` step).
+  Only the *post-job* rollback story still assumes a warm, still-present previous revision
+  (runbook: "instant manual revert").
+- `infra.yml`'s prod apply and `deploy.yml` share the `prod-mutation` concurrency group, so a
+  Terraform apply cannot interleave mid-rollout — it can only create an orphan *between* rollouts.
+
+## Decision
+
+### 1. The invariant: one active revision per app, holding 100% of traffic
+
+After a completed rollout, each of the three apps has **exactly one active revision** — the promoted
+candidate — at weight 100. Every other revision is deactivated, whoever created it. Deactivated
+revisions remain in ACA's revision history and cost nothing.
+
+### 2. Promote sweeps every non-promoted revision, matched by exclusion
+
+The promote step replaces the single `deactivate $prev` with a sweep: list all active revisions of
+the app and deactivate each one whose name is not the promoted candidate. No name patterns — the
+match is *"not the one we just promoted"*, so Terraform-minted revisions and previously-leaked ones
+are reaped on the next deploy regardless of origin. Each deactivation stays best-effort (a cleanup
+hiccup must not fail a healthy deploy mid-step); loudness is the assertion's job.
+
+### 3. A loud post-rollout assertion, ordered so it can never revert a healthy deploy
+
+A new final step asserts the §1 invariant per app — exactly one active revision, name equal to the
+candidate, traffic weight 100 — and **fails the pipeline** on any violation. It is placed *after*
+the `Roll back on failure` step in step order: when the assertion is reached, rollback has already
+been evaluated (and skipped), so an assertion failure reddens the run without touching traffic — a
+leftover active revision is a cost defect, not a serving defect, and the promoted revision has
+already passed both smokes. This is the regression guard the incident lacked: the silent
+`|| true` deactivation failure of 2026-07-05 would have failed the deploy red instead of hiding for
+four days.
+
+### 4. Rollback after the job is `revision activate` + traffic shift — one cold start, accepted
+
+The H7 premise "keep the previous revision for instant rollback" is retired (this amends
+ADR-0012 §5). In-job auto-rollback is unchanged — activate `prev`, steer traffic back, deactivate
+the candidate. After the job ends, rolling back means: `az containerapp revision activate` on the
+previous revision, then `az containerapp ingress traffic set` — one cold start (~43 s worst case,
+measured in ADR-0027), the same price ADR-0027 already accepted for any off-window visitor. Paying a
+warm replica 15 h/day to keep an instant-rollback path that has never been used post-smoke is
+exactly the economics ADR-0027 rejected.
+
+### 5. Terraform orphans are bounded, not prevented
+
+An out-of-band `terraform apply` still mints a 0%-traffic revision by design (ADR-0027 operational
+note); the operator shifts traffic and deactivates by hand per the runbook. If that step is
+forgotten, the orphan lives **at most until the next deploy** — the §2 sweep reaps it — and holds a
+replica only inside the warm window while it lives. The shared `prod-mutation` lock guarantees no
+apply can slip a revision in between the sweep and the assertion.
+
+## Consequences
+
+### Positive
+
+- The leak class is closed: no superseded or Terraform-minted revision can hold a warm replica past
+  the next deploy, and none can hold one silently — the assertion is red otherwise.
+- "Deployed but inert behind a stale revision" (the ADR-0025 fix's four dark days) can no longer
+  happen quietly: the 2026-07-05 deploy would have failed its assertion.
+- The runbook rollback path becomes honest — it documents what the pipeline actually leaves behind.
+- Staging gets the same sweep and assertion for free (same reusable workflow), keeping both
+  environments' revision lists clean.
+
+### Negative / Accepted Trade-offs
+
+- **Post-job rollback costs a cold start** instead of being instant. Accepted: same price as any
+  off-window request under ADR-0027, and the health-gated rollout makes post-smoke rollbacks rare.
+- A transient ARM read failure in the assertion can redden a rollout whose traffic is correctly
+  placed. Accepted: the step prints per-app state, so the operator verifies in one `az` call; a
+  re-run re-deploys the same digest idempotently.
+- Three extra `az` reads per app per rollout. Negligible.
+
+## Alternatives Considered
+
+### A. Keep the previous revision active for instant rollback (the H7 comment's design)
+
+Rejected. Under the warm window every active revision is a paid replica 15 h/day; ADR-0027 already
+decided cold starts are acceptable when the alternative is burning the credit. The incident shows
+the "kept" revision also keeps its *old* template and image — probing with yesterday's bugs.
+
+### B. Alert on a second active revision instead of failing the pipeline
+
+Rejected. On a solo project an alert is just a slower pipeline failure. The deploy job already holds
+the OIDC identity and the candidate names; the assertion is a few lines in the one place that knows
+the expected state — the ticket's "cheapest form".
+
+### C. Sweep in `infra.yml` after `terraform apply` too
+
+Rejected (YAGNI). The apply deliberately leaves its new revision at 0% for the operator to promote
+(ADR-0027 operational note) — an automatic sweep there would deactivate the revision the apply just
+created or, worse, guess at promotion. The mutation lock plus the next deploy's sweep already bound
+an orphan's lifetime.
+
+### D. Match CD-created revisions by name pattern (`--c*`)
+
+Rejected. The costly orphan of the incident was `--0000016` — a Terraform name. Exclusion-matching
+against the promoted candidate is the only rule that survives a new revision creator.
+
+## Implementation Notes
+
+- `.github/workflows/deploy.yml` — promote step: sweep replaces the single `deactivate $prev`; new
+  `Assert exactly one active revision per app` step after `Roll back on failure`; stale
+  `min_replicas=1` comments refreshed to the ADR-0027 world.
+- `.github/workflows/cd.yml` — header comment rewritten: superseded revisions are deactivated and
+  asserted away, not "kept, scales to zero".
+- `docs/deployment/runbook.md` — rollback path (activate + shift + cold-start caveat), pipeline
+  table row, out-of-band-apply note cross-referenced to the sweep.
+- `docs/adr/0012-continuous-deployment-pipeline.md` — §5 blockquote noting this amendment.
+
+## References
+
+- Ticket #407 (CD-01) — incident evidence: Azure CLI + Neon API forensics, 2026-07-09
+- ADR-0012 §5 — the H7 health-gated rollout this ADR amends
+- ADR-0025 — DB-free readiness probes (the fix that ran dark behind the leaked revision)
+- ADR-0027 — scheduled warm window; the economics this rollback strategy inherits
+- ADR-0023 — forward-only migrations (why rolling back *code* is always schema-safe)

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -464,7 +464,7 @@ Ongoing delivery to the live Azure environment is automated (ADR-0012). Four wor
 |---|---|---|
 | `cd.yml` → `build-and-push` | push to main, `v*` tag | builds the 4 images, **scans each with Trivy (fails on a fixable HIGH/CRITICAL)**, then pushes to GHCR **signed (cosign keyless) + attested (SLSA provenance + SBOM)** — `:sha-<short>`, `:latest` on main, semver on tags (audit 0001 H9 + H1) |
 | `cd.yml` → `deploy-staging` | push to main / dispatch, `STAGING_ENABLED == true`, **auto** (no approval) | identical health-gated rollout as `deploy-prod` targeting the `staging` environment; runs automatically after `build-and-push` (audit 0001 H10, ADR-0018) |
-| `cd.yml` → `deploy-prod` | push to main / dispatch, `STAGING_ENABLED == true`, **behind the `production` approval gate**, `needs: deploy-staging` | the whole health-gated rollout in ONE job (every Azure step shares the approved environment's OIDC identity): **pin every image tag to its immutable digest, then verify the digest's signed provenance** (`gh attestation verify`, fail-closed; every subsequent `az` step ships the digest, so a tag moved mid-rollout changes nothing) → OIDC login → migrator to success (**gate**) → deploy each app as a **candidate at 0% traffic** (`--revision-suffix`, labelled `cd-candidate`) → readiness (incl. frontend) + warm the auth origin → **smoke the candidate** inline (`scripts/smoke.sh`) → **promote** 100% traffic + deactivate the previous revision → **smoke production** → **roll back on any failure** (restore traffic to the previous revision, deactivate the candidate) — audit 0001 H7 |
+| `cd.yml` → `deploy-prod` | push to main / dispatch, `STAGING_ENABLED == true`, **behind the `production` approval gate**, `needs: deploy-staging` | the whole health-gated rollout in ONE job (every Azure step shares the approved environment's OIDC identity): **pin every image tag to its immutable digest, then verify the digest's signed provenance** (`gh attestation verify`, fail-closed; every subsequent `az` step ships the digest, so a tag moved mid-rollout changes nothing) → OIDC login → migrator to success (**gate**) → deploy each app as a **candidate at 0% traffic** (`--revision-suffix`, labelled `cd-candidate`) → readiness (incl. frontend) + warm the auth origin → **smoke the candidate** inline (`scripts/smoke.sh`) → **promote** 100% traffic + **sweep every superseded revision** (deactivate all active revisions except the promoted one — Terraform-minted ones included; #407/ADR-0029) → **smoke production** → **roll back on any failure** (restore traffic to the previous revision, deactivate the candidate) → **assert exactly one active revision per app** at 100% traffic (fails the run without touching traffic — the sweep's loud gate) — audit 0001 H7 |
 | `infra.yml` | PR / push to `iac/**`, dispatch | **`plan`** (prod + staging matrix) on PRs (preview in run summary); `apply-staging` (**auto**) → `apply-prod` (**gated**) on main |
 
 **The two-stage promotion model.** When `STAGING_ENABLED=true`, every merge to main builds once and **automatically deploys to staging** (no approval needed — `deploy-staging` is auto). The same `sha-<short>` then **waits at the `production` environment** for a human to approve. Clicking *Approve* (GitHub → the run → *Review deployments* → *Approve*) **is** the staging→prod promotion: the identical image that passed staging is what production receives. Test on staging first; approve when ready.
@@ -479,11 +479,28 @@ image built since that change has one; an older pre-H9 tag must be rebuilt from 
 **Roll back.** A *failed* rollout rolls back **automatically** (audit 0001 H7): the health-gated
 pipeline shifts traffic only after the candidate passes smoke, and on any failure the rollback step
 (in `deploy-prod`) restores 100% of traffic to the previous revision and deactivates the candidate —
-so a bad release never serves users. To revert a release *after* it was promoted, either re-run *CD* via dispatch with
-`image_tag` = the previous good `sha-<short>` (the rollout re-pins it to its digest and re-verifies
-its provenance) and approve, or — for an
-instant manual revert — shift traffic back to the still-present previous revision:
-`az containerapp ingress traffic set -n <app> -g <rg> --revision-weight <prev>=100 <candidate>=0`.
+so a bad release never serves users.
+
+**Roll back a completed deploy.** After a green rollout the previous revision is **deactivated, not
+kept warm** (#407 / ADR-0029 — an active 0%-traffic revision is a paid replica inside the warm
+window), so a manual revert is *activate → shift → deactivate*, and costs **one cold start** (~43 s
+worst case, measured in ADR-0027):
+
+```bash
+az containerapp revision list -n <app> -g <rg> --all \
+  --query "[].{name:name,active:properties.active,created:properties.createdTime}" -o table
+az containerapp revision activate -n <app> -g <rg> --revision <previous-good-revision>
+az containerapp ingress traffic set -n <app> -g <rg> \
+  --revision-weight <previous-good-revision>=100 <bad-revision>=0
+az containerapp revision deactivate -n <app> -g <rg> --revision <bad-revision>
+```
+
+The end state must satisfy the ADR-0029 invariant — exactly one active revision at 100% traffic.
+Alternatively re-run *CD* via dispatch with `image_tag` = the previous good `sha-<short>` (the
+rollout re-pins it to its digest and re-verifies its provenance) and approve — slower, but it
+exercises the full health-gated path and re-asserts the invariant for you. Rehearse the manual path
+against **staging** (same commands, staging RG/app names) before you ever need it on prod.
+
 DB migrations are forward-only — roll the schema forward, not back (ADR-0023); a bad migration is
 recovered by a Neon restore — the deploy's pre-migration auto-snapshot or PITR, see
 [Restore from the auto-snapshot](#restore-from-the-auto-snapshot-migr-04).
@@ -1071,6 +1088,14 @@ az containerapp replica list -n lotrotms-frontend-prod -g rg-lotrotms-prod-polc-
 > az containerapp ingress traffic set -n <app> -g <rg> --revision-weight <new>=100 <old>=0
 > az containerapp revision deactivate -n <app> -g <rg> --revision <old>
 > ```
+>
+> Forgetting the by-hand promotion no longer leaks forever: the next `deploy.yml` rollout sweeps
+> **every** active revision except the one it promotes (Terraform-minted ones included) and then
+> asserts exactly one active revision per app (#407 / ADR-0029). Until that next deploy, though, the
+> orphan revision holds a paid warm replica inside the warm window — the 2026-07-09 incident burned
+> 86 of 100 Neon CU-hours exactly this way — so promote or deactivate it promptly. An apply can
+> never interleave *mid*-rollout: `infra.yml` apply and `deploy.yml` share the per-environment
+> mutation lock (`prod-mutation` / `staging-mutation`).
 
 Availability is checked once a day by [`.github/workflows/health-ping.yml`](../../.github/workflows/health-ping.yml)
 (03:00 UTC — just before the window opens, so the probe pays the day's first cold start, not a visitor).


### PR DESCRIPTION
Closes #407

## What

- **`deploy.yml` — promote sweeps every superseded revision.** The single `deactivate $prev` (resolved from the highest traffic weight, `|| true`-swallowed) becomes a sweep: every active revision that is not the promoted candidate is deactivated, matched by exclusion — never a name pattern — so terraform-minted revisions (`--0000016`-style) and previously-leaked ones are reaped too. Each deactivation stays best-effort; loudness moved to the assert.
- **`deploy.yml` — post-rollout assertion.** A new final step fails the pipeline unless each app has exactly one active revision (the candidate) holding 100% of traffic. It is placed **after** the `Roll back on failure` step, so a red assertion can never revert correctly-placed traffic — a leftover revision is a cost defect, not a serving defect.
- **`cd.yml` header fixed.** The comment that hid the defect ("the previous revision is kept, 0% traffic, scales to zero") now states reality: superseded revisions are deactivated and asserted away; late rollback is `revision activate` + traffic shift.
- **ADR-0029** settles the rollback strategy the ticket flagged against ADR-0012 R8 (R8 itself was already reversed by ADR-0027 today): rolling back a completed deploy costs one cold start — the same price ADR-0027 accepted for any off-window visit. ADR-0012 §5 carries the amendment note.
- **Runbook**: "Roll back a completed deploy" flow (activate → shift → deactivate, cold-start caveat, staging-rehearsal note); the out-of-band `terraform apply` note explains that a forgotten manual promotion is now bounded by the next deploy's sweep, and that the shared `prod-mutation` lock keeps applies from interleaving mid-rollout.

## Why

On 2026-07-09 prod Neon stood at 86/100 CU-h: a terraform-minted revision at 0% traffic kept a `min_replicas=1` replica probing a DB-tagged `/health/ready` every 30 s for 8.5 days, and the deployed ADR-0025 fix ran dark behind it for 4 of them. Investigation showed the rollout has deactivated *a* previous revision since #258 — but only one, only via the traffic config, and silently — so the leak class survived. Under ADR-0027 each leaked active revision still buys a paid warm replica 15 h/day.

## Acceptance criteria → how met

- *Exactly one active revision per app at 100% after a deploy* — the sweep + the hard assertion (`deploy.yml`).
- *A second active revision fails the pipeline* — the assertion exits 1 with per-app diagnostics.
- *`cd.yml` no longer claims superseded revisions scale to zero* — header rewritten.
- *Rollback path documented + rehearsed on staging* — documented in the runbook incl. an explicit staging-rehearsal instruction; **the actual rehearsal run is deferred to the operator** (needs live Azure access; same commands against the staging RG).
- *Neon keeps suspending* — already true since the 2026-07-09 manual cleanup; this change prevents the next deploy from re-creating the leak.

## Test

- YAML parse + `bash -n` on every `run:` block of both workflows.
- The sweep loop and all three assertion branches (clean pass / extra active revision / wrong weight) exercised against a stubbed `az`.
- code-reviewer (Opus 4.8, max effort): APPROVE — no critical/major findings; step-ordering semantics (assert cannot re-trigger rollback) and `set -euo pipefail` interactions verified. Noted the one genuinely-new az call (`revision list --all`) will get its empirical proof on the automatic staging deploy, which runs before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)