### PR TITLE
AUDIT-EF-05: Index (and FK) the three GameVersion pointer columns on Translations

### DIFF
--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
@@ -1,3 +1,4 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
@@ -95,6 +96,36 @@ internal sealed class TranslationConfiguration : IEntityTypeConfiguration<Transl
         builder.HasOne<Translator>()
             .WithMany()
             .HasForeignKey(translation => translation.ApprovedById)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // The version pointers are id-only references to GameVersions (AUDIT-EF-05), mirroring the
+        // Translator FKs above. Convention gives each FK the index the DeleteGameVersion reference
+        // guard scans on (AnyReferencesGameVersionAsync ORs all three columns), and Restrict is the
+        // database backstop for that guard's check-then-act window — a concurrent import stamping
+        // the version between the check and the delete fails the delete instead of leaving
+        // dangling pointers.
+        builder.Property(translation => translation.IntroducedInVersion)
+            .HasColumnName(nameof(Translation.IntroducedInVersion));
+
+        builder.HasOne<GameVersion>()
+            .WithMany()
+            .HasForeignKey(translation => translation.IntroducedInVersion)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.Property(translation => translation.LastSourceChangeInVersion)
+            .HasColumnName(nameof(Translation.LastSourceChangeInVersion));
+
+        builder.HasOne<GameVersion>()
+            .WithMany()
+            .HasForeignKey(translation => translation.LastSourceChangeInVersion)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.Property(translation => translation.RemovedInVersion)
+            .HasColumnName(nameof(Translation.RemovedInVersion));
+
+        builder.HasOne<GameVersion>()
+            .WithMany()
+            .HasForeignKey(translation => translation.RemovedInVersion)
             .OnDelete(DeleteBehavior.Restrict);
 
         // Get-only property — EF Core convention skips it without an explicit mapping.

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260710192201_AddGameVersionPointerForeignKeys.Designer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260710192201_AddGameVersionPointerForeignKeys.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationWriteDbContext))]
-    partial class ApplicationWriteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710192201_AddGameVersionPointerForeignKeys")]
+    partial class AddGameVersionPointerForeignKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260710192201_AddGameVersionPointerForeignKeys.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260710192201_AddGameVersionPointerForeignKeys.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameVersionPointerForeignKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Translations_IntroducedInVersion",
+                schema: "translation",
+                table: "Translations",
+                column: "IntroducedInVersion");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Translations_LastSourceChangeInVersion",
+                schema: "translation",
+                table: "Translations",
+                column: "LastSourceChangeInVersion");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Translations_RemovedInVersion",
+                schema: "translation",
+                table: "Translations",
+                column: "RemovedInVersion");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Translations_GameVersions_IntroducedInVersion",
+                schema: "translation",
+                table: "Translations",
+                column: "IntroducedInVersion",
+                principalSchema: "translation",
+                principalTable: "GameVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Translations_GameVersions_LastSourceChangeInVersion",
+                schema: "translation",
+                table: "Translations",
+                column: "LastSourceChangeInVersion",
+                principalSchema: "translation",
+                principalTable: "GameVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Translations_GameVersions_RemovedInVersion",
+                schema: "translation",
+                table: "Translations",
+                column: "RemovedInVersion",
+                principalSchema: "translation",
+                principalTable: "GameVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Translations_GameVersions_IntroducedInVersion",
+                schema: "translation",
+                table: "Translations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Translations_GameVersions_LastSourceChangeInVersion",
+                schema: "translation",
+                table: "Translations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Translations_GameVersions_RemovedInVersion",
+                schema: "translation",
+                table: "Translations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Translations_IntroducedInVersion",
+                schema: "translation",
+                table: "Translations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Translations_LastSourceChangeInVersion",
+                schema: "translation",
+                table: "Translations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Translations_RemovedInVersion",
+                schema: "translation",
+                table: "Translations");
+        }
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/GameVersionPointerForeignKeyTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/GameVersionPointerForeignKeyTests.cs
@@ -1,0 +1,128 @@
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.GameVersions;
+
+/// <summary>
+/// Pins the database backstop behind the DeleteGameVersion reference guard (AUDIT-EF-05): the three
+/// version pointer columns on Translations carry Restrict FKs to GameVersions, so even a delete that
+/// bypasses <c>AnyReferencesGameVersionAsync</c> (the guard's check-then-act window — e.g. a
+/// concurrent import stamping the version between the check and the delete) cannot leave dangling
+/// pointers. Deliberately drives the DbContext directly: the endpoint path is covered by
+/// <see cref="DeleteGameVersionTests"/>.
+/// </summary>
+[Collection("TranslationApi")]
+public sealed class GameVersionPointerForeignKeyTests : IAsyncLifetime
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 10, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly TranslationSystemApiFactory _factory;
+
+    public GameVersionPointerForeignKeyTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\" CASCADE;");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    public enum VersionPointer
+    {
+        Introduced,
+        LastSourceChange,
+        Removed,
+    }
+
+    [Theory]
+    [InlineData(VersionPointer.Introduced)]
+    [InlineData(VersionPointer.LastSourceChange)]
+    [InlineData(VersionPointer.Removed)]
+    public async Task DeleteGameVersion_RowStillReferencedByAPointerColumn_ShouldBeRejectedByTheForeignKey(
+        VersionPointer pointer)
+    {
+        // Arrange — a translation whose given pointer references the version under deletion (the
+        // other pointers reference a different version, so each FK is exercised in isolation).
+        GameVersionId baseVersionId = await SeedVersionAsync("47.0");
+        GameVersionId referencedVersionId = await SeedVersionAsync("48.0");
+        await SeedTranslationWithPointerAsync(pointer, baseVersionId, referencedVersionId);
+
+        // Act
+        DbUpdateException thrown = await Should.ThrowAsync<DbUpdateException>(
+            () => DeleteVersionAsync(referencedVersionId));
+
+        // Assert — a PostgreSQL foreign-key violation (23503) blocked the delete and the row survived.
+        PostgresException postgresException = thrown.InnerException.ShouldBeOfType<PostgresException>();
+        postgresException.SqlState.ShouldBe(PostgresErrorCodes.ForeignKeyViolation);
+        (await VersionExistsAsync(referencedVersionId)).ShouldBeTrue();
+    }
+
+    private async Task<GameVersionId> SeedVersionAsync(string version)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+
+        return gameVersion.Id;
+    }
+
+    private async Task SeedTranslationWithPointerAsync(
+        VersionPointer pointer,
+        GameVersionId baseVersionId,
+        GameVersionId referencedVersionId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        Translation row = Translation.CreateUntranslated(
+            FragmentKey.Create(620756992, 1001).Value,
+            TranslationSource.Create("Witaj", null, null).Value,
+            pointer is VersionPointer.Introduced ? referencedVersionId : baseVersionId,
+            Now).Value;
+
+        switch (pointer)
+        {
+            case VersionPointer.LastSourceChange:
+                row.ApplySourceChange(TranslationSource.Create("Witaj ponownie", null, null).Value, referencedVersionId, Now);
+                break;
+            case VersionPointer.Removed:
+                row.MarkRemoved(referencedVersionId, Now);
+                break;
+        }
+
+        dbContext.Translations.Add(row);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task DeleteVersionAsync(GameVersionId versionId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = await dbContext.GameVersions.SingleAsync(version => version.Id == versionId);
+        dbContext.GameVersions.Remove(gameVersion);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task<bool> VersionExistsAsync(GameVersionId versionId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        return await dbContext.GameVersions.AnyAsync(version => version.Id == versionId);
+    }
+}


### PR DESCRIPTION
Closes #355

## What

`Translations.IntroducedInVersion`, `LastSourceChangeInVersion` and `RemovedInVersion` now carry real FKs to `GameVersions` with `DeleteBehavior.Restrict`, mirroring the Translator FK pattern in the same configuration. Convention creates the three indexes, so `AnyReferencesGameVersionAsync` (the `DeleteGameVersion` guard) stops full-scanning — PostgreSQL can BitmapOr the three btrees — and the guard's check-then-act window gets a database backstop: a concurrent import stamping the version between the check and the delete now fails the delete (23503) instead of leaving dangling pointers.

- `TranslationConfiguration`: three `HasOne<GameVersion>().WithMany().HasForeignKey(...).OnDelete(Restrict)` blocks.
- Migration `20260710192201_AddGameVersionPointerForeignKeys`: 3 `CreateIndex` + 3 `AddForeignKey`, purely additive — passes `check-migration-safety.sh` with no acknowledgment marker.
- New `GameVersionPointerForeignKeyTests`: one theory case per pointer column, proving against real PostgreSQL that a DbContext-level delete (bypassing the guard) is rejected with 23503 and the version row survives.
- Includes #438's fixture commit so this branch's own suite is green; it drops out on rebase after #438 merges.

## Merge order (hard precondition)

1. Merge #438 first — the N-1 gate (ADR-0024) runs the *previous release's* integration suite against this PR's schema; before #438, that suite mints dangling `GameVersionId`s and the gate goes red on a schema change the running app is fully compatible with.
2. `git rebase main` here (the duplicated fixture commit drops out), then this PR's checks go green.

Proven locally: `scripts/n1-compat.sh <prep-branch>` (= post-#438 main against this schema) is **GREEN**, both contexts.

## Pre-merge operational check (code-reviewer finding)

`AddForeignKey` validates existing rows and migrations are forward-only (ADR-0023). Every stored pointer was written from a live `GameVersion` row and referenced versions cannot be deleted today, so orphans should not exist — but the unbackstopped race this PR fixes means staging/prod deserve a 30-second check before merge:

```sql
SELECT count(*) FROM translation."Translations" t LEFT JOIN translation."GameVersions" g ON g."Id" = t."IntroducedInVersion" WHERE g."Id" IS NULL;
SELECT count(*) FROM translation."Translations" t LEFT JOIN translation."GameVersions" g ON g."Id" = t."LastSourceChangeInVersion" WHERE t."LastSourceChangeInVersion" IS NOT NULL AND g."Id" IS NULL;
SELECT count(*) FROM translation."Translations" t LEFT JOIN translation."GameVersions" g ON g."Id" = t."RemovedInVersion" WHERE t."RemovedInVersion" IS NOT NULL AND g."Id" IS NULL;
```

All three must return 0 on staging and prod; otherwise the migrator blocks the deploy.

## Test evidence

- Solution build: zero warnings (TreatWarningsAsErrors).
- Unit suites: 276 + 145 + 171 green.
- `TranslationSystem.API.Tests.Integration`: 196/196 green — `DeleteGameVersionTests` untouched (assertions intact).
- `code-reviewer` agent: APPROVE (findings folded in above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)