### PR TITLE
AUDIT-SEC-09: ForwardedHeaders trusts any upstream (KnownProxies/KnownNetworks cleared, no ForwardLimit) — spoofable client IP/scheme if the port is ever reachable off-proxy

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -87,6 +87,9 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: "http://+:8080"
+      # Trust X-Forwarded-* only from the pinned stack subnet (the Caddy hop) — #399. Keep in
+      # lockstep with the ipam subnet at the bottom of this file.
+      ForwardedHeaders__KnownNetworks__0: "10.60.0.0/24"
       ConnectionStrings__AuthDatabase: ${ConnectionStrings__AuthDatabase}
       # Public issuer served by the proxy — stamped into every token's 'iss'; reachable identically
       # from the browser (front-channel) and the Frontend container (back-channel) through the proxy.
@@ -132,6 +135,9 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: "http://+:8080"
+      # Trust X-Forwarded-* only from the pinned stack subnet (the Caddy hop) — #399. Keep in
+      # lockstep with the ipam subnet at the bottom of this file.
+      ForwardedHeaders__KnownNetworks__0: "10.60.0.0/24"
       ConnectionStrings__TranslationDatabase: ${ConnectionStrings__TranslationDatabase}
       # In Production OpenIddict rejects plain HTTP, so tms-api fetches OIDC metadata + JWKS through
       # the proxy over https (why it trusts the local CA via the entrypoint above). Issuer = the public
@@ -170,6 +176,9 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: "http://+:8080"
+      # Trust X-Forwarded-* only from the pinned stack subnet (the Caddy hop) — #399. Keep in
+      # lockstep with the ipam subnet at the bottom of this file.
+      ForwardedHeaders__KnownNetworks__0: "10.60.0.0/24"
       # OIDC RP: a single Authority (the proxy origin) drives the browser /authorize redirect AND the
       # container's discovery/token/userinfo back-channel — both resolve to the proxy (browser via
       # hosts file, container via the proxy's network aliases below).
@@ -244,3 +253,13 @@ volumes:
   lotrokoniecdev-prod-auth-keys:
   lotrokoniecdev-prod-frontend-keys:
   lotrokoniecdev-prod-caddy-data:
+
+networks:
+  # Pinned subnet so the apps can restrict forwarded-header trust to the in-stack Caddy hop via
+  # ForwardedHeaders__KnownNetworks__0 above (#399). 10.60.0.0/24 sits outside Docker's default
+  # auto-pool (172.17-31.x), so it cannot collide with the auto-assigned dev-stack network; if it
+  # ever clashes with something host-local, change it here and in the three env vars in lockstep.
+  default:
+    ipam:
+      config:
+        - subnet: 10.60.0.0/24

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -90,6 +90,7 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 | `OpenIddict__WebClient__RedirectUris__0` | `https://localhost:7017/callback` | `https://lotro-translator.pl/callback` | ✅ non-dev | plain | MUST equal the Frontend callback (its public origin + `AuthSystem__CallbackPath`). |
 | `OpenIddict__WebClient__PostLogoutRedirectUris__0` | `https://localhost:7017` | `https://lotro-translator.pl` | ✅ non-dev | plain | Frontend post-logout return URL. |
 | `Cors__AllowedOrigins__0` | — (AllowAnyOrigin) | `https://lotro-translator.pl` | ✅ non-dev | plain | Bare origin = Frontend public URL. Lowercase, no port-if-default, no path/slash. |
+| `ForwardedHeaders__KnownNetworks__0` | — (dev skips `UseForwardedHeaders`) | proxy subnet CIDR, or unset on ACA | optional | plain | Restricts `X-Forwarded-*` trust to the proxy hop (#399). `compose.prod.yaml` sets `10.60.0.0/24`; unset = trust every upstream (`ForwardLimit=1`) — safe only while `:8080` is never published. Malformed CIDR aborts boot. |
 | `DataProtection__KeyRingPath` | — (host default) | `/keys` | ✅ non-dev | plain | Persistent, replica-shared volume; else logins/antiforgery/reset links break on deploy/scale. |
 | `Email__Host` | `mailpit` | `smtp.sendgrid.net` | ✅ all | plain | SMTP host. Validated on start (every environment). |
 | `Email__Port` | `1025` | `587` | ✅ all | plain | 1–65535. |
@@ -112,6 +113,7 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 | `Auth__Authority` | — (unset → falls back to `Issuer`, `https://localhost:5003`) | `https://auth.lotro-translator.pl` | optional² | plain | Back-channel for OIDC metadata + JWKS. ²Unset → falls back to `Issuer`; the dev host run relies on that fallback to reach the host auth Kestrel. Prod: must be `https` (OpenIddict rejects plain HTTP) and reachable from the container. |
 | `Auth__Audience` | `lotrokoniecdev-api` | `lotrokoniecdev-api` | ✅ all | plain | Default in base `appsettings.json`. |
 | `Cors__AllowedOrigins__0` | — (AllowAnyOrigin) | `https://lotro-translator.pl` | ✅ non-dev | plain | Bare origin = Frontend public URL. |
+| `ForwardedHeaders__KnownNetworks__0` | — (dev skips `UseForwardedHeaders`) | proxy subnet CIDR, or unset on ACA | optional | plain | Restricts `X-Forwarded-*` trust to the proxy hop (#399). See the auth-api row. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` | aspire / `grpc` | collector / `grpc` | optional | plain | Empty endpoint = export disabled. |
 | `Bootstrap__Enabled` | `false` | `false` | optional | plain | One-time DB seed of the first export (spec 0001). Off by default. |
 | `Bootstrap__GameVersion` / `Bootstrap__ExportedTextPath` / `Bootstrap__PolishTextPath` | — / — / `/app/translations/polish.txt` | as needed | optional | plain | Only consulted when `Bootstrap__Enabled=true`. |
@@ -134,6 +136,7 @@ Staging/Production.
 | `AuthSystem__Scopes` | `openid,email,profile,roles,api,offline_access` | same | ✅ all | plain | At least one scope. |
 | `TranslationSystem__BaseUrl` | `https://localhost:5002/` | `https://tms.lotro-translator.pl/` | ✅ all | plain | TMS API origin (trailing slash). |
 | `DataProtection__KeyRingPath` | — (host default) | `/keys` | ✅ non-dev | plain | Persistent, replica-shared volume (ADR-0005); else antiforgery + auth cookies break on deploy/scale. |
+| `ForwardedHeaders__KnownNetworks__0` | — (dev skips `UseForwardedHeaders`) | proxy subnet CIDR, or unset on ACA | optional | plain | Restricts `X-Forwarded-*` trust to the proxy hop (#399). See the auth-api row. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` | — | collector / `grpc` | optional | plain | Empty endpoint = export disabled. |
 
 ### migrator
@@ -254,10 +257,14 @@ The cross-service settings that are individually valid but break the system when
 
 5. **Behind a TLS-terminating ingress, forwarded headers are load-bearing.** The ingress MUST send
    `X-Forwarded-Proto` (and Host); all three apps read them (`UseForwardedHeaders`, M6-02) to
-   reconstruct the `https` scheme used for `iss`, `redirect_uri`, and `Secure` cookies. The containers
-   trust **all** upstream proxies (`KnownProxies`/`KnownIPNetworks` cleared) — safe **only** because
-   they are never reachable except through the ingress, so **do not expose `:8080` publicly**. In prod
-   the apps serve HTTP only; the proxy owns TLS.
+   reconstruct the `https` scheme used for `iss`, `redirect_uri`, and `Secure` cookies. Trust is
+   scoped per environment (#399): where the proxy subnet is knowable, set
+   `ForwardedHeaders__KnownNetworks__n` to its CIDR(s) — `compose.prod.yaml` pins its network to
+   `10.60.0.0/24` and sets the variable for all three apps; a malformed CIDR aborts boot. Where the
+   ingress hop has no stable IP (ACA), leave it unset — the apps then trust every upstream with an
+   explicit `ForwardLimit = 1`, which is safe **only** under the recorded invariant that the
+   container port is never reachable except through the ingress, so **do not expose `:8080`
+   publicly**. In prod the apps serve HTTP only; the proxy owns TLS.
 
 6. **The Data Protection keyring must be persistent and shared.** auth-api + frontend need
    `DataProtection__KeyRingPath` pointing at a persistent, replica-shared volume (`/keys`). An

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -131,17 +131,41 @@ try
     // container receives plain HTTP with X-Forwarded-* headers. Honour them so Request.Scheme is
     // https — OAuth redirects, scheme-derived HATEOAS hrefs, Secure cookies, and UseHttpsRedirection
     // all depend on it. (The OpenIddict token/discovery `iss` is NOT scheme-derived: it is pinned
-    // from OpenIddictSettings.Issuer, so it stays correct regardless of these headers.) The ingress
-    // hop has no stable IP, so KnownIPNetworks/KnownProxies are cleared (every upstream proxy is
-    // trusted), which is safe only because the container is never exposed directly: it is always
-    // reached through the ingress that sets these headers (ADR-0008).
+    // from OpenIddictSettings.Issuer, so it stays correct regardless of these headers.)
+    //
+    // Trust policy (#399): where the proxy subnet is knowable, ForwardedHeaders:KnownNetworks
+    // restricts trust to those CIDRs (compose.prod.yaml pins the Caddy network and sets it); where
+    // the ingress hop has no stable IP (ACA), the list stays empty — every upstream is trusted —
+    // which is safe only under the recorded invariant that the container port is NEVER published
+    // directly: ACA ingress is the sole route (iac/) and compose.prod.yaml uses expose:, not ports:.
+    // ForwardLimit = 1 is explicit either way: exactly one proxy hop sets these headers, so only
+    // the right-most X-Forwarded-* entry (the ingress-observed client) is ever applied. A malformed
+    // CIDR — or a knob that is set yet yields no entries (e.g. a scalar value missing the __0
+    // index) — aborts boot here (fail-fast, ADR-0008 §3 spirit), never silently widens trust.
+    IConfigurationSection trustedProxyNetworksSection =
+        builder.Configuration.GetSection("ForwardedHeaders:KnownNetworks");
+    System.Net.IPNetwork[] trustedProxyNetworks = (trustedProxyNetworksSection.Get<string[]>() ?? [])
+        .Select(cidr => System.Net.IPNetwork.Parse(cidr))
+        .ToArray();
+    if (trustedProxyNetworksSection.Exists() && trustedProxyNetworks.Length == 0)
+    {
+        throw new InvalidOperationException(
+            "ForwardedHeaders:KnownNetworks is set but yielded no networks - "
+            + "expected indexed CIDR values (ForwardedHeaders__KnownNetworks__0).");
+    }
+
     builder.Services.Configure<ForwardedHeadersOptions>(options =>
     {
         options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
                                    | ForwardedHeaders.XForwardedProto
                                    | ForwardedHeaders.XForwardedHost;
+        options.ForwardLimit = 1;
         options.KnownIPNetworks.Clear();
         options.KnownProxies.Clear();
+        foreach (System.Net.IPNetwork trustedProxyNetwork in trustedProxyNetworks)
+        {
+            options.KnownIPNetworks.Add(trustedProxyNetwork);
+        }
     });
 
     builder.Services.Configure<RouteHandlerOptions>(options =>

--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -75,16 +75,41 @@ try
     // Behind a cloud ingress (ACA / ALB / any reverse proxy) TLS terminates at the proxy and the
     // container receives plain HTTP with X-Forwarded-* headers. Honour them so Request.Scheme is
     // https, which keeps the OIDC redirect_uri, antiforgery/Secure cookies, and UseHttpsRedirection
-    // correct. The ingress hop has no stable IP, so KnownIPNetworks/KnownProxies are cleared (every
-    // upstream proxy is trusted), which is safe only because the container is never exposed directly:
-    // it is always reached through the ingress that sets these headers (ADR-0008).
+    // correct.
+    //
+    // Trust policy (#399): where the proxy subnet is knowable, ForwardedHeaders:KnownNetworks
+    // restricts trust to those CIDRs (compose.prod.yaml pins the Caddy network and sets it); where
+    // the ingress hop has no stable IP (ACA), the list stays empty — every upstream is trusted —
+    // which is safe only under the recorded invariant that the container port is NEVER published
+    // directly: ACA ingress is the sole route (iac/) and compose.prod.yaml uses expose:, not ports:.
+    // ForwardLimit = 1 is explicit either way: exactly one proxy hop sets these headers, so only
+    // the right-most X-Forwarded-* entry (the ingress-observed client) is ever applied. A malformed
+    // CIDR — or a knob that is set yet yields no entries (e.g. a scalar value missing the __0
+    // index) — aborts boot here (fail-fast, ADR-0008 §3 spirit), never silently widens trust.
+    IConfigurationSection trustedProxyNetworksSection =
+        builder.Configuration.GetSection("ForwardedHeaders:KnownNetworks");
+    System.Net.IPNetwork[] trustedProxyNetworks = (trustedProxyNetworksSection.Get<string[]>() ?? [])
+        .Select(cidr => System.Net.IPNetwork.Parse(cidr))
+        .ToArray();
+    if (trustedProxyNetworksSection.Exists() && trustedProxyNetworks.Length == 0)
+    {
+        throw new InvalidOperationException(
+            "ForwardedHeaders:KnownNetworks is set but yielded no networks - "
+            + "expected indexed CIDR values (ForwardedHeaders__KnownNetworks__0).");
+    }
+
     builder.Services.Configure<ForwardedHeadersOptions>(options =>
     {
         options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
                                    | ForwardedHeaders.XForwardedProto
                                    | ForwardedHeaders.XForwardedHost;
+        options.ForwardLimit = 1;
         options.KnownIPNetworks.Clear();
         options.KnownProxies.Clear();
+        foreach (System.Net.IPNetwork trustedProxyNetwork in trustedProxyNetworks)
+        {
+            options.KnownIPNetworks.Add(trustedProxyNetwork);
+        }
     });
 
     // HSTS hardening (audit #0001 / M7): a one-year max-age covering subdomains and flagged for the

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
@@ -93,16 +93,41 @@ try
     // Behind a cloud ingress (ACA / ALB / any reverse proxy) TLS terminates at the proxy and the
     // container receives plain HTTP with X-Forwarded-* headers. Honour them so Request.Scheme is
     // https, which keeps the JWT issuer, HATEOAS hrefs, Secure cookies, and UseHttpsRedirection
-    // correct. The ingress hop has no stable IP, so KnownIPNetworks/KnownProxies are cleared — i.e.
-    // every upstream proxy is trusted. That is safe only because the container is never exposed
-    // directly: it is always reached through the ingress that sets these headers (ADR-0008).
+    // correct.
+    //
+    // Trust policy (#399): where the proxy subnet is knowable, ForwardedHeaders:KnownNetworks
+    // restricts trust to those CIDRs (compose.prod.yaml pins the Caddy network and sets it); where
+    // the ingress hop has no stable IP (ACA), the list stays empty — every upstream is trusted —
+    // which is safe only under the recorded invariant that the container port is NEVER published
+    // directly: ACA ingress is the sole route (iac/) and compose.prod.yaml uses expose:, not ports:.
+    // ForwardLimit = 1 is explicit either way: exactly one proxy hop sets these headers, so only
+    // the right-most X-Forwarded-* entry (the ingress-observed client) is ever applied. A malformed
+    // CIDR — or a knob that is set yet yields no entries (e.g. a scalar value missing the __0
+    // index) — aborts boot here (fail-fast, ADR-0008 §3 spirit), never silently widens trust.
+    IConfigurationSection trustedProxyNetworksSection =
+        builder.Configuration.GetSection("ForwardedHeaders:KnownNetworks");
+    System.Net.IPNetwork[] trustedProxyNetworks = (trustedProxyNetworksSection.Get<string[]>() ?? [])
+        .Select(cidr => System.Net.IPNetwork.Parse(cidr))
+        .ToArray();
+    if (trustedProxyNetworksSection.Exists() && trustedProxyNetworks.Length == 0)
+    {
+        throw new InvalidOperationException(
+            "ForwardedHeaders:KnownNetworks is set but yielded no networks - "
+            + "expected indexed CIDR values (ForwardedHeaders__KnownNetworks__0).");
+    }
+
     builder.Services.Configure<ForwardedHeadersOptions>(options =>
     {
         options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
                                    | ForwardedHeaders.XForwardedProto
                                    | ForwardedHeaders.XForwardedHost;
+        options.ForwardLimit = 1;
         options.KnownIPNetworks.Clear();
         options.KnownProxies.Clear();
+        foreach (System.Net.IPNetwork trustedProxyNetwork in trustedProxyNetworks)
+        {
+            options.KnownIPNetworks.Add(trustedProxyNetwork);
+        }
     });
 
     builder.Services.Configure<RouteHandlerOptions>(options =>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
@@ -1,0 +1,167 @@
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.Contracts.Discovery;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.Hateoas.ContentNegotiation;
+using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.ForwardedHeaders;
+
+/// <summary>
+/// Proves the forwarded-header TRUST boundary (#399): when <c>ForwardedHeaders:KnownNetworks</c>
+/// is configured, <c>X-Forwarded-*</c> is honoured only from peers inside those CIDRs — a spoofed
+/// header from anywhere else is ignored — and a malformed CIDR aborts boot instead of silently
+/// widening trust. The observable seam is the same as <see cref="ForwardedHeadersTests"/>: the
+/// anonymous discovery document's scheme-derived HATEOAS links. The peer address is injected by a
+/// first-in-pipeline middleware (an <see cref="IStartupFilter"/>), because the in-memory TestServer
+/// connection carries no RemoteIpAddress — and the middleware skips the known-proxy check entirely
+/// for address-less connections.
+/// </summary>
+[Collection("AuthApi")]
+public sealed class ForwardedHeadersTrustTests
+{
+    private const string TrustedProxyCidr = "10.60.0.0/24";
+
+    private readonly AuthSystemApiFactory _appFactory;
+
+    public ForwardedHeadersTrustTests(AuthSystemApiFactory appFactory)
+    {
+        _appFactory = appFactory;
+    }
+
+    [Fact]
+    public async Task Discovery_SpoofedForwardedProtoFromPeerOutsideKnownNetworks_KeepsHttpLinks()
+    {
+        // Arrange — 203.0.113.7 (TEST-NET-3) is outside the trusted proxy subnet.
+        using WebApplicationFactory<Program> factory =
+            FactoryWithKnownNetworks(TrustedProxyCidr, peerAddress: "203.0.113.7");
+        using HttpRequestMessage request = HateoasRequest();
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        DiscoveryResponse response = await SendDiscoveryAsync(factory, request);
+
+        // Assert — the spoofed proto must NOT flip the scheme.
+        response.Links.ShouldNotBeEmpty();
+        foreach (LinkDto link in response.Links)
+        {
+            Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+            uri!.Scheme.ShouldBe("http", $"href for rel='{link.Rel}' must ignore X-Forwarded-Proto from an untrusted peer");
+        }
+    }
+
+    [Fact]
+    public async Task Discovery_ForwardedProtoFromPeerInsideKnownNetworks_BuildsHttpsLinks()
+    {
+        // Arrange — the peer sits inside the trusted proxy subnet, like the real ingress hop.
+        using WebApplicationFactory<Program> factory =
+            FactoryWithKnownNetworks(TrustedProxyCidr, peerAddress: "10.60.0.5");
+        using HttpRequestMessage request = HateoasRequest();
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        DiscoveryResponse response = await SendDiscoveryAsync(factory, request);
+
+        // Assert — restricting trust must not break the legitimate proxy path.
+        response.Links.ShouldNotBeEmpty();
+        foreach (LinkDto link in response.Links)
+        {
+            Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+            uri!.Scheme.ShouldBe("https", $"href for rel='{link.Rel}' must honour the trusted proxy's X-Forwarded-Proto");
+        }
+    }
+
+    [Theory]
+    [InlineData("not-a-cidr")]
+    [InlineData("10.60.0.0/99")]
+    [InlineData("10.60.0.0")]
+    public void Startup_MalformedKnownNetworkCidr_FailsFast(string malformedCidr)
+    {
+        // Arrange
+        using WebApplicationFactory<Program> factory = _appFactory.WithWebHostBuilder(builder =>
+            builder.UseSetting("ForwardedHeaders:KnownNetworks:0", malformedCidr));
+
+        // Act & Assert — boot must abort instead of silently widening forwarded-header trust.
+        Should.Throw<FormatException>(() => factory.CreateClient());
+    }
+
+    [Fact]
+    public void Startup_KnownNetworksSetAsScalarWithoutIndex_FailsFast()
+    {
+        // Arrange — an operator typo: the knob set as a scalar (missing the __0 index) binds to
+        // null, which without the guard would silently revert to trust-everyone.
+        using WebApplicationFactory<Program> factory = _appFactory.WithWebHostBuilder(builder =>
+            builder.UseSetting("ForwardedHeaders:KnownNetworks", TrustedProxyCidr));
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => factory.CreateClient());
+    }
+
+    private WebApplicationFactory<Program> FactoryWithKnownNetworks(string trustedCidr, string peerAddress)
+    {
+        return _appFactory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("ForwardedHeaders:KnownNetworks:0", trustedCidr);
+            builder.ConfigureTestServices(services =>
+                services.AddSingleton<IStartupFilter>(
+                    new FakeRemoteIpStartupFilter(IPAddress.Parse(peerAddress))));
+        });
+    }
+
+    private static HttpRequestMessage HateoasRequest()
+    {
+        HttpRequestMessage request = new(HttpMethod.Get, new Uri("", UriKind.Relative));
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypes.HateoasJson));
+        return request;
+    }
+
+    private static async Task<DiscoveryResponse> SendDiscoveryAsync(
+        WebApplicationFactory<Program> factory,
+        HttpRequestMessage request)
+    {
+        JsonSerializerOptions jsonSerializerOptions =
+            factory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+
+        using HttpClient httpClient = factory.CreateClient();
+        HttpResponseMessage httpResponse = await httpClient.SendAsync(request);
+        string stringResponse = await httpResponse.EnsureSuccessWithDetailsAsync();
+        httpResponse.Content.Headers.ContentType?.MediaType.ShouldBe(MediaTypes.HateoasJson);
+
+        return JsonSerializer.Deserialize<DiscoveryResponse>(stringResponse, jsonSerializerOptions)!;
+    }
+
+    /// <summary>
+    /// Stamps a fake peer address as the FIRST middleware in the pipeline, so the forwarded-headers
+    /// middleware (also pipeline-first, from Program.cs) sees a connection it can trust-check.
+    /// </summary>
+    private sealed class FakeRemoteIpStartupFilter : IStartupFilter
+    {
+        private readonly IPAddress _peerAddress;
+
+        public FakeRemoteIpStartupFilter(IPAddress peerAddress)
+        {
+            _peerAddress = peerAddress;
+        }
+
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return app =>
+            {
+                app.Use(async (context, nextMiddleware) =>
+                {
+                    context.Connection.RemoteIpAddress = _peerAddress;
+                    await nextMiddleware(context);
+                });
+                next(app);
+            };
+        }
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
@@ -1,0 +1,195 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.ForwardedHeaders;
+
+/// <summary>
+/// Proves the forwarded-header TRUST boundary (#399) on the TMS host — the twin of the AuthSystem
+/// suite's <c>ForwardedHeadersTrustTests</c> (the wiring is deliberately duplicated per host, so
+/// each copy is pinned): when <c>ForwardedHeaders:KnownNetworks</c> is configured,
+/// <c>X-Forwarded-*</c> is honoured only from peers inside those CIDRs, and a malformed or
+/// mis-shaped knob aborts boot instead of silently widening trust. The observable seam is the same
+/// as <see cref="ForwardedHeadersTests"/>: the scheme-derived HATEOAS self link. The peer address
+/// is injected by a first-in-pipeline middleware (an <see cref="IStartupFilter"/>), because the
+/// in-memory TestServer connection carries no RemoteIpAddress — and the middleware skips the
+/// known-proxy check entirely for address-less connections.
+/// </summary>
+[Collection("TranslationApi")]
+public sealed class ForwardedHeadersTrustTests : IAsyncLifetime
+{
+    private const string TrustedProxyCidr = "10.60.0.0/24";
+    private const string Route = "/api/v1/game-versions";
+    private static readonly DateTimeOffset Now = new(2026, 7, 10, 0, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+
+    public ForwardedHeadersTrustTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\" CASCADE;");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task GetResource_SpoofedForwardedProtoFromPeerOutsideKnownNetworks_KeepsHttpLinks()
+    {
+        // Arrange — 203.0.113.7 (TEST-NET-3) is outside the trusted proxy subnet.
+        GameVersionId id = await SeedAsync("48.0");
+        using WebApplicationFactory<Program> factory =
+            FactoryWithKnownNetworks(TrustedProxyCidr, peerAddress: "203.0.113.7");
+        using HttpClient client = TranslatorClient(factory);
+        using HttpRequestMessage request = HateoasRequest($"{Route}/{id.Value}");
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        GameVersionResponse response = await SendHateoasAsync<GameVersionResponse>(client, request);
+
+        // Assert — the spoofed proto must NOT flip the scheme.
+        LinkDto selfLink = response.Links.ShouldHaveSingleItem();
+        Uri.TryCreate(selfLink.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+        uri!.Scheme.ShouldBe("http", "the self link must ignore X-Forwarded-Proto from an untrusted peer");
+    }
+
+    [Fact]
+    public async Task GetResource_ForwardedProtoFromPeerInsideKnownNetworks_BuildsHttpsLinks()
+    {
+        // Arrange — the peer sits inside the trusted proxy subnet, like the real ingress hop.
+        GameVersionId id = await SeedAsync("48.1");
+        using WebApplicationFactory<Program> factory =
+            FactoryWithKnownNetworks(TrustedProxyCidr, peerAddress: "10.60.0.5");
+        using HttpClient client = TranslatorClient(factory);
+        using HttpRequestMessage request = HateoasRequest($"{Route}/{id.Value}");
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        GameVersionResponse response = await SendHateoasAsync<GameVersionResponse>(client, request);
+
+        // Assert — restricting trust must not break the legitimate proxy path.
+        LinkDto selfLink = response.Links.ShouldHaveSingleItem();
+        Uri.TryCreate(selfLink.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+        uri!.Scheme.ShouldBe("https", "the self link must honour the trusted proxy's X-Forwarded-Proto");
+    }
+
+    [Fact]
+    public void Startup_MalformedKnownNetworkCidr_FailsFast()
+    {
+        // Arrange — the full malformed-input matrix lives in the AuthSystem twin; one case here
+        // pins that THIS host's copy of the wiring fails fast too.
+        using WebApplicationFactory<Program> factory = _factory.WithWebHostBuilder(builder =>
+            builder.UseSetting("ForwardedHeaders:KnownNetworks:0", "not-a-cidr"));
+
+        // Act & Assert — boot must abort instead of silently widening forwarded-header trust.
+        Should.Throw<FormatException>(() => factory.CreateClient());
+    }
+
+    [Fact]
+    public void Startup_KnownNetworksSetAsScalarWithoutIndex_FailsFast()
+    {
+        // Arrange — an operator typo: the knob set as a scalar (missing the __0 index) binds to
+        // null, which without the guard would silently revert to trust-everyone.
+        using WebApplicationFactory<Program> factory = _factory.WithWebHostBuilder(builder =>
+            builder.UseSetting("ForwardedHeaders:KnownNetworks", TrustedProxyCidr));
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => factory.CreateClient());
+    }
+
+    private WebApplicationFactory<Program> FactoryWithKnownNetworks(string trustedCidr, string peerAddress)
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("ForwardedHeaders:KnownNetworks:0", trustedCidr);
+            builder.ConfigureTestServices(services =>
+                services.AddSingleton<IStartupFilter>(
+                    new FakeRemoteIpStartupFilter(IPAddress.Parse(peerAddress))));
+        });
+    }
+
+    private static HttpClient TranslatorClient(WebApplicationFactory<Program> factory)
+    {
+        HttpClient client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Translator));
+        return client;
+    }
+
+    private static HttpRequestMessage HateoasRequest(string url)
+    {
+        HttpRequestMessage request = new(HttpMethod.Get, url);
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypes.HateoasJson));
+        return request;
+    }
+
+    private static async Task<T> SendHateoasAsync<T>(HttpClient client, HttpRequestMessage request)
+        where T : class
+    {
+        HttpResponseMessage response = await client.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe(MediaTypes.HateoasJson);
+
+        return (await response.Content.ReadFromJsonAsync<T>(JsonOptions))!;
+    }
+
+    private async Task<GameVersionId> SeedAsync(string version)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+
+        return gameVersion.Id;
+    }
+
+    /// <summary>
+    /// Stamps a fake peer address as the FIRST middleware in the pipeline, so the forwarded-headers
+    /// middleware (also pipeline-first, from Program.cs) sees a connection it can trust-check.
+    /// </summary>
+    private sealed class FakeRemoteIpStartupFilter : IStartupFilter
+    {
+        private readonly IPAddress _peerAddress;
+
+        public FakeRemoteIpStartupFilter(IPAddress peerAddress)
+        {
+            _peerAddress = peerAddress;
+        }
+
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return app =>
+            {
+                app.Use(async (context, nextMiddleware) =>
+                {
+                    context.Connection.RemoteIpAddress = _peerAddress;
+                    await nextMiddleware(context);
+                });
+                next(app);
+            };
+        }
+    }
+}


### PR DESCRIPTION
Closes #399

## What

- All three hosts (auth-api, tms-api, frontend) now read an optional `ForwardedHeaders:KnownNetworks` knob (CIDR list): when set, `X-Forwarded-*` is trusted **only** from peers inside those networks; when unset (ACA — the ingress hop has no stable IP), the previous trust-everyone behavior stays, now with an explicit `ForwardLimit = 1` and the "container port is never directly published" invariant recorded in the code comment (AC1/AC3).
- Fail-fast: a malformed CIDR **or** a mis-shaped knob (set, yet yielding no indexed entries — e.g. missing `__0`) aborts boot instead of silently widening trust.
- `compose.prod.yaml` pins its network to `10.60.0.0/24` (outside Docker's auto-pool) and sets `ForwardedHeaders__KnownNetworks__0` for all three apps, scoping trust to the Caddy hop; with `ForwardLimit = 1` the right-most XFF entry (the Caddy-observed real client) still keys the rate limiters (AC2).
- Runbook: gotcha §5 rewritten + a knob row in each of the three env-var matrices.

## Why

Defense-in-depth (audit AUDIT-SEC-09): with both trust lists cleared, any peer that ever reaches the container port off-proxy could spoof `X-Forwarded-For` (defeating the `/connect/token` brute-force limiter) and `X-Forwarded-Proto`. Trust is now restricted where the proxy subnet is knowable, and the unset-knob fallback is provably byte-identical to the previous behavior (verified against the .NET 10 middleware source in review).

## Tests

- New `ForwardedHeadersTrustTests` twins in the auth **and** tms integration suites: spoofed `X-Forwarded-Proto` from a peer outside the trusted CIDR is ignored / honored from inside it (fake peer IP stamped by a first-in-pipeline `IStartupFilter`; seam = scheme-derived HATEOAS links), malformed-CIDR matrix and the scalar-knob mis-shape both fail startup.
- Solution build 0 warnings; unit 276, auth integration 244, TMS integration 191, frontend unit 313, TMS unit 164 — all green; `docker compose -f compose.prod.yaml config` valid.
- `code-reviewer` gate: APPROVE (after fixing its two findings: the silent scalar-knob fallback + missing tms-api tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)