### PR TITLE
loop: worker effort high / reviews xhigh, salvage branches instead of stash, CodeQL merge gate

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -3,7 +3,7 @@ name: code-reviewer
 description: Use this agent to review code changes against ticket acceptance criteria, find regressions, architecture violations, audit for unhandled edge cases (anti-happy-path gate), and verify test coverage. Invoke after implementing a feature or before creating a PR.
 tools: Read, Grep, Glob, Bash
 model: fable
-effort: high
+effort: xhigh
 ---
 
 You are a senior code reviewer for the LotroKoniecDev project — a C# .NET Clean Architecture solution with 5 layers (CLI → Application → Domain ← Infrastructure, Primitives). Your job is to catch bugs, architectural violations, behavioral regressions, **unhandled edge cases**, and missing tests BEFORE code is merged. A change that demonstrably works on the happy path but has never been pushed off it is **not** done — proving it is hardened against edge cases is part of every review (Phase 6).

--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -50,6 +50,13 @@ push → `gh pr create` (the interactive "ask before pushing" rule is waived). Y
    line: after APPROVE, commit (message references the ticket, ends with the `Co-Authored-By:`
    footer), push, `gh pr create --fill --body "Closes #$ARGUMENTS"`. Never report DONE while work
    is only staged. Do NOT merge.
+8. **CodeQL — clear every finding before you finish.** Wait for the PR's `CodeQL` check to
+   complete (`gh pr checks <pr> --watch --fail-fast` or poll; docs-only diffs skip it), then list
+   the PR's open alerts:
+   `gh api "repos/{owner}/{repo}/code-scanning/alerts?ref=refs/pull/<pr>/merge&state=open"`.
+   Fix every alert and push again (re-check after the re-run); dismissal instead of a fix is
+   allowed only with a real stated reason. The conductor's merge gate refuses any PR with open
+   alerts, so leaving one means the ticket ends in triage, not in a merge.
 
 ## Scope & safety
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ scripts/claude/backlog-loop.sh 123 130                 # exactly these tickets, 
 caffeinate -is scripts/claude/backlog-loop.sh          # overnight run on macOS (blocks sleep)
 scripts/claude/next-ticket.sh                          # print the next READY ticket (priority + deps)
 scripts/claude/work-ticket.sh 123                      # one ticket, one fresh headless session
-# defaults: fable (Fable 5) · effort xhigh · permission-mode auto — override via LOOP_MODEL /
+# defaults: fable (Fable 5) · effort high (reviews at xhigh) · permission-mode auto — override via LOOP_MODEL /
 # LOOP_EFFORT / LOOP_PERMISSION_MODE / LOOP_UNSAFE=1 · full manual: docs/claude-loop.md
 
 # TMS — EF Core migrations (write context owns them; --connection makes it work without appsettings/live DB)
@@ -351,12 +351,13 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 - **Right-size the design — YAGNI by default.** Before proposing an abstraction, cache, config
   knob, queue, or new infra, check it solves a **real, present** need from the current
   spec/ticket — not a hypothetical future. Pick the simple path and note the trade-off in one line.
-- **Agent fan-out is budgeted; reviews run on Fable 5 at high effort** (temporary switch
-  2026-07-09; previous standing rule was Opus 4.8 + effort max). Hard cap: **max 4 subagents in
-  parallel**, no chained waves by default; a small diff gets reviewed **inline, zero agents**.
-  The `code-reviewer` agent, `/code-review` and `/security-review` run with **model Fable 5 +
-  effort high** unless the prompt for that run explicitly says otherwise. Applies to interactive
-  sessions and loop-mode workers alike.
+- **Agent fan-out is budgeted; reviews run on Fable 5 at xhigh effort, everything else at high**
+  (2026-07-11; supersedes the 2026-07-09 all-xhigh switch; previous standing rule was Opus 4.8 +
+  effort max). Hard cap: **max 4 subagents in parallel**, no chained waves by default; a small
+  diff gets reviewed **inline, zero agents**. The `code-reviewer` agent, `/code-review` and
+  `/security-review` run with **model Fable 5 + effort xhigh**; loop-mode worker sessions run at
+  **effort high** (`LOOP_EFFORT` default) — unless the prompt for that run explicitly says
+  otherwise. Applies to interactive sessions and loop-mode workers alike.
 - **Frontend is Static SSR — enforced, not just documented.** No WebAssembly, no SignalR circuit,
   no per-user server state; forms post via `<form method="post" @formname @onsubmit>` (the SSR
   `@onsubmit` special-case) or `<EditForm OnValidSubmit>` — never interactive `@on*` handlers,
@@ -477,7 +478,11 @@ structure.
    diff (**`/security-review`** for anything touching native interop, file protection, or auth).
    **Green build + zero warnings + clean review = "done" — not before.**
 5. **PR closes the ticket.** Title mirrors the ticket; body contains `Closes #<n>`.
-   Ask before pushing.
+   Ask before pushing. **No merge with open CodeQL alerts:** green checks are not enough — the
+   CodeQL check succeeds even when it uploads findings. Before any merge (interactive or loop),
+   list `gh api "repos/{owner}/{repo}/code-scanning/alerts?ref=refs/pull/<n>/merge&state=open"`
+   and fix every alert (dismiss only with a stated reason); the loop's merge gate enforces this
+   mechanically.
 6. **Feed the flywheel.** Reusable correction → persist it: agent lesson →
    `.claude/agent-memory/<agent>/`; global rule → **this file**; real decision → new ADR;
    empirical DAT/update finding → `docs/knowledge-base/` (dated). The same mistake made twice
@@ -507,9 +512,11 @@ deliberately serial.)
 
 **Git hygiene — fully close each ticket before the next; never let two tickets' work share an
 uncommitted working copy.** The runner enforces it mechanically: it refuses to start on a dirty
-working copy, runs strictly serially, stashes (never deletes) anything a failed or blocked run
-leaves behind (`claude-loop salvage #<n>`), and returns to a freshly-pulled main between tickets.
-The worker (`/work-ticket`) never merges — the runner owns the merge gate. BLOCKED tickets get the
+working copy, runs strictly serially, commits (never deletes, never stashes) anything a failed or blocked run
+leaves behind on a dedicated `loop-salvage/<n>-<timestamp>` branch, and returns to a
+freshly-pulled main between tickets. The worker (`/work-ticket`) never merges — the runner owns
+the merge gate, and that gate also refuses any PR with **open CodeQL alerts** (fail closed; the
+worker clears them first, see §5). BLOCKED tickets get the
 `loop-blocked` label plus the open questions posted as an issue comment — triage is
 `gh issue list --label loop-blocked` (raw per-ticket session logs stay in
 `logs/claude-loop/<run>/` for debugging only). Business questions are **extracted for the user,

--- a/docs/claude-loop.md
+++ b/docs/claude-loop.md
@@ -95,13 +95,13 @@ one ticket with `LOOP_TRUST_GATE=0`, or add the commenter to `LOOP_TRUSTED_LOGIN
 
 | Var | Default | Meaning |
 |---|---|---|
-| `LOOP_EFFORT` | `xhigh` | claude effort per ticket |
+| `LOOP_EFFORT` | `high` | claude effort per ticket (reviews inside the session run at `xhigh` via the `code-reviewer` agent definition) |
 | `LOOP_MODEL` | `fable` | Fable 5 (temporary switch 2026-07-09; previously `opus` — Opus 4.8 with its native 1M-token context window) |
 | `LOOP_PERMISSION_MODE` | `auto` | headless permission mode |
 | `LOOP_ALLOWED_TOOLS` | git/gh/dotnet/scripts | loop-scoped Bash allowlist passed via `--allowedTools` |
 | `LOOP_UNSAFE` | `0` | `1` = `--dangerously-skip-permissions` (full overnight autonomy) |
 | `LOOP_MAX_BUDGET_USD` | (none) | optional per-ticket API budget cap |
-| `LOOP_TICKET_TIMEOUT_MIN` | `90` | wall-clock kill switch per ticket; leftovers are stashed |
+| `LOOP_TICKET_TIMEOUT_MIN` | `90` | wall-clock kill switch per ticket; leftovers are committed on a `loop-salvage/…` branch |
 | `LOOP_CHECKS_TIMEOUT_MIN` | `30` | wait for pr-verify before falling back to `--auto` merge |
 | `LOOP_GH_USER` | `koniecdev` | gh account whose token backs the loop's gh write calls (PR merge, labels, issue comments); an existing `GH_TOKEN` in the environment wins |
 | `LOOP_SKIP_LABELS` | `loop-blocked,qa,post-mvp,audit` | picker label exclusions |
@@ -111,7 +111,7 @@ one ticket with `LOOP_TRUST_GATE=0`, or add the commenter to `LOOP_TRUSTED_LOGIN
 | `LOOP_TRUSTED_LOGINS` | (none) | provenance gate: extra logins (a second maintainer account, a bot) |
 | `LOOP_TRUST_GATE` | `1` | `0` = skip the provenance gate **for the whole run** (you read the issue *and* its comments yourself) — use it only on a single explicitly-named ticket |
 | `LOOP_LIMIT_SLEEP_MIN` | `60` | nap length when the usage limit is hit |
-| `LOOP_LIMIT_RETRIES` | `4` | max naps before giving up |
+| `LOOP_LIMIT_RETRIES` | `8` | max naps before giving up (a limit hit at the start of a 5h usage window needs up to ~5h of naps) |
 | `LOOP_MAX_CONSECUTIVE_FAILURES` | `2` | systemic-failure circuit breaker |
 
 Example overnight run with a hard per-ticket budget:
@@ -135,9 +135,12 @@ Per-ticket outcomes:
   The ticket gets the `loop-blocked` label and the exact questions as an issue comment. Triage:
   `gh issue list --label loop-blocked` → answer in a comment → remove the label → the loop can
   pick it up again.
-- **failed / timeout** — session error or kill switch; leftovers are stashed as
-  `claude-loop salvage #<n>` (`git stash list`), main is restored. Two consecutive failures stop
-  the whole loop (something systemic).
+- **failed / timeout** — session error or kill switch; leftovers are committed on a dedicated
+  `loop-salvage/<n>-<timestamp>` branch (never stash — ordinary named git history), main is
+  restored. Two consecutive failures stop the whole loop (something systemic).
+- **codeql-alerts** — required checks passed but the PR carries open code-scanning alerts; the
+  merge is refused, the alerts are posted as a PR comment, and the PR is left open for triage
+  (an unreadable code-scanning API also refuses — fail closed).
 - **usage limit** — the loop naps (`LOOP_LIMIT_SLEEP_MIN`) and retries the same ticket.
 - **untrusted** — the ticket failed the provenance gate; it is skipped without spawning a session
   and without counting toward the failure circuit breaker (drain mode never selects one anyway).
@@ -148,9 +151,11 @@ Per-ticket outcomes:
   the session so no invocation path bypasses it. Self-tested by
   `scripts/tests/claude-loop-provenance.tests.sh`, which runs in `pr-verify` and `ci`.
 - The runner **refuses a dirty working copy** and never deletes work — anything left behind is
-  stashed, never reset.
+  committed on a dedicated `loop-salvage/<n>-<timestamp>` branch, never stashed, never reset.
 - The worker session may commit/push/PR (that authorization is the point of loop mode) but **never
-  merges**; the runner merges only after required checks pass, and never with `--delete-branch`.
+  merges**; the runner merges only after required checks pass **and the PR has zero open CodeQL
+  alerts** (the worker is instructed to clear them; the runner enforces it), and never with
+  `--delete-branch`.
 - Business decisions are never invented: they come back as BLOCKED questions on the issue.
 - Default permission mode is `auto` plus a loop-scoped git/gh/dotnet/scripts `--allowedTools`
   allowlist (interactive sessions are unaffected). `LOOP_UNSAFE=1` trades that for

--- a/scripts/claude/backlog-loop.sh
+++ b/scripts/claude/backlog-loop.sh
@@ -11,13 +11,15 @@
 #   scripts/claude/backlog-loop.sh 123 130      # exactly these tickets, in this order
 #   caffeinate -is scripts/claude/backlog-loop.sh   # overnight on macOS (blocks sleep)
 #
-# Env (all forwarded to work-ticket.sh): LOOP_EFFORT (default xhigh), LOOP_MODEL (default fable),
+# Env (all forwarded to work-ticket.sh): LOOP_EFFORT (default high; reviews run at xhigh via the
+#   code-reviewer agent definition), LOOP_MODEL (default fable),
 #   LOOP_CONFIG_DIR (default ~/.claude-account1 — which account runs the loop),
 #   LOOP_PERMISSION_MODE (default auto), LOOP_UNSAFE, LOOP_MAX_BUDGET_USD,
 #   LOOP_TICKET_TIMEOUT_MIN, LOOP_CHECKS_TIMEOUT_MIN, LOOP_SKIP_LABELS,
 #   LOOP_TRUSTED_ASSOCIATIONS / LOOP_TRUSTED_LOGINS / LOOP_TRUST_GATE (the provenance gate —
 #   ADR-0026; it also fires on explicitly-named tickets, which never touch the picker).
-#   Loop-only: LOOP_LIMIT_SLEEP_MIN (default 60), LOOP_LIMIT_RETRIES (default 4),
+#   Loop-only: LOOP_LIMIT_SLEEP_MIN (default 60), LOOP_LIMIT_RETRIES (default 8 — a limit hit at
+#   the start of a 5h usage window needs up to ~5h of naps to outlive it),
 #   LOOP_MAX_CONSECUTIVE_FAILURES (default 2).
 #
 # Raw per-ticket session logs land in logs/claude-loop/<timestamp>/ (debugging only);
@@ -47,7 +49,7 @@ if [ "${#EXPLICIT_TICKETS[@]}" -gt 0 ]; then EXPLICIT_MODE=1; fi
 EXPLICIT_INDEX=0
 
 LIMIT_SLEEP_MIN="${LOOP_LIMIT_SLEEP_MIN:-60}"
-LIMIT_RETRIES="${LOOP_LIMIT_RETRIES:-4}"
+LIMIT_RETRIES="${LOOP_LIMIT_RETRIES:-8}"
 MAX_FAILURES="${LOOP_MAX_CONSECUTIVE_FAILURES:-2}"
 
 LOCK="$REPO_ROOT/.claude/backlog-loop.lock"

--- a/scripts/claude/work-ticket.sh
+++ b/scripts/claude/work-ticket.sh
@@ -8,7 +8,8 @@
 #
 # Usage: work-ticket.sh <issue-number> [run-dir]
 # Env:
-#   LOOP_EFFORT             claude effort level (default: xhigh)
+#   LOOP_EFFORT             claude effort level (default: high — reviews inside the session run
+#                           at xhigh via the code-reviewer agent definition)
 #   LOOP_MODEL              model (default: fable — Fable 5; temporary switch 2026-07-09,
 #                           previously opus — Opus 4.8 with its native 1M-token context window)
 #   LOOP_CONFIG_DIR         Claude config dir = which account runs the loop
@@ -27,7 +28,7 @@
 #   LOOP_TRUSTED_ASSOCIATIONS / LOOP_TRUSTED_LOGINS / LOOP_TRUST_GATE — see issue-trust.sh
 #
 # Exit codes: 0 merged · 2 blocked · 3 error (incl. a provenance gate that could not reach the API)
-#             4 timeout · 5 checks failed / merge failed · 6 usage limit hit
+#             4 timeout · 5 checks failed / open CodeQL alerts / merge failed · 6 usage limit hit
 #             7 auto-merge queued (checks still running) · 10 dirty working copy
 #             11 issue refused by the provenance gate (untrusted author or commenter)
 set -euo pipefail
@@ -42,7 +43,7 @@ esac
 RUN_DIR="${2:-$REPO_ROOT/logs/claude-loop/adhoc-$(date +%Y%m%d-%H%M%S)}"
 mkdir -p "$RUN_DIR"
 
-EFFORT="${LOOP_EFFORT:-xhigh}"
+EFFORT="${LOOP_EFFORT:-high}"
 MODEL="${LOOP_MODEL:-fable}"
 export CLAUDE_CONFIG_DIR="${LOOP_CONFIG_DIR:-$HOME/.claude-account1}"
 PERMISSION_MODE="${LOOP_PERMISSION_MODE:-auto}"
@@ -91,11 +92,19 @@ if [ "$trust_rc" -ne 0 ]; then
     exit 3
 fi
 
-# Stash (never delete) anything a failed/blocked session left behind, and return to main.
+# Commit (never delete, never stash) anything a failed/blocked session left behind: leftovers
+# become ordinary named git history on a dedicated `loop-salvage/<issue>-<timestamp>` branch,
+# cut from wherever the session got to (so partial commits on the ticket branch stay reachable
+# from it too). Then return to main.
 salvage() {
     if [ -n "$(git status --porcelain)" ]; then
-        git stash push --include-untracked -m "claude-loop salvage #$ISSUE $(date +%F-%H%M)" >/dev/null 2>&1 || true
-        log "leftover changes stashed (git stash list | grep 'salvage #$ISSUE')"
+        salvage_branch="loop-salvage/$ISSUE-$(date +%Y%m%d-%H%M%S)"
+        git checkout -b "$salvage_branch" --quiet 2>/dev/null || true
+        git add -A >/dev/null 2>&1 || true
+        git commit --quiet --no-verify \
+            -m "claude-loop: salvage uncommitted work for #$ISSUE" \
+            -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>" >/dev/null 2>&1 || true
+        log "leftover changes committed on branch $salvage_branch"
     fi
     git checkout main --quiet 2>/dev/null || true
 }
@@ -246,6 +255,27 @@ while :; do
     fi
     sleep 45
 done
+
+# ── CodeQL gate: every code-scanning finding must be handled BEFORE merge ──────────────────────
+# Green `gh pr checks` does NOT cover this — the CodeQL check succeeds even when it uploads
+# alerts. Query the PR's open alerts directly and fail CLOSED: an unreadable API refuses to
+# merge blind (same philosophy as the provenance gate). Docs-only PRs skip CodeQL and simply
+# return an empty list here.
+alerts="$(gh api "repos/{owner}/{repo}/code-scanning/alerts?ref=refs/pull/$pr_num/merge&state=open&per_page=100" \
+    --jq '[.[] | "- \(.rule.id) (\(.rule.severity)) \(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)"] | join("\n")' \
+    2>/dev/null)" || {
+    meta outcome codeql-unverifiable
+    salvage
+    log "could not read code-scanning alerts for PR #$pr_num — refusing to merge blind"
+    exit 5
+}
+if [ -n "$alerts" ]; then
+    meta outcome codeql-alerts
+    gh pr comment "$pr_num" --body "$(printf '🤖 **claude-loop: merge refused — open CodeQL alerts on this PR.** Fix each one (or dismiss it with a stated reason) before merging:\n\n%s' "$alerts")" >/dev/null 2>&1 || true
+    salvage
+    log "open CodeQL alerts on PR #$pr_num — merge refused, PR left open for triage"
+    exit 5
+fi
 
 if ! gh pr merge "$pr_num" --squash; then
     meta outcome merge-failed


### PR DESCRIPTION
## What

- **Effort split:** loop worker sessions default to `--effort high` (`LOOP_EFFORT`); reviews run at `xhigh` — the `code-reviewer` agent frontmatter carries it, and the CLAUDE.md rule extends it to `/code-review` and `/security-review`.
- **No more stash:** `salvage()` now commits any leftover work on a dedicated `loop-salvage/<issue>-<timestamp>` branch with a named commit — plain git history instead of `git stash`.
- **CodeQL merge gate:** the conductor refuses to merge any PR that has open code-scanning alerts (`?ref=refs/pull/<n>/merge&state=open`), posts the alert list as a PR comment, and fails closed when the API is unreadable. The `/work-ticket` worker gets a new step 8: wait for the CodeQL check and clear every alert before reporting DONE. Interactive rule added to CLAUDE.md workflow §5.
- **Limit resilience:** `LOOP_LIMIT_RETRIES` default 4 → 8, so a usage limit hit at the start of a 5h window is outlived (8 × 60-min naps).

Docs (`docs/claude-loop.md`) and script headers updated to match. Provenance test suite green (34/34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)