### PR TITLE
AUDIT-SEC-10: Frontend auth cookie uses SecurePolicy=SameAsRequest — session cookie's Secure flag depends on proxy scheme forwarding

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthenticationDependencyInjectionExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthenticationDependencyInjectionExtensions.cs
@@ -63,7 +63,7 @@ internal static class AuthenticationDependencyInjectionExtensions
                     options.Cookie.Name = ".lotrokoniecdev.auth";
                     options.Cookie.HttpOnly = true;
                     options.Cookie.SameSite = SameSiteMode.Lax;
-                    options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+                    // SecurePolicy is environment-dependent — set in ConfigureCookieSecurePolicy below.
                     // Lock path so SignIn/SignOut cookies always match — without this, a future code path
                     // that signs in under a non-root PathBase would produce a cookie that /auth/logout
                     // (PathBase="") cannot delete.
@@ -77,6 +77,9 @@ internal static class AuthenticationDependencyInjectionExtensions
                 })
                 .AddOpenIdConnect();
 
+            services.AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
+                .Configure<IHostEnvironment>(ConfigureCookieSecurePolicy);
+
             services.AddOptions<OpenIdConnectOptions>(OpenIdConnectDefaults.AuthenticationScheme)
                 .Configure<IOptions<AuthSystemSettings>>(ConfigureOpenIdConnect);
 
@@ -89,6 +92,23 @@ internal static class AuthenticationDependencyInjectionExtensions
         CookieTokenRefresher refresher = context.HttpContext
             .RequestServices.GetRequiredService<CookieTokenRefresher>();
         return refresher.ValidateAsync(context);
+    }
+
+    /// <summary>
+    /// AUDIT-SEC-10 (#400): outside Development the session cookie is unconditionally <c>Secure</c>.
+    /// <see cref="CookieSecurePolicy.SameAsRequest"/> would tie the flag to <c>Request.Scheme</c>,
+    /// which behind the TLS-terminating proxy is derived from <c>X-Forwarded-Proto</c> — a single
+    /// scheme mismatch would write the cookie without <c>Secure</c> and let the browser send it over
+    /// plain HTTP. Development keeps <see cref="CookieSecurePolicy.SameAsRequest"/> so a plain-HTTP
+    /// local run still produces a cookie the browser accepts.
+    /// </summary>
+    private static void ConfigureCookieSecurePolicy(
+        CookieAuthenticationOptions options,
+        IHostEnvironment environment)
+    {
+        options.Cookie.SecurePolicy = environment.IsDevelopment()
+            ? CookieSecurePolicy.SameAsRequest
+            : CookieSecurePolicy.Always;
     }
 
     private static void ConfigureOpenIdConnect(

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/AuthenticationDependencyInjectionExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/AuthenticationDependencyInjectionExtensionsTests.cs
@@ -1,10 +1,14 @@
 using LotroKoniecDev.Frontend.Infrastructure.Auth;
 using LotroKoniecDev.Frontend.Settings;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using NSubstitute;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Auth;
 
@@ -26,7 +30,50 @@ public sealed class AuthenticationDependencyInjectionExtensionsTests
         options.UsePkce.ShouldBeTrue();
     }
 
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    [InlineData("Testing")]
+    public void AddFrontendAuthentication_CookieOptions_NonDevelopmentEnvironment_RequiresSecureCookieUnconditionally(
+        string environmentName)
+    {
+        CookieAuthenticationOptions options = ResolveConfiguredCookieOptions(environmentName);
+
+        options.Cookie.SecurePolicy.ShouldBe(CookieSecurePolicy.Always);
+    }
+
+    [Fact]
+    public void AddFrontendAuthentication_CookieOptions_DevelopmentEnvironment_UsesSameAsRequest()
+    {
+        CookieAuthenticationOptions options = ResolveConfiguredCookieOptions("Development");
+
+        options.Cookie.SecurePolicy.ShouldBe(CookieSecurePolicy.SameAsRequest);
+    }
+
     private static OpenIdConnectOptions ResolveConfiguredOidcOptions()
+    {
+        ServiceCollection services = CreateFrontendAuthenticationServices();
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        return provider
+            .GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>()
+            .Get(OpenIdConnectDefaults.AuthenticationScheme);
+    }
+
+    private static CookieAuthenticationOptions ResolveConfiguredCookieOptions(string environmentName)
+    {
+        ServiceCollection services = CreateFrontendAuthenticationServices();
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(environmentName);
+        services.AddSingleton(environment);
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        return provider
+            .GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+            .Get(CookieAuthenticationDefaults.AuthenticationScheme);
+    }
+
+    private static ServiceCollection CreateFrontendAuthenticationServices()
     {
         ServiceCollection services = new();
         services.AddLogging();
@@ -41,10 +88,7 @@ public sealed class AuthenticationDependencyInjectionExtensionsTests
             Scopes = ["openid", "email", "profile"],
         }));
         services.AddFrontendAuthentication();
-        using ServiceProvider provider = services.BuildServiceProvider();
 
-        return provider
-            .GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>()
-            .Get(OpenIdConnectDefaults.AuthenticationScheme);
+        return services;
     }
 }


### PR DESCRIPTION
Closes #400

## What

The Frontend session cookie's `SecurePolicy` is now environment-dependent: `Always` outside Development, `SameAsRequest` only in Development. Configured via `AddOptions<CookieAuthenticationOptions>(...).Configure<IHostEnvironment>(...)`, mirroring the existing OIDC options pattern in the same file.

## Why

`SameAsRequest` ties the `Secure` flag to `Request.Scheme`, which behind the TLS-terminating proxy is derived from `X-Forwarded-Proto`. A single scheme mismatch would write the session cookie without `Secure`, letting the browser send it over plain HTTP. Setting `Always` outside Development removes that dependency (companion to AUDIT-SEC-09 / #430). The AuthSystem cookie already uses `Always` unconditionally.

## Tests

- New `[Theory]`: Production/Staging/Testing resolve the cookie scheme options with `SecurePolicy = Always`.
- New `[Fact]`: Development keeps `SameAsRequest` (plain-HTTP host loop unaffected).
- Frontend unit suite: 317 passed; solution build green with zero warnings.

Behind the proxy nothing changes behaviorally — forwarded HTTPS requests already produced a `Secure` cookie; the flag just no longer depends on the header. The Playwright E2E frontend container runs `Development` over HTTPS, so it is also unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)