### PR TITLE
AUDIT-SEC-04: Cap HTTP response sizes so a hostile server cannot OOM the patcher

### DIFF
--- a/src/Patcher/LotroKoniecDev.Domain/Core/Errors/InfrastructureDomainErrors.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Core/Errors/InfrastructureDomainErrors.cs
@@ -49,8 +49,14 @@ public static partial class DomainErrors
 
     public static class GameUpdateCheck
     {
+        public const string ResponseTooLargeCode = "GameUpdateCheck.ResponseTooLarge";
+
         public static Error NetworkError(string message) =>
             IoError("GameUpdateCheck", "NetworkError", message);
+
+        public static Error ResponseTooLarge(long maxResponseBytes) =>
+            Error.IoError(ResponseTooLargeCode,
+                $"The response body exceeds the maximum allowed size of {maxResponseBytes} bytes.");
 
         public static Error VersionNotFoundInPage =>
             OperationFailed("GameUpdateCheck",

--- a/src/Patcher/LotroKoniecDev.Domain/Core/Errors/TranslationFileSyncDomainErrors.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Core/Errors/TranslationFileSyncDomainErrors.cs
@@ -8,8 +8,14 @@ public static partial class DomainErrors
     {
         public const string IntegrityCheckFailedCode = "TranslationFileSync.IntegrityCheckFailed";
 
+        public const string ResponseTooLargeCode = "TranslationFileSync.ResponseTooLarge";
+
         public static Error NetworkError(string message) =>
             IoError("TranslationFileSync", "NetworkError", message);
+
+        public static Error ResponseTooLarge(long maxResponseBytes) =>
+            Error.IoError(ResponseTooLargeCode,
+                $"The response body exceeds the maximum allowed size of {maxResponseBytes} bytes.");
 
         public static Error CacheWriteError(string path, string message) =>
             IoError("TranslationFileSync", "CacheWriteError", $"'{path}': {message}");

--- a/src/Patcher/LotroKoniecDev.Infrastructure/InfrastructureDependencyInjection.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/InfrastructureDependencyInjection.cs
@@ -33,6 +33,10 @@ public static class InfrastructureDependencyInjection
             HttpClient client = new();
             client.DefaultRequestHeaders.UserAgent.ParseAdd("LotroKoniecDev/1.0");
             client.Timeout = TimeSpan.FromSeconds(10);
+            // Defense in depth (AUDIT-SEC-04 / #394): any future caller buffering a response
+            // through the default completion option is still capped; today's callers enforce
+            // their own tighter caps via BoundedResponseReader.
+            client.MaxResponseContentBufferSize = TranslationFileDownloader.MaxResponseContentBytes;
             return client;
         });
         services.AddSingleton<IForumPageFetcher, ForumPageFetcher>();

--- a/src/Patcher/LotroKoniecDev.Infrastructure/Network/BoundedResponseReader.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/Network/BoundedResponseReader.cs
@@ -1,0 +1,39 @@
+using LotroKoniecDev.Domain.Core.Monads;
+
+namespace LotroKoniecDev.Infrastructure.Network;
+
+/// <summary>
+/// Reads an HTTP response body as a string while enforcing a hard byte cap, so a hostile or
+/// misbehaving server cannot exhaust process memory (AUDIT-SEC-04 / #394). A body whose declared
+/// <c>Content-Length</c> exceeds the cap is rejected before any byte is transferred; a chunked or
+/// lying response is cut off by the buffer limit while streaming. Callers must request the
+/// response with <see cref="HttpCompletionOption.ResponseHeadersRead"/> — the default completion
+/// option buffers the whole body inside <see cref="HttpClient"/> before any check here can run.
+/// </summary>
+internal static class BoundedResponseReader
+{
+    /// <summary>
+    /// Returns the decoded body, or <see cref="Maybe{T}.None"/> when it exceeds
+    /// <paramref name="maxResponseBytes"/>. Network failures keep surfacing as
+    /// <see cref="HttpRequestException"/> for the caller's existing handling.
+    /// </summary>
+    internal static async Task<Maybe<string>> TryReadAsStringAsync(
+        HttpContent content, long maxResponseBytes, CancellationToken cancellationToken)
+    {
+        if (content.Headers.ContentLength > maxResponseBytes)
+        {
+            return Maybe<string>.None;
+        }
+
+        try
+        {
+            await content.LoadIntoBufferAsync(maxResponseBytes, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.HttpRequestError == HttpRequestError.ConfigurationLimitExceeded)
+        {
+            return Maybe<string>.None;
+        }
+
+        return await content.ReadAsStringAsync(cancellationToken);
+    }
+}

--- a/src/Patcher/LotroKoniecDev.Infrastructure/Network/ForumPageFetcher.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/Network/ForumPageFetcher.cs
@@ -9,6 +9,13 @@ namespace LotroKoniecDev.Infrastructure.Network;
 /// </summary>
 public sealed class ForumPageFetcher : IForumPageFetcher
 {
+    /// <summary>
+    /// Hard cap on the fetched page size (AUDIT-SEC-04 / #394). The release-notes forum page is an
+    /// HTML document well under 1 MB, so 8 MiB is generous headroom while a hostile or misbehaving
+    /// server can no longer exhaust process memory.
+    /// </summary>
+    public const long MaxResponseContentBytes = 8 * 1024 * 1024;
+
     private const string ReleaseNotesUrl =
         "https://forums.lotro.com/index.php?forums/release-notes-and-known-issues.7/";
 
@@ -23,18 +30,31 @@ public sealed class ForumPageFetcher : IForumPageFetcher
     {
         try
         {
-            using HttpResponseMessage response = await _httpClient.GetAsync(ReleaseNotesUrl);
+            // ResponseHeadersRead keeps HttpClient from buffering the whole body before the size
+            // cap can run, which also moves the body read out of HttpClient.Timeout's scope — so
+            // the timeout is re-applied around the entire fetch.
+            using CancellationTokenSource timeoutCts = new(_httpClient.Timeout);
+
+            using HttpResponseMessage response = await _httpClient.GetAsync(
+                ReleaseNotesUrl, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token);
             response.EnsureSuccessStatusCode();
 
-            string content = await response.Content.ReadAsStringAsync();
-            return Result.Success(content);
+            Maybe<string> body = await BoundedResponseReader.TryReadAsStringAsync(
+                response.Content, MaxResponseContentBytes, timeoutCts.Token);
+            if (body.HasNoValue)
+            {
+                return Result.Failure<string>(
+                    DomainErrors.GameUpdateCheck.ResponseTooLarge(MaxResponseContentBytes));
+            }
+
+            return Result.Success(body.Value);
         }
         catch (HttpRequestException ex)
         {
             return Result.Failure<string>(
                 DomainErrors.GameUpdateCheck.NetworkError(ex.Message));
         }
-        catch (TaskCanceledException)
+        catch (OperationCanceledException)
         {
             return Result.Failure<string>(
                 DomainErrors.GameUpdateCheck.NetworkError("Request timed out."));

--- a/src/Patcher/LotroKoniecDev.Infrastructure/Network/TranslationFileDownloader.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/Network/TranslationFileDownloader.cs
@@ -15,6 +15,14 @@ namespace LotroKoniecDev.Infrastructure.Network;
 /// </summary>
 public sealed class TranslationFileDownloader : ITranslationFileDownloader
 {
+    /// <summary>
+    /// Hard cap on the downloaded body size (AUDIT-SEC-04 / #394). The full English export of the
+    /// game's text corpus measures ~82 MB in the same <c>||</c> format, and a complete Polish
+    /// translation file is the same order of magnitude, so 128 MiB leaves comfortable headroom
+    /// while a hostile or misbehaving server can no longer exhaust process memory.
+    /// </summary>
+    public const long MaxResponseContentBytes = 128 * 1024 * 1024;
+
     private const string TranslationFileRoute = "api/v1/translation-files/pl";
 
     private readonly HttpClient _httpClient;
@@ -37,7 +45,14 @@ public sealed class TranslationFileDownloader : ITranslationFileDownloader
                 request.Headers.TryAddWithoutValidation("If-None-Match", currentETag);
             }
 
-            using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+            // ResponseHeadersRead keeps HttpClient from buffering the whole body before the size
+            // cap can run, which also moves the body read out of HttpClient.Timeout's scope — so
+            // the timeout is re-applied around the entire fetch via a linked token.
+            using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(_httpClient.Timeout);
+
+            using HttpResponseMessage response = await _httpClient.SendAsync(
+                request, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token);
 
             if (response.StatusCode == HttpStatusCode.NotModified)
             {
@@ -46,7 +61,15 @@ public sealed class TranslationFileDownloader : ITranslationFileDownloader
 
             response.EnsureSuccessStatusCode();
 
-            string content = await response.Content.ReadAsStringAsync(cancellationToken);
+            Maybe<string> body = await BoundedResponseReader.TryReadAsStringAsync(
+                response.Content, MaxResponseContentBytes, timeoutCts.Token);
+            if (body.HasNoValue)
+            {
+                return Result.Failure<TranslationFileFetchResult>(
+                    DomainErrors.TranslationFileSync.ResponseTooLarge(MaxResponseContentBytes));
+            }
+
+            string content = body.Value;
             string eTag = response.Headers.ETag?.ToString() ?? string.Empty;
 
             if (!TranslationFileContentIntegrity.Matches(content, eTag))
@@ -61,7 +84,7 @@ public sealed class TranslationFileDownloader : ITranslationFileDownloader
         {
             return Result.Failure<TranslationFileFetchResult>(DomainErrors.TranslationFileSync.NetworkError(ex.Message));
         }
-        catch (TaskCanceledException)
+        catch (OperationCanceledException)
         {
             return Result.Failure<TranslationFileFetchResult>(DomainErrors.TranslationFileSync.NetworkError("The request timed out."));
         }

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -83,9 +83,10 @@ the suite runs on macOS too).
 
 ## Infrastructure Tests (LotroKoniecDev.Tests.Infrastructure)
 
-Tests that touch real infrastructure adapters (today: `GameLauncherTests` and
-`TranslationFileDownloaderTests` — the latter drives the downloader's integrity enforcement
-point over an in-memory stub `HttpMessageHandler`, no real network). Grows in M2
+Tests that touch real infrastructure adapters (today: `GameLauncherTests`,
+`TranslationFileDownloaderTests` and `ForumPageFetcherTests` — the network ones drive the
+adapters' integrity, response-size-cap and timeout enforcement points over an in-memory stub
+`HttpMessageHandler`, no real network). Grows in M2
 (PostgreSQL + EF Core) and whenever file-content verification is needed — asserting on real file
 output belongs here, never in `Tests.Unit`. Targets `net10.0-windows`: builds everywhere,
 **runs on Windows only** (on macOS the run aborts — expected).

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Shared/StallingContent.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Shared/StallingContent.cs
@@ -1,0 +1,27 @@
+using System.Net;
+
+namespace LotroKoniecDev.Tests.Infrastructure.Shared;
+
+/// <summary>
+/// Declares no length and stalls the body write until the caller's cancellation token fires —
+/// a hostile server that accepts the request and then feeds no bytes. The stall is bounded by a
+/// fallback delay, so a mis-wired cancellation token fails the test instead of hanging the run.
+/// </summary>
+internal sealed class StallingContent : HttpContent
+{
+    private static readonly TimeSpan StallFallback = TimeSpan.FromSeconds(10);
+
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+    {
+        await Task.Delay(StallFallback, cancellationToken);
+    }
+
+    protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        => SerializeToStreamAsync(stream, context, CancellationToken.None);
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = 0;
+        return false;
+    }
+}

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Shared/StubHttpMessageHandler.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Shared/StubHttpMessageHandler.cs
@@ -1,0 +1,17 @@
+namespace LotroKoniecDev.Tests.Infrastructure.Shared;
+
+/// <summary>
+/// In-memory <see cref="HttpMessageHandler"/> returning one prepared response — no real network.
+/// </summary>
+internal sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly HttpResponseMessage _response;
+
+    public StubHttpMessageHandler(HttpResponseMessage response)
+    {
+        _response = response;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromResult(_response);
+}

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Shared/UndeclaredLengthContent.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Shared/UndeclaredLengthContent.cs
@@ -1,0 +1,36 @@
+using System.Net;
+
+namespace LotroKoniecDev.Tests.Infrastructure.Shared;
+
+/// <summary>
+/// Streams the requested number of bytes without ever declaring a length
+/// (<see cref="TryComputeLength"/> returns <c>false</c>), forcing the reader onto its
+/// streaming code path — a chunked-style response from a server that may lie about size.
+/// </summary>
+internal sealed class UndeclaredLengthContent : HttpContent
+{
+    private readonly long _sizeInBytes;
+
+    public UndeclaredLengthContent(long sizeInBytes)
+    {
+        _sizeInBytes = sizeInBytes;
+    }
+
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        byte[] chunk = new byte[81920];
+        long remaining = _sizeInBytes;
+        while (remaining > 0)
+        {
+            int take = (int)Math.Min(chunk.Length, remaining);
+            await stream.WriteAsync(chunk.AsMemory(0, take));
+            remaining -= take;
+        }
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = 0;
+        return false;
+    }
+}

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Tests/ForumPageFetcherTests.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Tests/ForumPageFetcherTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Text;
+using LotroKoniecDev.Domain.Core.Errors;
+using LotroKoniecDev.Domain.Core.Monads;
+using LotroKoniecDev.Infrastructure.Network;
+using LotroKoniecDev.Tests.Infrastructure.Shared;
+
+namespace LotroKoniecDev.Tests.Infrastructure.Tests;
+
+/// <summary>
+/// Exercises the fetcher's response-size cap (AUDIT-SEC-04 / #394) over an in-memory stub
+/// handler — no real network. The forum page crosses a remote trust boundary, so an over-cap
+/// body must surface as a failure result instead of exhausting process memory.
+/// </summary>
+public sealed class ForumPageFetcherTests
+{
+    private const string PageContent = "<html>Update 48.0 Release Notes</html>";
+
+    [Fact]
+    public async Task FetchReleaseNotesPageAsync_PageWithinTheSizeCap_ShouldReturnItsContent()
+    {
+        // Arrange
+        using HttpResponseMessage response = OkResponse(PageContent);
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        ForumPageFetcher sut = new(httpClient);
+
+        // Act
+        Result<string> result = await sut.FetchReleaseNotesPageAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe(PageContent);
+    }
+
+    [Fact]
+    public async Task FetchReleaseNotesPageAsync_ResponseDeclaringABodyOverTheSizeCap_ShouldReturnFailure()
+    {
+        // Arrange — a Content-Length above the cap must be refused before any body byte is read.
+        using HttpResponseMessage response = OkResponse(PageContent);
+        response.Content.Headers.ContentLength = ForumPageFetcher.MaxResponseContentBytes + 1;
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        ForumPageFetcher sut = new(httpClient);
+
+        // Act
+        Result<string> result = await sut.FetchReleaseNotesPageAsync();
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe(DomainErrors.GameUpdateCheck.ResponseTooLargeCode);
+    }
+
+    [Fact]
+    public async Task FetchReleaseNotesPageAsync_UndeclaredBodyStreamingPastTheSizeCap_ShouldReturnFailure()
+    {
+        // Arrange — no Content-Length (chunked-style), the body itself overruns the cap while
+        // streaming: the buffer limit must cut it off instead of growing without bound.
+        using HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new UndeclaredLengthContent(ForumPageFetcher.MaxResponseContentBytes + 1)
+        };
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        ForumPageFetcher sut = new(httpClient);
+
+        // Act
+        Result<string> result = await sut.FetchReleaseNotesPageAsync();
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe(DomainErrors.GameUpdateCheck.ResponseTooLargeCode);
+    }
+
+    [Fact]
+    public async Task FetchReleaseNotesPageAsync_BodyThatStallsPastTheClientTimeout_ShouldFailAsTimedOutInsteadOfHanging()
+    {
+        // Arrange — ResponseHeadersRead moves the body read out of HttpClient.Timeout's scope;
+        // the fetcher must re-apply the timeout itself or a stalling server hangs preflight.
+        using HttpResponseMessage response = new(HttpStatusCode.OK) { Content = new StallingContent() };
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        httpClient.Timeout = TimeSpan.FromMilliseconds(250);
+        ForumPageFetcher sut = new(httpClient);
+
+        // Act
+        Result<string> result = await sut.FetchReleaseNotesPageAsync();
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("GameUpdateCheck.NetworkError");
+    }
+
+    [Fact]
+    public async Task FetchReleaseNotesPageAsync_ErrorStatusCode_ShouldReturnNetworkErrorFailure()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.InternalServerError);
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        ForumPageFetcher sut = new(httpClient);
+
+        // Act
+        Result<string> result = await sut.FetchReleaseNotesPageAsync();
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("GameUpdateCheck.NetworkError");
+    }
+
+    private static HttpResponseMessage OkResponse(string body) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "text/html")
+        };
+}

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Tests/TranslationFileDownloaderTests.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Tests/TranslationFileDownloaderTests.cs
@@ -5,6 +5,7 @@ using LotroKoniecDev.Application.Abstractions;
 using LotroKoniecDev.Domain.Core.Errors;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Infrastructure.Network;
+using LotroKoniecDev.Tests.Infrastructure.Shared;
 
 namespace LotroKoniecDev.Tests.Infrastructure.Tests;
 
@@ -90,6 +91,62 @@ public sealed class TranslationFileDownloaderTests
     }
 
     [Fact]
+    public async Task FetchAsync_ResponseDeclaringABodyOverTheSizeCap_ShouldRejectTheDownload()
+    {
+        // Arrange — a Content-Length above the cap (AUDIT-SEC-04 / #394) must be refused up front,
+        // before any body byte is read.
+        using HttpResponseMessage response = OkResponse(Content, $"\"{ContentHash}\"");
+        response.Content.Headers.ContentLength = TranslationFileDownloader.MaxResponseContentBytes + 1;
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe(DomainErrors.TranslationFileSync.ResponseTooLargeCode);
+    }
+
+    [Fact]
+    public async Task FetchAsync_UndeclaredBodyStreamingPastTheSizeCap_ShouldRejectTheDownload()
+    {
+        // Arrange — no Content-Length (chunked-style), the body itself overruns the cap while
+        // streaming: the buffer limit must cut it off instead of growing without bound.
+        using HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new UndeclaredLengthContent(TranslationFileDownloader.MaxResponseContentBytes + 1)
+        };
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe(DomainErrors.TranslationFileSync.ResponseTooLargeCode);
+    }
+
+    [Fact]
+    public async Task FetchAsync_BodyThatStallsPastTheClientTimeout_ShouldFailAsTimedOutInsteadOfHanging()
+    {
+        // Arrange — ResponseHeadersRead moves the body read out of HttpClient.Timeout's scope;
+        // the downloader must re-apply the timeout itself or a stalling server hangs the launch.
+        using HttpResponseMessage response = new(HttpStatusCode.OK) { Content = new StallingContent() };
+        using HttpClient httpClient = new(new StubHttpMessageHandler(response));
+        httpClient.Timeout = TimeSpan.FromMilliseconds(250);
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("TranslationFileSync.NetworkError");
+    }
+
+    [Fact]
     public async Task FetchAsync_NotModifiedResponse_ShouldReportTheCachedCopyCurrentWithoutAnyCheck()
     {
         // Arrange — a 304 carries no body, so there is nothing to verify.
@@ -118,18 +175,5 @@ public sealed class TranslationFileDownloaderTests
         }
 
         return response;
-    }
-
-    private sealed class StubHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly HttpResponseMessage _response;
-
-        public StubHttpMessageHandler(HttpResponseMessage response)
-        {
-            _response = response;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            => Task.FromResult(_response);
     }
 }


### PR DESCRIPTION
Closes #394

## What changed

- Both network callers (`TranslationFileDownloader`, `ForumPageFetcher`) now request responses with `HttpCompletionOption.ResponseHeadersRead` and read the body through the new `BoundedResponseReader`. Without the completion-option switch, `HttpClient` buffers the whole body inside `SendAsync` before any caller-side check can run.
- `BoundedResponseReader` enforces the cap twice: a declared `Content-Length` over the cap is refused before any byte is transferred, and a chunked or lying body is cut off mid-stream by `LoadIntoBufferAsync(maxBytes)` (over-cap throws `HttpRequestException` with `HttpRequestError.ConfigurationLimitExceeded` — verified empirically on .NET 10). Over-cap responses return the new `ResponseTooLarge` domain error as a clean `Result.Failure`.
- **Documented caps:** 128 MiB for the translation file, 8 MiB for the forum page. The ticket guessed "a few MB", but the real full-corpus `data/exported.txt` (same `||` format as a complete translation file) measures **82.5 MB**, so a few MB would break a complete Polish translation; 128 MiB keeps headroom while still preventing multi-GB DoS.
- Defense in depth: the shared `HttpClient` in DI also sets `MaxResponseContentBufferSize`, covering any future caller that buffers via the default completion option.
- Because `ResponseHeadersRead` moves the body read out of `HttpClient.Timeout`'s scope, each caller re-applies the timeout around the whole fetch (linked `CancellationTokenSource`), so a server that stalls the body still fails as a timeout instead of hanging `launch`/preflight. The catch blocks broadened from `TaskCanceledException` to `OperationCanceledException` accordingly.

## Acceptance criteria

- [x] A larger response fails cleanly with `Result.Failure`, no OOM — enforced at both the declared-length and streamed-bytes level.
- [x] Caps documented and large enough for the real artifacts (128 MiB vs 82.5 MB corpus; 8 MiB vs sub-1 MB page).
- [x] Tests: declared-over-cap, streamed-over-cap (chunked) and stalled-body paths on both callers; the stall tests were mutation-verified (dropping the cancellation token makes them fail in bounded time).
- [x] Existing downloader tests stay green with assertions untouched (the private stub handler moved verbatim to `Shared/`).

## Verification

`Tests.Infrastructure` targets `net10.0-windows`/x86 (CI excludes it by name), so the suite was verified by compiling the identical SUT + test sources into a throwaway cross-platform project: **13/13 green**. `tests/LotroKoniecDev.Tests.Unit`: 258/258 green. Solution build: 0 warnings. Code-reviewer verdict: **APPROVE** (after adding the stall-timeout tests it requested).

## Follow-up for a new ticket (out of scope here, flagged by review)

In `SyncTranslationFileCommandHandler`, a `ResponseTooLarge` refusal currently maps to the `OfflineUsedCache` outcome — the report says "server unreachable" although the server responded and was refused. It should get a refused-style outcome like the existing `IntegrityCheckFailedUsedCache` (AUDIT-SEC-01 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)