### PR TITLE
AUDIT-EF-05 follow-up: recalibrate the import bulk-insert budget for the indexed Translations table

### DIFF
--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
@@ -449,10 +449,12 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
     {
         // Arrange — a full-catalog-scale baseline (all added rows). Per-row EF wrote ~700k rows in
         // ~3 min (#214); the COPY path (ADR-0011) must load a hundreds-of-thousands-row baseline in
-        // seconds. The budget is spec 0004's < 10 s, which also unambiguously separates the bulk path
-        // from any regression to the multi-minute per-row write (a per-row write of this count alone
-        // would run tens of seconds). The count sits in the AC's "hundreds of thousands" range at a
-        // point that keeps the < 10 s ceiling stable on slower CI hardware.
+        // seconds. Spec 0004's original < 10 s budget was calibrated before the three GameVersion
+        // pointer indexes + FKs on Translations (#439) — each COPY'd row now maintains those indexes
+        // and validates the FKs, which pushed CI runners to straddle 10 s (10.3–11.7 s observed on
+        // the N-1 gate). 20 s restores the headroom while still unambiguously separating the bulk
+        // path from any regression to the per-row write: per #214's measurement, per-row at this
+        // count alone would run ~50 s.
         const int rowCount = 200_000;
         GameVersionId versionId = await SeedVersionAsync("48.0");
         using HttpClient client = AdminClient();
@@ -470,7 +472,7 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         summary.Added.ShouldBe(rowCount);
         (await CountTranslationsAsync()).ShouldBe(rowCount);
         (await GetVersionStatusAsync(versionId)).ShouldBe(GameVersionStatus.Processed);
-        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(10));
+        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(20));
     }
 
     [Fact]


### PR DESCRIPTION
## Context

The N-1 compat gate on #439 (run [#8](https://github.com/koniecdev/LotroKoniecDev/actions/runs/29118551337)) went red on a single test: `Import_LargeBaseline_ShouldBulkInsertEveryRowWithinTheBudget` — 10.34 s (attempt 2) / 11.72 s (run #7) against the < 10 s budget. Everything else is green; main CI passed on the squash commit.

The budget was calibrated (spec 0004 / #214) for a `Translations` table **without** the three GameVersion pointer indexes + FK constraints that #439 itself added. A 200k-row COPY now maintains three extra indexes and validates three FKs per row, which ate the CI-runner margin — the test straddles the ceiling instead of sitting under it. Every future migration-touching PR re-runs the N-1 gate with main's suite as the previous release, so the gate keeps crying wolf until the budget on main is recalibrated.

## Change

- Budget raised 10 s → 20 s + calibration comment updated. The test's purpose — unambiguously separating the COPY bulk path (ADR-0011) from a regression to per-row EF writes — is intact: per #214's measurement, per-row at 200k rows runs ~50 s.
- Test-only, no production code touched. The file is outside `n1-compat.yml`'s paths filter, so this PR itself does not trigger the gate.

## Verification

`dotnet test --filter FullyQualifiedName~Import_LargeBaseline_ShouldBulkInsertEveryRowWithinTheBudget` against real PostgreSQL (Testcontainers): **Passed, 5 s** including container spin-up.

Part of #355 (follow-up of #439).

🤖 Generated with [Claude Code](https://claude.com/claude-code)