### PR TITLE
AUDIT-SEC-03: Restrict datexport.dll native search path to assembly and safe directories

### DIFF
--- a/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatExportNative.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatExportNative.cs
@@ -1,6 +1,11 @@
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
+// Restricts native DLL resolution to the assembly directory and OS-safe directories, so the
+// Windows loader never probes the current working directory or %PATH% — a planted datexport.dll
+// would otherwise be loaded with admin rights via the elevated .bat wrappers (DLL planting).
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
+
 namespace LotroKoniecDev.Infrastructure.DatFile;
 
 /// <summary>

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Tests/DatExportNativeTests.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Tests/DatExportNativeTests.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using LotroKoniecDev.Infrastructure;
+
+namespace LotroKoniecDev.Tests.Infrastructure.Tests;
+
+public sealed class DatExportNativeTests
+{
+    [Fact]
+    public void InfrastructureAssembly_ShouldRestrictNativeDllSearchPaths_ToAssemblyAndSafeDirectories()
+    {
+        DefaultDllImportSearchPathsAttribute? attribute = typeof(InfrastructureDependencyInjection).Assembly
+            .GetCustomAttribute<DefaultDllImportSearchPathsAttribute>();
+
+        attribute.ShouldNotBeNull();
+        attribute.Paths.ShouldBe(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories);
+    }
+}


### PR DESCRIPTION
Closes #393

## What changed

- Added an assembly-level `[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]` in `DatExportNative.cs` — the only P/Invoke surface in the repo. It covers all 8 `[LibraryImport("datexport.dll")]` methods (the runtime falls back from method-level to assembly-level attribute for the generated stubs) and any future P/Invoke in the assembly.
- A short comment above the attribute records why the search path is restricted.
- New reflection test `DatExportNativeTests` in `Tests.Infrastructure` pins the attribute and its exact flags, so the restriction cannot silently regress.

## Why it is safe for resolution

- The .NET runtime probes `NATIVE_DLL_SEARCH_DIRECTORIES` (app output directory in the dev/.bat layout, extraction directory in the single-file publish) by absolute path **before** any OS-level search; that step is unaffected by the attribute, so `datexport.dll` and its co-located native dependencies (`zlib1T.dll`, `msvcr*`, `msvcp*`) keep loading exactly as before.
- The OS fallback search now uses `LOAD_LIBRARY_SEARCH_*` semantics: no current working directory, no `%PATH%`. `SafeDirectories` still includes the application directory and System32.
- In the single-file publish the bundled assembly has an empty location, so the `AssemblyDirectory` probe is skipped gracefully.

## Acceptance criteria

- [x] Native resolution no longer includes the current working directory (assembly-level attribute added).
- [x] `export` / `patch` / `launch` still resolve `datexport.dll` from the app directory — resolution-order analysis above; no patcher test assertions touched. Note: `Tests.Infrastructure` and E2E are win-x86/Windows-only and cannot execute on the arm64 dev box, so the Windows leg runs on the owner's machine as usual.
- [x] A short code comment records why the search path is restricted.

## Verification

- `dotnet build LotroKoniecDev.slnx` — green, 0 warnings.
- `dotnet test tests/LotroKoniecDev.Tests.Unit` — 258 passed.
- Attribute confirmed present in the compiled `LotroKoniecDev.Infrastructure.dll` metadata.
- Security review of the diff: no findings (the change is strictly narrowing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)