### PR TITLE
AUDIT-EF-04: Cache the progress/stats counters — the anonymous landing endpoint runs a full GROUP BY per hit

### DIFF
--- a/docs/tms-handbook.md
+++ b/docs/tms-handbook.md
@@ -1049,7 +1049,7 @@ hook). Wanting interactivity means writing an ADR first.
 
 | Route | Who | What it does |
 |---|---|---|
-| `/` | public | Landing page with a live progress meter (approved / awaiting / total) and download links |
+| `/` | public | Landing page with a progress meter (approved / awaiting / total; served from a 30 s server-side snapshot — AUDIT-EF-04/#354) and download links |
 | `/translations` | public | Searchable, filterable, paginated list; per-row Edit link; admin sees bulk-approve checkboxes |
 | `/editor/{id}` | logged in | Side-by-side editor: English (and previous English for NeedsReview) vs Polish; placeholder highlighting and mismatch warning; Save + Approve |
 | `/dashboard` | logged in | Progress tiles: total / translated / approved / remaining |

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Progress/GetPublicProgress.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Progress/GetPublicProgress.cs
@@ -7,6 +7,7 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
 
 namespace LotroKoniecDev.TranslationSystem.API.Features.Progress;
 
@@ -17,23 +18,68 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.Progress;
 /// <see cref="GameVersionStatus.Processed"/> game version. Deliberately a separate, explicitly
 /// anonymous slice rather than an opened-up dashboard endpoint: the public contract stays frozen
 /// while the translator dashboard evolves, and nothing beyond aggregate counters is exposed.
+///
+/// The snapshot is served from a short-TTL <see cref="HybridCache"/> entry (AUDIT-EF-04/#354):
+/// this is the most public, least protected endpoint, and recomputing approximate counters per
+/// anonymous hit only burns compute — within the TTL every request shares one computation.
+/// HTTP-level <c>no-store</c> stays; only the server-side recomputation is deduplicated.
 /// </summary>
 internal sealed class GetPublicProgress : IEndpoint
 {
+    /// <summary>
+    /// The single process-wide snapshot entry — the endpoint is anonymous, so every visitor shares
+    /// the same counters. Internal so the integration-test reset can evict it alongside its TRUNCATE.
+    /// </summary>
+    internal const string CounterCacheKey = "public-progress";
+
     internal sealed record Query : IQuery<Result<PublicProgressResponse>>;
 
     internal sealed class Handler : IQueryHandler<Query, Result<PublicProgressResponse>>
     {
-        private readonly IApplicationReadDbContext _readDbContext;
-
-        public Handler(IApplicationReadDbContext readDbContext)
+        /// <summary>
+        /// Bounded staleness on counters is fine (same philosophy as the ADR-0021 debounce); 30 s
+        /// caps the grouped scan at two per minute regardless of landing-page or bot traffic.
+        /// </summary>
+        private static readonly HybridCacheEntryOptions CounterTtlEntryOptions = new()
         {
-            _readDbContext = readDbContext;
+            Expiration = TimeSpan.FromSeconds(30),
+            LocalCacheExpiration = TimeSpan.FromSeconds(30)
+        };
+
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+        private readonly HybridCache _hybridCache;
+
+        public Handler(IServiceScopeFactory serviceScopeFactory, HybridCache hybridCache)
+        {
+            _serviceScopeFactory = serviceScopeFactory;
+            _hybridCache = hybridCache;
         }
 
         public async ValueTask<Result<PublicProgressResponse>> Handle(Query query, CancellationToken cancellationToken)
         {
-            Dictionary<TranslationStatus, int> countByStatus = await _readDbContext.Translations
+            PublicProgressResponse progress = await _hybridCache.GetOrCreateAsync(
+                CounterCacheKey,
+                this,
+                static (self, ct) => self.ComputeSnapshotAsync(ct),
+                CounterTtlEntryOptions,
+                cancellationToken: cancellationToken);
+
+            return Result.Success(progress);
+        }
+
+        /// <summary>
+        /// Computes on its OWN scope, never the calling request's: HybridCache runs ONE factory for
+        /// all concurrently joined callers, and the initiating request can abort — disposing its
+        /// request-scoped read context — while others stay joined. A fresh scope keeps the shared
+        /// computation alive for the survivors instead of faulting them with a disposed context.
+        /// </summary>
+        private async ValueTask<PublicProgressResponse> ComputeSnapshotAsync(CancellationToken cancellationToken)
+        {
+            await using AsyncServiceScope scope = _serviceScopeFactory.CreateAsyncScope();
+            IApplicationReadDbContext readDbContext =
+                scope.ServiceProvider.GetRequiredService<IApplicationReadDbContext>();
+
+            Dictionary<TranslationStatus, int> countByStatus = await readDbContext.Translations
                 .Where(translation => translation.RemovedInVersion == null)
                 .GroupBy(translation => translation.Status)
                 .Select(group => new { Status = group.Key, Count = group.Count() })
@@ -51,19 +97,17 @@ internal sealed class GetPublicProgress : IEndpoint
 
             // The catalog is current for the newest PROCESSED version: merely-detected (Unprocessed)
             // and skipped-over (Superseded) versions say nothing about the distributed content.
-            string? currentGameVersion = await _readDbContext.GameVersions
+            string? currentGameVersion = await readDbContext.GameVersions
                 .Where(gameVersion => gameVersion.Status == GameVersionStatus.Processed)
                 .OrderByDescending(gameVersion => gameVersion.DetectedAt)
                 .Select(gameVersion => gameVersion.LotroNotationVersion)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            PublicProgressResponse progress = new(
+            return new PublicProgressResponse(
                 Total: total,
                 Translated: translated,
                 Approved: approved,
                 CurrentGameVersion: currentGameVersion);
-
-            return Result.Success(progress);
         }
     }
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslationStats.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslationStats.cs
@@ -7,6 +7,7 @@ using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
 
 namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
 
@@ -16,23 +17,67 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
 /// amendment) — with a single grouped count per <see cref="TranslationStatus"/>, then buckets in
 /// memory, so it stays one cheap round-trip regardless of catalog size. Counters only, by design
 /// (YAGNI — not analytics).
+///
+/// Served from a short-TTL <see cref="HybridCache"/> entry (AUDIT-EF-04/#354) under its own key —
+/// deliberately not shared with <see cref="Progress.GetPublicProgress"/>: the slices stay
+/// independent and their responses differ; the cost is one extra grouped scan per TTL window.
 /// </summary>
 internal sealed class GetTranslationStats : IEndpoint
 {
+    /// <summary>
+    /// One entry for the whole dashboard — the counters are catalog-wide, not per user. Internal so
+    /// the integration-test reset can evict it alongside its TRUNCATE.
+    /// </summary>
+    internal const string CounterCacheKey = "translation-stats";
+
     internal sealed record Query : IQuery<Result<TranslationStatsResponse>>;
 
     internal sealed class Handler : IQueryHandler<Query, Result<TranslationStatsResponse>>
     {
-        private readonly IApplicationReadDbContext _readDbContext;
-
-        public Handler(IApplicationReadDbContext readDbContext)
+        /// <summary>
+        /// Bounded staleness on counters is fine (same philosophy as the ADR-0021 debounce); 30 s
+        /// keeps the dashboard responsive after an approve while deduplicating request bursts.
+        /// </summary>
+        private static readonly HybridCacheEntryOptions CounterTtlEntryOptions = new()
         {
-            _readDbContext = readDbContext;
+            Expiration = TimeSpan.FromSeconds(30),
+            LocalCacheExpiration = TimeSpan.FromSeconds(30)
+        };
+
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+        private readonly HybridCache _hybridCache;
+
+        public Handler(IServiceScopeFactory serviceScopeFactory, HybridCache hybridCache)
+        {
+            _serviceScopeFactory = serviceScopeFactory;
+            _hybridCache = hybridCache;
         }
 
         public async ValueTask<Result<TranslationStatsResponse>> Handle(Query query, CancellationToken cancellationToken)
         {
-            Dictionary<TranslationStatus, int> countByStatus = await _readDbContext.Translations
+            TranslationStatsResponse stats = await _hybridCache.GetOrCreateAsync(
+                CounterCacheKey,
+                this,
+                static (self, ct) => self.ComputeStatsAsync(ct),
+                CounterTtlEntryOptions,
+                cancellationToken: cancellationToken);
+
+            return Result.Success(stats);
+        }
+
+        /// <summary>
+        /// Computes on its OWN scope, never the calling request's: HybridCache runs ONE factory for
+        /// all concurrently joined callers, and the initiating request can abort — disposing its
+        /// request-scoped read context — while others stay joined. A fresh scope keeps the shared
+        /// computation alive for the survivors instead of faulting them with a disposed context.
+        /// </summary>
+        private async ValueTask<TranslationStatsResponse> ComputeStatsAsync(CancellationToken cancellationToken)
+        {
+            await using AsyncServiceScope scope = _serviceScopeFactory.CreateAsyncScope();
+            IApplicationReadDbContext readDbContext =
+                scope.ServiceProvider.GetRequiredService<IApplicationReadDbContext>();
+
+            Dictionary<TranslationStatus, int> countByStatus = await readDbContext.Translations
                 .Where(translation => translation.RemovedInVersion == null)
                 .GroupBy(translation => translation.Status)
                 .Select(group => new { Status = group.Key, Count = group.Count() })
@@ -51,13 +96,11 @@ internal sealed class GetTranslationStats : IEndpoint
                 + approved
                 + countByStatus.GetValueOrDefault(TranslationStatus.NeedsReview);
 
-            TranslationStatsResponse stats = new(
+            return new TranslationStatsResponse(
                 Total: total,
                 Translated: translated,
                 Approved: approved,
                 Remaining: total - approved);
-
-            return Result.Success(stats);
         }
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Progress/GetPublicProgressTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Progress/GetPublicProgressTests.cs
@@ -144,6 +144,23 @@ public sealed class GetPublicProgressTests : IAsyncLifetime
         progress.CurrentGameVersion.ShouldBeNull();
     }
 
+    [Fact]
+    public async Task Progress_RepeatedWithinTtl_ShouldNotRerunTheCounterQueries()
+    {
+        // Arrange — the first call populates the server-side cache (AUDIT-EF-04/#354).
+        await SeedAsync(Row(1, "a", TranslationStatus.Approved), Row(2, "b"));
+        PublicProgressResponse first = await ProgressAsync();
+        _factory.ReadContextSqlRecorder.Clear();
+
+        // Act
+        PublicProgressResponse second = await ProgressAsync();
+
+        // Assert — served entirely from the cache: identical payload and zero read-context SQL
+        // (the recorded command stream is the only seam that can prove "no second query").
+        second.ShouldBe(first);
+        _factory.ReadContextSqlRecorder.Commands.ShouldBeEmpty();
+    }
+
     /// <summary>Anonymous by construction: the shared helper never attaches a bearer token.</summary>
     private async Task<PublicProgressResponse> ProgressAsync()
     {

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationStatsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/GetTranslationStatsTests.cs
@@ -125,6 +125,23 @@ public sealed class GetTranslationStatsTests : IAsyncLifetime
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
 
+    [Fact]
+    public async Task Stats_RepeatedWithinTtl_ShouldNotRerunTheCounterQuery()
+    {
+        // Arrange — the first call populates the server-side cache (AUDIT-EF-04/#354).
+        await SeedAsync(Row(1, "a", TranslationStatus.Approved), Row(2, "b"));
+        TranslationStatsResponse first = await StatsAsync();
+        _factory.ReadContextSqlRecorder.Clear();
+
+        // Act
+        TranslationStatsResponse second = await StatsAsync();
+
+        // Assert — served entirely from the cache: identical payload and zero read-context SQL
+        // (translator provisioning touches only the write context, so the read stream stays clean).
+        second.ShouldBe(first);
+        _factory.ReadContextSqlRecorder.Commands.ShouldBeEmpty();
+    }
+
     private async Task<TranslationStatsResponse> StatsAsync()
     {
         HttpResponseMessage response = await TranslatorClient().GetAsync("/api/v1/translations/stats");

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -10,7 +11,9 @@ using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Testcontainers.PostgreSql;
 using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.API.Features.Progress;
 using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.API.Features.Translations;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 
@@ -95,11 +98,16 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
     /// (PERF-04, ADR-0021), then truncates the given tables. The quiesce is fused into the reset —
     /// never an opt-in pairing — because a rebuild still in flight from the previous class's writes
     /// would re-materialize an artifact row right after the TRUNCATE and poison assertions such as
-    /// the "no artifact yet" 404.
+    /// the "no artifact yet" 404. Evicting the counter-cache entries (AUDIT-EF-04/#354) is fused in
+    /// for the same reason: a cached snapshot outlives the TRUNCATE and would leak the previous
+    /// test's counters into the next one.
     /// </summary>
     public async Task ResetDatabaseAsync(string truncateSql)
     {
         await WaitForArtifactRebuildQuiesceAsync();
+
+        HybridCache hybridCache = Services.GetRequiredService<HybridCache>();
+        await hybridCache.RemoveAsync([GetPublicProgress.CounterCacheKey, GetTranslationStats.CounterCacheKey]);
 
         using IServiceScope scope = Services.CreateScope();
         ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/FakeReadDbContext.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/FakeReadDbContext.cs
@@ -11,20 +11,25 @@ using NSubstitute;
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Shared;
 
 /// <summary>
-/// A pure in-memory <see cref="IApplicationReadDbContext"/> double for unit-testing the write
-/// handlers' read-back projection: only the <see cref="Translations"/> set is populated (the only
-/// one the write handlers read). EF Core's async operators run via <see cref="TestAsyncQueryProvider{T}"/>.
+/// A pure in-memory <see cref="IApplicationReadDbContext"/> double for unit-testing read-side
+/// handlers: <see cref="Translations"/> is always populated, <see cref="GameVersions"/> optionally
+/// (the public progress snapshot reads both). EF Core's async operators run via
+/// <see cref="TestAsyncQueryProvider{T}"/>.
 /// </summary>
 internal sealed class FakeReadDbContext : IApplicationReadDbContext
 {
     private readonly List<TranslationReadModel> _translations;
+    private readonly List<GameVersionReadModel> _gameVersions;
 
-    public FakeReadDbContext(IEnumerable<TranslationReadModel> translations)
+    public FakeReadDbContext(
+        IEnumerable<TranslationReadModel> translations,
+        IEnumerable<GameVersionReadModel>? gameVersions = null)
     {
         _translations = [.. translations];
+        _gameVersions = [.. gameVersions ?? []];
     }
 
-    public DbSet<GameVersionReadModel> GameVersions => BuildSet(new List<GameVersionReadModel>());
+    public DbSet<GameVersionReadModel> GameVersions => BuildSet(_gameVersions);
 
     public DbSet<TranslationReadModel> Translations => BuildSet(_translations);
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/TestHybridCache.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/TestHybridCache.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Shared;
+
+/// <summary>
+/// Builds a fresh in-memory (L1-only) <see cref="HybridCache"/> per test: the default real
+/// implementation is a purely in-process memory store, so unit tests stay pure (no I/O) while
+/// exercising the genuine cache semantics (entry options, stampede protection, eviction).
+/// </summary>
+internal static class TestHybridCache
+{
+    public static HybridCache Create()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/TestReadScopeFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/TestReadScopeFactory.cs
@@ -1,0 +1,20 @@
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Shared;
+
+/// <summary>
+/// Wraps an <see cref="IApplicationReadDbContext"/> double in a real <see cref="IServiceScopeFactory"/>:
+/// the cached-counter handlers resolve their read context from a fresh scope per computation (so a
+/// joined caller never observes the initiating request's disposed context), and the unit seam hands
+/// them that scope machinery around the in-memory fake — still pure, no I/O.
+/// </summary>
+internal static class TestReadScopeFactory
+{
+    public static IServiceScopeFactory Create(IApplicationReadDbContext readDbContext)
+    {
+        ServiceCollection services = new();
+        services.AddScoped<IApplicationReadDbContext>(_ => readDbContext);
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/TranslatorProvisionerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/TranslatorProvisionerTests.cs
@@ -9,7 +9,6 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
-using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
@@ -29,20 +28,10 @@ public sealed class TranslatorProvisionerTests
         => Translator.Create(Identity, DisplayName.Create(displayName).Value, email: null, Now).Value;
 
     private TranslatorProvisioner CreateProvisioner(StubCurrentUserAccessor accessor)
-        => CreateProvisioner(accessor, CreateHybridCache());
+        => CreateProvisioner(accessor, TestHybridCache.Create());
 
     private TranslatorProvisioner CreateProvisioner(StubCurrentUserAccessor accessor, HybridCache hybridCache)
         => new(accessor, _translatorRepository, _unitOfWork, new FixedTimeProvider(Now), hybridCache);
-
-    // A fresh in-memory (L1-only) HybridCache per provisioner keeps each test isolated. The default
-    // real implementation is a purely in-process memory store, so the unit test stays pure (no I/O).
-    private static HybridCache CreateHybridCache()
-    {
-        ServiceCollection services = new();
-        services.AddLogging();
-        services.AddHybridCache();
-        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
-    }
 
     private static StubCurrentUserAccessor Accessor(
         ValueMaybe<IdentityId>? identity = null,
@@ -288,7 +277,7 @@ public sealed class TranslatorProvisionerTests
             Now).Value;
         _translatorRepository.GetByIdentityIdAsync(Identity, Arg.Any<CancellationToken>())
             .Returns(Maybe<Translator>.From(existing));
-        HybridCache sharedCache = CreateHybridCache();
+        HybridCache sharedCache = TestHybridCache.Create();
         TranslatorProvisioner firstRequest =
             CreateProvisioner(Accessor(username: firstName, email: firstEmail), sharedCache);
         TranslatorProvisioner secondRequest =

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Progress/GetPublicProgressHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Progress/GetPublicProgressHandlerTests.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.TranslationSystem.API.Features.Progress;
+using LotroKoniecDev.TranslationSystem.API.Tests.Unit.Shared;
+using LotroKoniecDev.TranslationSystem.Contracts.Progress;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Progress;
+
+public sealed class GetPublicProgressHandlerTests
+{
+    private const int FileId = 620756992;
+    private static readonly DateTimeOffset Now = new(2026, 7, 10, 0, 0, 0, TimeSpan.Zero);
+    private static readonly GameVersionId VersionId = GameVersionId.Create();
+
+    private readonly List<TranslationReadModel> _readModels = [];
+    private readonly List<GameVersionReadModel> _gameVersions = [];
+
+    [Fact]
+    public async Task Handle_WithMixedCatalog_ShouldBucketCountersAndPickTheNewestProcessedVersion()
+    {
+        // Arrange — 1 untranslated, 1 draft, 2 approved, 1 needs-review; the newest version is
+        // merely detected, so the older processed one is the current catalog version.
+        Given(1, TranslationStatus.Untranslated);
+        Given(2, TranslationStatus.Draft);
+        Given(3, TranslationStatus.Approved);
+        Given(4, TranslationStatus.Approved);
+        Given(5, TranslationStatus.NeedsReview);
+        GivenVersion("48.1", Now.AddDays(-1), GameVersionStatus.Processed);
+        GivenVersion("48.2", Now, GameVersionStatus.Unprocessed);
+
+        // Act
+        PublicProgressResponse progress = await HandleAsync();
+
+        // Assert
+        progress.Total.ShouldBe(5);
+        progress.Translated.ShouldBe(4);
+        progress.Approved.ShouldBe(2);
+        progress.CurrentGameVersion.ShouldBe("48.1");
+    }
+
+    [Fact]
+    public async Task Handle_SecondCallWithinTtl_ShouldServeTheSnapshotFromCacheWithoutRequerying()
+    {
+        // Arrange — two handlers share one cache but read different catalogs: a second database
+        // read would surface the grown catalog, so an identical snapshot proves the cache served it.
+        HybridCache hybridCache = TestHybridCache.Create();
+        Given(1, TranslationStatus.Approved);
+        GetPublicProgress.Handler first = new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels, _gameVersions)), hybridCache);
+        Given(2, TranslationStatus.Draft);
+        GivenVersion("48.1", Now, GameVersionStatus.Processed);
+        GetPublicProgress.Handler second = new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels, _gameVersions)), hybridCache);
+
+        // Act
+        Result<PublicProgressResponse> initial =
+            await first.Handle(new GetPublicProgress.Query(), CancellationToken.None);
+        Result<PublicProgressResponse> cached =
+            await second.Handle(new GetPublicProgress.Query(), CancellationToken.None);
+
+        // Assert — the whole snapshot is one entry: the version lookup is deduplicated with the
+        // counters, so the cached response still carries the first computation's null version.
+        initial.IsSuccess.ShouldBeTrue();
+        cached.IsSuccess.ShouldBeTrue();
+        cached.Value.ShouldBe(initial.Value);
+        cached.Value.Total.ShouldBe(1);
+        cached.Value.CurrentGameVersion.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_AfterTheEntryExpires_ShouldRecomputeTheSnapshotFromTheLiveCatalog()
+    {
+        // Arrange — eviction is the state HybridCache reaches once the TTL lapses (the expiry timer
+        // itself is HybridCache's contract); the handler must then recompute, not hold on.
+        HybridCache hybridCache = TestHybridCache.Create();
+        Given(1, TranslationStatus.Approved);
+        GetPublicProgress.Handler first = new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels, _gameVersions)), hybridCache);
+        Given(2, TranslationStatus.Draft);
+        GivenVersion("48.1", Now, GameVersionStatus.Processed);
+        GetPublicProgress.Handler second = new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels, _gameVersions)), hybridCache);
+        Result<PublicProgressResponse> initial =
+            await first.Handle(new GetPublicProgress.Query(), CancellationToken.None);
+        initial.Value.Total.ShouldBe(1);
+
+        // Act
+        await hybridCache.RemoveAsync(GetPublicProgress.CounterCacheKey);
+        Result<PublicProgressResponse> refreshed =
+            await second.Handle(new GetPublicProgress.Query(), CancellationToken.None);
+
+        // Assert
+        refreshed.IsSuccess.ShouldBeTrue();
+        refreshed.Value.Total.ShouldBe(2);
+        refreshed.Value.Translated.ShouldBe(2);
+        refreshed.Value.CurrentGameVersion.ShouldBe("48.1");
+    }
+
+    private async Task<PublicProgressResponse> HandleAsync()
+    {
+        GetPublicProgress.Handler handler =
+            new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels, _gameVersions)), TestHybridCache.Create());
+
+        Result<PublicProgressResponse> result =
+            await handler.Handle(new GetPublicProgress.Query(), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        return result.Value;
+    }
+
+    private void Given(int gossipId, TranslationStatus status, bool removed = false)
+        => _readModels.Add(new TranslationReadModel(
+            TranslationId.Create(),
+            FileId,
+            gossipId,
+            $"source-{gossipId}",
+            null,
+            null,
+            status == TranslationStatus.Untranslated ? null : "Polski tekst",
+            null,
+            null,
+            null,
+            status,
+            VersionId,
+            null,
+            removed ? VersionId : null,
+            Now,
+            Now));
+
+    private void GivenVersion(string notation, DateTimeOffset detectedAt, GameVersionStatus status)
+        => _gameVersions.Add(new GameVersionReadModel(GameVersionId.Create(), notation, detectedAt, status));
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/GetTranslationStatsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/GetTranslationStatsHandlerTests.cs
@@ -7,6 +7,7 @@ using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregat
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
+using Microsoft.Extensions.Caching.Hybrid;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Translations;
 
@@ -89,9 +90,59 @@ public sealed class GetTranslationStatsHandlerTests
         stats.Remaining.ShouldBe(3);
     }
 
+    [Fact]
+    public async Task Handle_SecondCallWithinTtl_ShouldServeCountersFromCacheWithoutRequerying()
+    {
+        // Arrange — two handlers share one cache but read different catalogs: a second database
+        // read would surface the grown catalog, so identical counters prove the cache served it.
+        HybridCache hybridCache = TestHybridCache.Create();
+        Given(1, TranslationStatus.Approved);
+        GetTranslationStats.Handler first = new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels)), hybridCache);
+        Given(2, TranslationStatus.Draft);
+        GetTranslationStats.Handler second = new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels)), hybridCache);
+
+        // Act
+        Result<TranslationStatsResponse> initial =
+            await first.Handle(new GetTranslationStats.Query(), CancellationToken.None);
+        Result<TranslationStatsResponse> cached =
+            await second.Handle(new GetTranslationStats.Query(), CancellationToken.None);
+
+        // Assert
+        initial.IsSuccess.ShouldBeTrue();
+        cached.IsSuccess.ShouldBeTrue();
+        cached.Value.ShouldBe(initial.Value);
+        cached.Value.Total.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Handle_AfterTheEntryExpires_ShouldRecomputeCountersFromTheLiveCatalog()
+    {
+        // Arrange — eviction is the state HybridCache reaches once the TTL lapses (the expiry timer
+        // itself is HybridCache's contract); the handler must then recompute, not hold on.
+        HybridCache hybridCache = TestHybridCache.Create();
+        Given(1, TranslationStatus.Approved);
+        GetTranslationStats.Handler first = new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels)), hybridCache);
+        Given(2, TranslationStatus.Draft);
+        GetTranslationStats.Handler second = new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels)), hybridCache);
+        Result<TranslationStatsResponse> initial =
+            await first.Handle(new GetTranslationStats.Query(), CancellationToken.None);
+        initial.Value.Total.ShouldBe(1);
+
+        // Act
+        await hybridCache.RemoveAsync(GetTranslationStats.CounterCacheKey);
+        Result<TranslationStatsResponse> refreshed =
+            await second.Handle(new GetTranslationStats.Query(), CancellationToken.None);
+
+        // Assert
+        refreshed.IsSuccess.ShouldBeTrue();
+        refreshed.Value.Total.ShouldBe(2);
+        refreshed.Value.Translated.ShouldBe(2);
+        refreshed.Value.Approved.ShouldBe(1);
+    }
+
     private async Task<TranslationStatsResponse> HandleAsync()
     {
-        GetTranslationStats.Handler handler = new(new FakeReadDbContext(_readModels));
+        GetTranslationStats.Handler handler = new(TestReadScopeFactory.Create(new FakeReadDbContext(_readModels)), TestHybridCache.Create());
 
         Result<TranslationStatsResponse> result =
             await handler.Handle(new GetTranslationStats.Query(), CancellationToken.None);


### PR DESCRIPTION
Closes #354

## What

Wraps both counter handlers — the anonymous `GET /api/v1/progress` (landing page) and the authorized `GET /api/v1/translations/stats` (dashboard) — in the already-registered L1-only `HybridCache` with a 30 s TTL, mirroring the PERF-07 `TranslatorProvisioner` call-site pattern. HTTP `no-store` behavior is unchanged; only the server-side recomputation is deduplicated.

## Why

Every hit ran the full `GROUP BY Status` over all active Translations (~800k rows) on 0.25 vCPU against Neon Free, where compute hours are the budget. Counters are approximate by nature, so recomputing them per anonymous request bought nothing. 30 s (the ticket's lower bound) caps the grouped scan at two per minute per slice while keeping the dashboard responsive after an approve.

## Decisions (per acceptance criteria)

- **Own cache entry per slice, not shared:** the slices stay independent (VSA), their responses differ (`CurrentGameVersion` vs `Remaining`), and the cost is one extra grouped scan per TTL window.
- **Fresh DI scope in the cache factory:** HybridCache runs ONE factory for all concurrently joined callers, so the factory must not capture the initiating request's scoped read context — an aborted request would fault the joined survivors with a disposed context. Found by code review; the `TranslatorProvisioner` twin of this race is tracked as #435.
- **Integration-test isolation:** `ResetDatabaseAsync` now evicts both counter entries alongside its TRUNCATE (fused, like the artifact-rebuild quiesce).

## Tests

- Unit: cache-seam tests for both handlers — second call within the TTL returns the first snapshot even though the catalog grew; after eviction (the state TTL expiry produces) the handler recomputes from the live catalog. New `GetPublicProgressHandlerTests` (the slice had integration-only coverage).
- Integration: repeated GET within the TTL executes **zero** read-context SQL, asserted via the `SqlCommandRecorder` seam, with identical payloads.
- Suites: build 0 warnings; TMS API unit 169/169; TMS API integration 193/193; patcher unit 276/276. `code-reviewer` verdict: APPROVE (after the fresh-scope fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)