### PR TITLE
LEGAL-01: Two-phase account deletion with a 14-day cancellation window (port TKS ADR-0017)

### DIFF
--- a/docs/adr/0031-gdpr-deletion-14-day-grace-period.md
+++ b/docs/adr/0031-gdpr-deletion-14-day-grace-period.md
@@ -1,0 +1,82 @@
+# ADR-0031: GDPR Account Deletion Runs Through a 14-Day Soft-Delete Grace Period
+
+**Status:** Accepted
+**Date:** 2026-07-11
+**Decision-makers:** Solo maintainer (ticket #452, legal & GDPR compliance pack #459)
+**Related:** `DeleteAccount` / `CancelAccountDeletion` (AuthSystem), `AccountErasureService`,
+`AccountDeletionFinalizer`, TKS ADR-0017 (the ported original), tickets #452, #459
+
+## Context
+
+`DeleteAccount` performed **immediate, irreversible anonymization** the moment the user
+submitted their password: auth-side PII wipe, permanent lockout, best-effort artifact
+cleanup. The password was the only barrier (no MFA on the endpoint), so a single
+credential-stuffing hit could erase an entire account with **zero recovery window** for the
+legitimate owner.
+
+GDPR does not require instant erasure: Art. 12(3) allows up to **one month**, and a
+cancellation window is the industry standard (GitHub 90 d, Google 20–60 d, Discord
+14–30 d). TheKittySaver replaced the exact same single-phase pattern with a two-phase flow
+(TKS ADR-0017, 2026-07-11); this ADR ports that decision.
+
+## Decision
+
+Deletion is **two-phase with a 14-day cancellation window** (`Gdpr:DeletionGracePeriod`,
+capped at 30 days by options validation to stay inside Art. 12(3)):
+
+1. **Schedule (synchronous).** Password check → set
+   `ApplicationUser.DeletionScheduledAt`, lock the account for the whole window
+   (`LockoutEnd = scheduledAt + grace`), rotate the security stamp, best-effort revoke
+   OpenIddict tokens/authorizations, and email a **one-time cancel link**. The link token
+   comes from a dedicated `DataProtectorTokenProvider`
+   (`AccountDeletionCancellationTokenProvider`) whose lifespan equals the grace period and
+   which binds to the security stamp (single-use by rotation). If the email cannot be
+   sent, the schedule is **unwound** — a grace window whose owner holds no cancel link is
+   worthless. Response: `204` + `X-Deletion-Scheduled-At` / `X-Deletion-Finalizes-At`
+   headers. Re-request while scheduled → `422 Auth.DeletionAlreadyScheduled` (the repo
+   maps `DataConflict` → 422).
+2. **Finalize (background).** `AccountDeletionFinalizerHostedService` polls
+   (`Gdpr:DeletionFinalizationPollInterval`, default 1 h; first run at startup for
+   post-downtime catch-up) for users with `DeletionScheduledAt + grace <= now` whose email
+   lacks the anonymization marker, and runs the extracted erasure pipeline
+   (`AccountErasureService`): auth anonymization → permanent lockout → artifact cleanup.
+   Per-user failures are logged and retried on the next run; `DeletionScheduledAt` stays
+   set after erasure as a non-PII audit trace.
+3. **Cancel (anytime in the window).** `POST /auth/account/cancel-deletion` (anonymous,
+   also driven by the hosted page `/Account/CancelDeletion`, which cancels only on POST so
+   mail-scanner prefetches are harmless): validates the token, clears schedule + lockout,
+   **removes the password hash** (the request may have come from whoever stole the
+   password), rotates the stamp, and returns a fresh reset token that sends the user
+   straight into the forced password-reset flow. Unknown email / bad / replayed token all
+   collapse into one generic `Auth.InvalidCancelDeletionToken`.
+
+**The emailed cancel link is the only recovery path.** During the window every other door
+is shut: hosted login and the Testing password grant reveal a dedicated
+"scheduled for deletion" state only *after* verifying the password (anti-enumeration);
+`connect/authorize` terminates live session cookies of locked/scheduled accounts instead
+of minting tokens; the refresh grant refuses them; forgot-/reset-password pretend success /
+return the generic invalid-token error without doing anything; and change-password rejects
+a still-valid pre-schedule JWT with `Auth.DeletionAlreadyScheduled` — its stamp rotation
+would otherwise kill the emailed cancel token, the only recovery path.
+
+**Deliberate deviation from TKS ADR-0017: no cross-context archival call.** TheKittySaver's
+erasure pipeline first archives AdoptionSystem person data over HTTP. Here the
+TranslationSystem stores only opaque `IdentityId` attribution references
+(`SubmittedById`/`ApprovedById`), which become non-attributable the moment the auth user is
+anonymized — no TMS-side call is needed, so the erasure service is auth-local and the
+eventual-consistency failure mode TKS ticket #175 documented cannot occur.
+
+## Consequences
+
+- Account takeover can no longer irreversibly destroy an account: the attacker's deletion
+  locks the account but the owner cancels via email and resets the password.
+- Deletion is no longer instant — the privacy policy explicitly discloses the 14-day window
+  (transparency, Art. 13/14). GDPR compliance is preserved (well under the 1-month limit).
+- The email becomes a hard dependency of *scheduling* (send failure rolls the schedule
+  back); SMTP outages surface as `Auth.DeletionSchedulingFailed`, not as silent data loss.
+- Half-erased states self-heal: the finalizer retries until the pipeline completes.
+- The old single-phase erasure tests are replaced by schedule/cancel/finalizer
+  integration suites; erasure E2E with real elapsed time is deliberately not attempted
+  (integration > E2E per the testing philosophy).
+- Reminder email 24 h before finalization is left out (same cut as TKS) — a follow-up
+  ticket can add it to the finalizer loop.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -5,16 +5,19 @@ using System.Text.Unicode;
 using FluentValidation;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.WebEncoders;
+using LotroKoniecDev.AuthSystem.API.BackgroundServices;
 using LotroKoniecDev.AuthSystem.API.ExceptionHandlers;
 using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.API.Features.Auth;
 using LotroKoniecDev.AuthSystem.API.Hateoas.AccountAggregateFactories;
 using LotroKoniecDev.AuthSystem.API.Hateoas.DiscoveryFactories;
 using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Services.Gdpr;
 using LotroKoniecDev.AuthSystem.API.Services.Maintenance;
 using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
 using LotroKoniecDev.Hateoas;
 using LotroKoniecDev.SharedKernel.Messaging;
 using LotroKoniecDev.SharedKernel.Monads;
@@ -62,9 +65,10 @@ internal static class ApiDependencyInjection
 
             services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly(), includeInternalTypes: true);
 
+            services.AddScoped<ICommandHandler<CancelAccountDeletion.Command, Result<CancelAccountDeletion.CancelledDeletion>>, CancelAccountDeletion.Handler>();
             services.AddScoped<ICommandHandler<ChangePassword.Command, Result>, ChangePassword.Handler>();
             services.AddScoped<ICommandHandler<ConfirmEmail.Command, Result>, ConfirmEmail.Handler>();
-            services.AddScoped<ICommandHandler<DeleteAccount.Command, Result>, DeleteAccount.Handler>();
+            services.AddScoped<ICommandHandler<DeleteAccount.Command, Result<DeleteAccount.ScheduledDeletion>>, DeleteAccount.Handler>();
             services.AddScoped<IQueryHandler<ExportAccountData.Query, Result<AccountDataExportResponse>>, ExportAccountData.Handler>();
             services.AddScoped<ICommandHandler<ForgotPassword.Command, Result>, ForgotPassword.Handler>();
             services.AddScoped<ICommandHandler<RegisterUser.Command, Result<IdentityId>>, RegisterUser.Handler>();
@@ -73,8 +77,14 @@ internal static class ApiDependencyInjection
 
             services.AddScoped<IEmailVerificationLinkFactory, EmailVerificationLinkFactory>();
             services.AddScoped<IPasswordResetLinkFactory, PasswordResetLinkFactory>();
+            services.AddScoped<ICancelDeletionLinkFactory, CancelDeletionLinkFactory>();
             services.AddScoped<IPasswordResetEmailSender, PasswordResetEmailSender>();
             services.AddScoped<IAccountConfirmationEmailSender, AccountConfirmationEmailSender>();
+            services.AddScoped<IAccountDeletionEmailSender, AccountDeletionEmailSender>();
+
+            services.AddScoped<IAccountErasureService, AccountErasureService>();
+            services.AddScoped<IAccountDeletionFinalizer, AccountDeletionFinalizer>();
+            services.AddHostedService<AccountDeletionFinalizerHostedService>();
 
             services.AddScoped<IUserSessionRevoker, UserSessionRevoker>();
 
@@ -92,6 +102,20 @@ internal static class ApiDependencyInjection
                 .ValidateOnStart();
 
             services.AddSingleton<IValidateOptions<OpenIddictSettings>, OpenIddictSettingsValidator>();
+
+            services.AddOptions<GdprSettings>()
+                .BindConfiguration(GdprSettings.ConfigurationSection)
+                .ValidateOnStart();
+
+            services.AddSingleton<IValidateOptions<GdprSettings>, GdprSettingsValidator>();
+
+            // The cancel-deletion token must stay valid for the whole grace period,
+            // unlike the 24h default token lifespan.
+            services.AddOptions<AccountDeletionCancellationTokenProviderOptions>()
+                .Configure<IOptions<GdprSettings>>((options, gdprSettings) =>
+                {
+                    options.TokenLifespan = gdprSettings.Value.DeletionGracePeriod;
+                });
 
             return services;
         }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiErrors/AuthErrors.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiErrors/AuthErrors.cs
@@ -59,4 +59,25 @@ internal static class AuthErrors
         new("Auth.AccountDeletionFailed",
             details,
             TypeOfError.Failure);
+
+    public static Error DeletionAlreadyScheduled =>
+        new("Auth.DeletionAlreadyScheduled",
+            "Account deletion is already scheduled.",
+            TypeOfError.DataConflict);
+
+    public static Error DeletionSchedulingFailed =>
+        new("Auth.DeletionSchedulingFailed",
+            "Account deletion could not be scheduled. Your account remains unchanged. " +
+            "Please try again later or contact support.",
+            TypeOfError.Failure);
+
+    public static Error InvalidCancelDeletionToken =>
+        new("Auth.InvalidCancelDeletionToken",
+            "The cancellation link is invalid or has expired.",
+            TypeOfError.Validation);
+
+    public static Error CancelDeletionFailed(string details) =>
+        new("Auth.CancelDeletionFailed",
+            details,
+            TypeOfError.Failure);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/AccountDeletionFinalizerHostedService.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/AccountDeletionFinalizerHostedService.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Services.Gdpr;
+using LotroKoniecDev.AuthSystem.API.Settings;
+
+namespace LotroKoniecDev.AuthSystem.API.BackgroundServices;
+
+/// <summary>
+/// Periodically finalizes GDPR account deletions whose grace period has elapsed.
+/// Runs once at startup (to catch up after downtime), then on every poll interval.
+/// </summary>
+internal sealed partial class AccountDeletionFinalizerHostedService : BackgroundService
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly GdprSettings _gdprSettings;
+    private readonly ILogger<AccountDeletionFinalizerHostedService> _logger;
+
+    public AccountDeletionFinalizerHostedService(
+        IServiceScopeFactory serviceScopeFactory,
+        TimeProvider timeProvider,
+        IOptions<GdprSettings> gdprSettings,
+        ILogger<AccountDeletionFinalizerHostedService> logger)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        _timeProvider = timeProvider;
+        _gdprSettings = gdprSettings.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await RunOnceAsync(stoppingToken);
+
+        using PeriodicTimer timer = new(_gdprSettings.DeletionFinalizationPollInterval, _timeProvider);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                await RunOnceAsync(stoppingToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Graceful shutdown.
+        }
+    }
+
+    private async Task RunOnceAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await using AsyncServiceScope scope = _serviceScopeFactory.CreateAsyncScope();
+            IAccountDeletionFinalizer finalizer =
+                scope.ServiceProvider.GetRequiredService<IAccountDeletionFinalizer>();
+
+            await finalizer.FinalizeDueAccountsAsync(stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogFinalizerRunFailed(_logger, ex);
+        }
+    }
+
+    [LoggerMessage(EventId = EventIds.GdprDeletionFinalizerRunFailed, Level = LogLevel.Error, Message = "GDPR deletion finalizer run failed. Will retry on the next poll.")]
+    private static partial void LogFinalizerRunFailed(ILogger logger, Exception exception);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -29,6 +29,15 @@ internal static class EventIds
     public const int GdprErasureArtifactsCleanupFailed = 2228;
     public const int GdprErasureEmergencyLockout = 2229;
     public const int GdprErasureEmergencyLockoutFailed = 2230;
+    public const int GdprDeletionScheduled = 2231;
+    public const int GdprDeletionCancelled = 2232;
+    public const int GdprDeletionFinalized = 2233;
+    public const int GdprCancelTokenInvalid = 2234;
+    public const int GdprDeletionScheduledEmailFailed = 2235;
+    public const int GdprDeletionCancelledEmailFailed = 2236;
+    public const int GdprDeletionScheduleUnwound = 2237;
+    public const int GdprDeletionFinalizerRunFailed = 2238;
+    public const int GdprDeletionFinalizerUserFailed = 2239;
 
     // Data Export (2240–2249)
     public const int ExportDataCompleted = 2241;
@@ -73,6 +82,20 @@ internal static class EventIds
     public const int LoginWrongPassword = 2622;
     public const int LoginSuccessful = 2623;
     public const int LoginEmailNotConfirmed = 2624;
+    public const int LoginDeletionScheduled = 2625;
     public const int PasswordResetCompletedViaUi = 2630;
     public const int RegisterCompletedViaUi = 2640;
+    public const int DeletionCancelledViaUi = 2650;
+
+    // GDPR Deletion Scheduling internals (2700–2709)
+    public const int GdprDeletionSchedulingUpdateFailed = 2700;
+    public const int GdprDeletionScheduleUnwindFailed = 2701;
+    public const int GdprDeletionScheduleUnwindException = 2702;
+    public const int GdprDeletionScheduleStampFailed = 2703;
+    public const int GdprDeletionScheduleArtifactRevocationFailed = 2704;
+    public const int GdprDeletionCancelStampFailed = 2705;
+
+    // Forgot/Reset Password deletion-window gates (2710–2719)
+    public const int ForgotPasswordDeletionScheduled = 2710;
+    public const int ResetPasswordDeletionScheduled = 2711;
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/DateTimeOffsetExtensions.cs
@@ -1,0 +1,15 @@
+namespace LotroKoniecDev.AuthSystem.API.Extensions;
+
+internal static class DateTimeOffsetExtensions
+{
+    private static readonly TimeZoneInfo PolandTimeZone =
+        TimeZoneInfo.FindSystemTimeZoneById("Europe/Warsaw");
+
+    /// <summary>
+    /// User-facing deadlines are rendered in the product's home timezone (lotro-translator.pl
+    /// serves a Polish audience). Formatting the raw UTC instant instead can state a
+    /// calendar day one earlier than the user's local perception near midnight.
+    /// </summary>
+    public static DateTimeOffset ToPolandTime(this DateTimeOffset value) =>
+        TimeZoneInfo.ConvertTime(value, PolandTimeZone);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/AuthorizeEndpoint.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/AuthorizeEndpoint.cs
@@ -77,6 +77,22 @@ internal sealed class AuthorizeEndpoint : IEndpoint
                 [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
 
+        // A live session cookie must not keep minting tokens for an account that is
+        // locked out or sitting in the GDPR deletion grace window (ADR-0031) — the
+        // session is terminated and the client is sent back through the login page.
+        if (user.DeletionScheduledAt is not null || await userManager.IsLockedOutAsync(user))
+        {
+            await httpContext.SignOutAsync(IdentityConstants.ApplicationScheme);
+
+            return Results.Forbid(
+                new AuthenticationProperties(new Dictionary<string, string?>
+                {
+                    [OpenIddictServerAspNetCoreConstants.Properties.Error] = Errors.LoginRequired,
+                    [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] = "The user account is no longer valid."
+                }),
+                [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
         ClaimsIdentity identity = new(
             authenticationType: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
             nameType: Claims.Name,

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/CancelAccountDeletion.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/CancelAccountDeletion.cs
@@ -1,0 +1,191 @@
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Identity;
+using LotroKoniecDev.AuthSystem.API.ApiErrors;
+using LotroKoniecDev.AuthSystem.API.Common;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.SharedKernel.Constants;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Features.Auth;
+
+/// <summary>
+/// Cancels a scheduled GDPR account deletion using the one-time token from the
+/// cancellation email (ADR-0031). Anonymous by design — the account is locked out for
+/// the whole grace window, so the emailed token is the only proof of ownership.
+/// Cancelling invalidates the current password (it may be the attacker's only asset)
+/// and hands back a fresh reset token that forces the password-reset flow.
+/// </summary>
+internal sealed partial class CancelAccountDeletion : IApiEndpoint
+{
+    internal sealed record Command(
+        string Email,
+        string Token,
+        string? IpAddress,
+        string? UserAgent) : ICommand<Result<CancelledDeletion>>;
+
+    internal sealed record CancelledDeletion(string PasswordResetToken);
+
+    internal sealed class CommandValidator : AbstractValidator<Command>
+    {
+        public CommandValidator()
+        {
+            RuleFor(x => x.Email)
+                .NotEmpty().WithMessage("A valid email address is required.")
+                .MaximumLength(EmailConstants.MaxLength)
+                    .WithMessage($"Email must not exceed {EmailConstants.MaxLength} characters.")
+                .Matches(EmailConstants.RegexPattern)
+                    .WithMessage("A valid email address is required.");
+
+            RuleFor(x => x.Token)
+                .NotEmpty().WithMessage("Cancellation token is required.");
+        }
+    }
+
+    internal sealed partial class Handler : ICommandHandler<Command, Result<CancelledDeletion>>
+    {
+        /// <summary>
+        /// Pre-computed hash for timing-equalization when user is not found.
+        /// </summary>
+        private static readonly string DummyPasswordHash =
+            new PasswordHasher<ApplicationUser>().HashPassword(new ApplicationUser(), "DummyP@ssw0rd!");
+
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IAccountDeletionEmailSender _emailSender;
+        private readonly IValidator<Command> _validator;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(
+            UserManager<ApplicationUser> userManager,
+            IAccountDeletionEmailSender emailSender,
+            IValidator<Command> validator,
+            ILogger<Handler> logger)
+        {
+            _userManager = userManager;
+            _emailSender = emailSender;
+            _validator = validator;
+            _logger = logger;
+        }
+
+        public async ValueTask<Result<CancelledDeletion>> Handle(Command command, CancellationToken cancellationToken)
+        {
+            ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                return Result.Failure<CancelledDeletion>(validationResult.ToValidationError(nameof(CancelAccountDeletion)));
+            }
+
+            string maskedEmail = command.Email.MaskEmail();
+            ApplicationUser? user = await _userManager.FindByEmailAsync(command.Email);
+
+            // Every path pays the same PBKDF2 cost. Burning the dummy hash only on the
+            // not-found branch would make existing accounts answer measurably FASTER
+            // (their path is just a cheap DataProtector check), turning response time
+            // into an inverted user-enumeration oracle.
+            _ = _userManager.PasswordHasher.VerifyHashedPassword(
+                new ApplicationUser(), DummyPasswordHash, "DummyP@ssw0rd!");
+
+            // Unknown email, no scheduled deletion and a bad token all collapse into the same
+            // generic error so the endpoint can't be used to probe account state.
+            if (user is null)
+            {
+                LogCancelTokenInvalid(_logger, maskedEmail, command.IpAddress, command.UserAgent);
+                return Result.Failure<CancelledDeletion>(AuthErrors.InvalidCancelDeletionToken);
+            }
+
+            bool tokenValid = await _userManager.VerifyUserTokenAsync(
+                user,
+                AccountDeletionCancellationTokenProvider.ProviderName,
+                AccountDeletionCancellationTokenProvider.CancelDeletionPurpose,
+                command.Token);
+
+            if (!tokenValid || user.DeletionScheduledAt is null)
+            {
+                LogCancelTokenInvalid(_logger, maskedEmail, command.IpAddress, command.UserAgent);
+                return Result.Failure<CancelledDeletion>(AuthErrors.InvalidCancelDeletionToken);
+            }
+
+            // The deletion may have been requested by whoever holds the current password,
+            // so the password dies with the cancellation; only the reset flow brings the
+            // account back.
+            user.DeletionScheduledAt = null;
+            user.LockoutEnd = null;
+            user.AccessFailedCount = 0;
+            user.PasswordHash = null;
+
+            IdentityResult updateResult = await _userManager.UpdateAsync(user);
+            if (!updateResult.Succeeded)
+            {
+                string errors = string.Join(", ", updateResult.Errors.Select(e => e.Description));
+                return Result.Failure<CancelledDeletion>(AuthErrors.CancelDeletionFailed(errors));
+            }
+
+            // Rotating the stamp makes the cancel token single-use and kills any leftover
+            // sessions; the reset token must be generated AFTER the rotation to stay valid.
+            IdentityResult stampResult = await _userManager.UpdateSecurityStampAsync(user);
+            if (!stampResult.Succeeded)
+            {
+                LogSecurityStampUpdateFailed(_logger, user.Id);
+            }
+
+            string passwordResetToken = await _userManager.GeneratePasswordResetTokenAsync(user);
+
+            Result emailResult = await _emailSender.SendDeletionCancelledEmailAsync(
+                user.Email!, cancellationToken);
+            if (emailResult.IsFailure)
+            {
+                LogCancelledEmailFailed(_logger, user.Id, emailResult.Error.Message);
+            }
+
+            LogDeletionCancelled(_logger, user.Id, command.IpAddress, command.UserAgent);
+
+            return Result.Success(new CancelledDeletion(passwordResetToken));
+        }
+
+        [LoggerMessage(EventId = EventIds.GdprDeletionCancelled, Level = LogLevel.Information, Message = "GDPR deletion cancelled for user {UserId}. IP: {IpAddress}, UserAgent: {UserAgent}")]
+        private static partial void LogDeletionCancelled(ILogger logger, Guid userId, string? ipAddress, string? userAgent);
+
+        [LoggerMessage(EventId = EventIds.GdprCancelTokenInvalid, Level = LogLevel.Warning, Message = "Invalid cancel-deletion token presented for {MaskedEmail}. IP: {IpAddress}, UserAgent: {UserAgent}")]
+        private static partial void LogCancelTokenInvalid(ILogger logger, string maskedEmail, string? ipAddress, string? userAgent);
+
+        [LoggerMessage(EventId = EventIds.GdprDeletionCancelledEmailFailed, Level = LogLevel.Error, Message = "Failed to send the deletion-cancelled confirmation email for user {UserId}: {Error}")]
+        private static partial void LogCancelledEmailFailed(ILogger logger, Guid userId, string error);
+
+        [LoggerMessage(EventId = EventIds.GdprDeletionCancelStampFailed, Level = LogLevel.Error, Message = "Failed to update security stamp for user {UserId} while cancelling deletion")]
+        private static partial void LogSecurityStampUpdateFailed(ILogger logger, Guid userId);
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapPost("auth/account/cancel-deletion", async (
+                CancelAccountDeletionRequest request,
+                HttpContext httpContext,
+                ICommandHandler<Command, Result<CancelledDeletion>> handler,
+                CancellationToken cancellationToken) =>
+            {
+                Command command = new(
+                    request.Email,
+                    request.Token,
+                    httpContext.Connection.RemoteIpAddress?.ToString(),
+                    httpContext.Request.Headers.UserAgent.ToString());
+
+                Result<CancelledDeletion> commandResult = await handler.Handle(command, cancellationToken);
+
+                return commandResult.IsFailure
+                    ? Results.Problem(commandResult.Error.ToProblemDetails())
+                    : Results.Ok(new CancelAccountDeletionResponse(commandResult.Value.PasswordResetToken));
+            })
+            .AllowAnonymous()
+            .RequireRateLimiting("auth-endpoint-limit")
+            .WithName(nameof(CancelAccountDeletion))
+            .WithTags("Account")
+            .Produces<CancelAccountDeletionResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/CancelAccountDeletion.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/CancelAccountDeletion.cs
@@ -136,7 +136,7 @@ internal sealed partial class CancelAccountDeletion : IApiEndpoint
             string passwordResetToken = await _userManager.GeneratePasswordResetTokenAsync(user);
 
             Result emailResult = await _emailSender.SendDeletionCancelledEmailAsync(
-                user.Email!, cancellationToken);
+                user.Id, user.Email!, cancellationToken);
             if (emailResult.IsFailure)
             {
                 LogCancelledEmailFailed(_logger, user.Id, emailResult.Error.Message);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ChangePassword.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ChangePassword.cs
@@ -69,6 +69,14 @@ internal sealed partial class ChangePassword : IApiEndpoint
                 return Result.Failure(AuthErrors.UserNotFound);
             }
 
+            // A still-valid pre-schedule access token must not mutate auth state during the
+            // grace window: the security-stamp rotation below would kill the emailed cancel
+            // link — the account's only recovery path while it is locked out (ADR-0031).
+            if (user.DeletionScheduledAt is not null)
+            {
+                return Result.Failure(AuthErrors.DeletionAlreadyScheduled);
+            }
+
             IdentityResult identityResult = await _userManager.ChangePasswordAsync(
                 user,
                 command.CurrentPassword,
@@ -136,6 +144,7 @@ internal sealed partial class ChangePassword : IApiEndpoint
             .Produces(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesProblem(StatusCodes.Status429TooManyRequests);
     }
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/DeleteAccount.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/DeleteAccount.cs
@@ -141,7 +141,7 @@ internal sealed partial class DeleteAccount : IApiEndpoint
                 AccountDeletionCancellationTokenProvider.CancelDeletionPurpose);
 
             Result emailResult = await _emailSender.SendDeletionScheduledEmailAsync(
-                email, cancelToken, finalizesAt, cancellationToken);
+                user.Id, email, cancelToken, finalizesAt, cancellationToken);
             if (emailResult.IsFailure)
             {
                 // Without the emailed link the owner has no way to cancel, so the schedule

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/DeleteAccount.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/DeleteAccount.cs
@@ -2,24 +2,38 @@ using System.Security.Claims;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
 using LotroKoniecDev.AuthSystem.API.ApiErrors;
 using LotroKoniecDev.AuthSystem.API.Common;
-using LotroKoniecDev.SharedKernel.Constants;
 using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
-
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
 using LotroKoniecDev.SharedKernel.Messaging;
 using LotroKoniecDev.SharedKernel.Monads;
 
 namespace LotroKoniecDev.AuthSystem.API.Features.Auth;
 
+/// <summary>
+/// Schedules GDPR account deletion instead of executing it immediately (ADR-0031):
+/// the account is locked for the grace period and a one-time cancellation link is emailed,
+/// so a stolen password alone can no longer erase an account irreversibly.
+/// The deletion finalizer performs the actual erasure once the grace period elapses.
+/// </summary>
 internal sealed partial class DeleteAccount : IApiEndpoint
 {
     internal sealed record Command(
         string UserId,
-        string Password) : ICommand<Result>;
+        string Password,
+        string? IpAddress,
+        string? UserAgent) : ICommand<Result<ScheduledDeletion>>;
+
+    internal sealed record ScheduledDeletion(
+        DateTimeOffset ScheduledAt,
+        DateTimeOffset FinalizesAt);
 
     internal sealed class CommandValidator : AbstractValidator<Command>
     {
@@ -33,11 +47,14 @@ internal sealed partial class DeleteAccount : IApiEndpoint
         }
     }
 
-    internal sealed partial class Handler : ICommandHandler<Command, Result>
+    internal sealed partial class Handler : ICommandHandler<Command, Result<ScheduledDeletion>>
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IOpenIddictTokenManager _tokenManager;
         private readonly IOpenIddictAuthorizationManager _authorizationManager;
+        private readonly IAccountDeletionEmailSender _emailSender;
+        private readonly TimeProvider _timeProvider;
+        private readonly GdprSettings _gdprSettings;
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
 
@@ -45,101 +62,104 @@ internal sealed partial class DeleteAccount : IApiEndpoint
             UserManager<ApplicationUser> userManager,
             IOpenIddictTokenManager tokenManager,
             IOpenIddictAuthorizationManager authorizationManager,
+            IAccountDeletionEmailSender emailSender,
+            TimeProvider timeProvider,
+            IOptions<GdprSettings> gdprSettings,
             IValidator<Command> validator,
             ILogger<Handler> logger)
         {
             _userManager = userManager;
             _tokenManager = tokenManager;
             _authorizationManager = authorizationManager;
+            _emailSender = emailSender;
+            _timeProvider = timeProvider;
+            _gdprSettings = gdprSettings.Value;
             _validator = validator;
             _logger = logger;
         }
 
-        public async ValueTask<Result> Handle(Command command, CancellationToken cancellationToken)
+        public async ValueTask<Result<ScheduledDeletion>> Handle(Command command, CancellationToken cancellationToken)
         {
             ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
             if (!validationResult.IsValid)
             {
-                return Result.Failure(validationResult.ToValidationError(nameof(DeleteAccount)));
+                return Result.Failure<ScheduledDeletion>(validationResult.ToValidationError(nameof(DeleteAccount)));
             }
 
             ApplicationUser? user = await _userManager.FindByIdAsync(command.UserId);
             if (user is null)
             {
-                return Result.Failure(AuthErrors.UserNotFound);
+                return Result.Failure<ScheduledDeletion>(AuthErrors.UserNotFound);
             }
-
-            LogGdprErasureInitiated(_logger, user.Id);
 
             bool passwordValid = await _userManager.CheckPasswordAsync(user, command.Password);
             if (!passwordValid)
             {
-                return Result.Failure(AuthErrors.InvalidCurrentPassword);
+                return Result.Failure<ScheduledDeletion>(AuthErrors.InvalidCurrentPassword);
             }
 
-            // No cross-context archival call (the KittySaver pattern is deliberately not lifted):
-            // the TranslationSystem stores only opaque IdentityId attribution references, which
-            // become non-attributable once the auth user below is anonymized.
-            // If any auth-side step fails, we must still try to lock the account
-            // so the data isn't accessible while support resolves the issue.
-            try
+            if (user.DeletionScheduledAt is not null)
             {
-                // Anonymize auth user data first (core GDPR requirement)
-                string anonymizedGuid = Guid.NewGuid().ToString("N");
-                user.UserName = anonymizedGuid;
-                user.NormalizedUserName = anonymizedGuid.ToUpperInvariant();
-                user.Email = $"{AnonymizationConstants.EmailPrefix}{anonymizedGuid}{AnonymizationConstants.EmailDomain}";
-                user.NormalizedEmail = $"{AnonymizationConstants.EmailPrefix.ToUpperInvariant()}{anonymizedGuid.ToUpperInvariant()}{AnonymizationConstants.EmailDomain.ToUpperInvariant()}";
-                user.PhoneNumber = null;
-                user.PasswordHash = null;
-                user.EmailConfirmed = false;
-                user.PhoneNumberConfirmed = false;
-                user.TwoFactorEnabled = false;
-                user.AccessFailedCount = 0;
-                user.DataProcessingConsentGiven = false;
-                user.DataProcessingConsentDate = null;
-                user.PrivacyPolicyAccepted = false;
-                user.PrivacyPolicyAcceptedDate = null;
-
-                IdentityResult updateResult = await _userManager.UpdateAsync(user);
-                if (!updateResult.Succeeded)
-                {
-                    string errors = string.Join(", ", updateResult.Errors.Select(e => e.Description));
-                    LogAnonymizationFailed(_logger, user.Id, errors);
-                    await TryLockAccountAsync(user);
-                    return Result.Failure(AuthErrors.AccountDeletionFailed(
-                        "Account deletion partially failed. Your account has been locked for security. Please contact support."));
-                }
-
-                LogAuthDataAnonymized(_logger, user.Id);
-
-                // Invalidate all sessions
-                await _userManager.UpdateSecurityStampAsync(user);
-
-                // Lock account permanently
-                await _userManager.SetLockoutEnabledAsync(user, true);
-                await _userManager.SetLockoutEndDateAsync(user, DateTimeOffset.MaxValue);
+                return Result.Failure<ScheduledDeletion>(AuthErrors.DeletionAlreadyScheduled);
             }
-            catch (Exception ex)
+
+            // The still-real email address; captured before any mutation so the
+            // cancellation link always reaches the legitimate owner.
+            string email = user.Email!;
+
+            DateTimeOffset scheduledAt = _timeProvider.GetUtcNow();
+            DateTimeOffset finalizesAt = scheduledAt + _gdprSettings.DeletionGracePeriod;
+
+            // Lock the account for the whole grace window so neither the requester nor
+            // a potential attacker can use it. Nothing is erased here — data stays intact
+            // until the finalizer runs after the grace period.
+            user.DeletionScheduledAt = scheduledAt;
+            user.LockoutEnabled = true;
+            user.LockoutEnd = finalizesAt;
+
+            IdentityResult updateResult = await _userManager.UpdateAsync(user);
+            if (!updateResult.Succeeded)
             {
-                LogAuthSideErasureFailed(_logger, ex, user.Id);
-                await TryLockAccountAsync(user);
-                return Result.Failure(AuthErrors.AccountDeletionFailed(
-                    "Account deletion partially failed. Your account has been locked for security. Please contact support."));
+                string errors = string.Join(", ", updateResult.Errors.Select(e => e.Description));
+                LogSchedulingUpdateFailed(_logger, user.Id, errors);
+                return Result.Failure<ScheduledDeletion>(AuthErrors.DeletionSchedulingFailed);
             }
 
-            // Best-effort cleanup: revoke tokens, remove roles/claims/logins.
-            // The account is already anonymized and locked at this point,
-            // so failures here don't compromise GDPR compliance.
-            await CleanupAuthArtifactsAsync(user, cancellationToken);
+            // Invalidate all sessions; the cancel token must be generated AFTER the stamp
+            // rotation because it binds to the security stamp (one-time-use guarantee).
+            IdentityResult stampResult = await _userManager.UpdateSecurityStampAsync(user);
+            if (!stampResult.Succeeded)
+            {
+                LogSecurityStampUpdateFailed(_logger, user.Id);
+            }
 
-            LogAccountDeleted(_logger, user.Id);
+            await TryRevokeOpenIddictArtifactsAsync(user, cancellationToken);
 
-            return Result.Success();
+            string cancelToken = await _userManager.GenerateUserTokenAsync(
+                user,
+                AccountDeletionCancellationTokenProvider.ProviderName,
+                AccountDeletionCancellationTokenProvider.CancelDeletionPurpose);
+
+            Result emailResult = await _emailSender.SendDeletionScheduledEmailAsync(
+                email, cancelToken, finalizesAt, cancellationToken);
+            if (emailResult.IsFailure)
+            {
+                // Without the emailed link the owner has no way to cancel, so the schedule
+                // is unwound and the user is asked to retry once mail delivery recovers.
+                LogScheduledEmailFailed(_logger, user.Id, emailResult.Error.Message);
+                await TryUnwindScheduleAsync(user);
+                return Result.Failure<ScheduledDeletion>(AuthErrors.DeletionSchedulingFailed);
+            }
+
+            LogDeletionScheduled(_logger, user.Id, finalizesAt, command.IpAddress, command.UserAgent);
+
+            return Result.Success(new ScheduledDeletion(scheduledAt, finalizesAt));
         }
 
-        private async Task CleanupAuthArtifactsAsync(ApplicationUser user, CancellationToken cancellationToken)
+        private async Task TryRevokeOpenIddictArtifactsAsync(ApplicationUser user, CancellationToken cancellationToken)
         {
+            // Best effort: refresh tokens are reference tokens, so revocation cuts them off
+            // immediately; self-contained access tokens simply expire within the hour.
             try
             {
                 string userId = user.Id.ToString();
@@ -153,75 +173,59 @@ internal sealed partial class DeleteAccount : IApiEndpoint
                 {
                     await _authorizationManager.TryRevokeAsync(authorization, cancellationToken);
                 }
-
-                IList<string> roles = await _userManager.GetRolesAsync(user);
-                if (roles.Count > 0)
-                {
-                    await _userManager.RemoveFromRolesAsync(user, roles);
-                }
-
-                IList<Claim> claims = await _userManager.GetClaimsAsync(user);
-                if (claims.Count > 0)
-                {
-                    await _userManager.RemoveClaimsAsync(user, claims);
-                }
-
-                IList<UserLoginInfo> logins = await _userManager.GetLoginsAsync(user);
-                foreach (UserLoginInfo login in logins)
-                {
-                    await _userManager.RemoveLoginAsync(user, login.LoginProvider, login.ProviderKey);
-                }
-
-                LogArtifactsCleaned(_logger, user.Id);
             }
             catch (Exception ex)
             {
-                LogArtifactsCleanupFailed(_logger, ex, user.Id);
+                LogArtifactRevocationFailed(_logger, ex, user.Id);
             }
         }
 
-        private async Task TryLockAccountAsync(ApplicationUser user)
+        private async Task TryUnwindScheduleAsync(ApplicationUser user)
         {
             try
             {
-                await _userManager.SetLockoutEnabledAsync(user, true);
-                await _userManager.SetLockoutEndDateAsync(user, DateTimeOffset.MaxValue);
-                await _userManager.UpdateSecurityStampAsync(user);
+                user.DeletionScheduledAt = null;
+                user.LockoutEnd = null;
 
-                LogEmergencyLockout(_logger, user.Id);
+                IdentityResult updateResult = await _userManager.UpdateAsync(user);
+                if (updateResult.Succeeded)
+                {
+                    LogScheduleUnwound(_logger, user.Id);
+                    return;
+                }
+
+                string errors = string.Join(", ", updateResult.Errors.Select(e => e.Description));
+                LogScheduleUnwindFailed(_logger, user.Id, errors);
             }
             catch (Exception ex)
             {
-                LogEmergencyLockoutFailed(_logger, ex, user.Id);
+                LogScheduleUnwindException(_logger, ex, user.Id);
             }
         }
 
-        [LoggerMessage(EventId = EventIds.GdprErasureInitiated, Level = LogLevel.Information, Message = "GDPR erasure request initiated for user {UserId}")]
-        private static partial void LogGdprErasureInitiated(ILogger logger, Guid userId);
+        [LoggerMessage(EventId = EventIds.GdprDeletionScheduled, Level = LogLevel.Information, Message = "GDPR deletion scheduled for user {UserId}; finalizes at {FinalizesAt}. IP: {IpAddress}, UserAgent: {UserAgent}")]
+        private static partial void LogDeletionScheduled(ILogger logger, Guid userId, DateTimeOffset finalizesAt, string? ipAddress, string? userAgent);
 
-        [LoggerMessage(EventId = EventIds.GdprErasureAnonymizationFailed, Level = LogLevel.Critical, Message = "Failed to anonymize user {UserId}. Manual cleanup required. Errors: {Errors}")]
-        private static partial void LogAnonymizationFailed(ILogger logger, Guid userId, string errors);
+        [LoggerMessage(EventId = EventIds.GdprDeletionScheduledEmailFailed, Level = LogLevel.Error, Message = "Failed to send the deletion-scheduled email for user {UserId}: {Error}. Unwinding the schedule.")]
+        private static partial void LogScheduledEmailFailed(ILogger logger, Guid userId, string error);
 
-        [LoggerMessage(EventId = EventIds.GdprErasureAuthAnonymized, Level = LogLevel.Information, Message = "GDPR erasure: auth data anonymized for user {UserId}")]
-        private static partial void LogAuthDataAnonymized(ILogger logger, Guid userId);
+        [LoggerMessage(EventId = EventIds.GdprDeletionScheduleUnwound, Level = LogLevel.Warning, Message = "Deletion schedule unwound for user {UserId} because the cancellation email could not be sent")]
+        private static partial void LogScheduleUnwound(ILogger logger, Guid userId);
 
-        [LoggerMessage(EventId = EventIds.GdprErasureAuthFailed, Level = LogLevel.Critical, Message = "Auth-side GDPR erasure failed for user {UserId}. Manual cleanup required.")]
-        private static partial void LogAuthSideErasureFailed(ILogger logger, Exception exception, Guid userId);
+        [LoggerMessage(EventId = EventIds.GdprDeletionScheduleUnwindFailed, Level = LogLevel.Critical, Message = "Failed to unwind the deletion schedule for user {UserId}: {Errors}. Account stays locked with a schedule but without a cancellation email. Manual intervention required.")]
+        private static partial void LogScheduleUnwindFailed(ILogger logger, Guid userId, string errors);
 
-        [LoggerMessage(EventId = EventIds.GdprErasureAccountDeleted, Level = LogLevel.Information, Message = "Account deleted (anonymized) for user {UserId}")]
-        private static partial void LogAccountDeleted(ILogger logger, Guid userId);
+        [LoggerMessage(EventId = EventIds.GdprDeletionScheduleUnwindException, Level = LogLevel.Critical, Message = "Exception while unwinding the deletion schedule for user {UserId}. Manual intervention required.")]
+        private static partial void LogScheduleUnwindException(ILogger logger, Exception exception, Guid userId);
 
-        [LoggerMessage(EventId = EventIds.GdprErasureArtifactsCleaned, Level = LogLevel.Information, Message = "GDPR erasure: tokens, authorizations, roles, claims, and logins cleaned up for user {UserId}")]
-        private static partial void LogArtifactsCleaned(ILogger logger, Guid userId);
+        [LoggerMessage(EventId = EventIds.GdprDeletionSchedulingUpdateFailed, Level = LogLevel.Error, Message = "Failed to persist the deletion schedule for user {UserId}: {Errors}")]
+        private static partial void LogSchedulingUpdateFailed(ILogger logger, Guid userId, string errors);
 
-        [LoggerMessage(EventId = EventIds.GdprErasureArtifactsCleanupFailed, Level = LogLevel.Warning, Message = "GDPR erasure: cleanup of auth artifacts failed for user {UserId}. Account is already anonymized and locked — artifacts will expire naturally.")]
-        private static partial void LogArtifactsCleanupFailed(ILogger logger, Exception exception, Guid userId);
+        [LoggerMessage(EventId = EventIds.GdprDeletionScheduleStampFailed, Level = LogLevel.Error, Message = "Failed to update security stamp for user {UserId} while scheduling deletion")]
+        private static partial void LogSecurityStampUpdateFailed(ILogger logger, Guid userId);
 
-        [LoggerMessage(EventId = EventIds.GdprErasureEmergencyLockout, Level = LogLevel.Warning, Message = "Emergency lockout applied for user {UserId} after partial GDPR erasure failure")]
-        private static partial void LogEmergencyLockout(ILogger logger, Guid userId);
-
-        [LoggerMessage(EventId = EventIds.GdprErasureEmergencyLockoutFailed, Level = LogLevel.Critical, Message = "Failed to apply emergency lockout for user {UserId}. Manual intervention required immediately.")]
-        private static partial void LogEmergencyLockoutFailed(ILogger logger, Exception exception, Guid userId);
+        [LoggerMessage(EventId = EventIds.GdprDeletionScheduleArtifactRevocationFailed, Level = LogLevel.Warning, Message = "Failed to revoke OpenIddict artifacts for user {UserId} while scheduling deletion. Refresh tokens may stay valid until expiry.")]
+        private static partial void LogArtifactRevocationFailed(ILogger logger, Exception exception, Guid userId);
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
@@ -229,7 +233,8 @@ internal sealed partial class DeleteAccount : IApiEndpoint
         endpointRouteBuilder.MapPost("auth/account/delete", async (
                 DeleteAccountRequest request,
                 ClaimsPrincipal user,
-                ICommandHandler<Command, Result> handler,
+                HttpContext httpContext,
+                ICommandHandler<Command, Result<ScheduledDeletion>> handler,
                 CancellationToken cancellationToken) =>
             {
                 string? userId = user.FindFirstValue(ClaimTypes.NameIdentifier)
@@ -240,13 +245,25 @@ internal sealed partial class DeleteAccount : IApiEndpoint
                     return Results.Unauthorized();
                 }
 
-                Command command = new(userId, request.Password);
+                Command command = new(
+                    userId,
+                    request.Password,
+                    httpContext.Connection.RemoteIpAddress?.ToString(),
+                    httpContext.Request.Headers.UserAgent.ToString());
 
-                Result commandResult = await handler.Handle(command, cancellationToken);
+                Result<ScheduledDeletion> commandResult = await handler.Handle(command, cancellationToken);
 
-                return commandResult.IsFailure
-                    ? Results.Problem(commandResult.Error.ToProblemDetails())
-                    : Results.NoContent();
+                if (commandResult.IsFailure)
+                {
+                    return Results.Problem(commandResult.Error.ToProblemDetails());
+                }
+
+                httpContext.Response.Headers[DeletionScheduledAtHeader] =
+                    commandResult.Value.ScheduledAt.ToString("O");
+                httpContext.Response.Headers[DeletionFinalizesAtHeader] =
+                    commandResult.Value.FinalizesAt.ToString("O");
+
+                return Results.NoContent();
             })
             .RequireAuthorization()
             .RequireRateLimiting("auth-endpoint-limit")
@@ -255,6 +272,10 @@ internal sealed partial class DeleteAccount : IApiEndpoint
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
     }
+
+    public const string DeletionScheduledAtHeader = "X-Deletion-Scheduled-At";
+    public const string DeletionFinalizesAtHeader = "X-Deletion-Finalizes-At";
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ExportAccountData.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ExportAccountData.cs
@@ -53,7 +53,8 @@ internal sealed partial class ExportAccountData : IApiEndpoint
                     appUser.DataProcessingConsentGiven,
                     appUser.DataProcessingConsentDate,
                     appUser.PrivacyPolicyAccepted,
-                    appUser.PrivacyPolicyAcceptedDate),
+                    appUser.PrivacyPolicyAcceptedDate,
+                    appUser.DeletionScheduledAt),
                 IsComplete: true);
 
             LogGdprExportCompleted(_logger, appUser.Id);
@@ -94,7 +95,8 @@ internal sealed partial class ExportAccountData : IApiEndpoint
                 return HateoasResults.Ok(queryResult.Value, r =>
                 {
                     r.Links = accountAggregateLinkFactory.CreateAccountLinks(
-                        isEmailConfirmed: r.AuthData.EmailConfirmed);
+                        isEmailConfirmed: r.AuthData.EmailConfirmed,
+                        isDeletionScheduled: r.AuthData.DeletionScheduledAt is not null);
                 });
             })
             .RequireAuthorization()

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ForgotPassword.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ForgotPassword.cs
@@ -89,11 +89,10 @@ internal sealed partial class ForgotPassword : IApiEndpoint
 
             string token = await _userManager.GeneratePasswordResetTokenAsync(user);
 
-            Result emailResult = await _emailSender.SendPasswordResetEmailAsync(command.Email, token, cancellationToken);
+            Result emailResult = await _emailSender.SendPasswordResetEmailAsync(user.Id, command.Email, token, cancellationToken);
             if (emailResult.IsFailure)
             {
-                string maskedEmail = command.Email.MaskEmail();
-                LogPasswordResetEmailFailed(_logger, maskedEmail, emailResult.Error.Message);
+                LogPasswordResetEmailFailed(_logger, user.Id, emailResult.Error.Message);
             }
 
             return Result.Success();
@@ -102,8 +101,8 @@ internal sealed partial class ForgotPassword : IApiEndpoint
         [LoggerMessage(EventId = EventIds.ForgotPasswordNonExistent, Level = LogLevel.Information, Message = "Password reset requested for non-existent email {Email}")]
         private static partial void LogPasswordResetNonExistent(ILogger logger, string email);
 
-        [LoggerMessage(EventId = EventIds.ForgotPasswordEmailFailed, Level = LogLevel.Error, Message = "Failed to send password reset email to {Email}: {Error}")]
-        private static partial void LogPasswordResetEmailFailed(ILogger logger, string email, string error);
+        [LoggerMessage(EventId = EventIds.ForgotPasswordEmailFailed, Level = LogLevel.Error, Message = "Failed to send password reset email for user {UserId}: {Error}")]
+        private static partial void LogPasswordResetEmailFailed(ILogger logger, Guid userId, string error);
 
         [LoggerMessage(EventId = EventIds.ForgotPasswordDeletionScheduled, Level = LogLevel.Information, Message = "Password reset skipped for user {UserId}: account deletion is scheduled")]
         private static partial void LogPasswordResetSkippedDeletionScheduled(ILogger logger, Guid userId);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ForgotPassword.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ForgotPassword.cs
@@ -78,6 +78,15 @@ internal sealed partial class ForgotPassword : IApiEndpoint
                 return Result.Success();
             }
 
+            // While GDPR deletion is scheduled, the emailed cancel-deletion link is the only
+            // recovery path — a password reset would neither unlock the account nor stop the
+            // deletion. Pretend success so account state can't be probed.
+            if (user.DeletionScheduledAt is not null)
+            {
+                LogPasswordResetSkippedDeletionScheduled(_logger, user.Id);
+                return Result.Success();
+            }
+
             string token = await _userManager.GeneratePasswordResetTokenAsync(user);
 
             Result emailResult = await _emailSender.SendPasswordResetEmailAsync(command.Email, token, cancellationToken);
@@ -95,6 +104,9 @@ internal sealed partial class ForgotPassword : IApiEndpoint
 
         [LoggerMessage(EventId = EventIds.ForgotPasswordEmailFailed, Level = LogLevel.Error, Message = "Failed to send password reset email to {Email}: {Error}")]
         private static partial void LogPasswordResetEmailFailed(ILogger logger, string email, string error);
+
+        [LoggerMessage(EventId = EventIds.ForgotPasswordDeletionScheduled, Level = LogLevel.Information, Message = "Password reset skipped for user {UserId}: account deletion is scheduled")]
+        private static partial void LogPasswordResetSkippedDeletionScheduled(ILogger logger, Guid userId);
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
@@ -139,11 +139,10 @@ internal sealed partial class RegisterUser : IApiEndpoint
 
                 string emailToken = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                 Result emailResult = await _accountConfirmationEmailSender.SendEmailConfirmationAsync(
-                    command.Email, emailToken, cancellationToken);
+                    user.Id, command.Email, emailToken, cancellationToken);
                 if (emailResult.IsFailure)
                 {
-                    string maskedEmail = command.Email.MaskEmail();
-                    LogConfirmationEmailFailed(_logger, maskedEmail, emailResult.Error.Message);
+                    LogConfirmationEmailFailed(_logger, user.Id, emailResult.Error.Message);
 
                     await _userManager.ConfirmEmailAsync(user, emailToken);
                 }
@@ -165,8 +164,8 @@ internal sealed partial class RegisterUser : IApiEndpoint
             return IdentityId.Create(user.Id);
         }
 
-        [LoggerMessage(EventId = EventIds.RegisterEmailFallback, Level = LogLevel.Warning, Message = "Failed to send confirmation email to {Email}: {Error}. Auto-confirming account as fallback")]
-        private static partial void LogConfirmationEmailFailed(ILogger logger, string email, string error);
+        [LoggerMessage(EventId = EventIds.RegisterEmailFallback, Level = LogLevel.Warning, Message = "Failed to send confirmation email for user {UserId}: {Error}. Auto-confirming account as fallback")]
+        private static partial void LogConfirmationEmailFailed(ILogger logger, Guid userId, string error);
 
         [LoggerMessage(EventId = EventIds.RegisterConcurrentRace, Level = LogLevel.Warning, Message = "Concurrent registration race condition for email {Email}")]
         private static partial void LogConcurrentRegistration(ILogger logger, Exception exception, string email);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ResendEmailConfirmation.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ResendEmailConfirmation.cs
@@ -90,10 +90,10 @@ internal sealed partial class ResendEmailConfirmation : IApiEndpoint
             string token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
 
             Result emailResult = await _accountConfirmationEmailSender.SendEmailConfirmationAsync(
-                command.Email, token, cancellationToken);
+                user.Id, command.Email, token, cancellationToken);
             if (emailResult.IsFailure)
             {
-                LogResendEmailFailed(_logger, maskedEmail, emailResult.Error.Message);
+                LogResendEmailFailed(_logger, user.Id, emailResult.Error.Message);
             }
 
             return Result.Success(); //anti-enumeration pattern
@@ -105,8 +105,8 @@ internal sealed partial class ResendEmailConfirmation : IApiEndpoint
         [LoggerMessage(EventId = EventIds.ResendConfirmAlreadyConfirmed, Level = LogLevel.Information, Message = "Email confirmation resend requested for already confirmed email {Email}")]
         private static partial void LogResendAlreadyConfirmed(ILogger logger, string email);
 
-        [LoggerMessage(EventId = EventIds.ResendConfirmEmailFailed, Level = LogLevel.Error, Message = "Failed to send confirmation email to {Email}: {Error}")]
-        private static partial void LogResendEmailFailed(ILogger logger, string email, string error);
+        [LoggerMessage(EventId = EventIds.ResendConfirmEmailFailed, Level = LogLevel.Error, Message = "Failed to send confirmation email for user {UserId}: {Error}")]
+        private static partial void LogResendEmailFailed(ILogger logger, Guid userId, string error);
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ResetPassword.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ResetPassword.cs
@@ -83,6 +83,14 @@ internal sealed partial class ResetPassword : IApiEndpoint
                 return Result.Failure(AuthErrors.InvalidPasswordResetToken);
             }
 
+            // While GDPR deletion is scheduled, only the emailed cancel-deletion link may
+            // restore the account. The generic invalid-token error prevents state probing.
+            if (user.DeletionScheduledAt is not null)
+            {
+                LogPasswordResetBlockedDeletionScheduled(_logger, user.Id);
+                return Result.Failure(AuthErrors.InvalidPasswordResetToken);
+            }
+
             IdentityResult identityResult = await _userManager.ResetPasswordAsync(user, command.Token, command.NewPassword);
 
             if (!identityResult.Succeeded)
@@ -113,6 +121,9 @@ internal sealed partial class ResetPassword : IApiEndpoint
 
         [LoggerMessage(EventId = EventIds.ResetPasswordSecurityStampFailed, Level = LogLevel.Error, Message = "Failed to update security stamp for user {UserId} after password change")]
         private static partial void LogSecurityStampUpdateFailed(ILogger logger, Guid userId);
+
+        [LoggerMessage(EventId = EventIds.ResetPasswordDeletionScheduled, Level = LogLevel.Warning, Message = "Password reset blocked for user {UserId}: account deletion is scheduled")]
+        private static partial void LogPasswordResetBlockedDeletionScheduled(ILogger logger, Guid userId);
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/TokenEndpoint.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/TokenEndpoint.cs
@@ -93,6 +93,27 @@ internal sealed class TokenEndpoint : IEndpoint
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
+        // A deletion-scheduled account is also locked out, so this gate must run before the
+        // lockout-aware sign-in check. The specific error is revealed only after the password
+        // is verified, keeping the endpoint unusable for account-state probing.
+        if (user.DeletionScheduledAt is not null)
+        {
+            bool deletionScheduledPasswordValid = await userManager.CheckPasswordAsync(user, request.Password!);
+            if (!deletionScheduledPasswordValid)
+            {
+                await userManager.AccessFailedAsync(user);
+                return Results.Problem(
+                    title: Errors.InvalidGrant,
+                    detail: "The email/password combination is invalid.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            return Results.Problem(
+                title: Errors.InvalidGrant,
+                detail: "account_deletion_scheduled",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
         SignInResult result = await signInManager.CheckPasswordSignInAsync(user, request.Password!, lockoutOnFailure: true);
 
         if (result.IsLockedOut || !result.Succeeded)
@@ -130,6 +151,17 @@ internal sealed class TokenEndpoint : IEndpoint
         ApplicationUser? user = await userManager.FindByIdAsync(userId);
 
         if (user is null)
+        {
+            return Results.Problem(
+                title: Errors.InvalidGrant,
+                detail: "The refresh token is no longer valid.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        // Refresh tokens are revoked when GDPR deletion is scheduled, but revocation is
+        // best-effort — this gate guarantees a locked or deletion-scheduled account can
+        // never refresh its way back to a usable access token.
+        if (user.DeletionScheduledAt is not null || await userManager.IsLockedOutAsync(user))
         {
             return Results.Problem(
                 title: Errors.InvalidGrant,

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/AccountAggregateLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/AccountAggregateLinkFactory.cs
@@ -14,7 +14,7 @@ internal sealed class AccountAggregateLinkFactory : IAccountAggregateLinkFactory
         _linkFactory = linkFactory;
     }
 
-    public List<LinkDto> CreateAccountLinks(bool isEmailConfirmed)
+    public List<LinkDto> CreateAccountLinks(bool isEmailConfirmed, bool isDeletionScheduled)
     {
         List<LinkDto> links = [];
 
@@ -23,6 +23,19 @@ internal sealed class AccountAggregateLinkFactory : IAccountAggregateLinkFactory
             endpoint: nameof(ExportAccountData),
             rel: Rels.Self,
             method: HttpMethods.Get));
+
+        // While deletion is scheduled the account is locked; the only meaningful
+        // transition is cancelling the deletion (via the emailed one-time token),
+        // so the normal account rels are suppressed as dead ends.
+        if (isDeletionScheduled)
+        {
+            links.AddIfPresent(_linkFactory.Create(
+                endpoint: nameof(CancelAccountDeletion),
+                rel: Rels.CancelDeletion,
+                method: HttpMethods.Post));
+
+            return links;
+        }
 
         // Always-available state transitions for an authenticated, active account
         links.AddIfPresent(_linkFactory.Create(

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/IAccountAggregateLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/IAccountAggregateLinkFactory.cs
@@ -17,5 +17,9 @@ internal interface IAccountAggregateLinkFactory
     /// Whether the user's email has already been confirmed. Drives the
     /// visibility of the <c>resend-email-confirmation</c> state transition.
     /// </param>
-    List<LinkDto> CreateAccountLinks(bool isEmailConfirmed);
+    /// <param name="isDeletionScheduled">
+    /// Whether GDPR deletion is scheduled for the account. While scheduled,
+    /// the only advertised transition is <c>cancel-deletion</c> (ADR-0031).
+    /// </param>
+    List<LinkDto> CreateAccountLinks(bool isEmailConfirmed, bool isDeletionScheduled);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/CancelDeletion.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/CancelDeletion.cshtml
@@ -1,0 +1,363 @@
+@page
+@model LotroKoniecDev.AuthSystem.API.Pages.Account.CancelDeletionModel
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Anulowanie usunięcia konta — lotro-translator.pl</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@@400;500;600;700;800&family=JetBrains+Mono:wght@@400;500&display=swap" rel="stylesheet" />
+    <style>
+        :root {
+            --bg:        oklch(0.16 0.011 80);
+            --bg-2:      oklch(0.20 0.013 80);
+            --surface:   oklch(0.23 0.014 80);
+            --surface-hi:oklch(0.28 0.016 80);
+            --border:    oklch(0.34 0.016 80);
+            --border-hi: oklch(0.44 0.020 80);
+
+            --text:      oklch(0.96 0.008 85);
+            --text-mute: oklch(0.80 0.012 85);
+            --text-dim:  oklch(0.68 0.014 85);
+
+            --accent:     oklch(0.78 0.11 84);
+            --accent-hi:  oklch(0.85 0.12 84);
+            --accent-dim: oklch(0.48 0.07 84);
+            --accent-soft:oklch(0.32 0.05 84);
+
+            --danger:      oklch(0.68 0.16 25);
+            --danger-hi:   oklch(0.76 0.18 25);
+            --danger-dim:  oklch(0.42 0.10 25);
+            --danger-soft: oklch(0.30 0.07 25);
+
+            --radius: 14px;
+            --radius-sm: 8px;
+            --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
+
+            --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
+            --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        }
+
+        * { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; }
+        body {
+            background: var(--bg);
+            color: var(--text);
+            font-family: var(--font-sans);
+            font-size: 15px;
+            line-height: 1.55;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            min-height: 100vh;
+        }
+        a { color: inherit; text-decoration: none; }
+        button { font-family: inherit; cursor: pointer; }
+
+        .app {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            background:
+                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
+        }
+
+        .auth-top {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            padding: 16px 28px;
+            border-bottom: 1px solid var(--border);
+            background: oklch(0.15 0.011 80 / 0.7);
+            backdrop-filter: blur(10px);
+        }
+        .brand {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            color: var(--text);
+            font-weight: 700;
+            font-size: 16px;
+            letter-spacing: -0.01em;
+        }
+        .brand-mark {
+            width: 30px; height: 30px;
+            border-radius: 8px;
+            background: linear-gradient(160deg, var(--accent), var(--accent-dim));
+            color: oklch(0.16 0.012 80);
+            display: grid;
+            place-items: center;
+            box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
+        }
+        .brand-mark svg { width: 17px; height: 17px; }
+        .brand-accent { color: var(--accent-hi); }
+        .auth-top .top-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 7px;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--text-mute);
+            padding: 7px 13px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-2);
+            transition: color .15s, border-color .15s, background .15s;
+        }
+        .auth-top .top-link:hover { color: var(--text); border-color: var(--border-hi); background: var(--surface-hi); }
+        .auth-top .top-link svg { width: 13px; height: 13px; }
+
+        .auth-main {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 48px 24px 56px;
+        }
+        .auth-stack { width: 100%; max-width: 416px; }
+
+        .auth-eyebrow {
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.18em;
+            color: var(--accent);
+            text-align: center;
+            margin: 0 0 16px;
+            text-transform: uppercase;
+        }
+        .auth-eyebrow.danger { color: var(--danger-hi); }
+
+        .auth-panel {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            overflow: hidden;
+            width: 100%;
+        }
+        .auth-panel-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 18px 24px;
+            border-bottom: 1px solid var(--border);
+            background: linear-gradient(to bottom,
+                oklch(0.25 0.016 80 / 0.6),
+                oklch(0.22 0.014 80 / 0));
+        }
+        .auth-panel-head h2 {
+            margin: 0;
+            font-size: 16px;
+            font-weight: 700;
+            letter-spacing: -0.005em;
+            color: var(--text);
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .auth-panel-head .panel-icon {
+            width: 30px; height: 30px;
+            border-radius: 8px;
+            background: var(--bg-2);
+            border: 1px solid var(--border);
+            color: var(--accent-hi);
+            display: grid;
+            place-items: center;
+            flex: 0 0 30px;
+        }
+        .auth-panel-head .panel-icon svg { width: 16px; height: 16px; }
+        .auth-panel-head .panel-aside {
+            font-family: var(--font-mono);
+            font-size: 10.5px;
+            color: var(--text-mute);
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+        .auth-panel-body {
+            padding: 22px 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+        .auth-lead {
+            margin: -2px 0 0;
+            font-size: 13.5px;
+            color: var(--text-mute);
+            line-height: 1.5;
+        }
+
+        .auth-alert {
+            display: flex;
+            align-items: flex-start;
+            gap: 10px;
+            padding: 13px 15px;
+            background: oklch(0.30 0.07 25 / 0.4);
+            border: 1px solid var(--danger-dim);
+            border-radius: var(--radius-sm);
+            color: oklch(0.92 0.04 25);
+            font-size: 13px;
+            line-height: 1.45;
+        }
+        .auth-alert > svg { width: 18px; height: 18px; flex: 0 0 18px; color: var(--danger-hi); margin-top: 1px; }
+        .auth-alert .t { font-weight: 600; display: block; }
+        .auth-alert .s {
+            display: block;
+            margin-top: 3px;
+            color: oklch(0.82 0.06 25);
+            font-size: 12.5px;
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            padding: 13px 20px;
+            border-radius: var(--radius-sm);
+            border: 1px solid transparent;
+            font-weight: 600;
+            font-size: 14.5px;
+            transition: transform .08s, background .15s, border-color .15s, color .15s;
+        }
+        .btn:active { transform: translateY(1px); }
+        .btn svg { width: 16px; height: 16px; flex: 0 0 16px; }
+        .btn-primary {
+            background: var(--accent);
+            color: oklch(0.16 0.012 80);
+            border-color: oklch(0.62 0.09 84);
+        }
+        .btn-primary:hover { background: var(--accent-hi); }
+        .btn-ghost {
+            background: transparent;
+            color: var(--text-mute);
+            border-color: var(--border);
+        }
+        .btn-ghost:hover { color: var(--text); border-color: var(--border-hi); background: var(--surface-hi); }
+        .btn-block { width: 100%; }
+
+        .auth-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 2px; }
+
+        .auth-meta {
+            margin-top: 16px;
+            font-family: var(--font-mono);
+            font-size: 10.5px;
+            letter-spacing: 0.08em;
+            color: var(--text-dim);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            text-transform: uppercase;
+        }
+        .auth-meta svg { width: 12px; height: 12px; color: var(--accent-hi); }
+
+        .foot {
+            padding: 22px 28px 26px;
+            border-top: 1px solid var(--border);
+            text-align: center;
+        }
+        .foot p {
+            margin: 0;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            color: var(--text-mute);
+        }
+
+        @@media (max-width: 640px) {
+            .auth-top { padding: 14px 18px; }
+            .auth-top .top-link span { display: none; }
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <div class="auth-top">
+            <a href="https://lotro-translator.pl" class="brand">
+                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="1.1" fill="currentColor"/></svg></span>
+                <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
+            </a>
+            <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
+        </div>
+
+        <div class="auth-main">
+            <div class="auth-stack">
+                @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+                {
+                    <p class="auth-eyebrow danger">Bezpieczeństwo konta</p>
+                    <section class="auth-panel" aria-labelledby="cancel-h">
+                        <header class="auth-panel-head">
+                            <h2 id="cancel-h">
+                                <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></span>
+                                Anulowanie usunięcia konta
+                            </h2>
+                            <span class="panel-aside">Błąd</span>
+                        </header>
+                        <div class="auth-panel-body">
+                            <div class="auth-alert" role="alert" data-testid="cancel-deletion-error">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.7 3h16.94a2 2 0 0 0 1.7-3L13.69 3.86a2 2 0 0 0-3.4 0z"/></svg>
+                                <div>
+                                    <span class="t">Link wygasł lub jest nieprawidłowy</span>
+                                    <span class="s">@Model.ErrorMessage Link anulujący można wykorzystać tylko raz i działa do dnia zaplanowanego usunięcia konta. Jeśli potrzebujesz pomocy, skontaktuj się z nami.</span>
+                                </div>
+                            </div>
+                            <div class="auth-actions">
+                                <a href="/Account/Login" class="btn btn-ghost btn-block">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m11 19-7-7 7-7"/></svg>
+                                    Powrót do logowania
+                                </a>
+                            </div>
+                        </div>
+                    </section>
+                }
+                else
+                {
+                    <p class="auth-eyebrow">Bezpieczeństwo konta</p>
+                    <section class="auth-panel" aria-labelledby="cancel-h">
+                        <header class="auth-panel-head">
+                            <h2 id="cancel-h">
+                                <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></span>
+                                Anulowanie usunięcia konta
+                            </h2>
+                            <span class="panel-aside">Krok 1/2</span>
+                        </header>
+                        <div class="auth-panel-body">
+                            <p class="auth-lead">
+                                Twoje konto <strong>@Model.Email</strong> jest zaplanowane do trwałego usunięcia.
+                                Kliknij poniższy przycisk, aby anulować usunięcie. Ze względów bezpieczeństwa
+                                dotychczasowe hasło przestanie działać — w następnym kroku ustawisz nowe.
+                            </p>
+                            <form method="post" data-testid="cancel-deletion-form">
+                                <input type="hidden" asp-for="Email" />
+                                <input type="hidden" asp-for="Token" />
+                                <div class="auth-actions">
+                                    <button type="submit" class="btn btn-primary btn-block" data-testid="cancel-deletion-submit">
+                                        Anuluj usunięcie konta
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m13 5 7 7-7 7"/></svg>
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </section>
+                }
+                <p class="auth-meta"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg> Połączenie szyfrowane · TLS 1.3</p>
+            </div>
+        </div>
+
+        <footer class="foot">
+            <p>lotro-translator.pl — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/CancelDeletion.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/CancelDeletion.cshtml.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.RateLimiting;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Features.Auth;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
+
+/// <summary>
+/// Landing page for the cancel-deletion link emailed when GDPR account deletion is
+/// scheduled (ADR-0031). GET only renders a confirmation form — a mail scanner
+/// prefetching the link must not cancel anything — and POST performs the cancellation,
+/// then sends the user straight into the forced password-reset flow.
+/// </summary>
+[EnableRateLimiting("auth-endpoint-limit")]
+internal sealed partial class CancelDeletionModel : PageModel
+{
+    private readonly ICommandHandler<CancelAccountDeletion.Command, Result<CancelAccountDeletion.CancelledDeletion>> _handler;
+    private readonly ILogger<CancelDeletionModel> _logger;
+
+    public CancelDeletionModel(
+        ICommandHandler<CancelAccountDeletion.Command, Result<CancelAccountDeletion.CancelledDeletion>> handler,
+        ILogger<CancelDeletionModel> logger)
+    {
+        _handler = handler;
+        _logger = logger;
+    }
+
+    [BindProperty]
+    public string Email { get; set; } = string.Empty;
+
+    [BindProperty]
+    public string Token { get; set; } = string.Empty;
+
+    public string? ErrorMessage { get; set; }
+
+    public void OnGet(string? email = null, string? token = null)
+    {
+        Email = email ?? string.Empty;
+        Token = token ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Token))
+        {
+            ErrorMessage = "Link anulujący usunięcie konta jest nieprawidłowy.";
+        }
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Token))
+        {
+            ErrorMessage = "Link anulujący usunięcie konta jest nieprawidłowy.";
+            return Page();
+        }
+
+        CancelAccountDeletion.Command command = new(
+            Email,
+            Token,
+            HttpContext.Connection.RemoteIpAddress?.ToString(),
+            HttpContext.Request.Headers.UserAgent.ToString());
+
+        Result<CancelAccountDeletion.CancelledDeletion> commandResult =
+            await _handler.Handle(command, HttpContext.RequestAborted);
+
+        if (commandResult.IsFailure)
+        {
+            ErrorMessage = "Link anulujący usunięcie konta jest nieprawidłowy lub wygasł.";
+            return Page();
+        }
+
+        string maskedEmail = Email.MaskEmail();
+        LogDeletionCancelledViaUi(_logger, maskedEmail);
+
+        return RedirectToPage("/Account/ResetPassword", new
+        {
+            email = Email,
+            token = commandResult.Value.PasswordResetToken
+        });
+    }
+
+    [LoggerMessage(EventId = EventIds.DeletionCancelledViaUi, Level = LogLevel.Information, Message = "Account deletion cancelled via UI for {MaskedEmail}. Redirecting to the forced password reset.")]
+    private static partial void LogDeletionCancelledViaUi(ILogger logger, string maskedEmail);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ForgotPassword.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ForgotPassword.cshtml.cs
@@ -57,7 +57,7 @@ internal sealed partial class ForgotPasswordModel : PageModel
         else
         {
             string token = await _userManager.GeneratePasswordResetTokenAsync(user);
-            await _emailSender.SendPasswordResetEmailAsync(Email, token, HttpContext.RequestAborted);
+            await _emailSender.SendPasswordResetEmailAsync(user.Id, Email, token, HttpContext.RequestAborted);
             LogPasswordResetTokenGenerated(_logger, user.Id);
         }
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
@@ -1,9 +1,12 @@
+using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
 using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 
 namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
@@ -30,13 +33,16 @@ internal sealed partial class LoginModel : PageModel
         new PasswordHasher<ApplicationUser>().HashPassword(new ApplicationUser(), "DummyP@ssw0rd!");
 
     private readonly UserManager<ApplicationUser> _userManager;
+    private readonly GdprSettings _gdprSettings;
     private readonly ILogger<LoginModel> _logger;
 
     public LoginModel(
         UserManager<ApplicationUser> userManager,
+        IOptions<GdprSettings> gdprSettings,
         ILogger<LoginModel> logger)
     {
         _userManager = userManager;
+        _gdprSettings = gdprSettings.Value;
         _logger = logger;
     }
 
@@ -79,6 +85,28 @@ internal sealed partial class LoginModel : PageModel
                 new ApplicationUser(), DummyPasswordHash, Password);
             LogUserNotFound(_logger, Email.MaskEmail(), HttpContext.Connection.RemoteIpAddress);
             ErrorMessage = GenericCredentialErrorMessage;
+            return Page();
+        }
+
+        // A deletion-scheduled account is also locked out, so this branch must run first.
+        // The specific message is revealed only after the password is verified — with a
+        // wrong password the caller gets the same generic error as everywhere else.
+        if (user.DeletionScheduledAt is not null)
+        {
+            bool deletionScheduledPasswordValid = await _userManager.CheckPasswordAsync(user, Password);
+            if (!deletionScheduledPasswordValid)
+            {
+                await _userManager.AccessFailedAsync(user);
+                LogWrongPassword(_logger, user.Id, HttpContext.Connection.RemoteIpAddress);
+                ErrorMessage = GenericCredentialErrorMessage;
+                return Page();
+            }
+
+            LogDeletionScheduled(_logger, user.Id, HttpContext.Connection.RemoteIpAddress);
+            DateTimeOffset deletionDate = user.DeletionScheduledAt.Value + _gdprSettings.DeletionGracePeriod;
+            ErrorMessage =
+                $"Twoje konto jest zaplanowane do usunięcia dnia {deletionDate.ToPolandTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}. " +
+                "Jeśli chcesz je zachować, kliknij w link anulujący usunięcie, który wysłaliśmy na Twój adres e-mail.";
             return Page();
         }
 
@@ -174,4 +202,7 @@ internal sealed partial class LoginModel : PageModel
 
     [LoggerMessage(EventId = EventIds.LoginSuccessful, Level = LogLevel.Information, Message = "User {UserId} logged in successfully")]
     private static partial void LogUserLoggedIn(ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.LoginDeletionScheduled, Level = LogLevel.Information, Message = "Login blocked: account deletion is scheduled. UserId: {UserId}, IP: {IP}")]
+    private static partial void LogDeletionScheduled(ILogger logger, Guid userId, System.Net.IPAddress? ip);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
@@ -251,13 +251,13 @@
             <ul>
                 <li><strong>Prawo dostępu</strong> — możesz uzyskać kopię swoich danych przechowywanych w serwisie.</li>
                 <li><strong>Prawo do sprostowania</strong> — poprawisz nieaktualne lub błędne dane w ustawieniach konta.</li>
-                <li><strong>Prawo do usunięcia</strong> — usuniesz konto, a Twoje dane zostaną trwale zanonimizowane.</li>
+                <li><strong>Prawo do usunięcia</strong> — usuniesz konto, a Twoje dane zostaną trwale zanonimizowane. Usunięcie następuje po 14-dniowym okresie ochronnym: przez ten czas konto pozostaje zablokowane, a na Twój adres e-mail wysyłamy jednorazowy link pozwalający anulować usunięcie (np. gdy prośbę złożył ktoś, kto przejął Twoje hasło). Po upływie okresu ochronnego dane są nieodwracalnie anonimizowane — w terminie zgodnym z art. 12 ust. 3 RODO.</li>
                 <li><strong>Prawo do przenoszenia (eksport)</strong> — pobierzesz swoje dane w ustrukturyzowanym formacie.</li>
                 <li><strong>Prawo sprzeciwu</strong> — wycofasz zgodę na przetwarzanie w dowolnym momencie.</li>
             </ul>
 
             <h2><span class="sec-num">05</span> Okres przechowywania</h2>
-            <p>Dane konta przechowujemy przez czas jego istnienia. Po usunięciu konta dane osobowe są anonimizowane, a wkład tłumaczeniowy pozostaje w serwisie wyłącznie z nieprzypisywalnym identyfikatorem. Dane techniczne usuwamy po wygaśnięciu uzasadnionego okresu bezpieczeństwa.</p>
+            <p>Dane konta przechowujemy przez czas jego istnienia. Żądanie usunięcia konta uruchamia 14-dniowy okres ochronny, w którym konto jest zablokowane, a usunięcie można anulować linkiem z wiadomości e-mail; po jego upływie dane osobowe są anonimizowane, a wkład tłumaczeniowy pozostaje w serwisie wyłącznie z nieprzypisywalnym identyfikatorem. Dane techniczne usuwamy po wygaśnięciu uzasadnionego okresu bezpieczeństwa.</p>
 
             <h2><span class="sec-num">06</span> Kontakt</h2>
             <p>Pytania dotyczące przetwarzania danych lub realizacji praw kieruj na adres <a href="mailto:koniecdev@@gmail.com">koniecdev@@gmail.com</a>. Przysługuje Ci również prawo wniesienia skargi do Prezesa Urzędu Ochrony Danych Osobowych.</p>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml.cs
@@ -80,6 +80,16 @@ internal sealed partial class ResetPasswordModel : PageModel
             return Page();
         }
 
+        // While GDPR deletion is scheduled, only the emailed cancel-deletion link may
+        // restore the account. The generic invalid-token message prevents state probing.
+        if (user.DeletionScheduledAt is not null)
+        {
+            LogPasswordResetBlockedDeletionScheduled(_logger, user.Id);
+            TokenInvalid = true;
+            ErrorMessage = "Link do resetu hasła jest nieprawidłowy lub wygasł.";
+            return Page();
+        }
+
         IdentityResult result = await _userManager.ResetPasswordAsync(user, Token, NewPassword);
 
         if (!result.Succeeded)
@@ -106,4 +116,7 @@ internal sealed partial class ResetPasswordModel : PageModel
 
     [LoggerMessage(EventId = EventIds.PasswordResetCompletedViaUi, Level = LogLevel.Information, Message = "Password reset completed via UI for user {UserId}. Tokens and authorizations revoked.")]
     private static partial void LogPasswordResetCompleted(ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.ResetPasswordDeletionScheduled, Level = LogLevel.Warning, Message = "Password reset blocked for user {UserId}: account deletion is scheduled")]
+    private static partial void LogPasswordResetBlockedDeletionScheduled(ILogger logger, Guid userId);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountConfirmationEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountConfirmationEmailSender.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
-using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
 using LotroKoniecDev.SharedKernel.Monads;
 
@@ -22,7 +21,7 @@ internal sealed class AccountConfirmationEmailSender : IAccountConfirmationEmail
         _logger = logger;
     }
 
-    public async Task<Result> SendEmailConfirmationAsync(string email, string confirmationToken, CancellationToken cancellationToken)
+    public async Task<Result> SendEmailConfirmationAsync(Guid userId, string email, string confirmationToken, CancellationToken cancellationToken)
     {
         string rawLink = _emailVerificationLinkFactory.Create(email, confirmationToken);
         string link = WebUtility.HtmlEncode(rawLink);
@@ -33,7 +32,7 @@ internal sealed class AccountConfirmationEmailSender : IAccountConfirmationEmail
         using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
         {
             ["EmailOperation"] = "AccountConfirmation",
-            ["Recipient"] = email.MaskEmail()
+            ["RecipientUserId"] = userId
         });
 
         return await _emailService

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountDeletionEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountDeletionEmailSender.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+using System.Net;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+internal sealed class AccountDeletionEmailSender : IAccountDeletionEmailSender
+{
+    private readonly IEmailService _emailService;
+    private readonly ICancelDeletionLinkFactory _cancelDeletionLinkFactory;
+    private readonly ILogger<AccountDeletionEmailSender> _logger;
+
+    public AccountDeletionEmailSender(
+        IEmailService emailService,
+        ICancelDeletionLinkFactory cancelDeletionLinkFactory,
+        ILogger<AccountDeletionEmailSender> logger)
+    {
+        _emailService = emailService;
+        _cancelDeletionLinkFactory = cancelDeletionLinkFactory;
+        _logger = logger;
+    }
+
+    public async Task<Result> SendDeletionScheduledEmailAsync(
+        string email,
+        string cancelToken,
+        DateTimeOffset finalizesAt,
+        CancellationToken cancellationToken)
+    {
+        string rawLink = _cancelDeletionLinkFactory.Create(email, cancelToken);
+        string link = WebUtility.HtmlEncode(rawLink);
+        string deletionDate = finalizesAt.ToPolandTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        string emailBody =
+            $"<p>Otrzymaliśmy prośbę o usunięcie Twojego konta na lotro-translator.pl. " +
+            $"Konto zostanie trwale usunięte dnia <strong>{deletionDate}</strong>. " +
+            $"Do tego czasu konto pozostaje zablokowane.</p>" +
+            $"<p>Jeśli to nie Ty złożyłeś(-aś) tę prośbę, kliknij w poniższy link, aby anulować " +
+            $"usunięcie konta i ustawić nowe hasło: <a href='{link}'>anuluj usunięcie konta</a></p>";
+
+        using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["EmailOperation"] = "AccountDeletionScheduled",
+            ["Recipient"] = email.MaskEmail()
+        });
+
+        return await _emailService
+            .SendAsync(
+                receiverEmail: email,
+                subject: "Zaplanowano usunięcie konta",
+                body: emailBody,
+                isBodyHtml: true,
+                cancellationToken: cancellationToken);
+    }
+
+    public async Task<Result> SendDeletionCancelledEmailAsync(
+        string email,
+        CancellationToken cancellationToken)
+    {
+        const string emailBody =
+            "<p>Usunięcie Twojego konta na lotro-translator.pl zostało anulowane. " +
+            "Ze względów bezpieczeństwa dotychczasowe hasło przestało działać — " +
+            "ustaw nowe hasło, korzystając z formularza resetu hasła.</p>";
+
+        using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["EmailOperation"] = "AccountDeletionCancelled",
+            ["Recipient"] = email.MaskEmail()
+        });
+
+        return await _emailService
+            .SendAsync(
+                receiverEmail: email,
+                subject: "Anulowano usunięcie konta",
+                body: emailBody,
+                isBodyHtml: true,
+                cancellationToken: cancellationToken);
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountDeletionEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountDeletionEmailSender.cs
@@ -23,6 +23,7 @@ internal sealed class AccountDeletionEmailSender : IAccountDeletionEmailSender
     }
 
     public async Task<Result> SendDeletionScheduledEmailAsync(
+        Guid userId,
         string email,
         string cancelToken,
         DateTimeOffset finalizesAt,
@@ -42,7 +43,7 @@ internal sealed class AccountDeletionEmailSender : IAccountDeletionEmailSender
         using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
         {
             ["EmailOperation"] = "AccountDeletionScheduled",
-            ["Recipient"] = email.MaskEmail()
+            ["RecipientUserId"] = userId
         });
 
         return await _emailService
@@ -55,6 +56,7 @@ internal sealed class AccountDeletionEmailSender : IAccountDeletionEmailSender
     }
 
     public async Task<Result> SendDeletionCancelledEmailAsync(
+        Guid userId,
         string email,
         CancellationToken cancellationToken)
     {
@@ -66,7 +68,7 @@ internal sealed class AccountDeletionEmailSender : IAccountDeletionEmailSender
         using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
         {
             ["EmailOperation"] = "AccountDeletionCancelled",
-            ["Recipient"] = email.MaskEmail()
+            ["RecipientUserId"] = userId
         });
 
         return await _emailService

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/CancelDeletionLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/CancelDeletionLinkFactory.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Settings;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+internal interface ICancelDeletionLinkFactory
+{
+    string Create(string email, string cancelToken);
+}
+
+internal sealed class CancelDeletionLinkFactory : ICancelDeletionLinkFactory
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly string _scheme;
+    private readonly HostString _host;
+
+    public CancelDeletionLinkFactory(
+        LinkGenerator linkGenerator,
+        IOptions<OpenIddictSettings> openIddictSettings)
+    {
+        _linkGenerator = linkGenerator;
+
+        // Scheme + host come from the configured issuer, never the request Host header, so a
+        // forged Host cannot poison the cancel link that gets emailed to the account owner.
+        Uri issuer = new(openIddictSettings.Value.Issuer, UriKind.Absolute);
+        _scheme = issuer.Scheme;
+        _host = HostString.FromUriComponent(issuer);
+    }
+
+    public string Create(string email, string cancelToken)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            throw new ArgumentException("Email cannot be null or whitespace.", nameof(email));
+        }
+
+        if (string.IsNullOrWhiteSpace(cancelToken))
+        {
+            throw new ArgumentException("Cancel token cannot be null or whitespace.", nameof(cancelToken));
+        }
+
+        string? cancelLink = _linkGenerator.GetUriByPage(
+            page: "/Account/CancelDeletion",
+            handler: null,
+            values: new { email, token = cancelToken },
+            scheme: _scheme,
+            host: _host);
+
+        return cancelLink
+            ?? throw new InvalidOperationException(
+                "Could not create cancel-deletion link. Ensure the '/Account/CancelDeletion' page is registered.");
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IAccountConfirmationEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IAccountConfirmationEmailSender.cs
@@ -5,6 +5,7 @@ namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 internal interface IAccountConfirmationEmailSender
 {
     Task<Result> SendEmailConfirmationAsync(
+        Guid userId,
         string email,
         string confirmationToken,
         CancellationToken cancellationToken);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IAccountDeletionEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IAccountDeletionEmailSender.cs
@@ -5,12 +5,14 @@ namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 internal interface IAccountDeletionEmailSender
 {
     Task<Result> SendDeletionScheduledEmailAsync(
+        Guid userId,
         string email,
         string cancelToken,
         DateTimeOffset finalizesAt,
         CancellationToken cancellationToken);
 
     Task<Result> SendDeletionCancelledEmailAsync(
+        Guid userId,
         string email,
         CancellationToken cancellationToken);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IAccountDeletionEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IAccountDeletionEmailSender.cs
@@ -1,0 +1,16 @@
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+internal interface IAccountDeletionEmailSender
+{
+    Task<Result> SendDeletionScheduledEmailAsync(
+        string email,
+        string cancelToken,
+        DateTimeOffset finalizesAt,
+        CancellationToken cancellationToken);
+
+    Task<Result> SendDeletionCancelledEmailAsync(
+        string email,
+        CancellationToken cancellationToken);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IPasswordResetEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IPasswordResetEmailSender.cs
@@ -4,5 +4,5 @@ namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 
 internal interface IPasswordResetEmailSender
 {
-    Task<Result> SendPasswordResetEmailAsync(string email, string resetToken, CancellationToken cancellationToken);
+    Task<Result> SendPasswordResetEmailAsync(Guid userId, string email, string resetToken, CancellationToken cancellationToken);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetEmailSender.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
-using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
 using LotroKoniecDev.SharedKernel.Monads;
 
@@ -22,7 +21,7 @@ internal sealed class PasswordResetEmailSender : IPasswordResetEmailSender
         _logger = logger;
     }
 
-    public async Task<Result> SendPasswordResetEmailAsync(string email, string resetToken, CancellationToken cancellationToken)
+    public async Task<Result> SendPasswordResetEmailAsync(Guid userId, string email, string resetToken, CancellationToken cancellationToken)
     {
         string rawLink = _passwordResetLinkFactory.Create(email, resetToken);
         string link = WebUtility.HtmlEncode(rawLink);
@@ -33,7 +32,7 @@ internal sealed class PasswordResetEmailSender : IPasswordResetEmailSender
         using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
         {
             ["EmailOperation"] = "PasswordReset",
-            ["Recipient"] = email.MaskEmail()
+            ["RecipientUserId"] = userId
         });
 
         return await _emailService

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/AccountDeletionFinalizer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/AccountDeletionFinalizer.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Settings;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.SharedKernel.Constants;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Gdpr;
+
+/// <summary>
+/// Finds accounts whose deletion grace period has elapsed and erases them.
+/// Idempotent and restart-safe: already-anonymized accounts are filtered out by the
+/// anonymization email marker, per-user failures are logged and retried on the next run,
+/// and concurrent runs lose harmlessly on the Identity concurrency stamp.
+/// </summary>
+internal sealed partial class AccountDeletionFinalizer : IAccountDeletionFinalizer
+{
+    private readonly AuthDbContext _dbContext;
+    private readonly IAccountErasureService _accountErasureService;
+    private readonly TimeProvider _timeProvider;
+    private readonly GdprSettings _gdprSettings;
+    private readonly ILogger<AccountDeletionFinalizer> _logger;
+
+    public AccountDeletionFinalizer(
+        AuthDbContext dbContext,
+        IAccountErasureService accountErasureService,
+        TimeProvider timeProvider,
+        IOptions<GdprSettings> gdprSettings,
+        ILogger<AccountDeletionFinalizer> logger)
+    {
+        _dbContext = dbContext;
+        _accountErasureService = accountErasureService;
+        _timeProvider = timeProvider;
+        _gdprSettings = gdprSettings.Value;
+        _logger = logger;
+    }
+
+    public async Task<int> FinalizeDueAccountsAsync(CancellationToken cancellationToken)
+    {
+        DateTimeOffset dueBefore = _timeProvider.GetUtcNow() - _gdprSettings.DeletionGracePeriod;
+
+        List<ApplicationUser> dueUsers = await _dbContext.Users
+            .Where(u => u.DeletionScheduledAt != null
+                        && u.DeletionScheduledAt <= dueBefore
+                        && !u.Email!.EndsWith(AnonymizationConstants.EmailDomain))
+            .ToListAsync(cancellationToken);
+
+        int finalizedCount = 0;
+
+        foreach (ApplicationUser user in dueUsers)
+        {
+            Result erasureResult = await _accountErasureService.EraseAsync(user, cancellationToken);
+
+            if (erasureResult.IsFailure)
+            {
+                LogFinalizationFailedForUser(_logger, user.Id, erasureResult.Error.Message);
+                continue;
+            }
+
+            LogDeletionFinalized(_logger, user.Id);
+            finalizedCount++;
+        }
+
+        return finalizedCount;
+    }
+
+    [LoggerMessage(EventId = EventIds.GdprDeletionFinalized, Level = LogLevel.Information, Message = "GDPR deletion finalized for user {UserId} after the grace period elapsed")]
+    private static partial void LogDeletionFinalized(ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.GdprDeletionFinalizerUserFailed, Level = LogLevel.Error, Message = "GDPR deletion finalization failed for user {UserId}: {Error}. Will retry on the next run.")]
+    private static partial void LogFinalizationFailedForUser(ILogger logger, Guid userId, string error);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/AccountErasureService.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/AccountErasureService.cs
@@ -1,0 +1,188 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using OpenIddict.Abstractions;
+using LotroKoniecDev.AuthSystem.API.ApiErrors;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.SharedKernel.Constants;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Gdpr;
+
+/// <summary>
+/// The irreversible half of GDPR account deletion: auth-side anonymization, permanent
+/// lockout and artifact cleanup. Invoked by the deletion finalizer once the grace period
+/// has elapsed (see ADR-0031). No cross-context call is needed: the TranslationSystem
+/// stores only opaque IdentityId attribution references, which become non-attributable
+/// once the auth user is anonymized. Idempotent: callers skip users whose email already
+/// carries the anonymization marker.
+/// </summary>
+internal sealed partial class AccountErasureService : IAccountErasureService
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IOpenIddictTokenManager _tokenManager;
+    private readonly IOpenIddictAuthorizationManager _authorizationManager;
+    private readonly ILogger<AccountErasureService> _logger;
+
+    public AccountErasureService(
+        UserManager<ApplicationUser> userManager,
+        IOpenIddictTokenManager tokenManager,
+        IOpenIddictAuthorizationManager authorizationManager,
+        ILogger<AccountErasureService> logger)
+    {
+        _userManager = userManager;
+        _tokenManager = tokenManager;
+        _authorizationManager = authorizationManager;
+        _logger = logger;
+    }
+
+    public async Task<Result> EraseAsync(ApplicationUser user, CancellationToken cancellationToken)
+    {
+        LogGdprErasureInitiated(_logger, user.Id);
+
+        // If any auth-side step fails, we must still try to lock the account
+        // so the data isn't accessible while the finalizer retries on its next run.
+        try
+        {
+            // Anonymize auth user data first (core GDPR requirement).
+            // DeletionScheduledAt stays set as a non-PII audit trace of when erasure was requested.
+            string anonymizedGuid = Guid.NewGuid().ToString("N");
+            user.UserName = anonymizedGuid;
+            user.NormalizedUserName = anonymizedGuid.ToUpperInvariant();
+            user.Email = $"{AnonymizationConstants.EmailPrefix}{anonymizedGuid}{AnonymizationConstants.EmailDomain}";
+            user.NormalizedEmail = $"{AnonymizationConstants.EmailPrefix.ToUpperInvariant()}{anonymizedGuid.ToUpperInvariant()}{AnonymizationConstants.EmailDomain.ToUpperInvariant()}";
+            user.PhoneNumber = null;
+            user.PasswordHash = null;
+            user.EmailConfirmed = false;
+            user.PhoneNumberConfirmed = false;
+            user.TwoFactorEnabled = false;
+            user.AccessFailedCount = 0;
+            user.DataProcessingConsentGiven = false;
+            user.DataProcessingConsentDate = null;
+            user.PrivacyPolicyAccepted = false;
+            user.PrivacyPolicyAcceptedDate = null;
+
+            // The permanent lockout rides in the SAME update as the anonymization marker.
+            // The finalizer selects pending work by the marker alone, so a user must never
+            // end up marked-but-unlocked — a later separate lockout write could fail and
+            // would then be excluded from every future retry.
+            user.LockoutEnabled = true;
+            user.LockoutEnd = DateTimeOffset.MaxValue;
+
+            IdentityResult updateResult = await _userManager.UpdateAsync(user);
+            if (!updateResult.Succeeded)
+            {
+                string errors = string.Join(", ", updateResult.Errors.Select(e => e.Description));
+                LogAnonymizationFailed(_logger, user.Id, errors);
+                await TryLockAccountAsync(user);
+                return Result.Failure(AuthErrors.AccountDeletionFailed(
+                    "Account erasure partially failed. The account stays locked; the finalizer will retry."));
+            }
+
+            LogAuthDataAnonymized(_logger, user.Id);
+
+            // Invalidate all sessions
+            await _userManager.UpdateSecurityStampAsync(user);
+        }
+        catch (Exception ex)
+        {
+            LogAuthSideErasureFailed(_logger, ex, user.Id);
+            await TryLockAccountAsync(user);
+            return Result.Failure(AuthErrors.AccountDeletionFailed(
+                "Account erasure partially failed. The account stays locked; the finalizer will retry."));
+        }
+
+        // Best-effort cleanup: revoke tokens, remove roles/claims/logins.
+        // The account is already anonymized and locked at this point,
+        // so failures here don't compromise GDPR compliance.
+        await CleanupAuthArtifactsAsync(user, cancellationToken);
+
+        LogAccountDeleted(_logger, user.Id);
+
+        return Result.Success();
+    }
+
+    private async Task CleanupAuthArtifactsAsync(ApplicationUser user, CancellationToken cancellationToken)
+    {
+        try
+        {
+            string userId = user.Id.ToString();
+
+            await foreach (object token in _tokenManager.FindBySubjectAsync(userId, cancellationToken))
+            {
+                await _tokenManager.TryRevokeAsync(token, cancellationToken);
+            }
+
+            await foreach (object authorization in _authorizationManager.FindBySubjectAsync(userId, cancellationToken))
+            {
+                await _authorizationManager.TryRevokeAsync(authorization, cancellationToken);
+            }
+
+            IList<string> roles = await _userManager.GetRolesAsync(user);
+            if (roles.Count > 0)
+            {
+                await _userManager.RemoveFromRolesAsync(user, roles);
+            }
+
+            IList<Claim> claims = await _userManager.GetClaimsAsync(user);
+            if (claims.Count > 0)
+            {
+                await _userManager.RemoveClaimsAsync(user, claims);
+            }
+
+            IList<UserLoginInfo> logins = await _userManager.GetLoginsAsync(user);
+            foreach (UserLoginInfo login in logins)
+            {
+                await _userManager.RemoveLoginAsync(user, login.LoginProvider, login.ProviderKey);
+            }
+
+            LogArtifactsCleaned(_logger, user.Id);
+        }
+        catch (Exception ex)
+        {
+            LogArtifactsCleanupFailed(_logger, ex, user.Id);
+        }
+    }
+
+    private async Task TryLockAccountAsync(ApplicationUser user)
+    {
+        try
+        {
+            await _userManager.SetLockoutEnabledAsync(user, true);
+            await _userManager.SetLockoutEndDateAsync(user, DateTimeOffset.MaxValue);
+            await _userManager.UpdateSecurityStampAsync(user);
+
+            LogEmergencyLockout(_logger, user.Id);
+        }
+        catch (Exception ex)
+        {
+            LogEmergencyLockoutFailed(_logger, ex, user.Id);
+        }
+    }
+
+    [LoggerMessage(EventId = EventIds.GdprErasureInitiated, Level = LogLevel.Information, Message = "GDPR erasure initiated for user {UserId}")]
+    private static partial void LogGdprErasureInitiated(ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.GdprErasureAnonymizationFailed, Level = LogLevel.Critical, Message = "Failed to anonymize user {UserId}. The finalizer will retry. Errors: {Errors}")]
+    private static partial void LogAnonymizationFailed(ILogger logger, Guid userId, string errors);
+
+    [LoggerMessage(EventId = EventIds.GdprErasureAuthAnonymized, Level = LogLevel.Information, Message = "GDPR erasure: auth data anonymized for user {UserId}")]
+    private static partial void LogAuthDataAnonymized(ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.GdprErasureAuthFailed, Level = LogLevel.Critical, Message = "Auth-side GDPR erasure failed for user {UserId}. The finalizer will retry.")]
+    private static partial void LogAuthSideErasureFailed(ILogger logger, Exception exception, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.GdprErasureAccountDeleted, Level = LogLevel.Information, Message = "Account deleted (anonymized) for user {UserId}")]
+    private static partial void LogAccountDeleted(ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.GdprErasureArtifactsCleaned, Level = LogLevel.Information, Message = "GDPR erasure: tokens, authorizations, roles, claims, and logins cleaned up for user {UserId}")]
+    private static partial void LogArtifactsCleaned(ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.GdprErasureArtifactsCleanupFailed, Level = LogLevel.Warning, Message = "GDPR erasure: cleanup of auth artifacts failed for user {UserId}. Account is already anonymized and locked — artifacts will expire naturally.")]
+    private static partial void LogArtifactsCleanupFailed(ILogger logger, Exception exception, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.GdprErasureEmergencyLockout, Level = LogLevel.Warning, Message = "Emergency lockout applied for user {UserId} after partial GDPR erasure failure")]
+    private static partial void LogEmergencyLockout(ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = EventIds.GdprErasureEmergencyLockoutFailed, Level = LogLevel.Critical, Message = "Failed to apply emergency lockout for user {UserId}. Manual intervention required immediately.")]
+    private static partial void LogEmergencyLockoutFailed(ILogger logger, Exception exception, Guid userId);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/IAccountDeletionFinalizer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/IAccountDeletionFinalizer.cs
@@ -1,0 +1,6 @@
+namespace LotroKoniecDev.AuthSystem.API.Services.Gdpr;
+
+internal interface IAccountDeletionFinalizer
+{
+    Task<int> FinalizeDueAccountsAsync(CancellationToken cancellationToken);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/IAccountErasureService.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/IAccountErasureService.cs
@@ -1,0 +1,9 @@
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Gdpr;
+
+internal interface IAccountErasureService
+{
+    Task<Result> EraseAsync(ApplicationUser user, CancellationToken cancellationToken);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/GdprSettings.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/GdprSettings.cs
@@ -1,0 +1,9 @@
+namespace LotroKoniecDev.AuthSystem.API.Settings;
+
+internal sealed class GdprSettings
+{
+    public const string ConfigurationSection = "Gdpr";
+
+    public TimeSpan DeletionGracePeriod { get; init; } = TimeSpan.FromDays(14);
+    public TimeSpan DeletionFinalizationPollInterval { get; init; } = TimeSpan.FromHours(1);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/GdprSettingsValidator.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/GdprSettingsValidator.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Options;
+
+namespace LotroKoniecDev.AuthSystem.API.Settings;
+
+internal sealed class GdprSettingsValidator : IValidateOptions<GdprSettings>
+{
+    public ValidateOptionsResult Validate(string? name, GdprSettings options)
+    {
+        List<string> errors = [];
+
+        if (options.DeletionGracePeriod <= TimeSpan.Zero)
+        {
+            errors.Add("DeletionGracePeriod must be positive.");
+        }
+
+        // GDPR Art. 12(3): erasure must complete "without undue delay",
+        // at most one month after the request.
+        if (options.DeletionGracePeriod > TimeSpan.FromDays(30))
+        {
+            errors.Add("DeletionGracePeriod must not exceed 30 days.");
+        }
+
+        if (options.DeletionFinalizationPollInterval < TimeSpan.FromMinutes(1))
+        {
+            errors.Add("DeletionFinalizationPollInterval must be at least 1 minute.");
+        }
+
+        // A poll interval longer than the grace period would leave finalization to the
+        // startup catch-up run alone and silently overshoot the Art. 12(3) deadline.
+        if (options.DeletionFinalizationPollInterval > options.DeletionGracePeriod)
+        {
+            errors.Add("DeletionFinalizationPollInterval must not exceed DeletionGracePeriod.");
+        }
+
+        return errors.Count > 0
+            ? ValidateOptionsResult.Fail(errors)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.json
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.json
@@ -28,6 +28,10 @@
   "DataProtection": {
     "KeyRingPath": ""
   },
+  "Gdpr": {
+    "DeletionGracePeriod": "14.00:00:00",
+    "DeletionFinalizationPollInterval": "01:00:00"
+  },
   "AdminUser": {
     "Username": "",
     "Email": "",

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/AccountDataExportResponse.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/AccountDataExportResponse.cs
@@ -19,4 +19,5 @@ public sealed record AuthDataExportDto(
     bool DataProcessingConsentGiven,
     DateTimeOffset? DataProcessingConsentDate,
     bool PrivacyPolicyAccepted,
-    DateTimeOffset? PrivacyPolicyAcceptedDate);
+    DateTimeOffset? PrivacyPolicyAcceptedDate,
+    DateTimeOffset? DeletionScheduledAt);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/CancelAccountDeletionRequest.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/CancelAccountDeletionRequest.cs
@@ -1,0 +1,5 @@
+namespace LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+
+public sealed record CancelAccountDeletionRequest(
+    string Email,
+    string Token);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/CancelAccountDeletionResponse.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/CancelAccountDeletionResponse.cs
@@ -1,0 +1,9 @@
+namespace LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+
+/// <summary>
+/// Cancelling a (possibly attacker-initiated) deletion invalidates the current password,
+/// so the response carries a fresh reset token that sends the caller straight into the
+/// forced password-reset flow.
+/// </summary>
+public sealed record CancelAccountDeletionResponse(
+    string PasswordResetToken);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Hateoas/Rels.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Hateoas/Rels.cs
@@ -7,6 +7,7 @@ public static class Rels
     // Account aggregate
     public const string ChangePassword = "change-password";
     public const string DeleteAccount = "delete-account";
+    public const string CancelDeletion = "cancel-deletion";
     public const string ResendEmailConfirmation = "resend-email-confirmation";
 
     // Discovery

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Domain/Aggregates/ApplicationUsers/Entities/ApplicationUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Domain/Aggregates/ApplicationUsers/Entities/ApplicationUser.cs
@@ -8,4 +8,5 @@ public sealed class ApplicationUser : IdentityUser<Guid>
     public DateTimeOffset? DataProcessingConsentDate { get; set; }
     public bool PrivacyPolicyAccepted { get; set; }
     public DateTimeOffset? PrivacyPolicyAcceptedDate { get; set; }
+    public DateTimeOffset? DeletionScheduledAt { get; set; }
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
@@ -29,5 +29,11 @@ internal sealed class ApplicationUserConfiguration : IEntityTypeConfiguration<Ap
             .HasDefaultValue(false);
 
         builder.Property(u => u.PrivacyPolicyAcceptedDate);
+
+        builder.Property(u => u.DeletionScheduledAt);
+
+        // Partial index: the deletion finalizer polls only the handful of rows with a schedule set.
+        builder.HasIndex(u => u.DeletionScheduledAt)
+            .HasFilter($"\"{nameof(ApplicationUser.DeletionScheduledAt)}\" IS NOT NULL");
     }
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/AccountDeletionCancellationTokenProvider.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/AccountDeletionCancellationTokenProvider.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Identity;
+
+/// <summary>
+/// Options for the cancel-deletion token provider. The default token providers cap
+/// their lifespan at 24h (<see cref="DataProtectionTokenProviderOptions"/>), while the
+/// cancellation link must stay valid for the whole deletion grace period — the API layer
+/// rebinds <see cref="DataProtectionTokenProviderOptions.TokenLifespan"/> to
+/// <c>Gdpr:DeletionGracePeriod</c> at startup.
+/// </summary>
+public sealed class AccountDeletionCancellationTokenProviderOptions : DataProtectionTokenProviderOptions
+{
+    public AccountDeletionCancellationTokenProviderOptions()
+    {
+        Name = AccountDeletionCancellationTokenProvider.ProviderName;
+        TokenLifespan = TimeSpan.FromDays(14);
+    }
+}
+
+/// <summary>
+/// Issues the one-time, signed, time-bounded token embedded in the cancel-deletion
+/// email link. The token binds to the user's security stamp, so rotating the stamp
+/// (which both scheduling and cancelling do) makes every previously issued token unusable.
+/// </summary>
+public sealed class AccountDeletionCancellationTokenProvider : DataProtectorTokenProvider<ApplicationUser>
+{
+    public const string ProviderName = "AccountDeletionCancellation";
+    public const string CancelDeletionPurpose = "CancelAccountDeletion";
+
+    public AccountDeletionCancellationTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<AccountDeletionCancellationTokenProviderOptions> options,
+        ILogger<AccountDeletionCancellationTokenProvider> logger)
+        : base(dataProtectionProvider, options, logger)
+    {
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260711123259_AddDeletionScheduledAtToUsers.Designer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260711123259_AddDeletionScheduledAtToUsers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711123259_AddDeletionScheduledAtToUsers")]
+    partial class AddDeletionScheduledAtToUsers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260711123259_AddDeletionScheduledAtToUsers.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260711123259_AddDeletionScheduledAtToUsers.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeletionScheduledAtToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "DeletionScheduledAt",
+                schema: "authsystem",
+                table: "Users",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_DeletionScheduledAt",
+                schema: "authsystem",
+                table: "Users",
+                column: "DeletionScheduledAt",
+                filter: "\"DeletionScheduledAt\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_DeletionScheduledAt",
+                schema: "authsystem",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "DeletionScheduledAt",
+                schema: "authsystem",
+                table: "Users");
+        }
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/PersistenceDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/PersistenceDependencyInjection.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationRoles.Entities;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
 using LotroKoniecDev.AuthSystem.Persistence.Settings;
 using LotroKoniecDev.Options;
 using LotroKoniecDev.SharedKernel.Constants;
@@ -53,6 +54,8 @@ public static class PersistenceDependencyInjection
                 .AddRoles<ApplicationRole>()
                 .AddSignInManager()
                 .AddDefaultTokenProviders()
+                .AddTokenProvider<AccountDeletionCancellationTokenProvider>(
+                    AccountDeletionCancellationTokenProvider.ProviderName)
                 .AddEntityFrameworkStores<AuthDbContext>();
 
             services.Configure<DataProtectionTokenProviderOptions>(options =>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -89,6 +89,18 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
             services.AddSingleton<IAccountConfirmationEmailSender>(sp =>
                 sp.GetRequiredService<SpyAccountConfirmationEmailSender>());
 
+            // Replace deletion email sender with spy for capturing cancel tokens in tests
+            ServiceDescriptor? existingDeletionSender = services
+                .FirstOrDefault(d => d.ServiceType == typeof(IAccountDeletionEmailSender));
+            if (existingDeletionSender is not null)
+            {
+                services.Remove(existingDeletionSender);
+            }
+
+            services.AddSingleton<SpyAccountDeletionEmailSender>();
+            services.AddSingleton<IAccountDeletionEmailSender>(sp =>
+                sp.GetRequiredService<SpyAccountDeletionEmailSender>());
+
             // Replace AuthDbContext to use the test connection string directly
             ServiceDescriptor? dbContextDescriptor = services
                 .FirstOrDefault(d => d.ServiceType == typeof(DbContextOptions<AuthDbContext>));

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Bases/AsyncLifetimeTestBase.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Bases/AsyncLifetimeTestBase.cs
@@ -11,16 +11,20 @@ public abstract class AsyncLifetimeTestBase : IAsyncLifetime
     protected AuthSystemApiFactory Factory { get; }
     protected SpyAccountConfirmationEmailSender AccountConfirmationEmailSpy { get; }
     protected SpyPasswordResetEmailSender PasswordResetEmailSpy { get; }
+    protected SpyAccountDeletionEmailSender AccountDeletionEmailSpy { get; }
 
     protected AsyncLifetimeTestBase(AuthSystemApiFactory factory)
     {
         Factory = factory;
         AccountConfirmationEmailSpy = factory.Services.GetRequiredService<SpyAccountConfirmationEmailSender>();
         PasswordResetEmailSpy = factory.Services.GetRequiredService<SpyPasswordResetEmailSender>();
+        AccountDeletionEmailSpy = factory.Services.GetRequiredService<SpyAccountDeletionEmailSender>();
     }
 
     public virtual async Task InitializeAsync()
     {
+        AccountDeletionEmailSpy.Reset();
+
         await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
         CleanerService cleaner = scope.ServiceProvider.GetRequiredService<CleanerService>();
         await cleaner.CleanAsync();

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountConfirmationEmailSender.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountConfirmationEmailSender.cs
@@ -15,7 +15,7 @@ public sealed class SpyAccountConfirmationEmailSender : IAccountConfirmationEmai
     public int CallCount => Volatile.Read(ref _callCount);
     public bool ShouldFail { get; set; }
 
-    public Task<Result> SendEmailConfirmationAsync(string email, string confirmationToken, CancellationToken cancellationToken)
+    public Task<Result> SendEmailConfirmationAsync(Guid userId, string email, string confirmationToken, CancellationToken cancellationToken)
     {
         LastEmail = email;
         LastConfirmationToken = confirmationToken;

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountDeletionEmailSender.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountDeletionEmailSender.cs
@@ -1,0 +1,55 @@
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+
+#pragma warning disable CA1515
+public sealed class SpyAccountDeletionEmailSender : IAccountDeletionEmailSender
+#pragma warning restore CA1515
+{
+    private int _scheduledCallCount;
+    private int _cancelledCallCount;
+
+    public string? LastScheduledEmail { get; private set; }
+    public string? LastCancelToken { get; private set; }
+    public DateTimeOffset? LastFinalizesAt { get; private set; }
+    public string? LastCancelledEmail { get; private set; }
+    public int ScheduledCallCount => Volatile.Read(ref _scheduledCallCount);
+    public int CancelledCallCount => Volatile.Read(ref _cancelledCallCount);
+    public bool ShouldFailScheduledEmail { get; set; }
+
+    public Task<Result> SendDeletionScheduledEmailAsync(
+        string email,
+        string cancelToken,
+        DateTimeOffset finalizesAt,
+        CancellationToken cancellationToken)
+    {
+        LastScheduledEmail = email;
+        LastCancelToken = cancelToken;
+        LastFinalizesAt = finalizesAt;
+        Interlocked.Increment(ref _scheduledCallCount);
+
+        return ShouldFailScheduledEmail
+            ? Task.FromResult(Result.Failure(new Error("Test.EmailFailed", "Simulated email failure")))
+            : Task.FromResult(Result.Success());
+    }
+
+    public Task<Result> SendDeletionCancelledEmailAsync(string email, CancellationToken cancellationToken)
+    {
+        LastCancelledEmail = email;
+        Interlocked.Increment(ref _cancelledCallCount);
+        return Task.FromResult(Result.Success());
+    }
+
+    public void Reset()
+    {
+        LastScheduledEmail = null;
+        LastCancelToken = null;
+        LastFinalizesAt = null;
+        LastCancelledEmail = null;
+        Interlocked.Exchange(ref _scheduledCallCount, 0);
+        Interlocked.Exchange(ref _cancelledCallCount, 0);
+        ShouldFailScheduledEmail = false;
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountDeletionEmailSender.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountDeletionEmailSender.cs
@@ -20,6 +20,7 @@ public sealed class SpyAccountDeletionEmailSender : IAccountDeletionEmailSender
     public bool ShouldFailScheduledEmail { get; set; }
 
     public Task<Result> SendDeletionScheduledEmailAsync(
+        Guid userId,
         string email,
         string cancelToken,
         DateTimeOffset finalizesAt,
@@ -35,7 +36,7 @@ public sealed class SpyAccountDeletionEmailSender : IAccountDeletionEmailSender
             : Task.FromResult(Result.Success());
     }
 
-    public Task<Result> SendDeletionCancelledEmailAsync(string email, CancellationToken cancellationToken)
+    public Task<Result> SendDeletionCancelledEmailAsync(Guid userId, string email, CancellationToken cancellationToken)
     {
         LastCancelledEmail = email;
         Interlocked.Increment(ref _cancelledCallCount);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyPasswordResetEmailSender.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyPasswordResetEmailSender.cs
@@ -13,7 +13,7 @@ public sealed class SpyPasswordResetEmailSender : IPasswordResetEmailSender
     public string? LastResetToken { get; private set; }
     public int CallCount => Volatile.Read(ref _callCount);
 
-    public Task<Result> SendPasswordResetEmailAsync(string email, string resetToken, CancellationToken cancellationToken)
+    public Task<Result> SendPasswordResetEmailAsync(Guid userId, string email, string resetToken, CancellationToken cancellationToken)
     {
         LastEmail = email;
         LastResetToken = resetToken;

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AccountDeletionFinalizerTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AccountDeletionFinalizerTests.cs
@@ -1,0 +1,177 @@
+using System.Net.Http.Headers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Services.Gdpr;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.SharedKernel.Constants;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+/// <summary>
+/// Drives the grace-period finalization through its scoped entry point
+/// (<see cref="IAccountDeletionFinalizer"/>) — the hosted service merely calls it on a
+/// timer — and asserts the observable outcome: anonymized rows and dead logins.
+/// </summary>
+public sealed class AccountDeletionFinalizerTests : EndpointsTestBase
+{
+    private const string TestPassword = "TestPass1!";
+
+    public AccountDeletionFinalizerTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public async Task Finalizer_ShouldAnonymizeAccount_WhenGracePeriodElapsed()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, IdentityId identityId) = await RegisterAndScheduleDeletionAsync();
+        await BackdateScheduleAsync(identityId.Value, TimeSpan.FromDays(15));
+
+        // Act
+        int finalizedCount = await RunFinalizerAsync();
+
+        // Assert
+        finalizedCount.ShouldBe(1);
+
+        ApplicationUser user = await GetUserAsync(identityId.Value);
+        user.Email.ShouldStartWith(AnonymizationConstants.EmailPrefix);
+        user.Email.ShouldEndWith(AnonymizationConstants.EmailDomain);
+        user.UserName.ShouldNotBe(registerRequest.Username);
+        user.PhoneNumber.ShouldBeNull();
+        user.PasswordHash.ShouldBeNull();
+        user.EmailConfirmed.ShouldBeFalse();
+        user.DataProcessingConsentGiven.ShouldBeFalse();
+        user.DataProcessingConsentDate.ShouldBeNull();
+        user.PrivacyPolicyAccepted.ShouldBeFalse();
+        user.PrivacyPolicyAcceptedDate.ShouldBeNull();
+        user.LockoutEnabled.ShouldBeTrue();
+        user.LockoutEnd.ShouldBe(DateTimeOffset.MaxValue);
+
+        // DeletionScheduledAt stays set as the non-PII audit trace.
+        user.DeletionScheduledAt.ShouldNotBeNull();
+
+        // Artifact cleanup removed roles and claims.
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        bool hasRoles = await db.UserRoles.AnyAsync(ur => ur.UserId == identityId.Value);
+        hasRoles.ShouldBeFalse();
+        bool hasClaims = await db.UserClaims.AnyAsync(uc => uc.UserId == identityId.Value);
+        hasClaims.ShouldBeFalse();
+
+        HttpResponseMessage loginResponse = await RequestTokenAsync(registerRequest.Email, TestPassword);
+        loginResponse.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Finalizer_ShouldNotTouchAccount_BeforeGracePeriodElapses()
+    {
+        // Arrange — freshly scheduled, still well inside the 14-day window
+        (RegisterRequest registerRequest, IdentityId identityId) = await RegisterAndScheduleDeletionAsync();
+
+        // Act
+        int finalizedCount = await RunFinalizerAsync();
+
+        // Assert
+        finalizedCount.ShouldBe(0);
+
+        ApplicationUser user = await GetUserAsync(identityId.Value);
+        user.Email.ShouldBe(registerRequest.Email);
+        user.DeletionScheduledAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Finalizer_ShouldBeIdempotent_WhenRunRepeatedly()
+    {
+        // Arrange
+        (_, IdentityId identityId) = await RegisterAndScheduleDeletionAsync();
+        await BackdateScheduleAsync(identityId.Value, TimeSpan.FromDays(15));
+
+        // Act
+        int firstRunCount = await RunFinalizerAsync();
+        int secondRunCount = await RunFinalizerAsync();
+
+        // Assert — the second run sees the anonymization marker and skips the account
+        firstRunCount.ShouldBe(1);
+        secondRunCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Finalizer_ShouldIgnoreAccounts_WithoutScheduledDeletion()
+    {
+        // Arrange — a healthy account, never scheduled
+        (RegisterRequest registerRequest, IdentityId identityId) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        // Act
+        int finalizedCount = await RunFinalizerAsync();
+
+        // Assert
+        finalizedCount.ShouldBe(0);
+
+        ApplicationUser user = await GetUserAsync(identityId.Value);
+        user.Email.ShouldBe(registerRequest.Email);
+        user.DeletionScheduledAt.ShouldBeNull();
+    }
+
+    private async Task<int> RunFinalizerAsync()
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        IAccountDeletionFinalizer finalizer =
+            scope.ServiceProvider.GetRequiredService<IAccountDeletionFinalizer>();
+        return await finalizer.FinalizeDueAccountsAsync(CancellationToken.None);
+    }
+
+    private async Task BackdateScheduleAsync(Guid userId, TimeSpan age)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        ApplicationUser user = await db.Users.FirstAsync(u => u.Id == userId);
+        user.DeletionScheduledAt = DateTimeOffset.UtcNow - age;
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<(RegisterRequest Request, IdentityId IdentityId)> RegisterAndScheduleDeletionAsync()
+    {
+        (RegisterRequest registerRequest, IdentityId identityId) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
+
+        DeleteAccountRequest deleteRequest = new(TestPassword);
+        using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/delete");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Content = JsonContent.Create(deleteRequest);
+
+        HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        return (registerRequest, identityId);
+    }
+
+    private async Task<HttpResponseMessage> RequestTokenAsync(string email, string password)
+    {
+        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = email,
+            ["password"] = password,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api"
+        });
+
+        return await ApiClient.Http.PostAsync(new Uri("connect/token", UriKind.Relative), tokenRequest);
+    }
+
+    private async Task<ApplicationUser> GetUserAsync(Guid userId)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        return await db.Users.AsNoTracking().FirstAsync(u => u.Id == userId);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/CancelAccountDeletionEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/CancelAccountDeletionEndpointTests.cs
@@ -1,0 +1,217 @@
+using System.Net.Http.Headers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+public sealed class CancelAccountDeletionEndpointTests : EndpointsTestBase
+{
+    private const string TestPassword = "TestPass1!";
+
+    public CancelAccountDeletionEndpointTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public async Task CancelDeletion_ShouldClearScheduleAndLockout_WhenTokenIsValid()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, IdentityId identityId) = await RegisterAndScheduleDeletionAsync();
+        string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
+
+        // Act
+        HttpResponseMessage response = await SendCancelRequestAsync(registerRequest.Email, cancelToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        ApplicationUser user = await GetUserAsync(identityId.Value);
+        user.DeletionScheduledAt.ShouldBeNull();
+        user.LockoutEnd.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CancelDeletion_ShouldInvalidateOldPassword_AndForcePasswordReset()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, IdentityId identityId) = await RegisterAndScheduleDeletionAsync();
+        string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
+
+        // Act
+        HttpResponseMessage response = await SendCancelRequestAsync(registerRequest.Email, cancelToken);
+
+        // Assert — the possibly-compromised password dies with the cancellation
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        ApplicationUser user = await GetUserAsync(identityId.Value);
+        user.PasswordHash.ShouldBeNull();
+
+        HttpResponseMessage oldPasswordLogin = await RequestTokenAsync(registerRequest.Email, TestPassword);
+        oldPasswordLogin.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CancelDeletion_ShouldReturnResetToken_ThatCompletesTheRecoveryFlow()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) = await RegisterAndScheduleDeletionAsync();
+        string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
+
+        // Act — cancel, then walk the forced reset flow end to end
+        HttpResponseMessage cancelResponse = await SendCancelRequestAsync(registerRequest.Email, cancelToken);
+        cancelResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        CancelAccountDeletionResponse cancelBody = (await cancelResponse.Content
+            .ReadFromJsonAsync<CancelAccountDeletionResponse>(ApiClient.JsonOptions))!;
+        cancelBody.PasswordResetToken.ShouldNotBeNullOrWhiteSpace();
+
+        const string newPassword = "BrandNewPass1!";
+        ResetPasswordRequest resetRequest = new(registerRequest.Email, cancelBody.PasswordResetToken, newPassword);
+        HttpResponseMessage resetResponse = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/reset-password", UriKind.Relative), resetRequest);
+
+        // Assert — account fully recovered with the new password
+        resetResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        HttpResponseMessage newPasswordLogin = await RequestTokenAsync(registerRequest.Email, newPassword);
+        newPasswordLogin.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task CancelDeletion_ShouldSendConfirmationEmail()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) = await RegisterAndScheduleDeletionAsync();
+        string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
+
+        // Act
+        HttpResponseMessage response = await SendCancelRequestAsync(registerRequest.Email, cancelToken);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        AccountDeletionEmailSpy.CancelledCallCount.ShouldBe(1);
+        AccountDeletionEmailSpy.LastCancelledEmail.ShouldBe(registerRequest.Email);
+    }
+
+    [Fact]
+    public async Task CancelDeletion_ShouldReturnBadRequest_WhenTokenIsGarbage()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, IdentityId identityId) = await RegisterAndScheduleDeletionAsync();
+
+        // Act
+        HttpResponseMessage response = await SendCancelRequestAsync(registerRequest.Email, "not-a-real-token");
+
+        // Assert — schedule stays in place
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("Auth.InvalidCancelDeletionToken");
+
+        ApplicationUser user = await GetUserAsync(identityId.Value);
+        user.DeletionScheduledAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task CancelDeletion_ShouldReturnBadRequest_WhenEmailIsUnknown()
+    {
+        // Act
+        HttpResponseMessage response = await SendCancelRequestAsync(
+            "nobody@example.com", "some-token");
+
+        // Assert — same generic error as a bad token (no account-state probing)
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("Auth.InvalidCancelDeletionToken");
+    }
+
+    [Fact]
+    public async Task CancelDeletion_ShouldReturnBadRequest_WhenDeletionIsNotScheduled()
+    {
+        // Arrange — registered user without a scheduled deletion
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        // Act
+        HttpResponseMessage response = await SendCancelRequestAsync(registerRequest.Email, "some-token");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("Auth.InvalidCancelDeletionToken");
+    }
+
+    [Fact]
+    public async Task CancelDeletion_ShouldRejectTokenReplay_AfterSuccessfulCancellation()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, IdentityId identityId) = await RegisterAndScheduleDeletionAsync();
+        string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
+
+        HttpResponseMessage firstResponse = await SendCancelRequestAsync(registerRequest.Email, cancelToken);
+        firstResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Act — the security stamp rotated on cancel, so the token is single-use
+        HttpResponseMessage replayResponse = await SendCancelRequestAsync(registerRequest.Email, cancelToken);
+
+        // Assert
+        replayResponse.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        ApplicationUser user = await GetUserAsync(identityId.Value);
+        user.DeletionScheduledAt.ShouldBeNull();
+    }
+
+    private async Task<(RegisterRequest Request, IdentityId IdentityId)> RegisterAndScheduleDeletionAsync()
+    {
+        (RegisterRequest registerRequest, IdentityId identityId) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
+
+        DeleteAccountRequest deleteRequest = new(TestPassword);
+        using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/delete");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Content = JsonContent.Create(deleteRequest);
+
+        HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        AccountDeletionEmailSpy.LastCancelToken.ShouldNotBeNullOrWhiteSpace();
+
+        return (registerRequest, identityId);
+    }
+
+    private async Task<HttpResponseMessage> SendCancelRequestAsync(string email, string token)
+    {
+        CancelAccountDeletionRequest cancelRequest = new(email, token);
+
+        return await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/account/cancel-deletion", UriKind.Relative), cancelRequest);
+    }
+
+    private async Task<HttpResponseMessage> RequestTokenAsync(string email, string password)
+    {
+        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = email,
+            ["password"] = password,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api"
+        });
+
+        return await ApiClient.Http.PostAsync(new Uri("connect/token", UriKind.Relative), tokenRequest);
+    }
+
+    private async Task<ApplicationUser> GetUserAsync(Guid userId)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        return await db.Users.AsNoTracking().FirstAsync(u => u.Id == userId);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeleteAccountEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeleteAccountEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Features.Auth;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
@@ -8,104 +9,176 @@ using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
-using LotroKoniecDev.SharedKernel.Constants;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 
 namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
 
 public sealed class DeleteAccountEndpointTests : EndpointsTestBase
 {
+    private const string TestPassword = "TestPass1!";
+
     public DeleteAccountEndpointTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
 
     [Fact]
-    public async Task DeleteAccount_ShouldReturnNoContent_WhenPasswordIsCorrect()
+    public async Task DeleteAccount_ShouldReturnNoContentWithSchedulingHeaders_WhenPasswordIsCorrect()
     {
         // Arrange
-        const string password = "TestPass1!";
-
         (RegisterRequest registerRequest, _) =
-            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Email, password);
-
-        DeleteAccountRequest deleteRequest = new(password);
-
-        using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/delete");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        request.Content = JsonContent.Create(deleteRequest);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
         // Act
-        HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
+        HttpResponseMessage response = await SendDeleteRequestAsync(accessToken, TestPassword);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        response.Headers.TryGetValues(DeleteAccount.DeletionScheduledAtHeader, out IEnumerable<string>? scheduledAtValues)
+            .ShouldBeTrue($"the {DeleteAccount.DeletionScheduledAtHeader} header must be present");
+        response.Headers.TryGetValues(DeleteAccount.DeletionFinalizesAtHeader, out IEnumerable<string>? finalizesAtValues)
+            .ShouldBeTrue($"the {DeleteAccount.DeletionFinalizesAtHeader} header must be present");
+
+        string? scheduledAtHeader = scheduledAtValues!.SingleOrDefault();
+        string? finalizesAtHeader = finalizesAtValues!.SingleOrDefault();
+
+        scheduledAtHeader.ShouldNotBeNullOrWhiteSpace();
+        finalizesAtHeader.ShouldNotBeNullOrWhiteSpace();
+
+        DateTimeOffset scheduledAt = DateTimeOffset.Parse(scheduledAtHeader, System.Globalization.CultureInfo.InvariantCulture);
+        DateTimeOffset finalizesAt = DateTimeOffset.Parse(finalizesAtHeader, System.Globalization.CultureInfo.InvariantCulture);
+        (finalizesAt - scheduledAt).ShouldBe(TimeSpan.FromDays(14));
     }
 
     [Fact]
-    public async Task DeleteAccount_ShouldPreventLogin_AfterDeletion()
+    public async Task DeleteAccount_ShouldScheduleDeletionAndLockAccount_WithoutAnonymizingData()
     {
         // Arrange
-        const string password = "TestPass1!";
+        (RegisterRequest registerRequest, IdentityId identityId) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
 
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
+
+        // Act
+        HttpResponseMessage response = await SendDeleteRequestAsync(accessToken, TestPassword);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        ApplicationUser user = await GetUserAsync(identityId.Value);
+
+        user.DeletionScheduledAt.ShouldNotBeNull();
+        user.LockoutEnabled.ShouldBeTrue();
+        user.LockoutEnd.ShouldBe(user.DeletionScheduledAt.Value.AddDays(14));
+
+        // Data stays intact during the grace window — only the finalizer anonymizes.
+        user.Email.ShouldBe(registerRequest.Email);
+        user.UserName.ShouldBe(registerRequest.Username);
+        user.PasswordHash.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAccount_ShouldSendCancellationEmail_WhenScheduling()
+    {
+        // Arrange
         (RegisterRequest registerRequest, _) =
-            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Email, password);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
-        DeleteAccountRequest deleteRequest = new(password);
+        // Act
+        HttpResponseMessage response = await SendDeleteRequestAsync(accessToken, TestPassword);
 
-        using HttpRequestMessage deleteReq = new(HttpMethod.Post, "auth/account/delete");
-        deleteReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        deleteReq.Content = JsonContent.Create(deleteRequest);
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        AccountDeletionEmailSpy.ScheduledCallCount.ShouldBe(1);
+        AccountDeletionEmailSpy.LastScheduledEmail.ShouldBe(registerRequest.Email);
+        AccountDeletionEmailSpy.LastCancelToken.ShouldNotBeNullOrWhiteSpace();
+    }
 
-        await ApiClient.Http.SendAsync(deleteReq);
+    [Fact]
+    public async Task DeleteAccount_ShouldPreventLogin_DuringGraceWindow()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
 
-        // Act — try to login with old credentials
-        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
-        {
-            ["grant_type"] = "password",
-            ["username"] = registerRequest.Email,
-            ["password"] = password,
-            ["client_id"] = "lotrokoniecdev-test",
-            ["scope"] = "email profile roles api"
-        });
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
+        await SendDeleteRequestAsync(accessToken, TestPassword);
 
-        HttpResponseMessage loginResponse = await ApiClient.Http.PostAsync(
-            new Uri("connect/token", UriKind.Relative), tokenRequest);
+        // Act — try to login with the (still correct) credentials
+        HttpResponseMessage loginResponse = await RequestTokenAsync(registerRequest.Email, TestPassword);
 
-        // Assert — login should fail (user anonymized + locked)
+        // Assert — the dedicated error lets clients show the "scheduled for deletion" state
         loginResponse.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await loginResponse.Content.ReadAsStringAsync();
+        body.ShouldContain("account_deletion_scheduled");
+    }
+
+    [Fact]
+    public async Task DeleteAccount_ShouldReturnGenericLoginError_WhenPasswordIsWrongDuringGraceWindow()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
+        await SendDeleteRequestAsync(accessToken, TestPassword);
+
+        // Act — wrong password must not reveal that deletion is scheduled
+        HttpResponseMessage loginResponse = await RequestTokenAsync(registerRequest.Email, "WrongPassword1!");
+
+        // Assert
+        loginResponse.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await loginResponse.Content.ReadAsStringAsync();
+        body.ShouldNotContain("account_deletion_scheduled");
+    }
+
+    [Fact]
+    public async Task DeleteAccount_ShouldReturnUnprocessableEntity_WhenAlreadyScheduled()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
+        HttpResponseMessage firstResponse = await SendDeleteRequestAsync(accessToken, TestPassword);
+        firstResponse.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        // Act — the JWT is self-contained, so it stays usable within its lifetime
+        HttpResponseMessage secondResponse = await SendDeleteRequestAsync(accessToken, TestPassword);
+
+        // Assert
+        secondResponse.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        string body = await secondResponse.Content.ReadAsStringAsync();
+        body.ShouldContain("Auth.DeletionAlreadyScheduled");
+        AccountDeletionEmailSpy.ScheduledCallCount.ShouldBe(1);
     }
 
     [Fact]
     public async Task DeleteAccount_ShouldReturnBadRequest_WhenPasswordIsWrong()
     {
         // Arrange
-        const string password = "TestPass1!";
+        (RegisterRequest registerRequest, IdentityId identityId) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
 
-        (RegisterRequest registerRequest, _) =
-            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
-
-        string accessToken = await GetAccessTokenAsync(registerRequest.Email, password);
-
-        DeleteAccountRequest deleteRequest = new("WrongPassword1!");
-
-        using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/delete");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        request.Content = JsonContent.Create(deleteRequest);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
         // Act
-        HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
+        HttpResponseMessage response = await SendDeleteRequestAsync(accessToken, "WrongPassword1!");
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        ApplicationUser user = await GetUserAsync(identityId.Value);
+        user.DeletionScheduledAt.ShouldBeNull();
     }
 
     [Fact]
     public async Task DeleteAccount_ShouldReturnUnauthorized_WhenNotAuthenticated()
     {
         // Arrange
-        DeleteAccountRequest deleteRequest = new("TestPass1!");
+        DeleteAccountRequest deleteRequest = new(TestPassword);
 
         // Act
         using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/delete");
@@ -117,64 +190,68 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
     }
 
     [Fact]
-    public async Task DeleteAccount_ShouldAnonymizeUserData_WhenAccountIsDeleted()
+    public async Task DeleteAccount_ShouldUnwindSchedule_WhenCancellationEmailFails()
     {
         // Arrange
-        const string password = "TestPass1!";
-
         (RegisterRequest registerRequest, IdentityId identityId) =
-            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
 
-        string accessToken = await GetAccessTokenAsync(registerRequest.Email, password);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
+        AccountDeletionEmailSpy.ShouldFailScheduledEmail = true;
+
+        try
+        {
+            // Act
+            HttpResponseMessage response = await SendDeleteRequestAsync(accessToken, TestPassword);
+
+            // Assert — without the emailed cancel link the owner couldn't cancel,
+            // so the schedule is rolled back and the account stays usable.
+            response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+            string body = await response.Content.ReadAsStringAsync();
+            body.ShouldContain("Auth.DeletionSchedulingFailed");
+
+            ApplicationUser user = await GetUserAsync(identityId.Value);
+            user.DeletionScheduledAt.ShouldBeNull();
+
+            HttpResponseMessage loginResponse = await RequestTokenAsync(registerRequest.Email, TestPassword);
+            loginResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+        finally
+        {
+            AccountDeletionEmailSpy.ShouldFailScheduledEmail = false;
+        }
+    }
+
+    private async Task<HttpResponseMessage> SendDeleteRequestAsync(string accessToken, string password)
+    {
         DeleteAccountRequest deleteRequest = new(password);
 
         using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/delete");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         request.Content = JsonContent.Create(deleteRequest);
 
-        // Act
-        HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
-
-        // Assert — deletion succeeded
-        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
-
-        // Assert — verify anonymization in database
-        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
-        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
-
-        ApplicationUser user = await db.Users.FirstAsync(u => u.Id == identityId.Value);
-
-        // PII fields should be anonymized
-        user.UserName.ShouldNotBe(registerRequest.Username);
-        user.Email.ShouldEndWith(AnonymizationConstants.EmailDomain);
-        user.Email.ShouldStartWith(AnonymizationConstants.EmailPrefix);
-        user.PhoneNumber.ShouldBeNull();
-        user.PasswordHash.ShouldBeNull();
-
-        // Consent flags should be cleared
-        user.DataProcessingConsentGiven.ShouldBeFalse();
-        user.DataProcessingConsentDate.ShouldBeNull();
-        user.PrivacyPolicyAccepted.ShouldBeFalse();
-        user.PrivacyPolicyAcceptedDate.ShouldBeNull();
-
-        // Security fields should be reset
-        user.EmailConfirmed.ShouldBeFalse();
-        user.PhoneNumberConfirmed.ShouldBeFalse();
-        user.TwoFactorEnabled.ShouldBeFalse();
-        user.AccessFailedCount.ShouldBe(0);
-
-        // Account should be permanently locked
-        user.LockoutEnabled.ShouldBeTrue();
-        user.LockoutEnd.ShouldBe(DateTimeOffset.MaxValue);
-
-        // Roles should be removed
-        bool hasRoles = await db.UserRoles.AnyAsync(ur => ur.UserId == identityId.Value);
-        hasRoles.ShouldBeFalse();
-
-        // Claims should be removed
-        bool hasClaims = await db.UserClaims.AnyAsync(uc => uc.UserId == identityId.Value);
-        hasClaims.ShouldBeFalse();
+        return await ApiClient.Http.SendAsync(request);
     }
 
+    private async Task<HttpResponseMessage> RequestTokenAsync(string email, string password)
+    {
+        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = email,
+            ["password"] = password,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api"
+        });
+
+        return await ApiClient.Http.PostAsync(new Uri("connect/token", UriKind.Relative), tokenRequest);
+    }
+
+    private async Task<ApplicationUser> GetUserAsync(Guid userId)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        return await db.Users.AsNoTracking().FirstAsync(u => u.Id == userId);
+    }
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeletionGraceWindowTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeletionGraceWindowTests.cs
@@ -1,0 +1,347 @@
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+/// <summary>
+/// Cross-endpoint behavior of the 14-day deletion grace window (ADR-0031): the hosted
+/// login page reveals the scheduled state only to the password holder, the password
+/// flows cannot bypass the window, tokens cannot be refreshed, and the emailed cancel
+/// link drives the hosted recovery flow.
+/// </summary>
+[Collection("AuthApi")]
+public sealed partial class DeletionGraceWindowTests : AsyncLifetimeTestBase
+{
+    private const string TestPassword = "TestPass1!";
+
+    protected override TestApiClient ApiClient { get; }
+
+    private readonly HttpClient _noRedirectClient;
+
+    public DeletionGraceWindowTests(AuthSystemApiFactory appFactory) : base(appFactory)
+    {
+        JsonSerializerOptions jsonSerializerOptions =
+            appFactory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+
+        ApiClient = new TestApiClient(appFactory.CreateClient(), jsonSerializerOptions);
+
+        _noRedirectClient = appFactory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+    }
+
+    [Fact]
+    public async Task LoginPage_ShouldShowScheduledDeletionMessage_WhenPasswordIsCorrect()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) = await RegisterAndScheduleDeletionAsync();
+
+        // Act
+        HttpResponseMessage response = await PostLoginFormAsync(registerRequest.Email, TestPassword);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("zaplanowane do usunięcia");
+    }
+
+    [Fact]
+    public async Task LoginPage_ShouldShowGenericError_WhenPasswordIsWrongDuringGraceWindow()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) = await RegisterAndScheduleDeletionAsync();
+
+        // Act
+        HttpResponseMessage response = await PostLoginFormAsync(registerRequest.Email, "WrongPassword1!");
+
+        // Assert — the scheduled state must not leak without the correct password
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Nieprawidłowy e-mail lub hasło");
+        html.ShouldNotContain("zaplanowane do usunięcia");
+    }
+
+    [Fact]
+    public async Task ForgotPassword_ShouldPretendSuccessWithoutSendingEmail_DuringGraceWindow()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) = await RegisterAndScheduleDeletionAsync();
+        PasswordResetEmailSpy.Reset();
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/forgot-password", UriKind.Relative),
+            new ForgotPasswordRequest(registerRequest.Email));
+
+        // Assert — anti-enumeration success, but the reset email must not go out
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        PasswordResetEmailSpy.CallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ResetPassword_ShouldRejectPreIssuedToken_DuringGraceWindow()
+    {
+        // Arrange — obtain a reset token BEFORE scheduling the deletion
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        PasswordResetEmailSpy.Reset();
+        HttpResponseMessage forgotResponse = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/forgot-password", UriKind.Relative),
+            new ForgotPasswordRequest(registerRequest.Email));
+        forgotResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string preIssuedResetToken = PasswordResetEmailSpy.LastResetToken!;
+
+        await ScheduleDeletionAsync(registerRequest.Email);
+
+        // Act — the pre-issued token must not restore access during the grace window
+        HttpResponseMessage resetResponse = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/reset-password", UriKind.Relative),
+            new ResetPasswordRequest(registerRequest.Email, preIssuedResetToken, "BrandNewPass1!"));
+
+        // Assert
+        resetResponse.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await resetResponse.Content.ReadAsStringAsync();
+        body.ShouldContain("Auth.InvalidPasswordResetToken");
+    }
+
+    [Fact]
+    public async Task ChangePassword_ShouldBeBlockedAndPreserveCancelToken_DuringGraceWindow()
+    {
+        // Arrange — the ADR-0031 threat: the attacker holds a pre-schedule access token
+        // (self-contained JWTs stay valid for their TTL) plus the current password, and
+        // tries to rotate the security stamp the emailed cancel token is bound to
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+        string preScheduleAccessToken = await GetAccessTokenAsync(registerRequest.Email);
+        await ScheduleDeletionAsync(registerRequest.Email);
+        string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
+
+        ChangePasswordRequest changeRequest = new(TestPassword, "AttackerNewPass1!");
+        using HttpRequestMessage request = new(HttpMethod.Post, "auth/change-password");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", preScheduleAccessToken);
+        request.Content = JsonContent.Create(changeRequest);
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
+
+        // Assert — blocked, and the emailed cancel link still works afterwards
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        string body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("Auth.DeletionAlreadyScheduled");
+
+        HttpResponseMessage cancelResponse = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/account/cancel-deletion", UriKind.Relative),
+            new CancelAccountDeletionRequest(registerRequest.Email, cancelToken));
+        cancelResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RefreshGrant_ShouldRejectRefreshToken_DuringGraceWindow()
+    {
+        // Arrange — a refresh token issued BEFORE scheduling; revocation on schedule is
+        // best-effort, so the refresh-grant gate is the guarantee
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        using FormUrlEncodedContent passwordGrant = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = registerRequest.Email,
+            ["password"] = TestPassword,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api offline_access"
+        });
+        HttpResponseMessage loginResponse = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), passwordGrant);
+        loginResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string loginContent = await loginResponse.Content.ReadAsStringAsync();
+        string refreshToken;
+        using (JsonDocument loginJson = JsonDocument.Parse(loginContent))
+        {
+            refreshToken = loginJson.RootElement.GetProperty("refresh_token").GetString()!;
+        }
+
+        await ScheduleDeletionAsync(registerRequest.Email);
+
+        using FormUrlEncodedContent refreshGrant = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+            ["client_id"] = "lotrokoniecdev-test"
+        });
+
+        // Act
+        HttpResponseMessage refreshResponse = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), refreshGrant);
+
+        // Assert — a scheduled account must not refresh its way back to a usable token
+        refreshResponse.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CancelDeletionPage_ShouldRenderConfirmationForm_OnGet()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) = await RegisterAndScheduleDeletionAsync();
+        string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
+
+        // Act — a GET (e.g. a mail scanner prefetch) must NOT cancel anything
+        HttpResponseMessage response = await _noRedirectClient.GetAsync(new Uri(
+            $"/Account/CancelDeletion?email={Uri.EscapeDataString(registerRequest.Email)}&token={Uri.EscapeDataString(cancelToken)}",
+            UriKind.Relative));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("cancel-deletion-form");
+
+        HttpResponseMessage loginResponse = await PostLoginFormAsync(registerRequest.Email, TestPassword);
+        string loginHtml = await loginResponse.Content.ReadAsStringAsync();
+        loginHtml.ShouldContain("zaplanowane do usunięcia");
+    }
+
+    [Fact]
+    public async Task CancelDeletionPage_ShouldCancelAndRedirectToPasswordReset_OnPost()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, _) = await RegisterAndScheduleDeletionAsync();
+        string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
+
+        string pageUrl =
+            $"/Account/CancelDeletion?email={Uri.EscapeDataString(registerRequest.Email)}&token={Uri.EscapeDataString(cancelToken)}";
+        HttpResponseMessage pageResponse = await _noRedirectClient.GetAsync(new Uri(pageUrl, UriKind.Relative));
+        pageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string pageHtml = await pageResponse.Content.ReadAsStringAsync();
+        string? antiForgeryToken = ExtractAntiForgeryToken(pageHtml);
+
+        Dictionary<string, string> formData = new()
+        {
+            ["Email"] = registerRequest.Email,
+            ["Token"] = cancelToken
+        };
+        if (antiForgeryToken is not null)
+        {
+            formData["__RequestVerificationToken"] = antiForgeryToken;
+        }
+
+        using FormUrlEncodedContent content = new(formData);
+        using HttpRequestMessage postRequest = new(HttpMethod.Post, pageUrl);
+        postRequest.Content = content;
+        if (pageResponse.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
+        {
+            foreach (string cookie in cookies)
+            {
+                postRequest.Headers.Add("Cookie", cookie.Split(';')[0]);
+            }
+        }
+
+        // Act
+        HttpResponseMessage response = await _noRedirectClient.SendAsync(postRequest);
+
+        // Assert — the page hands the user straight into the forced password reset
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        string? location = response.Headers.Location?.ToString();
+        location.ShouldNotBeNull();
+        location.ShouldContain("/Account/ResetPassword");
+        location.ShouldContain("token=");
+    }
+
+    private async Task<(RegisterRequest Request, string CancelToken)> RegisterAndScheduleDeletionAsync()
+    {
+        (RegisterRequest registerRequest, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        await ScheduleDeletionAsync(registerRequest.Email);
+
+        return (registerRequest, AccountDeletionEmailSpy.LastCancelToken!);
+    }
+
+    private async Task ScheduleDeletionAsync(string email)
+    {
+        string accessToken = await GetAccessTokenAsync(email);
+
+        DeleteAccountRequest deleteRequest = new(TestPassword);
+        using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/delete");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Content = JsonContent.Create(deleteRequest);
+
+        HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    private async Task<string> GetAccessTokenAsync(string email)
+    {
+        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = email,
+            ["password"] = TestPassword,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api"
+        });
+
+        HttpResponseMessage tokenResponse = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), tokenRequest);
+        tokenResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string content = await tokenResponse.Content.ReadAsStringAsync();
+        using JsonDocument json = JsonDocument.Parse(content);
+        return json.RootElement.GetProperty("access_token").GetString()!;
+    }
+
+    private async Task<HttpResponseMessage> PostLoginFormAsync(string email, string password)
+    {
+        HttpResponseMessage loginPageResponse = await _noRedirectClient.GetAsync(
+            new Uri("/Account/Login", UriKind.Relative));
+        loginPageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string loginPageHtml = await loginPageResponse.Content.ReadAsStringAsync();
+        string? antiForgeryToken = ExtractAntiForgeryToken(loginPageHtml);
+
+        Dictionary<string, string> loginFormData = new()
+        {
+            ["Email"] = email,
+            ["Password"] = password
+        };
+        if (antiForgeryToken is not null)
+        {
+            loginFormData["__RequestVerificationToken"] = antiForgeryToken;
+        }
+
+        using FormUrlEncodedContent content = new(loginFormData);
+        using HttpRequestMessage request = new(HttpMethod.Post, "/Account/Login");
+        request.Content = content;
+        if (loginPageResponse.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
+        {
+            foreach (string cookie in cookies)
+            {
+                request.Headers.Add("Cookie", cookie.Split(';')[0]);
+            }
+        }
+
+        return await _noRedirectClient.SendAsync(request);
+    }
+
+    private static string? ExtractAntiForgeryToken(string html)
+    {
+        Match match = AntiForgeryTokenRegex().Match(html);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [GeneratedRegex("""name="__RequestVerificationToken".*?value="([^"]+)""")]
+    private static partial Regex AntiForgeryTokenRegex();
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Hateoas/AccountAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Hateoas/AccountAggregateHateoasTests.cs
@@ -77,6 +77,35 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
     }
 
     [Fact]
+    public async Task ExportAccountData_ShouldExposeOnlyCancelDeletionTransition_WhenDeletionIsScheduled()
+    {
+        // Arrange - schedule GDPR deletion; the self-contained JWT stays valid within
+        // its lifetime, so the aggregate remains readable during the grace window and
+        // must advertise cancel-deletion as the only meaningful transition.
+        (RegisterRequest registerRequest, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
+
+        using HttpRequestMessage deleteRequest = new(HttpMethod.Post, "auth/account/delete");
+        deleteRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        deleteRequest.Content = JsonContent.Create(new DeleteAccountRequest(TestPassword));
+        HttpResponseMessage deleteResponse = await ApiClient.Http.SendAsync(deleteRequest);
+        deleteResponse.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        // Act
+        AccountDataExportResponse response = await RequestHateoasResponseAsync(accessToken);
+
+        // Assert
+        response.AuthData.DeletionScheduledAt.ShouldNotBeNull();
+        response.Links.Count.ShouldBe(2);
+        response.Links.ShouldContain(l => l.Rel == Rels.Self && l.Method == "GET");
+        response.Links.ShouldContain(l => l.Rel == Rels.CancelDeletion && l.Method == "POST");
+        response.Links.ShouldNotContain(
+            l => l.Rel == Rels.ChangePassword || l.Rel == Rels.DeleteAccount,
+            "a deletion-scheduled account must not advertise dead transitions");
+    }
+
+    [Fact]
     public async Task ExportAccountData_SelfLink_ShouldPointAtDataExportEndpoint()
     {
         // Arrange


### PR DESCRIPTION
Closes #452

## What

Replaces the immediate, irreversible account anonymization with a two-phase flow (ADR-0031, port of TKS ADR-0017):

1. **Schedule (sync):** password check → `DeletionScheduledAt` + lockout for the whole window, stamp rotation, best-effort OpenIddict revocation, one-time cancel link e-mailed (dedicated `DataProtectorTokenProvider`, lifespan = grace period, stamp-bound). E-mail failure unwinds the schedule. `204` + `X-Deletion-Scheduled-At` / `X-Deletion-Finalizes-At`; repeat → `422`.
2. **Finalize (background):** hosted service polls (1 h, first run at startup) and runs the extracted `AccountErasureService` on accounts past the grace period; per-user failures retry next run; `DeletionScheduledAt` survives as a non-PII audit trace.
3. **Cancel:** `POST /auth/account/cancel-deletion` (anonymous) + hosted `/Account/CancelDeletion` page (POST-only cancel): clears schedule + lockout, removes the password hash, rotates the stamp, forces the password-reset flow. One generic error for every invalid case, timing-equalized.

Side doors shut during the window: login page + Testing password grant (state revealed only after a valid password), `connect/authorize` (signs out scheduled/locked sessions), refresh grant, forgot-/reset-password (pretend success / generic error), **change-password** (would kill the cancel token via stamp rotation).

Deliberate deviation from TKS: no cross-context archival call — the TMS stores only opaque `IdentityId` attribution, non-attributable once the auth user is anonymized.

Also: `Gdpr` settings with options validation (grace ≤ 30 d per Art. 12(3), poll ≥ 1 min and ≤ grace), `DeletionScheduledAt` in the account data export, HATEOAS advertises only `cancel-deletion` while scheduled, privacy policy discloses the window, additive migration (nullable column + partial index, N-1 safe).

## Tests

- Build: zero warnings. Unit: 277/277. Auth integration: **272/272** (Testcontainers PostgreSQL).
- New/rewritten suites: `DeleteAccountEndpointTests` (schedule phase incl. unwind-on-e-mail-failure), `CancelAccountDeletionEndpointTests` (incl. token replay + full forced-reset recovery), `AccountDeletionFinalizerTests` (due/not-due/idempotent), `DeletionGraceWindowTests` (login/forgot/reset/change-password/refresh-grant gates + mail-scanner-safe cancel page), HATEOAS cancel-only link set.
- `code-reviewer` gate run at Fable 5 / effort high: both critical findings (missing ChangePassword gate, missing grace-window suite) fixed; minors (duplicate EventId, header assertion, poll-interval ceiling) fixed; parity notes accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)