### PR TITLE
TP-11: Automate the GameVersion export→import pipeline — Option A, live-test KB, ADR-0030

### DIFF
--- a/docs/adr/0030-game-version-export-stays-manual-vm-runner-deferred.md
+++ b/docs/adr/0030-game-version-export-stays-manual-vm-runner-deferred.md
@@ -1,0 +1,157 @@
+# ADR-0030: Game-version export stays manual — VM runner deferred, pipeline instrumented
+
+**Status:** Accepted
+**Date:** 2026-07-11
+**Decision-makers:** Solo maintainer
+**Related:** Patcher (export/launch flow), `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md` (Out of scope), tickets #443 (TP-11), #85 (M2-18 forum watcher), #384 (TP-07), #52 (Discord notifications), knowledge-base live-test entries
+
+## Context
+
+Spec 0001 built the hard half of the update lifecycle: version-bound import with diff +
+invalidation of stale translations. The one fully manual link left is producing a fresh
+`exported.txt` after each game update and uploading it. Spec 0001's Out of scope rejected
+"automating game updates on a VM to regenerate exports" on cost grounds — a rejection that
+implicitly assumed re-provisioning a VM per run. Ticket #443 revisits it with new information:
+a persistent, patch-only Windows VM (e.g. `dockurr/windows` on KVM, one durable disk, started
+and stopped like a real machine) has a much smaller ongoing cost.
+
+The force that actually matters was named in the #443 discussion: the **staleness window**.
+Between an SSG update and the admin's manual export→import, every patcher user actively
+re-applies now-obsolete translations onto changed English content — the launcher rewrites
+changed subfiles (reverting them to new English), while the distributed `polish.txt` still
+carries the old rows until the import diff invalidates them; the CLI auto-download + `patch`
+loop re-injects them. Window length = detection latency + the admin's physical access to a
+Windows box with LOTRO. Compounding it: a single-maintainer bus factor — admin unavailability
+suspends the loop indefinitely.
+
+Facts that constrain the choice today:
+
+- **The pipeline head does not exist yet.** The TMS GameVersion import endpoint (spec 0001
+  Contract) is still M2 work-in-progress; an unattended runner would automate the tail of a
+  pipeline with a missing head.
+- **Cadence and effort are small.** Updates run roughly monthly (48.0 Apr → 48.7 Jun → 48.8 Jul,
+  `docs/knowledge-base/`); once at the machine, the ceremony is minutes. The project is
+  pre-release with zero production users — the window currently hurts nobody.
+- **Three VM prerequisites are unconfirmed:** whether `TurbineLauncher.exe` patches without a
+  GPU; whether a silent/patch-only path exists (the Russian project's Elanor uses undocumented
+  flags `-disablePatch -nosplash -skiprawdownload` on the same launcher —
+  `docs/knowledge-base/russian-project.md` — suggesting more exist); Windows licensing for an
+  unattended runner.
+- **No cheap host.** The dev Mac has no KVM; Azure nested-virt VM sizes are real money against a
+  nearly exhausted credit and the standing FinOps posture (ADR-0020, ADR-0027).
+- **Elevation was the other friction.** `DatFileHandler.Open` and `ReadVersion` always passed
+  native flag 130 (Read|Write); the write intent is why non-elevated opens of the live DAT failed
+  twice empirically — a `launch` on 2026-04-23, an `export` on 2026-06-25
+  (`live-test-2026-04-23.md`, `live-test-2026-06-25.md`). #443 Option A (same PR as this ADR)
+  switches read paths to flag 2, pending real-Windows confirmation.
+
+## Decision
+
+### 1. The VM/VPS runner is deferred — spec 0001's rejection is upheld, with new reasoning
+
+Not "re-provisioning cost" anymore. Deferred because the pipeline head is missing, three
+technical prerequisites are unconfirmed, a KVM host is a standing cost, and the staleness window
+has no victims pre-release (YAGNI). The runner design sketched in #443 is preserved there as a
+case study, not a backlog item. This includes the research spike: even standing the VM up once
+needs a KVM host and hours, and its answers buy nothing actionable until the triggers in §3 fire.
+
+### 2. The manual pipeline is instrumented — three concrete moves
+
+- **Read path de-elevated (#443 Option A, this PR).** `export` and version reads open the DAT
+  read-only (native flag 2); `export.bat` stops self-elevating. The ceremony loses its UAC step,
+  and any future runner's export task needs no elevation engineering at all.
+- **Detection latency bounded (#85 scope amendment).** The M2-18 forum watcher additionally
+  notifies the admin **by e-mail** when a new GameVersion is detected (previously: structured log
+  only for MVP). Discord webhook stays post-MVP (#52). #85 currently sits in Post-MVP/Backlog per
+  its triage comment and the owner signalled on 2026-07-11 the intent to revive it soon; this ADR
+  is the scope record, to be mirrored onto the ticket as a comment when it is picked up.
+- **Reaction effort scripted (future ticket, after the import endpoint exists).** A one-shot
+  "ceremony script" — update LOTRO → `export` → upload to the import endpoint — runnable on any
+  Windows box with LOTRO: the admin's gaming PC today, a VM tomorrow. VM-ready by design:
+  non-interactive, exit-coded, idempotent. Whether it runs by hand, as a scheduled task, or
+  inside a VM is a deployment detail decided when needed.
+
+### 3. Explicit reconsider triggers for the VM
+
+Re-open (new ADR or spec revision) when **any** of:
+
+- (a) real users exist and a staleness window measurably exceeds a few days more than once;
+- (b) the import endpoint + ceremony script both exist, making the VM a thin shell around a
+  proven script;
+- (c) a KVM-capable host becomes available at negligible marginal cost;
+- (d) admin availability becomes structurally worse.
+
+Until a trigger fires, no VM work happens — including "just a quick spike".
+
+### 4. The staleness window is an accepted, documented risk
+
+Between an update and the next import, the distributed file may re-apply stale rows onto changed
+content. Accepted while pre-release; the e-mail alert plus the scripted ceremony keep the window
+as short as the admin can make it, and TMS-side correctness self-heals at first import
+(diff invalidation, spec 0001).
+
+## Consequences
+
+### Positive
+
+- Zero new infrastructure, cost, or licensing exposure; FinOps posture intact.
+- The decision is reversible on named, checkable conditions instead of vibes.
+- #85's scope is sharpened (e-mail alert) while the watcher itself stays unchanged.
+- The ceremony script becomes the reusable kernel of *any* future runner — manual, scheduled,
+  or VM — so deferring the VM wastes no work.
+- Option A lands independent value now: UAC-free export on a real Windows box.
+
+### Negative / Accepted Trade-offs
+
+- The staleness window remains, bounded only by the admin's responsiveness to the e-mail.
+- The bus factor is mitigated, not solved: anyone with repo access and a Windows box + LOTRO can
+  run the ceremony, but nothing runs unattended.
+- The e-mail alert adds a small SMTP need to the TMS side when #85 lands (the AuthSystem already
+  ships the pattern to lift).
+
+## Alternatives Considered
+
+### A. Persistent VM/VPS runner now (`dockurr/windows` on a KVM host)
+
+Fully closes the loop and the bus factor. Rejected. The pipeline head (import endpoint) doesn't
+exist; GPU-less patching, a silent launcher path, and licensing are all unconfirmed; a KVM host
+is a standing cost against a nearly exhausted budget; no users feel the window today.
+
+### B. Research spike only (stand the VM up once, answer the unknowns)
+
+Rejected for now. The spike itself needs the KVM host and non-trivial hours, and its findings are
+not actionable until §3's triggers fire; run it as the first step *after* a trigger, not before.
+
+### C. Scheduled task on the admin's gaming PC
+
+Cheapest automation: the box already receives every update because the admin plays. Rejected as a
+commitment today — but its kernel is adopted: §2's ceremony script *is* this alternative minus
+the scheduler, and adding the scheduled task later is configuration, not code.
+
+### D. Do nothing (pure manual, no instrumentation)
+
+Rejected. Two live tests showed the stored forum version silently staling between rare Windows
+sessions (`live-test-2026-07-11.md`); e-mail alert + UAC-free export + a script are near-zero
+cost and buy most of the practical value of automation.
+
+## Implementation Notes
+
+- This ADR ships in #443's PR together with: the Option A code change (`DatFileAccess` enum,
+  `DatExportNative.OpenFlagsRead`, `IDatFileHandler.Open(string, DatFileAccess)`,
+  `DatFileHandler`, `ExportTextsQueryHandler`, `PatchingService`, unit/E2E tests), the
+  de-elevated `export.bat`, and `docs/knowledge-base/live-test-2026-07-11.md`.
+- `docs/specs/0001-…md` Out of scope gains a dated re-examination pointer to this ADR.
+- #85: the e-mail scope is recorded here and mirrored onto the ticket as a comment at pickup;
+  implementation lands with that ticket.
+- The ceremony-script ticket is cut when the GameVersion import endpoint exists (trigger (b)
+  approaches), not now.
+
+## References
+
+- `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md` — Out of scope + Contract
+- Ticket #443 (TP-11) — the revisit request and the preserved VM design sketch
+- Tickets #85 (M2-18 forum watcher), #384 (TP-07 lotro-data watcher), #52 (Discord webhook, post-MVP)
+- `docs/knowledge-base/live-test-2026-04-23.md`, `live-test-2026-06-25.md`,
+  `live-test-2026-07-11.md` — elevation findings + the staleness evidence
+- `docs/knowledge-base/russian-project.md` — Elanor's undocumented launcher flags
+- ADR-0020, ADR-0027 — the FinOps posture the VM host would violate

--- a/docs/knowledge-base/README.md
+++ b/docs/knowledge-base/README.md
@@ -51,6 +51,13 @@ Detailed analysis: [live-test-2026-06-25.md](live-test-2026-06-25.md) · committ
 - datexport.dll READ + WRITE confirmed on 48.7 DAT schema; vnum 112/3 unchanged (4th cycle); forum-fetcher independently returned "48.7"
 - DAT grew by exactly +1 MiB = one allocation block (reinforces chunk-based model)
 
+### Live Test — 2026-07-11 (48.8) — first real-world AUDIT-SEC run
+Detailed analysis: [live-test-2026-07-11.md](live-test-2026-07-11.md)
+- All 7 AUDIT-SEC PRs (#422-429) validated on real Windows for the first time: 42/42 Infrastructure + 23/23 E2E on a main worktree
+- AUDIT-SEC-02 (launcher Authenticode) + AUDIT-SEC-03 (restricted DLL search path) confirmed by a live SKIP launch and a forced live PATCH (8/8, 0 warnings) against the real signed launcher and production DAT
+- Live forum fetch returned 48.8 while vnum stayed 112/3 — 5th unchanged cycle
+- `launch`'s SKIP path never refreshes the stored ForumVersion — only a standalone `patch` does (code-verified); the manual export→import gap is decided in #443 + ADR-0030
+
 ### Live Test — Chunk Patches 2026-03-16..22
 Detailed analysis: [live-test-2026-03-16.md](live-test-2026-03-16.md)
 - 5 chunk-patch tests, all simplified-flow branches verified

--- a/docs/knowledge-base/live-test-2026-07-11.md
+++ b/docs/knowledge-base/live-test-2026-07-11.md
@@ -1,0 +1,57 @@
+---
+name: Live test 2026-07-11 — 48.8, first real-world AUDIT-SEC run
+description: First real-Windows validation of the 7 AUDIT-SEC PRs (#422-429) merged Linux-only — 42/42 Tests.Infrastructure + 23/23 Tests.E2E on a main worktree; live SKIP launch + forced PATCH (8/8, 0 warnings) against the real signed SSG launcher and production DAT; ForumVersion=48.8 captured while vnum stayed 112/3 (5th cycle); SKIP path never refreshes the stored ForumVersion — only a standalone `patch` does.
+type: project
+---
+# Live Test 2026-07-11 — 48.8, pierwszy realny przebieg AUDIT-SEC
+
+**Rzadka sesja Windows. Cel: pierwsza empiryczna weryfikacja audytowych PR-ów bezpieczeństwa na
+prawdziwym Windows/DAT + przegląd zachowania launch/patch po cyklu 48.7 → 48.8.**
+
+## Outcome
+
+✅ **Wszystko zielone.** Na worktree `main`: **42/42** `Tests.Infrastructure` + **23/23** `Tests.E2E`.
+Żywy `launch` (SKIP path) i wymuszony żywy `patch` (PATCH path — 8/8 translacji, 0 warningów)
+przeszły przeciwko prawdziwemu, podpisanemu launcherowi SSG i produkcyjnemu DAT.
+
+## AUDIT-SEC — pierwsza realna konfirmacja
+
+- Wszystkie 7 świeżych PR-ów `AUDIT-SEC` (#422-429) było zmergowanych **bez ani jednego przebiegu
+  na realnym Windows / realnym DAT** — projekty Windows-only (`Tests.Infrastructure`, `Tests.E2E`)
+  są poza Linux CI z konwencji nazw. Ten test domknął tę lukę.
+- **AUDIT-SEC-02** (weryfikacja podpisu Authenticode launchera): żywy launch przeszedł weryfikację
+  prawdziwego launchera SSG.
+- **AUDIT-SEC-03** (restricted native DLL search path dla `datexport.dll`): obie ścieżki —
+  SKIP (odczyt rezydentnych translacji nietknięty przez update) i PATCH (8/8 applied) —
+  działały z ograniczonym probingiem DLL.
+
+**Lekcja operacyjna:** każda realna sesja Windows powinna zaczynać się od odpalenia obu
+Windows-only suite'ów na czystym worktree `main` — to jedyna empiryczna brama dla zmian
+dotykających natywnego interopu.
+
+## Forum fetch + vnum — piąty cykl bez zmiany
+
+- Żywy forum fetch poprawnie złapał **ForumVersion=48.8**.
+- Vnum: **112/3 unchanged** — 45.x → 47.x → 48.0 → 48.7 → **48.8**, piąty cykl z rzędu.
+  „vnum = schema, NOT content" ([vnum-observations.md](vnum-observations.md)) potwierdzone kolejny raz.
+- Translacje rezydujące w DAT przetrwały cykl 48.7 → 48.8 nietknięte (SKIP path — hash match);
+  wymuszony `patch` potwierdził ścieżkę WRITE na aktualnym DAT.
+
+## SKIP path nigdy nie odświeża ForumVersion (nie bug — zachowanie do zapamiętania)
+
+Z lektury kodu (stan na 2026-07-11), potwierdzone na żywo:
+
+- `launch` w gałęzi SKIP **w ogóle nie dotyka** zapisanej wersji; w gałęzi PATCH zapisuje
+  wersję, ale przekazuje **stary** stored `ForumVersion` bez zmian
+  (`SimplifiedGameLaunchingStrategy.cs:136-141`).
+- Jedyne miejsce, które zapisuje świeżo pobraną wersję z forum, to standalone `patch` —
+  preflight + baseline-save (`PatchCommand.cs:110-121`).
+- Skutek: stored forum version potrafi cicho zestarzeć się między sesjami, dopóki nie odpali się
+  jawnego `patch`. Dokładnie to obserwowaliśmy między sesjami live-testów.
+
+## Wąskie gardło pipeline'u — decyzja
+
+Ręczny krok „update LOTRO → `export` → upload do TMS" pozostaje jedynym w pełni manualnym ogniwem
+update-lifecycle'u (spec 0001 świadomie odrzuciła automatyzację VM). Rewizja tej decyzji z nową
+informacją + kierunek (read-only export bez UAC, e-mail alert w #85, VM-ready skrypt ceremonii):
+**ticket #443 + ADR-0030**.

--- a/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
+++ b/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
@@ -63,7 +63,8 @@ player's patcher downloads a translation file that never shows outdated text in 
 ## Out of scope
 
 - **Automating game updates on a VM to regenerate exports** — explicitly rejected (cost); the
-  admin's own LOTRO install + manual upload is the pipeline.
+  admin's own LOTRO install + manual upload is the pipeline. *(Re-examined 2026-07-11 via #443 —
+  rejection upheld; ADR-0030 records the instrumented-manual decision and the reconsider triggers.)*
 - Crowdsourced game-version reports & two-source confirmation (#84, #31) — post-MVP as labeled;
   the forum is the sole detection source for now.
 - `TranslationHistory` / full audit trail of content changes (#50, post-MVP). This spec stores at

--- a/export.bat
+++ b/export.bat
@@ -2,17 +2,12 @@
 setlocal
 cd /d "%~dp0"
 
-rem AUDIT-SEC-06: user arguments must never be re-parsed by an elevated shell. They cross
-rem the elevation boundary as an environment variable (inherited by the elevated instance),
-rem and delayed expansion below inserts them after cmd parsing, so metacharacters stay literal.
-if not "%~1"=="--elevated" set "LOTRO_WRAPPER_ARGS=%*"
-
-net session >nul 2>&1
-if errorlevel 1 (
-    echo Requesting administrator privileges...
-    powershell -NoProfile -Command "Start-Process -FilePath '%~f0' -ArgumentList '--elevated' -Verb RunAs"
-    exit /b
-)
+rem Export opens the DAT read-only (#443 Option A, native flag 2), so no elevation here.
+rem If a live-DAT export ever fails with DatFile.CannotOpen, run it from an elevated shell
+rem and report on #443 — that would disprove the read-only-flag assumption.
+rem Delayed expansion below inserts user arguments after cmd parsing, so metacharacters
+rem stay literal (AUDIT-SEC-06 hardening, kept even without the elevation boundary).
+set "LOTRO_WRAPPER_ARGS=%*"
 
 dotnet build src\Patcher\LotroKoniecDev.Cli -v:minimal -nologo
 if errorlevel 1 exit /b 1

--- a/src/Patcher/LotroKoniecDev.Application/Abstractions/DatFilesServices/IDatFileHandler.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Abstractions/DatFilesServices/IDatFileHandler.cs
@@ -1,3 +1,5 @@
+using LotroKoniecDev.Primitives.Enums;
+
 namespace LotroKoniecDev.Application.Abstractions.DatFilesServices;
 
 /// <summary>
@@ -9,8 +11,9 @@ public interface IDatFileHandler : IDisposable
     /// Opens a DAT file and returns the file handle.
     /// </summary>
     /// <param name="datFilePath">Path to the DAT file.</param>
+    /// <param name="access">The native open mode: read-only or read-write.</param>
     /// <returns>Result containing the file handle or an error.</returns>
-    Result<int> Open(string datFilePath);
+    Result<int> Open(string datFilePath, DatFileAccess access);
 
     /// <summary>
     /// Gets sizes and iterations of all subfiles in the DAT archive.

--- a/src/Patcher/LotroKoniecDev.Application/Features/Exporting/ExportTextsQueryHandler.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/Exporting/ExportTextsQueryHandler.cs
@@ -6,6 +6,7 @@ using LotroKoniecDev.Domain.Core.BuildingBlocks;
 using LotroKoniecDev.Domain.Core.Errors;
 using LotroKoniecDev.Domain.Models;
 using LotroKoniecDev.Primitives.Constants;
+using LotroKoniecDev.Primitives.Enums;
 
 namespace LotroKoniecDev.Application.Features.Exporting;
 
@@ -39,7 +40,7 @@ internal sealed class ExportTextsQueryHandler : IQueryHandler<ExportTextsQuery, 
                 Error.Validation($"{nameof(ExportTextsQuery)}.Validation", "OutputPath must not be empty."));
         }
 
-        Result<int> openResult = _datFileHandler.Open(query.DatFilePath);
+        Result<int> openResult = _datFileHandler.Open(query.DatFilePath, DatFileAccess.Read);
         if (openResult.IsFailure)
         {
             return Result.Failure<ExportSummaryResponse>(openResult.Error);

--- a/src/Patcher/LotroKoniecDev.Application/Features/Patching/PatchingService.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/Patching/PatchingService.cs
@@ -3,6 +3,7 @@ using LotroKoniecDev.Application.Abstractions.DatFilesServices;
 using LotroKoniecDev.Application.Extensions;
 using LotroKoniecDev.Domain.Core.Errors;
 using LotroKoniecDev.Domain.Models;
+using LotroKoniecDev.Primitives.Enums;
 
 namespace LotroKoniecDev.Application.Features.Patching;
 
@@ -41,7 +42,7 @@ internal sealed class PatchingService : IPatchingService
             return Result.Failure<PatchSummaryResponse>(DomainErrors.Translation.NoTranslations);
         }
 
-        Result<int> datFileOpenResult = _datFileHandler.Open(datFilePath);
+        Result<int> datFileOpenResult = _datFileHandler.Open(datFilePath, DatFileAccess.ReadWrite);
 
         if (datFileOpenResult.IsFailure)
         {

--- a/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatExportNative.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatExportNative.cs
@@ -22,6 +22,11 @@ internal static partial class DatExportNative
     public const uint OpenFlagsReadWrite = 130;
 
     /// <summary>
+    /// Flags for opening DAT files read-only: Read (2).
+    /// </summary>
+    public const uint OpenFlagsRead = 2;
+
+    /// <summary>
     /// Opens a specified DAT file with extended configurations and retrieves detailed metadata about the file.
     /// This method establishes a connection to a DAT file, preparing it for reading and writing operations along with metadata extraction.
     /// </summary>

--- a/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatFileHandler.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatFileHandler.cs
@@ -3,6 +3,7 @@ using LotroKoniecDev.Application.Abstractions.DatFilesServices;
 using LotroKoniecDev.Domain.Core.Errors;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Domain.Models;
+using LotroKoniecDev.Primitives.Enums;
 
 namespace LotroKoniecDev.Infrastructure.DatFile;
 
@@ -19,11 +20,12 @@ public sealed class DatFileHandler : IDatFileHandler, IDatVersionReader
     /// Opens a LOTRO DAT file given its file path and returns a handle to the open file.
     /// </summary>
     /// <param name="datFilePath">The file path to the DAT file to be opened. It must not be null, empty, or whitespace.</param>
+    /// <param name="access">The native open mode: read-only opens work without write permission on the file.</param>
     /// <returns>
     /// A <see cref="Result{TValue}"/> containing the handle to the opened DAT file if the operation is successful;
     /// otherwise, a failure result with an error message describing why the file could not be opened.
     /// </returns>
-    public Result<int> Open(string datFilePath)
+    public Result<int> Open(string datFilePath, DatFileAccess access)
     {
         ThrowIfDisposed();
         ArgumentException.ThrowIfNullOrWhiteSpace(datFilePath);
@@ -37,12 +39,18 @@ public sealed class DatFileHandler : IDatFileHandler, IDatVersionReader
         byte[] datIdStamp = new byte[64];
         byte[] firstIterGuid = new byte[64];
 
+        uint openFlags = access switch
+        {
+            DatFileAccess.ReadWrite => DatExportNative.OpenFlagsReadWrite,
+            _ => DatExportNative.OpenFlagsRead
+        };
+
         try
         {
             int result = DatExportNative.OpenDatFileEx2(
                 requestedHandle,
                 datFilePath,
-                DatExportNative.OpenFlagsReadWrite,
+                openFlags,
                 out _,
                 out _,
                 out _,
@@ -74,6 +82,9 @@ public sealed class DatFileHandler : IDatFileHandler, IDatVersionReader
         }
     }
 
+    /// <summary>
+    /// Reads the DAT and game-data version numbers, opening the file read-only and closing it immediately.
+    /// </summary>
     public Result<DatVersionInfo> ReadVersion(string datFilePath)
     {
         ThrowIfDisposed();
@@ -93,7 +104,7 @@ public sealed class DatFileHandler : IDatFileHandler, IDatVersionReader
             int result = DatExportNative.OpenDatFileEx2(
                 requestedHandle,
                 datFilePath,
-                DatExportNative.OpenFlagsReadWrite,
+                DatExportNative.OpenFlagsRead,
                 out _,
                 out _,
                 out int vnumDatFile,

--- a/src/Patcher/LotroKoniecDev.Primitives/Enums/DatFileAccess.cs
+++ b/src/Patcher/LotroKoniecDev.Primitives/Enums/DatFileAccess.cs
@@ -1,0 +1,10 @@
+namespace LotroKoniecDev.Primitives.Enums;
+
+/// <summary>
+/// Selects the native open mode for a DAT file.
+/// </summary>
+public enum DatFileAccess
+{
+    Read,
+    ReadWrite
+}

--- a/tests/LotroKoniecDev.Tests.E2E/Tests/ExportE2ETests.cs
+++ b/tests/LotroKoniecDev.Tests.E2E/Tests/ExportE2ETests.cs
@@ -97,4 +97,39 @@ public sealed class ExportE2ETests
             minimalExpectedLines,
             $"Real DAT export should produce way more than {minimalExpectedLines} of text fragments");
     }
+
+    /// <summary>
+    /// Option A (#443) feasibility gate on real Windows: a read-only DAT copy is the faithful
+    /// proxy for a non-elevated export of the live Program Files DAT, so the read-only open
+    /// path must succeed without write access to the file.
+    /// </summary>
+    [SkippableFact]
+    public async Task Export_ShouldExitWithZero_WhenDatCopyIsReadOnly()
+    {
+        Skip.If(!_fixture.IsDatFileAvailable, "DAT file not found in TestData/");
+
+        //Arrange
+        string tempDatPath = _fixture.CreateTempDatCopy();
+        string outputPath = Path.Combine(Path.GetDirectoryName(tempDatPath)!, "readonly_export.txt");
+        File.SetAttributes(tempDatPath, File.GetAttributes(tempDatPath) | FileAttributes.ReadOnly);
+
+        try
+        {
+            //Act
+            CliResult result = await _fixture.RunCliAsync(
+                $"export -d \"{tempDatPath}\" -o \"{outputPath}\"");
+
+            //Assert
+            result.ExitCode.ShouldBe((int)CliExitCode.Success, $"stderr: {result.Stderr}");
+            File.Exists(outputPath).ShouldBeTrue("Export file should exist");
+            int dataLineCount = File.ReadLines(outputPath)
+                .Count(l => !string.IsNullOrWhiteSpace(l) && !l.TrimStart().StartsWith('#'));
+            dataLineCount.ShouldBeGreaterThan(0,
+                "Read-only export should produce data lines beyond the header");
+        }
+        finally
+        {
+            File.SetAttributes(tempDatPath, File.GetAttributes(tempDatPath) & ~FileAttributes.ReadOnly);
+        }
+    }
 }

--- a/tests/LotroKoniecDev.Tests.E2E/Tests/PatchE2ETests.cs
+++ b/tests/LotroKoniecDev.Tests.E2E/Tests/PatchE2ETests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace LotroKoniecDev.Tests.E2E.Tests;
 
 [Collection("E2E")]
@@ -115,5 +117,49 @@ public sealed class PatchE2ETests
         //Assert — should resolve "polish" → "translations/polish.txt" and succeed
         result.ExitCode.ShouldBe((int)CliExitCode.Success,
             $"Short name 'polish' should resolve to translations/polish.txt. stdout: {result.Stdout}");
+    }
+
+    /// <summary>
+    /// Option A (#443) feasibility gate on real Windows: the read-write open path must still
+    /// genuinely demand write access — patching a read-only DAT copy fails without changing a byte.
+    /// </summary>
+    [SkippableFact]
+    public async Task Patch_ShouldFailAndLeaveDatUnchanged_WhenDatCopyIsReadOnly()
+    {
+        Skip.If(!_fixture.IsDatFileAvailable, "DAT file not found in TestData/");
+
+        //Arrange
+        string tempDatPath = _fixture.CreateTempDatCopy();
+        string tempDir = Path.GetDirectoryName(tempDatPath)!;
+        File.SetAttributes(tempDatPath, File.GetAttributes(tempDatPath) | FileAttributes.ReadOnly);
+        byte[] hashBefore = await ComputeFileHashAsync(tempDatPath);
+
+        try
+        {
+            //Act
+            CliResult result = await _fixture.RunCliAsync(
+                $"patch \"{_fixture.TranslationsPolishPath}\" -d \"{tempDatPath}\"");
+
+            //Assert
+            result.ExitCode.ShouldNotBe((int)CliExitCode.Success,
+                "Patching a read-only DAT should fail because the read-write open demands write access");
+            byte[] hashAfter = await ComputeFileHashAsync(tempDatPath);
+            hashAfter.ShouldBe(hashBefore, "A failed patch must not change a single byte of the DAT");
+        }
+        finally
+        {
+            // The .backup copy inherits ReadOnly via File.Copy — clear the attribute on every
+            // file so the fixture's temp-dir cleanup does not fail on Windows.
+            foreach (string file in Directory.GetFiles(tempDir))
+            {
+                File.SetAttributes(file, File.GetAttributes(file) & ~FileAttributes.ReadOnly);
+            }
+        }
+    }
+
+    private static async Task<byte[]> ComputeFileHashAsync(string filePath)
+    {
+        await using FileStream stream = File.OpenRead(filePath);
+        return await SHA256.HashDataAsync(stream);
     }
 }

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Features/ExportTextsQueryHandlerTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Features/ExportTextsQueryHandlerTests.cs
@@ -48,7 +48,7 @@ public sealed class ExportTextsQueryHandlerTests : IDisposable
         result.IsFailure.ShouldBeTrue();
         result.Error.Type.ShouldBe(ErrorType.Validation);
         result.Error.Code.ShouldBe("ExportTextsQuery.Validation");
-        _mockHandler.DidNotReceive().Open(Arg.Any<string>());
+        _mockHandler.DidNotReceive().Open(Arg.Any<string>(), Arg.Any<DatFileAccess>());
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public sealed class ExportTextsQueryHandlerTests : IDisposable
         // Arrange
         string outputPath = Path.Combine(_tempDir, "output.txt");
 
-        _mockHandler.Open("test.dat").Returns(Result.Success(0));
+        _mockHandler.Open("test.dat", DatFileAccess.Read).Returns(Result.Success(0));
         _mockHandler.GetAllSubfileSizes(0).Returns(new Dictionary<int, (int, int)>
         {
             { 0x25000001, (100, 1) }
@@ -83,7 +83,7 @@ public sealed class ExportTextsQueryHandlerTests : IDisposable
         // Arrange
         string outputPath = Path.Combine(_tempDir, "output.txt");
         Error error = new("DatFile.CannotOpen", "Cannot open", ErrorType.IoError);
-        _mockHandler.Open("test.dat").Returns(Result.Failure<int>(error));
+        _mockHandler.Open("test.dat", DatFileAccess.Read).Returns(Result.Failure<int>(error));
 
         ExportTextsQuery query = new("test.dat", outputPath);
 
@@ -109,7 +109,7 @@ public sealed class ExportTextsQueryHandlerTests : IDisposable
         // Arrange
         string outputPath = Path.Combine(_tempDir, "output.txt");
 
-        _mockHandler.Open("test.dat").Returns(Result.Success(0));
+        _mockHandler.Open("test.dat", DatFileAccess.Read).Returns(Result.Success(0));
         _mockHandler.GetAllSubfileSizes(0).Returns(new Dictionary<int, (int, int)>
         {
             { 0x25000001, (100, 1) },
@@ -139,7 +139,7 @@ public sealed class ExportTextsQueryHandlerTests : IDisposable
         string outputPath = Path.Combine(_tempDir, "output.txt");
         Error loadError = new("SubFile.ParseError", "Corrupted", ErrorType.IoError);
 
-        _mockHandler.Open("test.dat").Returns(Result.Success(0));
+        _mockHandler.Open("test.dat", DatFileAccess.Read).Returns(Result.Success(0));
         _mockHandler.GetAllSubfileSizes(0).Returns(new Dictionary<int, (int, int)>
         {
             { 0x25000001, (100, 1) },
@@ -167,7 +167,7 @@ public sealed class ExportTextsQueryHandlerTests : IDisposable
         // Arrange
         string outputPath = Path.Combine(_tempDir, "output.txt");
 
-        _mockHandler.Open("test.dat").Returns(Result.Success(42));
+        _mockHandler.Open("test.dat", DatFileAccess.Read).Returns(Result.Success(42));
         _mockHandler.GetAllSubfileSizes(42)
             .Throws(new InvalidOperationException("Simulated failure"));
 

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Features/PatchingServiceTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Features/PatchingServiceTests.cs
@@ -30,7 +30,7 @@ public sealed class PatchingServiceTests
 
     private void SetupAllPassingDefaults()
     {
-        _datFileHandler.Open(Arg.Any<string>()).Returns(Result.Success(DatHandle));
+        _datFileHandler.Open(Arg.Any<string>(), DatFileAccess.ReadWrite).Returns(Result.Success(DatHandle));
         _datFileHandler.GetAllSubfileSizes(DatHandle).Returns(new Dictionary<int, (int, int)>
         {
             { TextFileId, (100, 1) }
@@ -121,7 +121,7 @@ public sealed class PatchingServiceTests
         SetupTranslations(CreateTranslation());
 
         Error openError = new("DatFile.CannotOpen", "Locked", ErrorType.IoError);
-        _datFileHandler.Open(Arg.Any<string>()).Returns(Result.Failure<int>(openError));
+        _datFileHandler.Open(Arg.Any<string>(), DatFileAccess.ReadWrite).Returns(Result.Failure<int>(openError));
 
         // Act
         Result<PatchSummaryResponse> result = _sut.ApplyTranslations("/translations/polish.txt", "/game/client_local_English.dat");
@@ -389,7 +389,7 @@ public sealed class PatchingServiceTests
         byte[] subFileData = TestDataFactory.CreateTextSubFileDataWithArgs(
             TextFileId, FragmentId1, ["Part1", "Part2", "Part3"], argRefs);
 
-        _datFileHandler.Open(Arg.Any<string>()).Returns(Result.Success(DatHandle));
+        _datFileHandler.Open(Arg.Any<string>(), DatFileAccess.ReadWrite).Returns(Result.Success(DatHandle));
         _datFileHandler.GetAllSubfileSizes(DatHandle).Returns(new Dictionary<int, (int, int)>
         {
             { TextFileId, (subFileData.Length, 1) }
@@ -440,7 +440,7 @@ public sealed class PatchingServiceTests
                 return Result.Success<IReadOnlyList<Translation>>(new List<Translation> { CreateTranslation() });
             });
 
-        _datFileHandler.Open(Arg.Any<string>())
+        _datFileHandler.Open(Arg.Any<string>(), DatFileAccess.ReadWrite)
             .Returns(_ =>
             {
                 callOrder.Add("open_dat");


### PR DESCRIPTION
Part of #443 (TP-11). The real-Windows live test stays open on the ticket — this PR ships everything doable off-Windows.

## What

- **Option A — read-only DAT opens.** New `DatFileAccess` enum; `IDatFileHandler.Open(path, access)` (explicit, no default); `export` and `ReadVersion` open the DAT with native flag 2 (Read) instead of 130 (Read|Write); `patch` keeps ReadWrite. `export.bat` no longer self-elevates (the AUDIT-SEC-06 delayed-expansion hardening stays).
- **Knowledge base.** `docs/knowledge-base/live-test-2026-07-11.md` + README index: first real-Windows run of the 7 AUDIT-SEC PRs (#422-429) — 42/42 Infrastructure + 23/23 E2E; AUDIT-SEC-02/03 confirmed live (SKIP launch + forced PATCH 8/8); ForumVersion=48.8 while vnum stayed 112/3 (5th cycle); `launch`'s SKIP path never refreshes the stored ForumVersion — only a standalone `patch` does.
- **Decision.** ADR-0030: the VM/VPS export runner is deferred (spec 0001 rejection upheld, new reasoning); the manual pipeline gets instrumented instead (read-only export, #85 admin e-mail scope amendment, future VM-ready ceremony script); four explicit reconsider triggers. Spec 0001 Out of scope carries a dated re-examination pointer.

## Why

Non-elevated opens of the live DAT fail today because every open requests write access — confirmed empirically twice (a `launch` in April, an `export` in June). Opening read-only should remove the UAC requirement from the export path entirely; whether `datexport.dll` honors flag 2 is exactly what the next Windows session verifies. The ADR closes the ticket's "decide in writing" task.

## Tests

- `dotnet build LotroKoniecDev.slnx` — zero warnings. `Tests.Unit` — 277/277 green. Existing assertions untouched, with one disclosed exception: the `DidNotReceive().Open(...)` matcher widened to include the new enum argument (strictly stronger — forbids opens in any mode).
- Two new Windows-only `SkippableFact` E2E tests are the feasibility gate for the next Windows session: export must succeed on a read-only DAT copy; patch must fail on it and leave the DAT byte-identical (SHA-256).

## Remains on #443 (why this is not "Closes")

Real-Windows verification: run the two new E2E tests + a non-elevated `export.bat` against the live DAT. Checklist posted on the ticket. If flag 2 turns out unsupported, the revert is one switch arm + the export.bat elevation block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
