### PR TITLE
AUDIT-EF-04 follow-up: TranslatorProvisioner's HybridCache factory runs on the initiating request's scoped dependencies

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/Provisioning/TranslatorProvisioner.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Auth/Provisioning/TranslatorProvisioner.cs
@@ -45,21 +45,18 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
     };
 
     private readonly ICurrentUserAccessor _currentUserAccessor;
-    private readonly ITranslatorRepository _translatorRepository;
-    private readonly IUnitOfWork _unitOfWork;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly TimeProvider _timeProvider;
     private readonly HybridCache _hybridCache;
 
     public TranslatorProvisioner(
         ICurrentUserAccessor currentUserAccessor,
-        ITranslatorRepository translatorRepository,
-        IUnitOfWork unitOfWork,
+        IServiceScopeFactory serviceScopeFactory,
         TimeProvider timeProvider,
         HybridCache hybridCache)
     {
         _currentUserAccessor = currentUserAccessor;
-        _translatorRepository = translatorRepository;
-        _unitOfWork = unitOfWork;
+        _serviceScopeFactory = serviceScopeFactory;
         _timeProvider = timeProvider;
         _hybridCache = hybridCache;
     }
@@ -160,7 +157,12 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
     /// <summary>
     /// The authoritative database resolution: returns the existing translator's id (refreshing its
     /// profile only when the claims actually changed) or creates a new row, re-reading the committed
-    /// row on a concurrent first-write race.
+    /// row on a concurrent first-write race. Runs the whole get-or-create write on its OWN scope,
+    /// never the calling request's (#435, mirroring #354): HybridCache runs ONE factory for all
+    /// concurrently joined callers, and the initiating request can abort — disposing its request
+    /// scope — while others stay joined. A fresh scope keeps the shared resolution alive for the
+    /// survivors instead of faulting them with a disposed context, and owning the unit of work here
+    /// means nothing this method tracks or saves ever leaks into a caller's pending changes.
     /// </summary>
     private async ValueTask<Result<TranslatorId>> ResolveAsync(
         IdentityId identityId,
@@ -168,9 +170,14 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
         Email? email,
         CancellationToken cancellationToken)
     {
+        await using AsyncServiceScope scope = _serviceScopeFactory.CreateAsyncScope();
+        ITranslatorRepository translatorRepository =
+            scope.ServiceProvider.GetRequiredService<ITranslatorRepository>();
+        IUnitOfWork unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
         DateTimeOffset now = _timeProvider.GetUtcNow();
 
-        Maybe<Translator> existing = await _translatorRepository.GetByIdentityIdAsync(identityId, cancellationToken);
+        Maybe<Translator> existing = await translatorRepository.GetByIdentityIdAsync(identityId, cancellationToken);
         if (existing.HasValue)
         {
             Translator translator = existing.Value;
@@ -182,7 +189,7 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
             if (claimsChanged)
             {
                 translator.RefreshProfile(displayName, email);
-                await _unitOfWork.SaveChangesAsync(cancellationToken);
+                await unitOfWork.SaveChangesAsync(cancellationToken);
             }
 
             return Result.Success(translator.Id);
@@ -194,29 +201,30 @@ internal sealed class TranslatorProvisioner : ITranslatorProvisioner
             return Result.Failure<TranslatorId>(createResult.Error);
         }
 
-        _translatorRepository.Insert(createResult.Value);
+        translatorRepository.Insert(createResult.Value);
 
         try
         {
-            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            await unitOfWork.SaveChangesAsync(cancellationToken);
             return Result.Success(createResult.Value.Id);
         }
         catch (DbUpdateException)
         {
             // Concurrent first-write race: another request inserted the row between our read and save.
-            // Drop our rejected insert from change tracking first — otherwise the retry below, and the
-            // caller's shared unit of work, would re-attempt the row the unique index already rejected
-            // — then re-read the committed row and refresh it.
-            _translatorRepository.Detach(createResult.Value);
+            // Drop our rejected insert from change tracking first — otherwise the retry below would
+            // re-attempt the row the unique index already rejected — then re-read the committed row
+            // and refresh it. The unit of work is owned by this scope, so the rejected insert can
+            // never re-fire on a caller's save.
+            translatorRepository.Detach(createResult.Value);
 
-            Maybe<Translator> raced = await _translatorRepository.GetByIdentityIdAsync(identityId, cancellationToken);
+            Maybe<Translator> raced = await translatorRepository.GetByIdentityIdAsync(identityId, cancellationToken);
             if (raced.HasNoValue)
             {
                 throw;
             }
 
             raced.Value.RefreshProfile(displayName, email);
-            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            await unitOfWork.SaveChangesAsync(cancellationToken);
             return Result.Success(raced.Value.Id);
         }
     }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslatorAggregate/Repositories/ITranslatorRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslatorAggregate/Repositories/ITranslatorRepository.cs
@@ -16,8 +16,8 @@ public interface ITranslatorRepository : IRepository<Translator, TranslatorId>
 
     /// <summary>
     /// Drops a not-yet-committed translator from change tracking. Used to discard the losing insert
-    /// after a concurrent first-write race (ADR-0004) so neither the retry nor the caller's shared
-    /// unit of work re-attempts the row the unique index already rejected.
+    /// after a concurrent first-write race (ADR-0004) so the provisioner's retry does not re-attempt
+    /// the row the unique index already rejected.
     /// </summary>
     void Detach(Translator translator);
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/TestWriteScopeFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/TestWriteScopeFactory.cs
@@ -1,0 +1,23 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Repositories;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Shared;
+
+/// <summary>
+/// Wraps repository/unit-of-work doubles in a real <see cref="IServiceScopeFactory"/> — the write
+/// twin of <see cref="TestReadScopeFactory"/>: the translator provisioner resolves its authoritative
+/// get-or-create write from a fresh scope per resolution (so a joined caller never observes the
+/// initiating request's disposed context), and the unit seam hands it that scope machinery around
+/// the substitutes — still pure, no I/O.
+/// </summary>
+internal static class TestWriteScopeFactory
+{
+    public static IServiceScopeFactory Create(ITranslatorRepository translatorRepository, IUnitOfWork unitOfWork)
+    {
+        ServiceCollection services = new();
+        services.AddScoped<ITranslatorRepository>(_ => translatorRepository);
+        services.AddScoped<IUnitOfWork>(_ => unitOfWork);
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/TranslatorProvisionerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Auth/TranslatorProvisionerTests.cs
@@ -31,7 +31,11 @@ public sealed class TranslatorProvisionerTests
         => CreateProvisioner(accessor, TestHybridCache.Create());
 
     private TranslatorProvisioner CreateProvisioner(StubCurrentUserAccessor accessor, HybridCache hybridCache)
-        => new(accessor, _translatorRepository, _unitOfWork, new FixedTimeProvider(Now), hybridCache);
+        => new(
+            accessor,
+            TestWriteScopeFactory.Create(_translatorRepository, _unitOfWork),
+            new FixedTimeProvider(Now),
+            hybridCache);
 
     private static StubCurrentUserAccessor Accessor(
         ValueMaybe<IdentityId>? identity = null,
@@ -317,6 +321,93 @@ public sealed class TranslatorProvisionerTests
         // insert attempt), proving no cached entry short-circuited it.
         second.IsSuccess.ShouldBeTrue();
         _translatorRepository.Received(2).Insert(Arg.Any<Translator>());
+    }
+
+    [Fact]
+    public async Task ProvisionCurrentAsync_WhenConcurrentRequestsRaceOnAColdCache_ShouldShareOneResolution()
+    {
+        // Arrange — two scoped requests of the same identity hit a cold shared cache concurrently:
+        // HybridCache's stampede protection must funnel both through ONE authoritative resolution.
+        // The repository blocks inside the factory until the gate opens, pinning the overlap.
+        Translator existing = Translator.Create(
+            Identity,
+            DisplayName.Create("Aragorn").Value,
+            Email.Create("aragorn@gondor.test").Value,
+            Now).Value;
+        TaskCompletionSource resolutionStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource resolutionGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        _translatorRepository.GetByIdentityIdAsync(Identity, Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                resolutionStarted.TrySetResult();
+                await resolutionGate.Task;
+                return Maybe<Translator>.From(existing);
+            });
+        HybridCache sharedCache = TestHybridCache.Create();
+        TranslatorProvisioner firstRequest = CreateProvisioner(Accessor(), sharedCache);
+        TranslatorProvisioner secondRequest = CreateProvisioner(Accessor(), sharedCache);
+
+        // Act — the first request enters the factory and blocks; the second arrives while it is in
+        // flight; then the gate releases the shared resolution for both.
+        Task<Result<TranslatorId>> first = firstRequest.ProvisionCurrentAsync(CancellationToken.None).AsTask();
+        await resolutionStarted.Task;
+        Task<Result<TranslatorId>> second = secondRequest.ProvisionCurrentAsync(CancellationToken.None).AsTask();
+        resolutionGate.SetResult();
+        Result<TranslatorId> firstResult = await first;
+        Result<TranslatorId> secondResult = await second;
+
+        // Assert — both callers resolve the same id off a single Translators lookup; nothing in the
+        // returned ids distinguishes a shared factory from two racing ones, so the call count is the
+        // only proof the resolution was deduplicated.
+        firstResult.IsSuccess.ShouldBeTrue();
+        secondResult.IsSuccess.ShouldBeTrue();
+        firstResult.Value.ShouldBe(existing.Id);
+        secondResult.Value.ShouldBe(existing.Id);
+        await _translatorRepository.Received(1).GetByIdentityIdAsync(Identity, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProvisionCurrentAsync_WhenInitiatingRequestAbortsWhileAnotherIsJoined_ShouldResolveTheSurvivor()
+    {
+        // Arrange — the #435 scenario: the request that started the shared factory aborts while a
+        // second request of the same identity is joined to it. The resolution must not depend on
+        // anything the aborted request owned, so the survivor still gets the id, never a fault.
+        Translator existing = Translator.Create(
+            Identity,
+            DisplayName.Create("Aragorn").Value,
+            Email.Create("aragorn@gondor.test").Value,
+            Now).Value;
+        TaskCompletionSource resolutionStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource resolutionGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        _translatorRepository.GetByIdentityIdAsync(Identity, Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                resolutionStarted.TrySetResult();
+                await resolutionGate.Task;
+                return Maybe<Translator>.From(existing);
+            });
+        HybridCache sharedCache = TestHybridCache.Create();
+        TranslatorProvisioner firstRequest = CreateProvisioner(Accessor(), sharedCache);
+        TranslatorProvisioner secondRequest = CreateProvisioner(Accessor(), sharedCache);
+        using CancellationTokenSource initiatingRequestAborted = new();
+
+        // Act — the initiating request enters the factory and blocks, the survivor joins the
+        // in-flight resolution, then the initiator aborts BEFORE the gate opens: its own call
+        // surfaces the cancellation while the shared factory keeps running for the survivor.
+        Task<Result<TranslatorId>> initiating =
+            firstRequest.ProvisionCurrentAsync(initiatingRequestAborted.Token).AsTask();
+        await resolutionStarted.Task;
+        Task<Result<TranslatorId>> survivor = secondRequest.ProvisionCurrentAsync(CancellationToken.None).AsTask();
+        initiatingRequestAborted.Cancel();
+        await Should.ThrowAsync<OperationCanceledException>(async () => await initiating);
+        resolutionGate.SetResult();
+        Result<TranslatorId> survivorResult = await survivor;
+
+        // Assert — the survivor resolves off the single shared lookup the aborted initiator started:
+        // the call count proves it consumed that factory's result rather than re-running its own.
+        survivorResult.IsSuccess.ShouldBeTrue();
+        survivorResult.Value.ShouldBe(existing.Id);
+        await _translatorRepository.Received(1).GetByIdentityIdAsync(Identity, Arg.Any<CancellationToken>());
     }
 
     private sealed class FixedTimeProvider : TimeProvider


### PR DESCRIPTION
Closes #435

## What

`TranslatorProvisioner.ResolveAsync` (the authoritative get-or-create path) no longer uses the request-scoped `ITranslatorRepository` / `IUnitOfWork` injected at construction. It resolves both from a fresh `AsyncServiceScope` (`IServiceScopeFactory`) that owns the whole read+write, mirroring the #354 fix for the counter endpoints. The fast path (cache hit within TTL) is untouched. The stale "caller's shared unit of work" rationale on `ITranslatorRepository.Detach` was updated — the rejected insert can no longer re-fire on a caller's save, only the in-scope retry matters.

## Why

The HybridCache factory is stampede-shared: one factory runs for all concurrently joined callers of the same identity. If the initiating request aborted (its DI scope disposed) while another request was still joined, the survivor faulted on a disposed scoped context and got a transient 500. The factory now touches only singletons (`IServiceScopeFactory`, `TimeProvider`) and immutable value state, so no caller's request lifetime can fault the shared resolution. Side benefit: the provisioner's write can no longer flush a handler's half-staged changes through the shared request UoW.

## Acceptance criteria

- **Factory no longer touches request-scoped services** — structural: the scoped ctor dependencies are gone; `ICurrentUserAccessor` (scoped) is read only before `GetOrCreateAsync`.
- **Existing `TranslatorProvisionerTests` green with assertions untouched** — only the `CreateProvisioner` arrange helper adapted (new `TestWriteScopeFactory`, the write twin of `TestReadScopeFactory`); every pre-existing test body is byte-identical.
- **Joined-caller-after-abort covered by a test** — `ProvisionCurrentAsync_WhenInitiatingRequestAbortsWhileAnotherIsJoined_ShouldResolveTheSurvivor` runs against the real `DefaultHybridCache`: the initiator cancels while blocked in the factory, gets `OperationCanceledException`, and the joined survivor resolves off the single shared lookup. Plus a cold-cache stampede-share test.

## Residual risk (recorded per AC)

The unit test pins the survivor semantics (abort + shared factory + single lookup) but cannot reproduce the original disposed-DbContext fault literally — NSubstitute doubles are not disposable, and the true repro needs real DI scope disposal mid-request. The defense is by construction: the factory can no longer reference request-scoped services at the type level, and integration + E2E suites exercise the real DI wiring.

## Tests

- `dotnet build LotroKoniecDev.slnx` — 0 warnings
- API unit 171/171, API integration (real PostgreSQL) 193/193, patcher unit 276/276, Domain 145/145, SharedKernel 69/69
- Both new concurrency tests ran 40x total (30 author + 10 review) without a flake
- `code-reviewer` gate: APPROVE, no required fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)