### PR TITLE
AUDIT-SEC-01: Enforce HTTPS and verify integrity of the auto-downloaded translation file before it is patched into the DAT

### DIFF
--- a/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
+++ b/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
@@ -227,6 +227,10 @@ For every row of the uploaded export, compared against the stored source state b
   + ETag, 304/unreachable → keep the cached file and proceed. Configurable API base URL; the
   manual `patch <name>` path stays untouched. Additive slice + its launch-flow wiring are the
   sole sanctioned freeze exception (ADR-0002 amendment).
+  *Amendment (AUDIT-SEC-01 / #391, 2026-07-09):* the base URL must be `https` (plain `http` only
+  for localhost), and a 200 body is saved only if it hash-matches the ETag — which **is** the hex
+  SHA-256 of the file's UTF-8 bytes (cross-context contract, guarded by tests on both sides). A
+  failed check is treated like unreachable: keep the cached file and proceed, launch never blocks.
 - **Files:** the `||` format is consumed/produced unchanged — this spec triggers **no** ADR-gated
   format change. Golden fixtures + round-trip tests on both sides stay the drift guard.
 - **Editor loop:** #98–#101 (list/get/upsert/approve) operate on the same Translation rows;

--- a/src/Patcher/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommandHandler.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommandHandler.cs
@@ -46,8 +46,14 @@ internal sealed class SyncTranslationFileCommandHandler
             // The launch must never block on the network (spec 0001 Q5): a failed fetch falls back to
             // the local translation file. Whether one actually exists is the launch path's concern
             // (it reports a missing file), not the sync's — so the network stays strictly best-effort.
-            return Result.Success(new TranslationFileSyncResponse(
-                TranslationFileSyncOutcome.OfflineUsedCache, fetchResult.Error.Message));
+            // A rejected download (integrity check, AUDIT-SEC-01) gets its own outcome so the report
+            // says the file was refused, not that the server was unreachable.
+            TranslationFileSyncOutcome outcome =
+                fetchResult.Error.Code == DomainErrors.TranslationFileSync.IntegrityCheckFailedCode
+                    ? TranslationFileSyncOutcome.IntegrityCheckFailedUsedCache
+                    : TranslationFileSyncOutcome.OfflineUsedCache;
+
+            return Result.Success(new TranslationFileSyncResponse(outcome, fetchResult.Error.Message));
         }
 
         TranslationFileFetchResult fetch = fetchResult.Value;

--- a/src/Patcher/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommandValidator.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/TranslationFileSyncing/SyncTranslationFileCommandValidator.cs
@@ -8,14 +8,16 @@ public sealed class SyncTranslationFileCommandValidator : AbstractValidator<Sync
     {
         RuleFor(command => command.TmsBaseUrl)
             .NotEmpty()
-            .Must(BeAnAbsoluteHttpUrl)
-            .WithMessage("The TMS base URL must be a valid absolute http(s) URL.");
+            .Must(BeAnAbsoluteHttpsUrl)
+            .WithMessage("The TMS base URL must be a valid absolute https URL (plain http is allowed only for localhost).");
 
         RuleFor(command => command.TranslationFilePath)
             .NotEmpty();
     }
 
-    private static bool BeAnAbsoluteHttpUrl(string value)
+    // Plain http hands the downloaded file to any on-path attacker (AUDIT-SEC-01 / #391), so only
+    // loopback — where no network hop exists — may skip TLS (local dev against a host Kestrel).
+    private static bool BeAnAbsoluteHttpsUrl(string value)
         => Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
-           && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+           && (uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback);
 }

--- a/src/Patcher/LotroKoniecDev.Application/Features/TranslationFileSyncing/TranslationFileContentIntegrity.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/TranslationFileSyncing/TranslationFileContentIntegrity.cs
@@ -1,0 +1,31 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LotroKoniecDev.Application.Features.TranslationFileSyncing;
+
+/// <summary>
+/// Verifies a downloaded translation file against the TMS distribution contract: the endpoint's
+/// strong <c>ETag</c> is the hex SHA-256 of the file's UTF-8 bytes (computed by the TMS
+/// <c>PrecomputedTranslationFileProjector</c>), so the client can detect a body corrupted or
+/// truncated in transit/storage (AUDIT-SEC-01 / #391). It is <b>not</b> an authenticity proof —
+/// the hash arrives in the same response as the body, so anyone who can speak for the server can
+/// forge a matching pair; authenticity rests entirely on TLS, which is why the sync validator
+/// refuses plain http for non-loopback hosts. A missing or weak ETag is unverifiable and
+/// therefore fails the check. Guarded on the server side by the
+/// <c>Get_ETagIsTheSha256OfTheBody_SoThePatcherIntegrityCheckAcceptsIt</c> integration test —
+/// changing either side's hash is a cross-context contract change.
+/// </summary>
+public static class TranslationFileContentIntegrity
+{
+    public static bool Matches(string content, string? eTag)
+    {
+        if (string.IsNullOrEmpty(eTag) || eTag.StartsWith("W/", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        string expectedHash = eTag.Trim('"');
+        string actualHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
+        return string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Patcher/LotroKoniecDev.Application/Features/TranslationFileSyncing/TranslationFileSyncResponse.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/TranslationFileSyncing/TranslationFileSyncResponse.cs
@@ -10,7 +10,10 @@ public enum TranslationFileSyncOutcome
     UpToDate,
 
     /// <summary>The server was unreachable; the launch continues with the local translation file so it is never blocked on the network.</summary>
-    OfflineUsedCache
+    OfflineUsedCache,
+
+    /// <summary>The downloaded file did not match the server's content hash and was rejected; the launch continues with the local translation file.</summary>
+    IntegrityCheckFailedUsedCache
 }
 
 /// <summary>The result of a translation-file sync, with a human-readable summary for the CLI report.</summary>
@@ -22,6 +25,8 @@ public sealed record TranslationFileSyncResponse(TranslationFileSyncOutcome Outc
         TranslationFileSyncOutcome.UpToDate => "Translation file is already up to date.",
         TranslationFileSyncOutcome.OfflineUsedCache =>
             $"Could not reach the translation server; continuing with the local translation file. {Detail}".TrimEnd(),
+        TranslationFileSyncOutcome.IntegrityCheckFailedUsedCache =>
+            $"The downloaded translation file failed the integrity check and was rejected; continuing with the local translation file. {Detail}".TrimEnd(),
         _ => Outcome.ToString()
     };
 }

--- a/src/Patcher/LotroKoniecDev.Cli/Commands/GlobalSettings.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/Commands/GlobalSettings.cs
@@ -10,7 +10,8 @@ internal class GlobalSettings : CommandSettings
     /// <summary>
     /// TMS distribution base URL the launch sync downloads the translation file from. Empty until the
     /// TMS is deployed — while blank the launch skips the sync and uses the local translation file. Set
-    /// here (or override per-run with <c>--tms-url</c>) once the server has a stable address.
+    /// here (or override per-run with <c>--tms-url</c>) once the server has a stable address. Must be
+    /// <c>https</c> — plain <c>http</c> passes validation only for localhost (AUDIT-SEC-01 / #391).
     /// </summary>
     public const string DefaultTmsBaseUrl = "";
 

--- a/src/Patcher/LotroKoniecDev.Domain/Core/Errors/TranslationFileSyncDomainErrors.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Core/Errors/TranslationFileSyncDomainErrors.cs
@@ -6,10 +6,15 @@ public static partial class DomainErrors
 {
     public static class TranslationFileSync
     {
+        public const string IntegrityCheckFailedCode = "TranslationFileSync.IntegrityCheckFailed";
+
         public static Error NetworkError(string message) =>
             IoError("TranslationFileSync", "NetworkError", message);
 
         public static Error CacheWriteError(string path, string message) =>
             IoError("TranslationFileSync", "CacheWriteError", $"'{path}': {message}");
+
+        public static Error IntegrityCheckFailed(string message) =>
+            Error.IoError(IntegrityCheckFailedCode, $"The downloaded translation file failed the integrity check: {message}");
     }
 }

--- a/src/Patcher/LotroKoniecDev.Infrastructure/Network/TranslationFileDownloader.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/Network/TranslationFileDownloader.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using LotroKoniecDev.Application.Abstractions;
+using LotroKoniecDev.Application.Features.TranslationFileSyncing;
 using LotroKoniecDev.Domain.Core.Errors;
 using LotroKoniecDev.Domain.Core.Monads;
 
@@ -8,6 +9,9 @@ namespace LotroKoniecDev.Infrastructure.Network;
 /// <summary>
 /// Downloads the Polish translation file from the TMS distribution endpoint over HTTP with a
 /// conditional <c>If-None-Match</c> request, so an unchanged file returns 304 rather than its bytes.
+/// A downloaded body is accepted only when it hash-matches the server's ETag
+/// (<see cref="TranslationFileContentIntegrity"/>) — a corrupted or tampered file is rejected here,
+/// and the sync falls back to the cached copy (AUDIT-SEC-01 / #391).
 /// </summary>
 public sealed class TranslationFileDownloader : ITranslationFileDownloader
 {
@@ -44,6 +48,13 @@ public sealed class TranslationFileDownloader : ITranslationFileDownloader
 
             string content = await response.Content.ReadAsStringAsync(cancellationToken);
             string eTag = response.Headers.ETag?.ToString() ?? string.Empty;
+
+            if (!TranslationFileContentIntegrity.Matches(content, eTag))
+            {
+                return Result.Failure<TranslationFileFetchResult>(DomainErrors.TranslationFileSync.IntegrityCheckFailed(
+                    "the response body does not match the server's ETag content hash."));
+            }
+
             return Result.Success(TranslationFileFetchResult.Modified(content, eTag));
         }
         catch (HttpRequestException ex)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/GetTranslationFile.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/GetTranslationFile.cs
@@ -20,6 +20,9 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 /// hash-only lookup (PERF-01/#286): the multi-MB <c>Content</c> column is TOASTed by PostgreSQL,
 /// so a revalidation that never reads it stays O(1) regardless of artifact size — content is
 /// fetched only when the client's validator no longer matches.
+/// The ETag doubles as the integrity hash (AUDIT-SEC-01/#391): the patcher recomputes the hex
+/// SHA-256 of the downloaded UTF-8 body and rejects the file on mismatch, so the hash algorithm
+/// and the strong-ETag format are a cross-context contract — change them only with the patcher.
 /// </summary>
 internal sealed class GetTranslationFile : IEndpoint
 {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/PrecomputedTranslationFileProjector.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/TranslationFiles/PrecomputedTranslationFileProjector.cs
@@ -60,6 +60,8 @@ internal sealed class PrecomputedTranslationFileProjector : IPrecomputedTranslat
                 .ToListAsync(cancellationToken);
 
             string content = serializer.Serialize(rows);
+            // Hex SHA-256 of the UTF-8 body is a cross-context contract: it ships as the distribution
+            // ETag and the patcher rejects a download that does not hash-match it (AUDIT-SEC-01/#391).
             string contentHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
             DateTimeOffset now = timeProvider.GetUtcNow();
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -83,7 +83,9 @@ the suite runs on macOS too).
 
 ## Infrastructure Tests (LotroKoniecDev.Tests.Infrastructure)
 
-Tests that touch real infrastructure adapters (today: `GameLauncherTests`). Grows in M2
+Tests that touch real infrastructure adapters (today: `GameLauncherTests` and
+`TranslationFileDownloaderTests` — the latter drives the downloader's integrity enforcement
+point over an in-memory stub `HttpMessageHandler`, no real network). Grows in M2
 (PostgreSQL + EF Core) and whenever file-content verification is needed — asserting on real file
 output belongs here, never in `Tests.Unit`. Targets `net10.0-windows`: builds everywhere,
 **runs on Windows only** (on macOS the run aborts — expected).

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Tests/TranslationFileDownloaderTests.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Tests/TranslationFileDownloaderTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using LotroKoniecDev.Application.Abstractions;
+using LotroKoniecDev.Domain.Core.Errors;
+using LotroKoniecDev.Domain.Core.Monads;
+using LotroKoniecDev.Infrastructure.Network;
+
+namespace LotroKoniecDev.Tests.Infrastructure.Tests;
+
+/// <summary>
+/// Exercises the downloader's integrity enforcement point (AUDIT-SEC-01 / #391) over an in-memory
+/// stub handler — no real network. The pure hash comparison itself is covered in
+/// <c>Tests.Unit/TranslationFileContentIntegrityTests</c>; these tests prove the downloader actually
+/// applies it before handing content to the sync.
+/// </summary>
+public sealed class TranslationFileDownloaderTests
+{
+    private const string BaseUrl = "https://tms.example.com";
+    private const string Content = "polish content";
+
+    /// <summary>Independently computed (shell <c>shasum -a 256</c>), never via the code under test.</summary>
+    private const string ContentHash = "579BDE6E87308282DEA0FCB1A3E8AF668BF6F558CC4545457C696EFB75F7FD18";
+
+    [Fact]
+    public async Task FetchAsync_BodyMatchingTheETagHash_ShouldReturnModifiedContent()
+    {
+        // Arrange
+        using HttpResponseMessage response = OkResponse(Content, $"\"{ContentHash}\"");
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.IsModified.ShouldBeTrue();
+        result.Value.Content.ShouldBe(Content);
+        result.Value.ETag.ShouldBe($"\"{ContentHash}\"");
+    }
+
+    [Fact]
+    public async Task FetchAsync_BodyNotMatchingTheETagHash_ShouldRejectTheDownload()
+    {
+        // Arrange — the served bytes do not hash to the advertised ETag (corruption or tampering).
+        using HttpResponseMessage response = OkResponse("tampered body", $"\"{ContentHash}\"");
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe(DomainErrors.TranslationFileSync.IntegrityCheckFailedCode);
+    }
+
+    [Fact]
+    public async Task FetchAsync_ResponseWithoutAnETag_ShouldRejectTheDownload()
+    {
+        // Arrange — no validator means no way to verify the body: fail closed.
+        using HttpResponseMessage response = OkResponse(Content, eTag: null);
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe(DomainErrors.TranslationFileSync.IntegrityCheckFailedCode);
+    }
+
+    [Fact]
+    public async Task FetchAsync_ResponseWithAWeakETag_ShouldRejectTheDownload()
+    {
+        // Arrange — a weak validator cannot guarantee byte equality, so it is as unverifiable as none.
+        using HttpResponseMessage response = OkResponse(Content, eTag: null);
+        response.Headers.ETag = new EntityTagHeaderValue($"\"{ContentHash}\"", isWeak: true);
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe(DomainErrors.TranslationFileSync.IntegrityCheckFailedCode);
+    }
+
+    [Fact]
+    public async Task FetchAsync_NotModifiedResponse_ShouldReportTheCachedCopyCurrentWithoutAnyCheck()
+    {
+        // Arrange — a 304 carries no body, so there is nothing to verify.
+        using HttpResponseMessage response = new(HttpStatusCode.NotModified);
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, "\"cached-etag\"", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.IsModified.ShouldBeFalse();
+    }
+
+    private static HttpResponseMessage OkResponse(string body, string? eTag)
+    {
+        HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "text/plain")
+        };
+
+        if (eTag is not null)
+        {
+            response.Headers.ETag = new EntityTagHeaderValue(eTag);
+        }
+
+        return response;
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public StubHttpMessageHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_response);
+    }
+}

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Features/SyncTranslationFileCommandHandlerTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Features/SyncTranslationFileCommandHandlerTests.cs
@@ -45,6 +45,61 @@ public sealed class SyncTranslationFileCommandHandlerTests
         await _downloader.DidNotReceive().FetchAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
+    [Theory]
+    [InlineData("http://tms.example.com")]
+    [InlineData("http://192.168.1.10:5002")]
+    [InlineData("HTTP://tms.example.com")]
+    [InlineData("http://localhost.evil.com")]
+    public async Task Handle_PlainHttpNonLocalhostUrl_ShouldReturnValidationErrorAndNotFetch(string baseUrl)
+    {
+        // Act — plain http hands the file to an on-path attacker (AUDIT-SEC-01), so it is rejected.
+        Result<TranslationFileSyncResponse> result =
+            await _sut.Handle(new SyncTranslationFileCommand(baseUrl, FilePath), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Type.ShouldBe(ErrorType.Validation);
+        await _downloader.DidNotReceive().FetchAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("https://tms.example.com")]
+    [InlineData("http://localhost:5002")]
+    [InlineData("http://127.0.0.1:5002")]
+    [InlineData("http://[::1]:5002")]
+    public async Task Handle_HttpsOrLoopbackHttpUrl_ShouldPassValidationAndFetch(string baseUrl)
+    {
+        // Arrange — loopback has no network hop, so the localhost dev exception keeps plain http.
+        _downloader.FetchAsync(baseUrl, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(TranslationFileFetchResult.NotModified()));
+
+        // Act
+        Result<TranslationFileSyncResponse> result =
+            await _sut.Handle(new SyncTranslationFileCommand(baseUrl, FilePath), CancellationToken.None);
+
+        // Assert — reaching the UpToDate outcome proves validation passed and the fetch ran.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Outcome.ShouldBe(TranslationFileSyncOutcome.UpToDate);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDownloadFailsTheIntegrityCheck_ShouldRejectItAndContinueWithLocalFile()
+    {
+        // Arrange — a tampered/corrupted download is rejected by the downloader (AUDIT-SEC-01); the
+        // sync must fall back to the cached file and never save the rejected content.
+        _downloader.FetchAsync(BaseUrl, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<TranslationFileFetchResult>(
+                DomainErrors.TranslationFileSync.IntegrityCheckFailed("hash mismatch")));
+
+        // Act
+        Result<TranslationFileSyncResponse> result = await _sut.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Outcome.ShouldBe(TranslationFileSyncOutcome.IntegrityCheckFailedUsedCache);
+        _cache.DidNotReceive().Save(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
     [Fact]
     public async Task Handle_WhenServerReturnsNewFile_ShouldSaveItAndReportUpdated()
     {

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Features/TranslationFileContentIntegrityTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Features/TranslationFileContentIntegrityTests.cs
@@ -1,0 +1,72 @@
+using LotroKoniecDev.Application.Features.TranslationFileSyncing;
+
+namespace LotroKoniecDev.Tests.Unit.Tests.Features;
+
+public sealed class TranslationFileContentIntegrityTests
+{
+    private const string Content = "polish content";
+
+    /// <summary>Independently computed (shell <c>shasum -a 256</c>), never via the code under test.</summary>
+    private const string ContentHash = "579BDE6E87308282DEA0FCB1A3E8AF668BF6F558CC4545457C696EFB75F7FD18";
+
+    [Theory]
+    [InlineData($"\"{ContentHash}\"")]
+    [InlineData("\"579bde6e87308282dea0fcb1a3e8af668bf6f558cc4545457c696efb75f7fd18\"")]
+    [InlineData(ContentHash)]
+    public void Matches_ETagCarryingTheBodyHash_ShouldBeTrue(string eTag)
+    {
+        // Act
+        bool matches = TranslationFileContentIntegrity.Matches(Content, eTag);
+
+        // Assert — quoted or bare, upper- or lowercase hex: all are the same strong validator.
+        matches.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("\"DEADBEEF\"")]
+    [InlineData($"W/\"{ContentHash}\"")]
+    public void Matches_MissingMismatchedOrWeakETag_ShouldBeFalse(string? eTag)
+    {
+        // Act
+        bool matches = TranslationFileContentIntegrity.Matches(Content, eTag);
+
+        // Assert — an unverifiable (missing/weak) validator must fail closed, like a wrong hash.
+        matches.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Matches_TamperedContentAgainstTheOriginalHash_ShouldBeFalse()
+    {
+        // Act
+        bool matches = TranslationFileContentIntegrity.Matches("polish content tampered", $"\"{ContentHash}\"");
+
+        // Assert
+        matches.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Matches_ContentWithPolishDiacritics_ShouldHashTheUtf8Bytes()
+    {
+        // Act — hash computed independently over the UTF-8 bytes of the text.
+        bool matches = TranslationFileContentIntegrity.Matches(
+            "Witaj w Śródziemiu!",
+            "\"8D58291BE990D0EAD8E30D5F350961AF361C1E15E5ACB892DE796C2B22AAA2FA\"");
+
+        // Assert
+        matches.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Matches_EmptyContentWithTheEmptyHash_ShouldBeTrue()
+    {
+        // Act — SHA-256 of zero bytes; an empty artifact is still a verifiable artifact.
+        bool matches = TranslationFileContentIntegrity.Matches(
+            string.Empty,
+            "\"E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855\"");
+
+        // Assert
+        matches.ShouldBeTrue();
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
@@ -1,5 +1,7 @@
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Text;
+using LotroKoniecDev.Application.Features.TranslationFileSyncing;
 using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.SharedKernel.Authorization;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds;
@@ -220,6 +222,25 @@ public sealed class GetTranslationFileTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_ETagIsTheSha256OfTheBody_SoThePatcherIntegrityCheckAcceptsIt()
+    {
+        // Arrange
+        await SeedAsync(gossipId: 1, polish: "Zażółć gęślą jaźń", status: SeedStatus.Approved);
+        await RebuildAsync();
+
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync(Route);
+        string body = await response.Content.ReadAsStringAsync();
+
+        // Assert — the patcher rejects any download whose body does not hash-match the ETag
+        // (AUDIT-SEC-01/#391), so the strong ETag must stay the hex SHA-256 of the UTF-8 body with
+        // nothing (e.g. a BOM) added in transit. Verified with the patcher's own integrity check.
+        response.Headers.ETag!.IsWeak.ShouldBeFalse();
+        response.Headers.ETag.Tag.ShouldBe($"\"{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(body)))}\"");
+        TranslationFileContentIntegrity.Matches(body, response.Headers.ETag.ToString()).ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #391

## What

- **HTTPS enforced at the trust boundary:** `SyncTranslationFileCommandValidator` accepts only `https` absolute URLs; plain `http` passes solely for loopback hosts (`Uri.IsLoopback` — `localhost`, `127.0.0.0/8`, `[::1]`), where no network hop exists. Uppercase schemes and lookalike hosts (`http://localhost.evil.com`) are rejected — pinned by tests.
- **Integrity check before save/use:** the TMS distribution ETag *is* the hex SHA-256 of the artifact's UTF-8 body (`PrecomputedTranslationFileProjector`). `TranslationFileDownloader` now recomputes the hash of the downloaded body and rejects the file on mismatch, missing ETag, or weak ETag (fail closed). The pure comparison lives in Application (`TranslationFileContentIntegrity`) so it is unit-testable.
- **Fallback keeps spec 0001 Q5:** a rejected download surfaces as the new `IntegrityCheckFailedUsedCache` outcome — the sync falls back to the cached file and launch never blocks on the network; the CLI report says the file was refused rather than pretending the server was unreachable.
- **Cross-context contract pinned on both sides:** TMS integration test asserts the served body hashes to the served strong ETag *using the patcher's own verifier*; endpoint/projector docs mark the hash as a contract; spec 0001 carries the amendment.

## Why

A network attacker (MITM/DNS spoofing) could feed arbitrary content into the game DAT through the every-launch auto-download when the URL was plain `http`, and nothing verified the payload. Fixed before the TMS ships to users (default URL is still empty). Note: the hash proves corruption/truncation integrity only — authenticity rests on TLS, which is why `http` is now refused for non-loopback hosts.

## Tests

- `Tests.Unit` 258/258 green — new `TranslationFileContentIntegrityTests` matrix (quoted/bare/lower/upper hex, mismatch, null/empty/weak ETag, UTF-8 diacritics, empty body) + new handler theories (http rejected incl. `HTTP://` and `localhost.evil.com`; https/loopback accepted incl. `[::1]`; integrity failure → fallback without `Save`). Existing sync tests untouched.
- New `TranslationFileDownloaderTests` (Tests.Infrastructure, stub `HttpMessageHandler`, no network) drive the enforcement point: match → Modified, mismatch/no-ETag/weak-ETag → `IntegrityCheckFailed`, 304 → NotModified. Windows-only at runtime (project targets `net10.0-windows`); compiled by the zero-warnings gate everywhere.
- TMS `GetTranslationFileTests` 12/12 green locally incl. the new ETag-is-SHA-256 contract test.
- Full solution build green, zero warnings. `code-reviewer` gate: APPROVE (after adding the downloader enforcement-point tests + validator bypass matrix it requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)