### PR TITLE
AUDIT-SEC-02: Verify the launcher's Authenticode signature and confirm drive-scanned install locations before launch

### DIFF
--- a/src/Patcher/LotroKoniecDev.Application/Abstractions/ILauncherSignatureVerifier.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Abstractions/ILauncherSignatureVerifier.cs
@@ -1,0 +1,11 @@
+namespace LotroKoniecDev.Application.Abstractions;
+
+public interface ILauncherSignatureVerifier
+{
+    /// <summary>
+    /// Verifies that the launcher executable carries a valid Authenticode signature from a known
+    /// LOTRO publisher. Any other outcome — unsigned, tampered, untrusted chain, foreign signer —
+    /// is a failure, so a planted executable is refused before it can run (AUDIT-SEC-02).
+    /// </summary>
+    Result VerifySignature(string launcherPath);
+}

--- a/src/Patcher/LotroKoniecDev.Cli/DatPathResolver.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/DatPathResolver.cs
@@ -1,6 +1,7 @@
 using LotroKoniecDev.Application.Abstractions.DatFilesServices;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Domain.Models;
+using LotroKoniecDev.Primitives.Enums;
 using static LotroKoniecDev.Cli.ConsoleWriter;
 
 namespace LotroKoniecDev.Cli;
@@ -39,7 +40,27 @@ internal sealed class DatPathResolver : IDatPathResolver
         DatFileLocation location = locations[0];
         WriteInfo($"Found LOTRO: {location.DisplayName}");
         WriteInfo($"  {location.Path}");
+
+        // A drive-scanned folder is an unauthenticated source — anyone with write access could
+        // have planted a DAT + launcher pair there, so it is never used silently (AUDIT-SEC-02).
+        if (location.Source is DatFileSource.DiskScan && !ConfirmScannedLocation())
+        {
+            WriteError("Scanned location rejected. Provide the DAT file path explicitly with -d.");
+            return null;
+        }
+
         return location.Path;
+    }
+
+    private static bool ConfirmScannedLocation()
+    {
+        Console.WriteLine();
+        WriteWarning("This installation was found by a drive scan, not a known install source.");
+        WriteWarning("On launch, LotroLauncher.exe from this folder will be started.");
+        Console.Write("Use this installation? [y/N]: ");
+
+        string? input = Console.ReadLine();
+        return string.Equals(input?.Trim(), "y", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? PromptUserChoice(IReadOnlyList<DatFileLocation> locations)
@@ -52,6 +73,11 @@ internal sealed class DatPathResolver : IDatPathResolver
         {
             Console.WriteLine($"  [{i + 1}] {locations[i].DisplayName}");
             Console.WriteLine($"      {locations[i].Path}");
+
+            if (locations[i].Source is DatFileSource.DiskScan)
+            {
+                Console.WriteLine("      [!] found by drive scan — make sure this is your real install");
+            }
         }
 
         Console.WriteLine();

--- a/src/Patcher/LotroKoniecDev.Domain/Core/Errors/InfrastructureDomainErrors.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Core/Errors/InfrastructureDomainErrors.cs
@@ -29,11 +29,16 @@ public static partial class DomainErrors
 
     public static class GameLaunch
     {
+        public const string UntrustedLauncherCode = "GameLaunch.UntrustedLauncher";
+
         public static Error GameAlreadyRunning =>
             OperationFailed("GameLaunch", "LOTRO is already running. Close the game before launching.");
 
         public static Error LauncherNotFound(string path) =>
             NotFound("GameLaunch", $"LotroLauncher.exe at '{path}'");
+
+        public static Error UntrustedLauncher(string path, string reason) =>
+            Error.Failure(UntrustedLauncherCode, $"Refusing to launch '{path}': {reason}.");
 
         public static Error LaunchFailed(string message) =>
             OperationFailed("GameLaunch", message);

--- a/src/Patcher/LotroKoniecDev.Infrastructure/GameLaunching/AuthenticodeLauncherSignatureVerifier.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/GameLaunching/AuthenticodeLauncherSignatureVerifier.cs
@@ -1,0 +1,78 @@
+using LotroKoniecDev.Application.Abstractions;
+using LotroKoniecDev.Domain.Core.Errors;
+using LotroKoniecDev.Domain.Core.Monads;
+
+namespace LotroKoniecDev.Infrastructure.GameLaunching;
+
+/// <summary>
+/// Verifies the launcher's Authenticode signature via WinVerifyTrust and pins the signer subject
+/// to the known LOTRO publishers, so an executable planted next to a drive-scanned DAT is refused
+/// before it can run — potentially elevated — under the tool's identity (AUDIT-SEC-02 / #392).
+/// </summary>
+public sealed class AuthenticodeLauncherSignatureVerifier : ILauncherSignatureVerifier
+{
+    // Standing Stone Games LLC signs the current launcher; Turbine, Inc. signed the legacy one
+    // (the same publisher history this repo's registry lookup already models). The signer's
+    // subject CN must equal one of these after normalization (case, commas, periods, extra
+    // whitespace) — exact equality, so a foreign "Turbine Dynamics Ltd"-style CN never matches,
+    // while legal-suffix punctuation variants of the real publishers still do.
+    private static readonly string[] TrustedPublisherCommonNames =
+    [
+        "standing stone games",
+        "standing stone games llc",
+        "turbine",
+        "turbine inc"
+    ];
+
+    public Result VerifySignature(string launcherPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(launcherPath);
+
+        int trustStatus = WinTrustNative.VerifyEmbeddedSignature(launcherPath, out string? signerCommonName);
+        if (trustStatus != WinTrustNative.Success)
+        {
+            return Result.Failure(DomainErrors.GameLaunch.UntrustedLauncher(
+                launcherPath, DescribeTrustFailure(trustStatus)));
+        }
+
+        if (string.IsNullOrWhiteSpace(signerCommonName))
+        {
+            return Result.Failure(DomainErrors.GameLaunch.UntrustedLauncher(
+                launcherPath, "its signer certificate could not be read"));
+        }
+
+        if (!IsTrustedPublisher(signerCommonName))
+        {
+            return Result.Failure(DomainErrors.GameLaunch.UntrustedLauncher(
+                launcherPath, $"it is signed by '{signerCommonName}' instead of a known LOTRO publisher"));
+        }
+
+        return Result.Success();
+    }
+
+    internal static bool IsTrustedPublisher(string signerCommonName)
+    {
+        string normalizedCommonName = NormalizeCompanyName(signerCommonName);
+
+        return TrustedPublisherCommonNames.Any(publisherName =>
+            string.Equals(normalizedCommonName, publisherName, StringComparison.Ordinal));
+    }
+
+    private static string NormalizeCompanyName(string value) =>
+        string.Join(' ', value
+            .ToLowerInvariant()
+            .Replace(",", string.Empty)
+            .Replace(".", string.Empty)
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+    private static string DescribeTrustFailure(int trustStatus) =>
+        trustStatus switch
+        {
+            WinTrustNative.TrustENoSignature => "it has no Authenticode signature",
+            WinTrustNative.TrustEBadDigest => "its signature does not match the file contents (the file was modified)",
+            WinTrustNative.TrustEExplicitDistrust => "its signature is explicitly distrusted on this machine",
+            WinTrustNative.CertEUntrustedRoot => "its signature chain does not lead to a trusted root",
+            WinTrustNative.TrustESubjectNotTrusted => "its signature is not trusted",
+            _ => $"signature verification failed with status 0x{trustStatus:X8}"
+        };
+}

--- a/src/Patcher/LotroKoniecDev.Infrastructure/GameLaunching/GameLauncher.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/GameLaunching/GameLauncher.cs
@@ -9,6 +9,13 @@ public sealed class GameLauncher : IGameLauncher
 {
     private const string LauncherExecutable = "LotroLauncher.exe";
 
+    private readonly ILauncherSignatureVerifier _signatureVerifier;
+
+    public GameLauncher(ILauncherSignatureVerifier signatureVerifier)
+    {
+        _signatureVerifier = signatureVerifier;
+    }
+
     public Result Launch(string datFilePath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(datFilePath);
@@ -22,6 +29,19 @@ public sealed class GameLauncher : IGameLauncher
 
         try
         {
+            // The DAT folder can come from an unauthenticated source (drive scan, user input), so
+            // the executable must prove its publisher before it runs — potentially elevated
+            // (AUDIT-SEC-02). The read handle is held across the verify → start window, denying
+            // writes and renames so the verified bytes cannot be swapped in between.
+            using FileStream launcherGuard = new(
+                launcherPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+            Result signatureResult = _signatureVerifier.VerifySignature(launcherPath);
+            if (signatureResult.IsFailure)
+            {
+                return signatureResult;
+            }
+
             Process? process = Process.Start(new ProcessStartInfo
             {
                 FileName = launcherPath,

--- a/src/Patcher/LotroKoniecDev.Infrastructure/GameLaunching/WinTrustNative.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/GameLaunching/WinTrustNative.cs
@@ -1,0 +1,191 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace LotroKoniecDev.Infrastructure.GameLaunching;
+
+/// <summary>
+/// P/Invoke wrapper for WinVerifyTrust (wintrust.dll) — verifies the embedded Authenticode
+/// signature of a file against the Windows trust machinery and surfaces the signer subject
+/// from the very certificate chain that was validated.
+/// </summary>
+internal static partial class WinTrustNative
+{
+    public const int Success = 0;
+
+    public const int TrustENoSignature = unchecked((int)0x800B0100);
+    public const int TrustESubjectNotTrusted = unchecked((int)0x800B0004);
+    public const int TrustEBadDigest = unchecked((int)0x80096010);
+    public const int TrustEExplicitDistrust = unchecked((int)0x800B0111);
+    public const int CertEUntrustedRoot = unchecked((int)0x800B0109);
+
+    private const uint WtdUiNone = 2;
+    private const uint WtdRevokeNone = 0;
+    private const uint WtdChoiceFile = 1;
+    private const uint WtdStateActionVerify = 1;
+    private const uint WtdStateActionClose = 2;
+    private const uint WtdRevocationCheckNone = 0x10;
+
+    private static readonly Guid WintrustActionGenericVerifyV2 =
+        new("00AAC56B-CD44-11D0-8CC2-00C04FC295EE");
+
+    // Per WinVerifyTrust docs, INVALID_HANDLE_VALUE suppresses all trust-provider UI.
+    private static readonly IntPtr InvalidHandleValue = new(-1);
+
+    /// <summary>
+    /// Verifies the embedded Authenticode signature of <paramref name="filePath"/>.
+    /// Revocation is not checked online, and a timestamped signature whose certificate has since
+    /// expired remains valid — gaming boxes are routinely offline and launchers age.
+    /// </summary>
+    /// <param name="filePath">The executable whose signature is verified.</param>
+    /// <param name="signerCommonName">On success, the common name (CN) of the signing
+    /// certificate's subject, read from the validated chain itself; <c>null</c> when it
+    /// cannot be read.</param>
+    /// <returns><see cref="Success"/> (zero) for a valid, trusted signature; otherwise the
+    /// WinVerifyTrust status code (e.g. <see cref="TrustENoSignature"/>).</returns>
+    public static unsafe int VerifyEmbeddedSignature(string filePath, out string? signerCommonName)
+    {
+        signerCommonName = null;
+
+        fixed (char* filePathPointer = filePath)
+        {
+            WintrustFileInfo fileInfo = new()
+            {
+                StructSize = (uint)sizeof(WintrustFileInfo),
+                FilePath = (IntPtr)filePathPointer
+            };
+
+            WintrustData data = new()
+            {
+                StructSize = (uint)sizeof(WintrustData),
+                UiChoice = WtdUiNone,
+                RevocationChecks = WtdRevokeNone,
+                UnionChoice = WtdChoiceFile,
+                FileInfo = (IntPtr)(&fileInfo),
+                StateAction = WtdStateActionVerify,
+                ProvFlags = WtdRevocationCheckNone
+            };
+
+            try
+            {
+                int status = WinVerifyTrust(InvalidHandleValue, in WintrustActionGenericVerifyV2, ref data);
+
+                if (status == Success)
+                {
+                    signerCommonName = ReadSignerCommonName(data.StateData);
+                }
+
+                return status;
+            }
+            finally
+            {
+                data.StateAction = WtdStateActionClose;
+                _ = WinVerifyTrust(InvalidHandleValue, in WintrustActionGenericVerifyV2, ref data);
+            }
+        }
+    }
+
+    private static unsafe string? ReadSignerCommonName(IntPtr stateData)
+    {
+        IntPtr providerData = WTHelperProvDataFromStateData(stateData);
+        if (providerData == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        CryptProviderSgnr* signer = (CryptProviderSgnr*)WTHelperGetProvSignerFromChain(
+            providerData, signerIndex: 0, counterSigner: 0, counterSignerIndex: 0);
+        if (signer is null || signer->CertChainCount == 0 || signer->CertChain is null)
+        {
+            return null;
+        }
+
+        // pasCertChain[0] is the end (signing) certificate of the validated chain.
+        IntPtr certContext = signer->CertChain->CertContext;
+        if (certContext == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        try
+        {
+            // The IntPtr constructor duplicates the CERT_CONTEXT, so the name outlives
+            // the WinVerifyTrust state this pointer belongs to.
+            using X509Certificate2 signerCertificate = new(certContext);
+            string commonName = signerCertificate.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+            return string.IsNullOrWhiteSpace(commonName) ? null : commonName;
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+    }
+
+    [LibraryImport("wintrust.dll", EntryPoint = "WinVerifyTrust")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    private static partial int WinVerifyTrust(IntPtr hwnd, in Guid actionId, ref WintrustData data);
+
+    [LibraryImport("wintrust.dll", EntryPoint = "WTHelperProvDataFromStateData")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    private static partial IntPtr WTHelperProvDataFromStateData(IntPtr stateData);
+
+    [LibraryImport("wintrust.dll", EntryPoint = "WTHelperGetProvSignerFromChain")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    private static partial IntPtr WTHelperGetProvSignerFromChain(
+        IntPtr providerData, uint signerIndex, int counterSigner, uint counterSignerIndex);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WintrustFileInfo
+    {
+        public uint StructSize;
+        public IntPtr FilePath;
+        public IntPtr FileHandle;
+        public IntPtr KnownSubjectGuid;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WintrustData
+    {
+        public uint StructSize;
+        public IntPtr PolicyCallbackData;
+        public IntPtr SipClientData;
+        public uint UiChoice;
+        public uint RevocationChecks;
+        public uint UnionChoice;
+        public IntPtr FileInfo;
+        public uint StateAction;
+        public IntPtr StateData;
+        public IntPtr UrlReference;
+        public uint ProvFlags;
+        public uint UiContext;
+        public IntPtr SignatureSettings;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private unsafe struct CryptProviderSgnr
+    {
+        public uint StructSize;
+        public uint VerifyAsOfLow;
+        public uint VerifyAsOfHigh;
+        public uint CertChainCount;
+        public CryptProviderCert* CertChain;
+        public uint SignerType;
+        public IntPtr Signer;
+        public uint Error;
+        public uint CounterSignersCount;
+        public IntPtr CounterSigners;
+        public IntPtr ChainContext;
+    }
+
+    /// <summary>
+    /// Prefix of the native CRYPT_PROVIDER_CERT — only the leading fields are read,
+    /// so the trailing native fields are deliberately not declared.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct CryptProviderCert
+    {
+        public uint StructSize;
+        public IntPtr CertContext;
+    }
+}

--- a/src/Patcher/LotroKoniecDev.Infrastructure/InfrastructureDependencyInjection.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/InfrastructureDependencyInjection.cs
@@ -23,6 +23,7 @@ public static class InfrastructureDependencyInjection
         services.AddScoped<DatFileHandler>();
         services.AddScoped<IDatFileHandler>(sp => sp.GetRequiredService<DatFileHandler>());
         services.AddScoped<IDatVersionReader>(sp => sp.GetRequiredService<DatFileHandler>());
+        services.AddSingleton<ILauncherSignatureVerifier, AuthenticodeLauncherSignatureVerifier>();
         services.AddSingleton<IGameLauncher, GameLauncher>();
         services.AddSingleton<IDatFileLocator, DatFileLocator>();
         services.AddSingleton<IGameProcessDetector, GameProcessDetector>();

--- a/src/Patcher/LotroKoniecDev.Infrastructure/LotroKoniecDev.Infrastructure.csproj
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/LotroKoniecDev.Infrastructure.csproj
@@ -14,6 +14,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="LotroKoniecDev.Tests.Infrastructure" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\LotroKoniecDev.Domain\LotroKoniecDev.Domain.csproj"/>
         <ProjectReference Include="..\LotroKoniecDev.Application\LotroKoniecDev.Application.csproj"/>
     </ItemGroup>

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Tests/AuthenticodeLauncherSignatureVerifierTests.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Tests/AuthenticodeLauncherSignatureVerifierTests.cs
@@ -1,0 +1,102 @@
+using LotroKoniecDev.Domain.Core.Errors;
+using LotroKoniecDev.Domain.Core.Monads;
+using LotroKoniecDev.Infrastructure.GameLaunching;
+
+namespace LotroKoniecDev.Tests.Infrastructure.Tests;
+
+/// <summary>
+/// Exercises the launch-boundary signature enforcement point (AUDIT-SEC-02 / #392) against real
+/// files and the real WinVerifyTrust machinery — Windows-only, like the rest of this project.
+/// </summary>
+public sealed class AuthenticodeLauncherSignatureVerifierTests
+{
+    private readonly AuthenticodeLauncherSignatureVerifier _sut = new();
+
+    [Fact]
+    public void VerifySignature_UnsignedExecutable_ShouldReturnUntrustedLauncherFailure()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            string unsignedLauncher = Path.Combine(tempDir, "LotroLauncher.exe");
+            File.WriteAllText(unsignedLauncher, "not a signed executable");
+
+            Result result = _sut.VerifySignature(unsignedLauncher);
+
+            result.IsFailure.ShouldBeTrue();
+            result.Error.Code.ShouldBe(DomainErrors.GameLaunch.UntrustedLauncherCode);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Launch_FakeUnsignedLauncherNextToScannedDat_ShouldBeRefused()
+    {
+        // The ticket's attack scenario end-to-end: a planted DAT + unsigned launcher pair in a
+        // writable folder must be refused by the real launcher + real verifier composition.
+        GameLauncher gameLauncher = new(_sut);
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            string fakeDatFile = Path.Combine(tempDir, "client_local_English.dat");
+            File.WriteAllText(fakeDatFile, "fake");
+            string fakeLauncher = Path.Combine(tempDir, "LotroLauncher.exe");
+            File.WriteAllText(fakeLauncher, "not a signed executable");
+
+            Result result = gameLauncher.Launch(fakeDatFile);
+
+            result.IsFailure.ShouldBeTrue();
+            result.Error.Code.ShouldBe(DomainErrors.GameLaunch.UntrustedLauncherCode);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void VerifySignature_NullOrWhitespacePath_ShouldThrow(string? launcherPath)
+    {
+        Should.Throw<ArgumentException>(() => _sut.VerifySignature(launcherPath!));
+    }
+
+    [Fact]
+    public void VerifySignature_NonexistentPath_ShouldReturnUntrustedLauncherFailure()
+    {
+        string nonexistentLauncher = Path.Combine(
+            Path.GetTempPath(), Guid.NewGuid().ToString(), "LotroLauncher.exe");
+
+        Result result = _sut.VerifySignature(nonexistentLauncher);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe(DomainErrors.GameLaunch.UntrustedLauncherCode);
+    }
+
+    [Theory]
+    [InlineData("Standing Stone Games LLC", true)]
+    [InlineData("Standing Stone Games, LLC", true)]
+    [InlineData("Standing Stone Games", true)]
+    [InlineData("standing stone games llc", true)]
+    [InlineData("Turbine, Inc.", true)]
+    [InlineData("Turbine Inc", true)]
+    [InlineData("Turbine", true)]
+    [InlineData("Turbine Dynamics Ltd", false)]
+    [InlineData("Standing Stone Games Fan Club", false)]
+    [InlineData("Evil Corp LLC", false)]
+    [InlineData("Microsoft Corporation", false)]
+    [InlineData("", false)]
+    public void IsTrustedPublisher_ShouldMatchOnlyKnownLotroPublisherCommonNames(string signerCommonName, bool expected)
+    {
+        AuthenticodeLauncherSignatureVerifier.IsTrustedPublisher(signerCommonName).ShouldBe(expected);
+    }
+}

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Tests/GameLauncherTests.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Tests/GameLauncherTests.cs
@@ -1,3 +1,5 @@
+using LotroKoniecDev.Application.Abstractions;
+using LotroKoniecDev.Domain.Core.Errors;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Infrastructure.GameLaunching;
 
@@ -5,7 +7,15 @@ namespace LotroKoniecDev.Tests.Infrastructure.Tests;
 
 public sealed class GameLauncherTests
 {
-    private readonly GameLauncher _sut = new();
+    private readonly ILauncherSignatureVerifier _signatureVerifier;
+    private readonly GameLauncher _sut;
+
+    public GameLauncherTests()
+    {
+        _signatureVerifier = Substitute.For<ILauncherSignatureVerifier>();
+        _signatureVerifier.VerifySignature(Arg.Any<string>()).Returns(Result.Success());
+        _sut = new GameLauncher(_signatureVerifier);
+    }
 
     [Fact]
     public void Launch_ShouldReturnFailure_WhenLauncherNotFound()
@@ -52,6 +62,32 @@ public sealed class GameLauncherTests
             result.IsFailure.ShouldBeTrue();
             result.Error.Code.ShouldBe("GameLaunch.NotFound");
             result.Error.Message.ShouldContain(tempDir);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Launch_ShouldReturnFailure_WhenLauncherSignatureIsRejected()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            string fakeDatFile = Path.Combine(tempDir, "client_local_English.dat");
+            File.WriteAllText(fakeDatFile, "fake");
+            string fakeLauncher = Path.Combine(tempDir, "LotroLauncher.exe");
+            File.WriteAllText(fakeLauncher, "not a signed executable");
+            _signatureVerifier.VerifySignature(fakeLauncher).Returns(Result.Failure(
+                DomainErrors.GameLaunch.UntrustedLauncher(fakeLauncher, "it has no Authenticode signature")));
+
+            Result result = _sut.Launch(fakeDatFile);
+
+            result.IsFailure.ShouldBeTrue();
+            result.Error.Code.ShouldBe(DomainErrors.GameLaunch.UntrustedLauncherCode);
         }
         finally
         {


### PR DESCRIPTION
Closes #392

## What changed

**Signature gate (Infrastructure + Application + Domain):**
- New `ILauncherSignatureVerifier` port (`Application/Abstractions`); `GameLauncher` refuses to `Process.Start` the launcher unless verification passes. Refusal is a failure `Result` with the new `GameLaunch.UntrustedLauncher` error code (same idiom as AUDIT-SEC-01's `IntegrityCheckFailed`).
- `AuthenticodeLauncherSignatureVerifier` + `WinTrustNative`: WinVerifyTrust (`WTD_UI_NONE`, no online revocation, timestamped-expired accepted — offline gaming boxes), VERIFY→CLOSE state lifecycle, explicit stdcall (x86 target). The signer certificate is extracted from the **validated chain itself** (`WTHelperProvDataFromStateData` → `WTHelperGetProvSignerFromChain` → `X509Certificate2(IntPtr)`), never re-parsed from disk.
- Publisher pin: the signer's simple name (CN) must equal — after normalizing case/commas/periods/whitespace — one of the known LOTRO publishers (Standing Stone Games / Turbine). Exact equality, so a foreign "Turbine Dynamics Ltd"-style CN never matches; normalization tolerates only punctuation variants of the real publishers, because an off-by-a-comma exact pin would brick every legitimate launch.
- TOCTOU: a `FileShare.Read` handle is held across verify → start, denying writes/renames/deletes of the verified bytes in the window (execute mapping shares as read, so the launch itself still works).

**Drive-scan confirmation (CLI):**
- `DatPathResolver` no longer silently uses a location found by the full drive scan: a single scanned hit requires an explicit y/N confirmation (default: refuse, including EOF), and scanned entries in the multi-installation prompt carry a `[!]` warning. An explicit `-d` path is unchanged (user-supplied by design).

## Acceptance criteria

- [x] `LotroLauncher.exe` is signature-checked (publisher verified) before `Process.Start`; bad/missing signature returns a failure `Result` — single call site, structurally behind the gate.
- [x] A drive-scanned executable path is confirmed by the user (or excluded) before use.
- [x] Test: a fake unsigned launcher next to a scanned DAT is refused — real WinVerifyTrust composition test in `AuthenticodeLauncherSignatureVerifierTests` plus a mocked-boundary test in `GameLauncherTests`.
- [x] Existing launch tests stay green with assertions untouched (only arrange changed: verifier injection).

## Verification

- `dotnet build LotroKoniecDev.slnx`: 0 warnings, 0 errors.
- `Tests.Unit`: 258/258 green (macOS).
- `Tests.Infrastructure` (incl. the new WinVerifyTrust tests) targets `net10.0-windows` — compiled under the zero-warnings gate here, executes on Windows only; please run once on the gaming box. The real signed launcher's CN passing the pin is also best confirmed there — on mismatch the error message prints the actual signer CN, so extending the allowlist is a one-line fix.
- code-reviewer agent: REQUEST CHANGES → fixes applied (publisher pin tightened from DN-substring to normalized exact CN equality; TOCTOU guard; extra fail-closed test) → **APPROVE**. Security review: no findings.

## Accepted residuals & follow-ups (out of scope here)

- A CA-issued code-signing cert whose CN is exactly "Turbine" would pass the pin — categorically higher bar than the substring match it replaces.
- `GetNameInfo(SimpleName)` falls back to OU/O/email when a cert has no CN — harmless (exact equality still applies), but the pin is technically "simple name", not strictly CN.
- Follow-up candidates: the cwd-relative `LocalFallback` DAT source also flows through without confirmation (signature gate still covers the launch); a genuine signed launcher in an attacker-writable folder remains susceptible to planted-DLL sideloading — the confirmation prompt is the gate for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)