### PR TITLE
AUDIT-SEC-06: Stop pasting raw %* / %CD% into the elevated cmd string in the .bat wrappers

### DIFF
--- a/export.bat
+++ b/export.bat
@@ -1,11 +1,26 @@
 @echo off
+setlocal
+cd /d "%~dp0"
+
+rem AUDIT-SEC-06: user arguments must never be re-parsed by an elevated shell. They cross
+rem the elevation boundary as an environment variable (inherited by the elevated instance),
+rem and delayed expansion below inserts them after cmd parsing, so metacharacters stay literal.
+if not "%~1"=="--elevated" set "LOTRO_WRAPPER_ARGS=%*"
+
 net session >nul 2>&1
 if errorlevel 1 (
     echo Requesting administrator privileges...
-    powershell -Command "Start-Process cmd -Verb RunAs -ArgumentList '/c cd /d \"%CD%\" && \"%~f0\" %*'"
+    powershell -NoProfile -Command "Start-Process -FilePath '%~f0' -ArgumentList '--elevated' -Verb RunAs"
     exit /b
 )
+
 dotnet build src\Patcher\LotroKoniecDev.Cli -v:minimal -nologo
 if errorlevel 1 exit /b 1
-src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe export %*
+
+setlocal EnableDelayedExpansion
+if defined LOTRO_WRAPPER_ARGS (
+    src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe export !LOTRO_WRAPPER_ARGS!
+) else (
+    src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe export
+)
 pause

--- a/lotro.bat
+++ b/lotro.bat
@@ -1,11 +1,26 @@
 @echo off
+setlocal
+cd /d "%~dp0"
+
+rem AUDIT-SEC-06: user arguments must never be re-parsed by an elevated shell. They cross
+rem the elevation boundary as an environment variable (inherited by the elevated instance),
+rem and delayed expansion below inserts them after cmd parsing, so metacharacters stay literal.
+if not "%~1"=="--elevated" set "LOTRO_WRAPPER_ARGS=%*"
+
 net session >nul 2>&1
 if errorlevel 1 (
     echo Requesting administrator privileges...
-    powershell -Command "Start-Process cmd -Verb RunAs -ArgumentList '/c cd /d \"%CD%\" && \"%~f0\" %*'"
+    powershell -NoProfile -Command "Start-Process -FilePath '%~f0' -ArgumentList '--elevated' -Verb RunAs"
     exit /b
 )
+
 dotnet build src\Patcher\LotroKoniecDev.Cli -v:minimal -nologo
 if errorlevel 1 exit /b 1
-src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe launch %*
+
+setlocal EnableDelayedExpansion
+if defined LOTRO_WRAPPER_ARGS (
+    src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe launch !LOTRO_WRAPPER_ARGS!
+) else (
+    src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe launch
+)
 pause

--- a/patch.bat
+++ b/patch.bat
@@ -1,11 +1,26 @@
 @echo off
+setlocal
+cd /d "%~dp0"
+
+rem AUDIT-SEC-06: user arguments must never be re-parsed by an elevated shell. They cross
+rem the elevation boundary as an environment variable (inherited by the elevated instance),
+rem and delayed expansion below inserts them after cmd parsing, so metacharacters stay literal.
+if not "%~1"=="--elevated" set "LOTRO_WRAPPER_ARGS=%*"
+
 net session >nul 2>&1
 if errorlevel 1 (
     echo Requesting administrator privileges...
-    powershell -Command "Start-Process cmd -Verb RunAs -ArgumentList '/c cd /d \"%CD%\" && \"%~f0\" %*'"
+    powershell -NoProfile -Command "Start-Process -FilePath '%~f0' -ArgumentList '--elevated' -Verb RunAs"
     exit /b
 )
+
 dotnet build src\Patcher\LotroKoniecDev.Cli -v:minimal -nologo
 if errorlevel 1 exit /b 1
-src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe patch %*
+
+setlocal EnableDelayedExpansion
+if defined LOTRO_WRAPPER_ARGS (
+    src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe patch !LOTRO_WRAPPER_ARGS!
+) else (
+    src\Patcher\LotroKoniecDev.Cli\bin\Debug\net10.0-windows\win-x86\LotroKoniecDev.Cli.exe patch
+)
 pause


### PR DESCRIPTION
Closes #396

## What

All three wrappers (`export.bat`, `patch.bat`, `lotro.bat`) self-elevated by building an elevated shell string:
`Start-Process cmd -Verb RunAs -ArgumentList '/c cd /d "%CD%" && "%~f0" %*'` — raw `%*` and `%CD%` were re-parsed by an elevated `cmd`, so an argument like `x & calc` from a hostile caller ran a second command as admin.

New pattern (identical in all three files, only the CLI verb differs):

1. `cd /d "%~dp0"` at the top pins the working directory to the repo root in both instances — `%CD%` no longer crosses the boundary at all (script paths were repo-root-relative anyway).
2. User arguments cross the UAC boundary **as data**: the unelevated instance stores `%*` in the `LOTRO_WRAPPER_ARGS` environment variable (inherited by the elevated instance) and elevates the script with a single fixed `--elevated` marker — the only variable text an elevated shell ever parses is the script's own path.
3. The elevated instance inserts the args into the CLI invocation with **delayed expansion** (`!LOTRO_WRAPPER_ARGS!`), which cmd substitutes after parsing the line — metacharacters stay literal argv tokens; Spectre.Console rejects them as unknown arguments and no second command runs.
4. `if defined` guard prevents the literal `!LOTRO_WRAPPER_ARGS!` artifact when no args were given.

## Acceptance criteria

- [x] No raw `%*` in any `cmd /c "... && ..."` string — args cross as data, never as shell text re-parsed by an elevated shell.
- [x] `x & calc` lands as literal argv in the CLI (verified against cmd's parse-phase ordering: operator tokenization precedes delayed expansion, and substituted text is not rescanned) — code-reviewer agent walked all three scripts line by line and approved.
- [ ] Manual Windows verification (this dev box is macOS — checklist below).

## Manual Windows checklist (AC3)

1. Double-click `export.bat` → UAC → export runs, window stays open.
2. `patch.bat polish` from an unelevated terminal → elevated window receives `polish` (this is the env-var-inheritance proof).
3. `lotro.bat polish -d "C:\Program Files (x86)\..."` → quoted path with spaces/parens survives.
4. `patch.bat "x & calc"` → CLI errors on unknown argument, no calculator.
5. Cancel the UAC prompt → wrapper exits like before.

## Notes

- Behavior change (improvement): running from an already-elevated terminal in a different CWD now works — the old scripts required CWD=repo root because of the relative `dotnet build` path.
- Reviewer's one Minor: under over-the-shoulder elevation (another admin's credentials in the UAC prompt) the env var lands in the other user's environment — `patch`/`launch` then fail loudly on the missing `<NAME>` argument; `export` silently runs with defaults. Accepted for the single-admin dev-box audience; the suggested extra `echo` of effective args was skipped (the CLI's own output already shows what it received).
- Build green with zero warnings; 276/276 patcher unit tests pass (no C# touched — gate run anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)