### PR TITLE
AUDIT-SEC-07: Patcher security tidy-up — ETag header validation, regex match timeout, log file rename

### DIFF
--- a/src/Patcher/LotroKoniecDev.Application/Features/UpdateChecking/GameUpdateChecker.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/UpdateChecking/GameUpdateChecker.cs
@@ -65,10 +65,21 @@ public sealed partial class GameUpdateChecker : IGameUpdateChecker
     /// </summary>
     private static string? ParseLatestVersion(string htmlContent)
     {
-        Match match = VersionRegex().Match(htmlContent);
-        return match.Success ? match.Groups[1].Value : null;
+        try
+        {
+            Match match = VersionRegex().Match(htmlContent);
+            return match.Success ? match.Groups[1].Value : null;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // A timed-out match on third-party HTML is treated as "could not parse" — the caller
+            // already handles a null version gracefully.
+            return null;
+        }
     }
 
-    [GeneratedRegex(@"Update\s+(\d+(?:\.\d+)*)\s+Release\s+Notes", RegexOptions.IgnoreCase)]
+    // The pattern is linear, so it is not ReDoS-prone today; the timeout is a guardrail against
+    // future edits to a regex that runs on third-party HTML (AUDIT-SEC-07 / #397).
+    [GeneratedRegex(@"Update\s+(\d+(?:\.\d+)*)\s+Release\s+Notes", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 1000)]
     private static partial Regex VersionRegex();
 }

--- a/src/Patcher/LotroKoniecDev.Cli/Program.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/Program.cs
@@ -4,6 +4,7 @@ using LotroKoniecDev.Infrastructure;
 using LotroKoniecDev.Cli.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
+using Serilog.Events;
 using Spectre.Console.Cli;
 
 namespace LotroKoniecDev.Cli;
@@ -12,10 +13,13 @@ public sealed class Program
 {
     private static async Task<int> Main(string[] args)
     {
-        string logFilePath = Path.Combine(GlobalSettings.DataDir, "launch_test.log");
+        // The file sink stays at Debug on purpose: it is the diagnostic trail users attach to bug
+        // reports (full paths included — the log never leaves the local machine unless shared).
+        // The console stays at Information so CLI output remains readable (AUDIT-SEC-07 / #397).
+        string logFilePath = Path.Combine(GlobalSettings.DataDir, "patcher.log");
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Debug()
-            .WriteTo.Console()
+            .WriteTo.Console(restrictedToMinimumLevel: LogEventLevel.Information)
             .WriteTo.File(logFilePath,
                 outputTemplate: "{Timestamp:HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
             .CreateLogger();

--- a/src/Patcher/LotroKoniecDev.Infrastructure/Network/TranslationFileDownloader.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/Network/TranslationFileDownloader.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using LotroKoniecDev.Application.Abstractions;
 using LotroKoniecDev.Application.Features.TranslationFileSyncing;
 using LotroKoniecDev.Domain.Core.Errors;
@@ -39,10 +40,13 @@ public sealed class TranslationFileDownloader : ITranslationFileDownloader
         {
             Uri requestUri = new($"{baseUrl.TrimEnd('/')}/{TranslationFileRoute}", UriKind.Absolute);
             using HttpRequestMessage request = new(HttpMethod.Get, requestUri);
-            if (!string.IsNullOrEmpty(currentETag))
+            // The stored value comes from an on-disk sidecar file, so it goes through the typed
+            // header API instead of TryAddWithoutValidation (AUDIT-SEC-07 / #397). A value that no
+            // longer parses as an ETag is simply dropped — the fetch degrades to a full download.
+            if (!string.IsNullOrEmpty(currentETag)
+                && EntityTagHeaderValue.TryParse(currentETag, out EntityTagHeaderValue? cachedETag))
             {
-                // The stored value is the server's quoted ETag; send it verbatim.
-                request.Headers.TryAddWithoutValidation("If-None-Match", currentETag);
+                request.Headers.IfNoneMatch.Add(cachedETag);
             }
 
             // ResponseHeadersRead keeps HttpClient from buffering the whole body before the size

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Shared/StubHttpMessageHandler.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Shared/StubHttpMessageHandler.cs
@@ -12,6 +12,11 @@ internal sealed class StubHttpMessageHandler : HttpMessageHandler
         _response = response;
     }
 
+    public HttpRequestMessage? LastRequest { get; private set; }
+
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        => Task.FromResult(_response);
+    {
+        LastRequest = request;
+        return Task.FromResult(_response);
+    }
 }

--- a/tests/LotroKoniecDev.Tests.Infrastructure/Tests/TranslationFileDownloaderTests.cs
+++ b/tests/LotroKoniecDev.Tests.Infrastructure/Tests/TranslationFileDownloaderTests.cs
@@ -147,6 +147,48 @@ public sealed class TranslationFileDownloaderTests
     }
 
     [Fact]
+    public async Task FetchAsync_WellFormedCachedETag_ShouldSendItAsTheIfNoneMatchHeader()
+    {
+        // Arrange — the sidecar value parses as an ETag, so the conditional header goes out
+        // through the typed API (AUDIT-SEC-07 / #397).
+        using HttpResponseMessage response = OkResponse(Content, $"\"{ContentHash}\"");
+        StubHttpMessageHandler handler = new(response);
+        using HttpClient httpClient = new(handler);
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, "\"cached-etag\"", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        handler.LastRequest.ShouldNotBeNull();
+        handler.LastRequest.Headers.IfNoneMatch.Single().Tag.ShouldBe("\"cached-etag\"");
+    }
+
+    [Theory]
+    [InlineData("\"etag\"\r\nX-Injected: attack")]
+    [InlineData("etag-without-quotes")]
+    public async Task FetchAsync_MalformedCachedETag_ShouldFetchTheFullFileWithoutTheConditionalHeader(string malformedETag)
+    {
+        // Arrange — a sidecar value that no longer parses as an ETag (tampering or corruption)
+        // must never reach the wire; the fetch degrades to a full download (AUDIT-SEC-07 / #397).
+        using HttpResponseMessage response = OkResponse(Content, $"\"{ContentHash}\"");
+        StubHttpMessageHandler handler = new(response);
+        using HttpClient httpClient = new(handler);
+        TranslationFileDownloader sut = new(httpClient);
+
+        // Act
+        Result<TranslationFileFetchResult> result = await sut.FetchAsync(BaseUrl, malformedETag, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.IsModified.ShouldBeTrue();
+        result.Value.Content.ShouldBe(Content);
+        handler.LastRequest.ShouldNotBeNull();
+        handler.LastRequest.Headers.IfNoneMatch.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task FetchAsync_NotModifiedResponse_ShouldReportTheCachedCopyCurrentWithoutAnyCheck()
     {
         // Arrange — a 304 carries no body, so there is nothing to verify.


### PR DESCRIPTION
Closes #397

## What

Three low/INFO hardening items from the Patcher security audit, in one small pass:

- **A — ETag header validation.** `TranslationFileDownloader` no longer sends the on-disk sidecar value via `TryAddWithoutValidation`. The value must parse with `EntityTagHeaderValue.TryParse`; a malformed value (CRLF injection attempt, unquoted garbage) is dropped and the fetch degrades to a full download.
- **B — Regex match timeout.** The forum version regex gets a 1s match timeout. The pattern is linear (not ReDoS-prone today) — the timeout is a guardrail for future pattern edits. A timed-out match maps to the existing could-not-parse path instead of crashing.
- **C — Log file rename.** `data/launch_test.log` → `data/patcher.log`. The file sink stays at Debug on purpose (diagnostic trail users attach to bug reports); the console sink is restricted to Information. The choice is recorded in a comment.

## Why

Defense-in-depth and tidy-up per the audit ticket. None of the three is a live exploit on a default single-user setup.

## Tests

- `dotnet build LotroKoniecDev.slnx` — green, zero warnings.
- `dotnet test tests/LotroKoniecDev.Tests.Unit` — 276/276 green, no assertions touched.
- New infrastructure tests: a well-formed cached ETag is sent as `If-None-Match`; a CRLF-injected or unquoted value never reaches the wire and the fetch still succeeds as a full download (`TryParse` behavior for these exact inputs verified empirically on .NET 10).
- `Tests.Infrastructure` targets `net10.0-windows`, so the new tests compile everywhere but execute on Windows only (same as the existing downloader tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)