### PR TITLE
AUDIT-SEC-11: CodeQL triage — raw recipient e-mail (PII) in sender log scopes; Secure flag on the session-expiry cookie; dismiss the Razor XSS FPs

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountConfirmationEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountConfirmationEmailSender.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
+using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
 using LotroKoniecDev.SharedKernel.Monads;
 
@@ -32,7 +33,7 @@ internal sealed class AccountConfirmationEmailSender : IAccountConfirmationEmail
         using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
         {
             ["EmailOperation"] = "AccountConfirmation",
-            ["Recipient"] = email
+            ["Recipient"] = email.MaskEmail()
         });
 
         return await _emailService

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetEmailSender.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
+using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
 using LotroKoniecDev.SharedKernel.Monads;
 
@@ -32,7 +33,7 @@ internal sealed class PasswordResetEmailSender : IPasswordResetEmailSender
         using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
         {
             ["EmailOperation"] = "PasswordReset",
-            ["Recipient"] = email
+            ["Recipient"] = email.MaskEmail()
         });
 
         return await _emailService

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/SessionExpiryNotice.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/DeadSession/SessionExpiryNotice.cs
@@ -26,7 +26,7 @@ internal sealed class SessionExpiryNotice : ISessionExpiryNotice
             return;
         }
 
-        httpContext.Response.Cookies.Append(CookieName, CookieValue, BuildOptions());
+        httpContext.Response.Cookies.Append(CookieName, CookieValue, BuildOptions(httpContext.Request.IsHttps));
     }
 
     public bool Consume()
@@ -45,28 +45,31 @@ internal sealed class SessionExpiryNotice : ISessionExpiryNotice
 
         if (!httpContext.Response.HasStarted)
         {
-            httpContext.Response.Cookies.Delete(CookieName, BuildDeleteOptions());
+            httpContext.Response.Cookies.Delete(CookieName, BuildDeleteOptions(httpContext.Request.IsHttps));
         }
 
         return true;
     }
 
     // Path "/" mirrors the auth + antiforgery cookies so the post-redirect read on any path finds it.
-    // HttpOnly because no client JS reads it. Secure is intentionally left at its default so the marker
-    // round-trips over both http and https dev origins — it carries no sensitive value, only a one-shot
+    // HttpOnly because no client JS reads it. Secure mirrors the request scheme: set on HTTPS (the dev
+    // https profile, prod behind the proxy via forwarded headers) and omitted on the plain-http dev
+    // profile so the marker still round-trips there — it carries no sensitive value, only a one-shot
     // "show the banner" flag.
-    private static CookieOptions BuildOptions() => new()
+    private static CookieOptions BuildOptions(bool isHttps) => new()
     {
         Path = "/",
         HttpOnly = true,
+        Secure = isHttps,
         SameSite = SameSiteMode.Lax,
         MaxAge = CookieLifetime,
         IsEssential = true
     };
 
-    private static CookieOptions BuildDeleteOptions() => new()
+    private static CookieOptions BuildDeleteOptions(bool isHttps) => new()
     {
         Path = "/",
+        Secure = isHttps,
         SameSite = SameSiteMode.Lax
     };
 }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/DeadSession/SessionExpiryNoticeTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/DeadSession/SessionExpiryNoticeTests.cs
@@ -71,6 +71,48 @@ public sealed class SessionExpiryNoticeTests
     }
 
     [Fact]
+    public void Raise_WhenRequestIsHttps_MarksTheCookieSecure()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.IsHttps = true;
+        SessionExpiryNotice notice = CreateNotice(httpContext);
+
+        notice.Raise();
+
+        httpContext.Response.Headers.SetCookie
+            .ToString()
+            .ShouldContain("secure", Case.Insensitive);
+    }
+
+    [Fact]
+    public void Raise_WhenRequestIsPlainHttp_LeavesTheCookieNonSecure()
+    {
+        DefaultHttpContext httpContext = new();
+        SessionExpiryNotice notice = CreateNotice(httpContext);
+
+        notice.Raise();
+
+        string setCookie = httpContext.Response.Headers.SetCookie.ToString();
+        setCookie.ShouldContain(SessionExpiryNotice.CookieName);
+        setCookie.ShouldNotContain("secure", Case.Insensitive);
+    }
+
+    [Fact]
+    public void Consume_WhenRequestIsHttps_EmitsSecureCookieDeletion()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.IsHttps = true;
+        httpContext.Request.Headers.Cookie = $"{SessionExpiryNotice.CookieName}=1";
+        SessionExpiryNotice notice = CreateNotice(httpContext);
+
+        notice.Consume();
+
+        httpContext.Response.Headers.SetCookie
+            .ToString()
+            .ShouldContain("secure", Case.Insensitive);
+    }
+
+    [Fact]
     public void Raise_WhenHttpContextIsNull_DoesNotThrow()
     {
         IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();


### PR DESCRIPTION
Closes #440

## What

Full CodeQL triage follow-through — the two real fixes plus alert bookkeeping:

- **PII in logs (alerts #2/#3, real):** both e-mail senders now put `email.MaskEmail()` into the `Recipient` scope value instead of the raw address, matching the masking discipline every log message in the same flows already follows. The actual e-mail addressing (`SendAsync(receiverEmail: email, …)`) is unchanged. The log-forging alerts #4/#5 flagged on the same lines vanish with this fix.
- **Session-expiry cookie (alert #1, deliberate + cheap hardening):** `SessionExpiryNotice` now sets `Secure = Request.IsHttps` (consistently in `BuildOptions` and `BuildDeleteOptions`) — Secure on HTTPS (dev https profile, prod behind Caddy via forwarded headers), still functional on the plain-http dev profile. The in-code decision comment is updated.
- **XSS alerts #6/#7:** dismissed as false positive directly on the CodeQL dashboard — Razor tag-helper attribute values are HTML-attribute-encoded, `asp-route-*` is URL-encoded, and `ReturnUrl` is `IsLocalUrl`-guarded on both pages; CodeQL does not model tag-helper encoding.

## Test

- `dotnet build LotroKoniecDev.slnx` — zero warnings.
- All unit suites green; `SessionExpiryNoticeTests` extended with three cases: Secure on HTTPS, non-Secure on plain HTTP, Secure deletion on HTTPS.

Alerts #1–#5 should auto-close on the first CodeQL scan of `main` after merge; if #4/#5 linger, dismiss per the ticket's justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)