### PR TITLE
AUDIT-SEC-05: Bounds-check DAT element counts against remaining stream bytes

### DIFF
--- a/src/Patcher/LotroKoniecDev.Domain/Core/Utilities/BinaryBoundsGuard.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Core/Utilities/BinaryBoundsGuard.cs
@@ -1,0 +1,39 @@
+namespace LotroKoniecDev.Domain.Core.Utilities;
+
+/// <summary>
+/// Validates element counts read from binary data against the bytes remaining in the stream,
+/// so a corrupt or crafted file fails fast with a clear parse error instead of driving
+/// allocation loops with an impossible count.
+/// </summary>
+public static class BinaryBoundsGuard
+{
+    /// <summary>
+    /// Ensures a declared element count can physically fit in the remaining stream bytes.
+    /// </summary>
+    /// <param name="reader">The binary reader (over a seekable stream) positioned after the count field.</param>
+    /// <param name="count">The element count read from the data.</param>
+    /// <param name="minBytesPerElement">The smallest valid encoded size of one element.</param>
+    /// <param name="elementName">The element name used in the error message.</param>
+    /// <exception cref="ArgumentNullException">When reader is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">When minBytesPerElement is not positive.</exception>
+    /// <exception cref="InvalidDataException">When the count is negative or cannot fit in the remaining bytes.</exception>
+    public static void EnsureCountFits(BinaryReader reader, int count, int minBytesPerElement, string elementName)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(minBytesPerElement);
+
+        if (count < 0)
+        {
+            throw new InvalidDataException($"Declared {elementName} count is negative: {count}.");
+        }
+
+        long remaining = reader.BaseStream.Length - reader.BaseStream.Position;
+        long required = (long)count * minBytesPerElement;
+
+        if (required > remaining)
+        {
+            throw new InvalidDataException(
+                $"Declared {elementName} count {count} requires at least {required} bytes, but only {remaining} remain.");
+        }
+    }
+}

--- a/src/Patcher/LotroKoniecDev.Domain/Models/Fragment.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Models/Fragment.cs
@@ -9,6 +9,11 @@ namespace LotroKoniecDev.Domain.Models;
 /// </summary>
 public sealed class Fragment
 {
+    private const int BytesPerUtf16Char = 2;
+    private const int ArgRefSize = 4;
+    private const int MinEncodedPieceSize = 1; // a zero-length piece still carries its VarLen length byte
+    private const int MinEncodedArgStringSize = 1; // a zero-length argument string still carries its VarLen length byte
+    private const int MinEncodedArgStringGroupSize = 4; // an empty group still carries its string-count int
 
     public ulong FragmentId { get; private set; }
     public List<string> Pieces { get; set; } = [];
@@ -88,11 +93,13 @@ public sealed class Fragment
     private void ReadPieces(BinaryReader reader)
     {
         int numPieces = reader.ReadInt32();
+        BinaryBoundsGuard.EnsureCountFits(reader, numPieces, MinEncodedPieceSize, "piece");
 
         for (int i = 0; i < numPieces; i++)
         {
             int pieceSize = VarLenEncoder.Read(reader);
-            byte[] bytes = reader.ReadBytes(pieceSize * 2); // UTF-16LE (2 bytes per char)
+            BinaryBoundsGuard.EnsureCountFits(reader, pieceSize, BytesPerUtf16Char, "piece character");
+            byte[] bytes = reader.ReadBytes(pieceSize * BytesPerUtf16Char);
             Pieces.Add(Encoding.Unicode.GetString(bytes));
         }
     }
@@ -100,26 +107,30 @@ public sealed class Fragment
     private void ReadArgRefs(BinaryReader reader)
     {
         int numArgRefs = reader.ReadInt32();
+        BinaryBoundsGuard.EnsureCountFits(reader, numArgRefs, ArgRefSize, "argument reference");
 
         for (int i = 0; i < numArgRefs; i++)
         {
-            ArgRefs.Add(reader.ReadBytes(4));
+            ArgRefs.Add(reader.ReadBytes(ArgRefSize));
         }
     }
 
     private void ReadArgStrings(BinaryReader reader)
     {
         int numArgStringGroups = reader.ReadByte();
+        BinaryBoundsGuard.EnsureCountFits(reader, numArgStringGroups, MinEncodedArgStringGroupSize, "argument string group");
 
         for (int i = 0; i < numArgStringGroups; i++)
         {
             List<string> group = new List<string>();
             int numStrings = reader.ReadInt32();
+            BinaryBoundsGuard.EnsureCountFits(reader, numStrings, MinEncodedArgStringSize, "argument string");
 
             for (int j = 0; j < numStrings; j++)
             {
                 int strSize = VarLenEncoder.Read(reader);
-                byte[] bytes = reader.ReadBytes(strSize * 2);
+                BinaryBoundsGuard.EnsureCountFits(reader, strSize, BytesPerUtf16Char, "argument string character");
+                byte[] bytes = reader.ReadBytes(strSize * BytesPerUtf16Char);
                 group.Add(Encoding.Unicode.GetString(bytes));
             }
 

--- a/src/Patcher/LotroKoniecDev.Domain/Models/SubFile.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Models/SubFile.cs
@@ -9,6 +9,8 @@ namespace LotroKoniecDev.Domain.Models;
 /// </summary>
 public sealed class SubFile
 {
+    private const int MinEncodedFragmentSize = 17; // FragmentId (8) + piece count (4) + arg-ref count (4) + arg-string-group count (1)
+
     public int FileId { get; private set; }
     public int Version { get; set; }
     public byte[] Unknown1 { get; private set; } = new byte[4];
@@ -54,6 +56,7 @@ public sealed class SubFile
         Unknown2 = reader.ReadByte();
 
         int numFragments = VarLenEncoder.Read(reader);
+        BinaryBoundsGuard.EnsureCountFits(reader, numFragments, MinEncodedFragmentSize, "fragment");
 
         for (int i = 0; i < numFragments; i++)
         {

--- a/tests/LotroKoniecDev.Tests.Unit/Shared/TestDataFactory.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Shared/TestDataFactory.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using LotroKoniecDev.Domain.Core.Utilities;
 
 namespace LotroKoniecDev.Tests.Unit.Shared;
 
@@ -65,6 +66,23 @@ internal static class TestDataFactory
         }
 
         writer.Write((byte)0); // numArgStringGroups
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Creates binary SubFile data that declares <paramref name="declaredFragmentCount"/> fragments
+    /// but contains no fragment data — an impossible count used to exercise parser bounds checks.
+    /// </summary>
+    internal static byte[] CreateTextSubFileDataWithImpossibleFragmentCount(int fileId, int declaredFragmentCount)
+    {
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream);
+
+        writer.Write(fileId);
+        writer.Write(new byte[4]); // Unknown1
+        writer.Write((byte)0); // Unknown2
+        VarLenEncoder.Write(writer, declaredFragmentCount); // numFragments (varlen)
 
         return stream.ToArray();
     }

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Extensions/DatFileHandlerExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Extensions/DatFileHandlerExtensionsTests.cs
@@ -1,0 +1,49 @@
+using LotroKoniecDev.Application.Abstractions.DatFilesServices;
+using LotroKoniecDev.Application.Extensions;
+using LotroKoniecDev.Domain.Core.Monads;
+using LotroKoniecDev.Domain.Models;
+using LotroKoniecDev.Primitives.Enums;
+using LotroKoniecDev.Tests.Unit.Shared;
+
+namespace LotroKoniecDev.Tests.Unit.Tests.Extensions;
+
+public sealed class DatFileHandlerExtensionsTests
+{
+    private const int Handle = 1;
+    private const int TextFileId = 0x25000001;
+
+    [Fact]
+    public void LoadSubFile_SubFileDeclaringImpossibleFragmentCount_ShouldReturnParseFailure()
+    {
+        // Arrange — subfile declaring the VarLen maximum of fragments with no fragment data behind the count
+        IDatFileHandler handler = Substitute.For<IDatFileHandler>();
+        byte[] corruptData = TestDataFactory.CreateTextSubFileDataWithImpossibleFragmentCount(TextFileId, 0x7FFF);
+        handler.GetSubfileData(Handle, TextFileId, corruptData.Length).Returns(Result.Success(corruptData));
+
+        // Act
+        Result<SubFile> result = handler.LoadSubFile(Handle, TextFileId, corruptData.Length);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("SubFile.Failed");
+        result.Error.Type.ShouldBe(ErrorType.Failure);
+        result.Error.Message.ShouldContain("fragment");
+    }
+
+    [Fact]
+    public void LoadSubFile_ValidSubFile_ShouldReturnParsedSubFile()
+    {
+        // Arrange
+        IDatFileHandler handler = Substitute.For<IDatFileHandler>();
+        byte[] validData = TestDataFactory.CreateTextSubFileData(TextFileId, "Test");
+        handler.GetSubfileData(Handle, TextFileId, validData.Length).Returns(Result.Success(validData));
+
+        // Act
+        Result<SubFile> result = handler.LoadSubFile(Handle, TextFileId, validData.Length);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.FragmentCount.ShouldBe(1);
+        result.Value.Fragments[1UL].GetFullText().ShouldBe("Test");
+    }
+}

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Models/FragmentTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Models/FragmentTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using LotroKoniecDev.Domain.Core.Utilities;
 using LotroKoniecDev.Domain.Models;
 
 namespace LotroKoniecDev.Tests.Unit.Tests.Models;
@@ -399,5 +400,176 @@ public sealed class FragmentTests
         reparsed.ArgRefs.Count.ShouldBe(1);
         reparsed.ArgStrings.Count.ShouldBe(1);
         reparsed.ArgStrings[0].ShouldBe(new[] { "Alpha", "Beta" });
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue)]
+    [InlineData(1000)]
+    [InlineData(-1)]
+    public void Parse_ImpossiblePieceCount_ShouldThrowInvalidDataException(int declaredPieces)
+    {
+        // Arrange — declares more pieces than the remaining bytes could ever hold
+        Fragment fragment = new();
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream);
+
+        writer.Write((ulong)100);
+        writer.Write(declaredPieces);
+
+        stream.Position = 0;
+        using BinaryReader reader = new(stream);
+
+        // Act
+        Action action = () => fragment.Parse(reader);
+
+        // Assert
+        action.ShouldThrow<InvalidDataException>();
+    }
+
+    [Fact]
+    public void Parse_PieceLengthExceedingRemainingBytes_ShouldThrowInvalidDataException()
+    {
+        // Arrange — the piece declares 300 characters (600 bytes) but only 4 bytes follow
+        Fragment fragment = new();
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream);
+
+        writer.Write((ulong)100);
+        writer.Write(1); // Num pieces = 1
+        VarLenEncoder.Write(writer, 300);
+        writer.Write(Encoding.Unicode.GetBytes("Hi"));
+
+        stream.Position = 0;
+        using BinaryReader reader = new(stream);
+
+        // Act
+        Action action = () => fragment.Parse(reader);
+
+        // Assert
+        action.ShouldThrow<InvalidDataException>();
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue)]
+    [InlineData(1000)]
+    [InlineData(-1)]
+    public void Parse_ImpossibleArgRefCount_ShouldThrowInvalidDataException(int declaredArgRefs)
+    {
+        // Arrange — a valid empty piece list, then an arg-ref count with no data behind it
+        Fragment fragment = new();
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream);
+
+        writer.Write((ulong)100);
+        writer.Write(0); // Num pieces
+        writer.Write(declaredArgRefs);
+
+        stream.Position = 0;
+        using BinaryReader reader = new(stream);
+
+        // Act
+        Action action = () => fragment.Parse(reader);
+
+        // Assert
+        action.ShouldThrow<InvalidDataException>();
+    }
+
+    [Fact]
+    public void Parse_ArgRefCountLargerThanRemainingBytes_ShouldThrowInvalidDataException()
+    {
+        // Arrange — declares 2 arg refs (8 bytes) but only one 4-byte ref is present
+        Fragment fragment = new();
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream);
+
+        writer.Write((ulong)100);
+        writer.Write(0); // Num pieces
+        writer.Write(2); // Num arg refs = 2
+        writer.Write(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+
+        stream.Position = 0;
+        using BinaryReader reader = new(stream);
+
+        // Act
+        Action action = () => fragment.Parse(reader);
+
+        // Assert
+        action.ShouldThrow<InvalidDataException>();
+    }
+
+    [Fact]
+    public void Parse_ArgStringGroupCountExceedingRemainingBytes_ShouldThrowInvalidDataException()
+    {
+        // Arrange — declares 255 arg string groups with no group data behind the count
+        Fragment fragment = new();
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream);
+
+        writer.Write((ulong)100);
+        writer.Write(0); // Num pieces
+        writer.Write(0); // Num arg refs
+        writer.Write((byte)255);
+
+        stream.Position = 0;
+        using BinaryReader reader = new(stream);
+
+        // Act
+        Action action = () => fragment.Parse(reader);
+
+        // Assert
+        action.ShouldThrow<InvalidDataException>();
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue)]
+    [InlineData(1000)]
+    [InlineData(-1)]
+    public void Parse_ImpossibleArgStringCount_ShouldThrowInvalidDataException(int declaredStrings)
+    {
+        // Arrange — one arg string group whose string count cannot fit in the remaining bytes
+        Fragment fragment = new();
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream);
+
+        writer.Write((ulong)100);
+        writer.Write(0); // Num pieces
+        writer.Write(0); // Num arg refs
+        writer.Write((byte)1); // 1 arg string group
+        writer.Write(declaredStrings);
+
+        stream.Position = 0;
+        using BinaryReader reader = new(stream);
+
+        // Act
+        Action action = () => fragment.Parse(reader);
+
+        // Assert
+        action.ShouldThrow<InvalidDataException>();
+    }
+
+    [Fact]
+    public void Parse_ArgStringLengthExceedingRemainingBytes_ShouldThrowInvalidDataException()
+    {
+        // Arrange — the arg string declares 300 characters (600 bytes) but only 4 bytes follow
+        Fragment fragment = new();
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream);
+
+        writer.Write((ulong)100);
+        writer.Write(0); // Num pieces
+        writer.Write(0); // Num arg refs
+        writer.Write((byte)1); // 1 arg string group
+        writer.Write(1); // group has 1 string
+        VarLenEncoder.Write(writer, 300);
+        writer.Write(Encoding.Unicode.GetBytes("Hi"));
+
+        stream.Position = 0;
+        using BinaryReader reader = new(stream);
+
+        // Act
+        Action action = () => fragment.Parse(reader);
+
+        // Assert
+        action.ShouldThrow<InvalidDataException>();
     }
 }

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Models/SubFileTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Models/SubFileTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using LotroKoniecDev.Domain.Models;
+using LotroKoniecDev.Tests.Unit.Shared;
 
 namespace LotroKoniecDev.Tests.Unit.Tests.Models;
 
@@ -189,5 +190,50 @@ public sealed class SubFileTests
         reparsedSubFile.Parse(serialized);
         reparsedSubFile.FragmentCount.ShouldBe(1);
         reparsedSubFile.Fragments[12345UL].GetFullText().ShouldBe("Test");
+    }
+
+    [Theory]
+    [InlineData(0x7FFF)] // VarLen maximum
+    [InlineData(1)]
+    public void Parse_ImpossibleFragmentCount_ShouldThrowInvalidDataException(int declaredFragments)
+    {
+        // Arrange — declares fragments with no fragment data behind the count
+        SubFile subFile = new();
+        byte[] data = TestDataFactory.CreateTextSubFileDataWithImpossibleFragmentCount(0x25000001, declaredFragments);
+
+        // Act
+        Action action = () => subFile.Parse(data);
+
+        // Assert
+        action.ShouldThrow<InvalidDataException>();
+    }
+
+    [Fact]
+    public void Parse_FragmentCountLargerThanRemainingData_ShouldThrowInvalidDataException()
+    {
+        // Arrange — declares 2 fragments but contains only one
+        SubFile subFile = new();
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream);
+
+        writer.Write(0x25000001); // File ID (text file)
+        writer.Write(new byte[4]); // Unknown1
+        writer.Write((byte)0);     // Unknown2
+        writer.Write((byte)2);     // Num fragments = 2
+
+        writer.Write((ulong)12345); // Fragment ID
+        writer.Write(1);             // Num pieces = 1
+        writer.Write((byte)4);       // Piece length = 4 (VarLen single byte)
+        writer.Write(Encoding.Unicode.GetBytes("Test"));
+        writer.Write(0);             // Num arg refs = 0
+        writer.Write((byte)0);       // Num arg string groups = 0
+
+        byte[] data = stream.ToArray();
+
+        // Act
+        Action action = () => subFile.Parse(data);
+
+        // Assert
+        action.ShouldThrow<InvalidDataException>();
     }
 }


### PR DESCRIPTION
Closes #395

## What

The DAT binary parser trusted on-disk element counts (`numFragments`, `numPieces`, `numArgRefs`, `numStrings`) and looped on them with no range check. This adds `BinaryBoundsGuard.EnsureCountFits`, called before every count-driven loop in `SubFile.Parse` and `Fragment.ReadPieces`/`ReadArgRefs`/`ReadArgStrings`: a count that cannot physically fit in the remaining stream bytes fails fast with a clear `InvalidDataException`, which the existing catch in `DatFileHandlerExtensions.LoadSubFile` converts to a clean `Result.Failure`. The VarLen string lengths (`pieceSize`, `strSize`) are guarded too, which also closes the `BinaryReader.ReadBytes` silent-short-read truncation hole.

Guards use the true minimum encoded size per element (fragment = 17 bytes, arg ref = 4, empty string = 1 VarLen byte, group = 4, char = 2), so no valid DAT file can ever trip a check — the change is behavior-preserving for well-formed data. Defense-in-depth only: the impact was already bounded by the subfile-sized buffer (see the ticket's threat model note).

## Acceptance criteria

- [x] `Fragment.ReadPieces` / `ReadArgRefs` / `ReadArgStrings` and `SubFile.Parse` reject a count larger than the remaining bytes allow, with a clear error
- [x] All existing patcher parse/round-trip tests and golden fixtures stay green, assertions untouched (diff to existing tests is purely additive; 276/276 unit tests pass, zero-warning build)
- [x] New unit test feeds a subfile with an impossible count and asserts a clean `Result.Failure` (`DatFileHandlerExtensionsTests`), plus a `[Theory]` matrix of impossible counts (negative, huge, `int.MaxValue`, truncated-mid-structure) at the domain seam

## Review

`code-reviewer` verdict: APPROVE. Its one minor finding (guard `minBytesPerElement` as a programmer error) is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)