### PR TITLE
CI-03: Run the E2E suite on Dependabot PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,11 +6,27 @@ name: E2E
 #   - e2e-frontend: additionally builds the Frontend image, boots the whole browser-facing stack (+ Mailpit +
 #                   the official Testcontainers Playwright browser), and drives the register→confirm→login→
 #                   logout loop in a real headless Chromium (ADR-0009).
-# Manual only — never on push/PR — so they cost nothing routinely. Both projects are named `...E2E.Tests`
-# (not `*.Tests.Unit`/`*.Tests.Integration`), so pr-verify/ci skip them by convention.
-# Run from the Actions tab or `gh workflow run e2e.yml`.
+# Both projects are named `...E2E.Tests` (not `*.Tests.Unit`/`*.Tests.Integration`), so pr-verify/ci skip
+# them by convention, and the suite runs automatically in exactly ONE place: Dependabot PRs whose diff
+# touches `Directory.Packages.props`, `.config/dotnet-tools.json` or a `Dockerfile*` (CI-03 / #405).
+# A weekly dependency bump is precisely the moment "does the whole thing still work end to end" is being
+# asked, and on a base-image bump the fixtures rebuild the images themselves — exercising the new base
+# deeper than a build-and-scan can reach. Everywhere else it stays manual (workflow_dispatch, any ref):
+# human PRs never run it (job-level actor gate below), a github-actions bump has nothing for E2E to
+# exercise (paths filter), and it is deliberately NOT in the main ruleset's required checks — it is a
+# signal the author reads before merging, not a gate, so a browser flake cannot block a security patch.
+# The suite references no repository secrets, so it passes with Dependabot's read-only GITHUB_TOKEN.
+# On pull_request the concurrency group resolves to `e2e-refs/pull/<n>/merge`, so a Dependabot rebase
+# force-push cancels the in-flight run instead of queueing a second.
+# Manual run: Actions tab or `gh workflow run e2e.yml`.
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'Directory.Packages.props'
+      - '.config/dotnet-tools.json'
+      - 'Dockerfile*'
+      - '**/Dockerfile*'
 
 concurrency:
   group: e2e-${{ github.ref }}
@@ -22,6 +38,8 @@ permissions:
 jobs:
   e2e:
     name: E2E (full stack via Testcontainers)
+    # Dependabot-only on pull_request; a bare actor gate would also skip manual dispatches.
+    if: github.event_name != 'pull_request' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-24.04
     timeout-minutes: 40
 
@@ -57,6 +75,8 @@ jobs:
 
   e2e-frontend:
     name: E2E Frontend (browser via Testcontainers + Playwright)
+    # Dependabot-only on pull_request; a bare actor gate would also skip manual dispatches.
+    if: github.event_name != 'pull_request' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-24.04
     timeout-minutes: 50
 


### PR DESCRIPTION
Closes #405

## What

`e2e.yml` gains a `pull_request` trigger, paths-filtered to `Directory.Packages.props`, `.config/dotnet-tools.json` and `Dockerfile*` (root **and** nested — the docker ecosystem bumps `src/**/Dockerfile` too), with a job-level gate on both jobs:

```yaml
if: github.event_name != 'pull_request' || github.actor == 'dependabot[bot]'
```

The compound condition (instead of the ticket's bare actor gate) is deliberate: a bare `github.actor == 'dependabot[bot]'` would also skip every human-started `workflow_dispatch`, breaking the "manual dispatch stays intact" criterion.

## Why

A weekly dependency bump is exactly the moment "does the whole thing still work end to end" is being asked — and on a base-image bump the Testcontainers fixtures rebuild the images themselves, exercising the new base deeper than a build-and-scan can. Full rationale is recorded in the workflow header comment.

## Acceptance criteria → how each is met

- **Runs on Dependabot PRs touching the three path families** — `on.pull_request.paths` + the actor gate above.
- **`workflow_dispatch` unchanged, any ref** — the gate passes every non-`pull_request` event.
- **Human PRs never run the suite** — on a human PR touching the paths both jobs skip instantly (0 minutes); PRs not touching the paths don't trigger at all.
- **No repository secrets** — unchanged; the workflow references none and keeps `permissions: contents: read`, so Dependabot's read-only token suffices. ⚠️ Real-Dependabot-PR verification is necessarily **post-merge** (no Dependabot PRs are open right now): on the next Dependabot PR touching `Directory.Packages.props`/`Dockerfile*`, confirm the run appears and passes (a `@dependabot rebase` comment on it forces a `synchronize` against the merged workflow).
- **Not a required check** — verified the `main` ruleset requires only `GitGuardian Security Checks`, `gitleaks`, `Pull Request Verification`; this PR touches no rulesets.
- **Rebase force-push cancels the in-flight run** — on `pull_request` the existing `concurrency: e2e-${{ github.ref }}` group resolves to `refs/pull/<n>/merge`, stable per PR, with `cancel-in-progress: true`.
- **Header comment records the why** — rewritten to cover the Dependabot trigger, the non-gate stance and the concurrency behavior.

## Tests

YAML-only change, no runtime surface. Validated with the same gate CI-02 just added: `actionlint 1.7.12` passes clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)