### PR TITLE
LEGAL-03: Terms of service — fan-project disclaimer + translation contribution license

### DIFF
--- a/docs/specs/0010-terms-of-service.md
+++ b/docs/specs/0010-terms-of-service.md
@@ -1,0 +1,161 @@
+# Spec 0010: Terms of service — fan-project disclaimer + translation contribution license
+
+- **Status:** Implemented
+- **Date:** 2026-07-12
+- **Author:** koniecdev
+- **Ticket:** #453 (LEGAL-03) — part of the legal & GDPR pack (epic #459)
+- **Related:** #452/PR#460 (LEGAL-01 two-phase deletion — the anonymized-retention design this
+  license must cover), spec 0009 (LEGAL-02 account UX), #458 (LEGAL-05 footer legal links —
+  depends on this), auth privacy policy `Pages/Account/PrivacyPolicy.cshtml`, TKS structural
+  mirror: `src/Frontend/TheKittySaver.Frontend/Components/Pages/Terms.razor` (8 sections + TOC)
+
+## Business context
+
+The service has no terms of service anywhere — no frontend page, nothing on the auth server —
+while production is live at lotro-translator.pl and staging allows self-registration. Two legal
+gaps make this critical: (1) LOTRO is the IP of Standing Stone Games / Middle-earth Enterprises
+and the platform must state its non-commercial fan-project status and non-affiliation; (2) the
+LEGAL-01 erasure design deliberately **keeps translation contributions in the service
+(anonymized) after account deletion** and distributes them in `polish.txt` — that retention and
+distribution is only defensible if every contributor granted an explicit license, which today
+exists nowhere. The privacy policy already promises this retention (§ retencja: "wkład
+tłumaczeniowy pozostaje w serwisie wyłącznie z nieprzypisywalnym identyfikatorem") without the
+contractual basis behind it.
+
+## Goal
+
+Any visitor (anonymous included) can read the terms of service in Polish; every new translator
+grants the contribution license as part of registration, so anonymized post-deletion retention
+and `polish.txt` distribution rest on an explicit grant instead of an assumption.
+
+## In scope
+
+- **Terms page on the frontend** — `Components/Pages/Terms/Terms.razor`, routes `/regulamin`
+  (canonical) + `/terms` (alias, mirrors TKS), static SSR, `[AllowAnonymous]` (the frontend's
+  `AuthorizeRouteView` defaults to authorized — same opt-out as `Home.razor`). Content is plain
+  Polish markup (no `IStringLocalizer` — our frontend has no localization infra and all pages are
+  hardcoded Polish). Structure mirrors TKS Terms: intro lede, numbered `legal-sec` sections with
+  anchor ids, sidebar table of contents, "last updated" date line. Sections (adapted from TKS's
+  8):
+  1. **Postanowienia ogólne** — service identity, operator contact, **fan-project status and
+     non-affiliation disclaimer** (SSG / Middle-earth Enterprises own LOTRO; the platform is a
+     non-commercial community translation project).
+  2. **Definicje** — Serwis, Użytkownik/Tłumacz, Wkład tłumaczeniowy, `polish.txt` (the
+     distributed translation file), Gra.
+  3. **Zasady korzystania** — acceptable use (no scraping/abuse, no unlawful or infringing
+     content in translations, quality/review workflow is at the operator's discretion).
+  4. **Konta** — registration, e-mail confirmation, deletion incl. the 14-day window (consistent
+     with the privacy policy; link, don't duplicate).
+  5. **Licencja na wkład tłumaczeniowy** — the load-bearing section: the contributor's grant
+     covering storage, modification (review/edits), distribution in `polish.txt` to players (via
+     the API/patcher), and **post-deletion retention in anonymized form**. Exact scope = owner
+     decision (open questions).
+  6. **Dane osobowe** — pointer section linking to the auth-server privacy policy
+     (`{auth origin}/Account/PrivacyPolicy`), like TKS §6.
+  7. **Reklamacje i kontakt** — contact channel, response time, no-warranty/liability limits
+     appropriate to a free non-commercial service.
+  8. **Postanowienia końcowe** — changes to the terms (procedure = owner decision), governing
+     law: **Poland** (per the ticket), severability.
+- **Footer link** — `MainLayout.razor` footer gains a "Regulamin" link to `/regulamin`
+  (the footer today is a single copyright line; LEGAL-05/#458 will later add the full legal-links
+  row — this ticket adds just the terms link so AC "reachable from the footer" holds).
+- **Registration checkbox** — `AuthSystem.API/Pages/Account/Register.cshtml` gains a third
+  required consent checkbox ("Akceptuję regulamin") next to the two existing ones, persisted as
+  `AcceptedTermsOfService` end-to-end (page model → `RegisterRequest` → handler → domain user →
+  EF column, additive N-1-safe migration). Registration without it fails validation. Existing
+  accounts are grandfathered (no backfill; column defaults to false). The terms link is
+  cross-origin (auth server → frontend origin), `target="_blank" rel="noopener"` like the
+  existing privacy-policy link; the frontend origin comes from configuration, not hardcoding.
+
+## Out of scope
+
+- The full footer legal-links row and the privacy-policy accuracy pass — that is #458 (LEGAL-05),
+  which depends on this ticket.
+- Terms versioning/history UI, diffing, or re-acceptance flows beyond what the owner decides for
+  registration.
+- Any change to the deletion/anonymization backend (LEGAL-01 shipped it; this ticket only
+  licenses what it already does).
+- Cookie banner (#454), data-export scope (#456).
+- English translation of the terms — the service is Polish-facing; `/terms` is only a route
+  alias.
+
+## Business rules & edge cases
+
+- The terms page must be publicly readable — an anonymous visitor landing from the registration
+  page must not hit the login redirect.
+- The contribution-license section must explicitly name both facts the erasure design assumes:
+  distribution in `polish.txt` and post-deletion retention of anonymized contributions. Vague
+  "you grant us a license" wording does not satisfy the AC.
+- The privacy policy and the terms must not contradict each other on retention wording; the terms
+  reference the policy for personal-data matters instead of restating it.
+- If the owner chooses a required checkbox at registration: registration must fail validation
+  without it, the acceptance must be persisted (like `AcceptedPrivacyPolicy`), and existing
+  accounts (staging self-registrations, production) need a decided treatment.
+- The "last updated" date is maintained manually in the page content (no CMS).
+
+## Contract
+
+- **Trigger:** browser `GET /regulamin` (alias `/terms`) on the frontend; links from the frontend
+  footer and the auth-server registration page.
+- **Input/Output:** static SSR page — no new TMS endpoints. Registration:
+  `RegisterRequest`/`Register.cshtml.cs` gain an `AcceptedTermsOfService` bool + persistence on
+  the auth user (EF migration on the auth context, forward-only per ADR-0023 — additive column,
+  N-1 safe).
+- **Errors:** none new; unauthenticated access must NOT produce the `RedirectToLogin` flow.
+- **Files touched:** `src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Terms/Terms.razor`
+  (+ any page CSS), `Components/Layout/MainLayout.razor`,
+  `src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml(.cs)`; checkbox
+  option additionally touches AuthSystem Domain/Persistence + a migration.
+
+## Acceptance criteria
+
+- [ ] Done when an anonymous visitor can open `/regulamin` on the frontend and read the full
+      terms (static SSR, no login redirect, SSR-purity gate stays green).
+- [ ] Done when the frontend footer contains a working "Regulamin" link on every page.
+- [ ] Done when the registration page references the terms per the owner's decision (link or
+      required checkbox), and — if checkbox — registration without it fails validation and the
+      acceptance is persisted.
+- [ ] Done when the contribution-license section explicitly covers (a) distribution of
+      contributions in `polish.txt`, (b) retention of anonymized contributions after account
+      deletion, in wording consistent with the privacy policy.
+- [ ] Done when the non-affiliation / fan-project disclaimer names SSG / Middle-earth Enterprises
+      and states non-commercial status.
+- [ ] Done when governing law is stated as Polish law and a changes-to-terms procedure (per owner
+      decision) is present.
+
+## Open questions
+
+Empirical — answered from the repo:
+
+- *Is the frontend page public by default?* No — `Routes.razor` wraps everything in
+  `AuthorizeRouteView`; public pages opt out with `[AllowAnonymous]` (`Home.razor` does).
+- *Does the frontend have localization to mirror TKS's `IStringLocalizer` Terms?* No — zero
+  `IStringLocalizer` usages; all pages hardcode Polish. The page is written as plain Polish
+  markup.
+- *What does registration already collect?* Two persisted consents (`AcceptedPrivacyPolicy`,
+  `AcceptedDataProcessingConsent`) with required checkboxes — the checkbox option has an exact
+  sibling to mirror.
+
+Business decisions — answered by the owner (2026-07-12, in-session):
+
+1. **License scope** — non-exclusive, royalty-free, perpetual, **irrevocable**, covering storage,
+   modification (review/edits), distribution in `polish.txt` to players via the API/patcher
+   (sublicense), and post-deletion retention in anonymized form.
+2. **Moral rights** — a non-exercise clause: the contributor undertakes not to exercise the
+   attribution right against anonymized distribution and authorizes the operator to publish the
+   contribution without attribution. No credits page.
+3. **Registration UX** — a **required persisted `AcceptedTermsOfService` checkbox** for new
+   registrations (mirror the two existing consents; additive N-1-safe migration). Existing
+   accounts are **grandfathered** — their contributions rest on the current privacy policy until
+   LEGAL-05 (#458).
+4. **Changes-to-terms procedure** — e-mail notification of material changes with **14 days'**
+   notice; a user who does not accept may delete the account. Notification is a manual operator
+   action, not new code.
+
+## Assumptions
+
+- Governing law is Poland — stated in the ticket by the owner; not re-asked.
+- The terms live on the frontend (ticket decision), not the auth server; the auth privacy policy
+  stays where it is and is linked, not moved.
+- Canonical route `/regulamin` with `/terms` alias, mirroring TKS.
+- Operator identity/contact in the terms reuses what the privacy policy already publishes.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/DatabaseSeederExtensions.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/DatabaseSeederExtensions.cs
@@ -88,7 +88,9 @@ internal static class DatabaseSeederExtensions
             DataProcessingConsentGiven = true,
             DataProcessingConsentDate = timeProvider.GetUtcNow(),
             PrivacyPolicyAccepted = true,
-            PrivacyPolicyAcceptedDate = timeProvider.GetUtcNow()
+            PrivacyPolicyAcceptedDate = timeProvider.GetUtcNow(),
+            TermsOfServiceAccepted = true,
+            TermsOfServiceAcceptedDate = timeProvider.GetUtcNow()
         };
 
         IdentityResult createResult = await userManager.CreateAsync(admin, password);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ExportAccountData.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ExportAccountData.cs
@@ -54,6 +54,8 @@ internal sealed partial class ExportAccountData : IApiEndpoint
                     appUser.DataProcessingConsentDate,
                     appUser.PrivacyPolicyAccepted,
                     appUser.PrivacyPolicyAcceptedDate,
+                    appUser.TermsOfServiceAccepted,
+                    appUser.TermsOfServiceAcceptedDate,
                     appUser.DeletionScheduledAt),
                 IsComplete: true);
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
@@ -23,7 +23,8 @@ internal sealed partial class RegisterUser : IApiEndpoint
         string Email,
         string Password,
         bool AcceptedPrivacyPolicy,
-        bool AcceptedDataProcessingConsent) : ICommand<Result<IdentityId>>;
+        bool AcceptedDataProcessingConsent,
+        bool AcceptedTermsOfService) : ICommand<Result<IdentityId>>;
 
     internal sealed class CommandValidator : AbstractValidator<Command>
     {
@@ -50,6 +51,9 @@ internal sealed partial class RegisterUser : IApiEndpoint
 
             RuleFor(x => x.AcceptedDataProcessingConsent)
                 .Equal(true).WithMessage("You must consent to data processing to register.");
+
+            RuleFor(x => x.AcceptedTermsOfService)
+                .Equal(true).WithMessage("You must accept the terms of service to register.");
         }
     }
 
@@ -108,7 +112,9 @@ internal sealed partial class RegisterUser : IApiEndpoint
                     DataProcessingConsentGiven = command.AcceptedDataProcessingConsent,
                     DataProcessingConsentDate = command.AcceptedDataProcessingConsent ? _timeProvider.GetUtcNow() : null,
                     PrivacyPolicyAccepted = command.AcceptedPrivacyPolicy,
-                    PrivacyPolicyAcceptedDate = command.AcceptedPrivacyPolicy ? _timeProvider.GetUtcNow() : null
+                    PrivacyPolicyAcceptedDate = command.AcceptedPrivacyPolicy ? _timeProvider.GetUtcNow() : null,
+                    TermsOfServiceAccepted = command.AcceptedTermsOfService,
+                    TermsOfServiceAcceptedDate = command.AcceptedTermsOfService ? _timeProvider.GetUtcNow() : null
                 };
 
                 IdentityResult result = await _userManager.CreateAsync(user, command.Password);
@@ -183,7 +189,8 @@ internal sealed partial class RegisterUser : IApiEndpoint
                     request.Email,
                     request.Password,
                     request.AcceptedPrivacyPolicy,
-                    request.AcceptedDataProcessingConsent);
+                    request.AcceptedDataProcessingConsent,
+                    request.AcceptedTermsOfService);
 
                 Result<IdentityId> commandResult = await handler.Handle(command, cancellationToken);
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
@@ -550,6 +550,21 @@
                                     <span class="box" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
                                     <span>Wyrażam zgodę na przetwarzanie moich danych osobowych w celu prowadzenia konta.</span>
                                 </label>
+                                <label class="checkbox">
+                                    <input asp-for="AcceptedTermsOfService" type="checkbox" data-testid="register-accept-terms" />
+                                    <span class="box" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
+                                    <span>
+                                        Akceptuję
+                                        @if (Model.TermsOfServiceUrl is not null)
+                                        {
+                                            <a href="@Model.TermsOfServiceUrl" target="_blank" rel="noopener">regulamin serwisu</a>
+                                        }
+                                        else
+                                        {
+                                            <text>regulamin serwisu</text>
+                                        }, w tym licencję na wkład tłumaczeniowy.
+                                    </span>
+                                </label>
                             </div>
 
                             <div class="auth-actions">

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml.cs
@@ -1,7 +1,9 @@
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
 using LotroKoniecDev.AuthSystem.API.Features.Auth;
+using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
 using LotroKoniecDev.SharedKernel.Constants;
 using LotroKoniecDev.SharedKernel.Messaging;
@@ -13,13 +15,16 @@ namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
 internal sealed partial class RegisterModel : PageModel
 {
     private readonly ICommandHandler<RegisterUser.Command, Result<IdentityId>> _registerUserHandler;
+    private readonly IOptions<OpenIddictSettings> _openIddictSettings;
     private readonly ILogger<RegisterModel> _logger;
 
     public RegisterModel(
         ICommandHandler<RegisterUser.Command, Result<IdentityId>> registerUserHandler,
+        IOptions<OpenIddictSettings> openIddictSettings,
         ILogger<RegisterModel> logger)
     {
         _registerUserHandler = registerUserHandler;
+        _openIddictSettings = openIddictSettings;
         _logger = logger;
     }
 
@@ -41,7 +46,22 @@ internal sealed partial class RegisterModel : PageModel
     [BindProperty]
     public bool AcceptedDataProcessingConsent { get; set; }
 
+    [BindProperty]
+    public bool AcceptedTermsOfService { get; set; }
+
     public bool IsRegistered { get; set; }
+
+    /// <summary>
+    /// Absolute URL of the terms-of-service page on the frontend, derived from the web client's
+    /// first post-logout redirect URI (the app root) so no separate frontend-origin setting is
+    /// needed. Null when the client is not configured (e.g. a bare test host) — the register page
+    /// then renders the consent label without a link.
+    /// </summary>
+    public string? TermsOfServiceUrl =>
+        _openIddictSettings.Value.WebClient.PostLogoutRedirectUris is [string appRoot, ..]
+        && Uri.TryCreate(appRoot, UriKind.Absolute, out Uri? appRootUri)
+            ? new Uri(appRootUri, "/regulamin").ToString()
+            : null;
 
     public string? ErrorMessage { get; set; }
 
@@ -96,12 +116,19 @@ internal sealed partial class RegisterModel : PageModel
             return Page();
         }
 
+        if (!AcceptedTermsOfService)
+        {
+            ErrorMessage = "Musisz zaakceptować regulamin serwisu, aby założyć konto.";
+            return Page();
+        }
+
         RegisterUser.Command command = new(
             Username.Trim(),
             Email.Trim(),
             Password,
             AcceptedPrivacyPolicy,
-            AcceptedDataProcessingConsent);
+            AcceptedDataProcessingConsent,
+            AcceptedTermsOfService);
 
         Result<IdentityId> result = await _registerUserHandler.Handle(command, cancellationToken);
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/AccountErasureService.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Gdpr/AccountErasureService.cs
@@ -60,6 +60,8 @@ internal sealed partial class AccountErasureService : IAccountErasureService
             user.DataProcessingConsentDate = null;
             user.PrivacyPolicyAccepted = false;
             user.PrivacyPolicyAcceptedDate = null;
+            user.TermsOfServiceAccepted = false;
+            user.TermsOfServiceAcceptedDate = null;
 
             // The permanent lockout rides in the SAME update as the anonymization marker.
             // The finalizer selects pending work by the marker alone, so a user must never

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/AccountDataExportResponse.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/AccountDataExportResponse.cs
@@ -20,4 +20,6 @@ public sealed record AuthDataExportDto(
     DateTimeOffset? DataProcessingConsentDate,
     bool PrivacyPolicyAccepted,
     DateTimeOffset? PrivacyPolicyAcceptedDate,
+    bool TermsOfServiceAccepted,
+    DateTimeOffset? TermsOfServiceAcceptedDate,
     DateTimeOffset? DeletionScheduledAt);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Register/RegisterRequest.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Register/RegisterRequest.cs
@@ -5,4 +5,5 @@ public sealed record RegisterRequest(
     string Email,
     string Password,
     bool AcceptedPrivacyPolicy,
-    bool AcceptedDataProcessingConsent);
+    bool AcceptedDataProcessingConsent,
+    bool AcceptedTermsOfService);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Domain/Aggregates/ApplicationUsers/Entities/ApplicationUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Domain/Aggregates/ApplicationUsers/Entities/ApplicationUser.cs
@@ -8,5 +8,7 @@ public sealed class ApplicationUser : IdentityUser<Guid>
     public DateTimeOffset? DataProcessingConsentDate { get; set; }
     public bool PrivacyPolicyAccepted { get; set; }
     public DateTimeOffset? PrivacyPolicyAcceptedDate { get; set; }
+    public bool TermsOfServiceAccepted { get; set; }
+    public DateTimeOffset? TermsOfServiceAcceptedDate { get; set; }
     public DateTimeOffset? DeletionScheduledAt { get; set; }
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
@@ -30,6 +30,11 @@ internal sealed class ApplicationUserConfiguration : IEntityTypeConfiguration<Ap
 
         builder.Property(u => u.PrivacyPolicyAcceptedDate);
 
+        builder.Property(u => u.TermsOfServiceAccepted)
+            .HasDefaultValue(false);
+
+        builder.Property(u => u.TermsOfServiceAcceptedDate);
+
         builder.Property(u => u.DeletionScheduledAt);
 
         // Partial index: the deletion finalizer polls only the handful of rows with a schedule set.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260711223030_AddTermsOfServiceAcceptanceToUsers.Designer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260711223030_AddTermsOfServiceAcceptanceToUsers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711223030_AddTermsOfServiceAcceptanceToUsers")]
+    partial class AddTermsOfServiceAcceptanceToUsers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260711223030_AddTermsOfServiceAcceptanceToUsers.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260711223030_AddTermsOfServiceAcceptanceToUsers.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTermsOfServiceAcceptanceToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "TermsOfServiceAccepted",
+                schema: "authsystem",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "TermsOfServiceAcceptedDate",
+                schema: "authsystem",
+                table: "Users",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TermsOfServiceAccepted",
+                schema: "authsystem",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "TermsOfServiceAcceptedDate",
+                schema: "authsystem",
+                table: "Users");
+        }
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
@@ -32,6 +32,9 @@
     <footer class="foot">
         <div class="container">
             <p>© @DateTime.UtcNow.Year lotro-translator.pl — polskie tłumaczenie The Lord of the Rings Online</p>
+            <p class="foot-links">
+                <a href="/regulamin">Regulamin</a>
+            </p>
         </div>
     </footer>
 </div>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/Account.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/Account.razor
@@ -142,6 +142,20 @@
                             }
                         </dd>
                     </div>
+                    <div class="dl-row">
+                        <dt><a href="/regulamin">Regulamin serwisu</a></dt>
+                        <dd>
+                            @if (auth.TermsOfServiceAccepted)
+                            {
+                                <span class="badge badge-success"><span class="dot"></span>Zaakceptowany</span>
+                                <span class="mono dim">@FormatDateTime(auth.TermsOfServiceAcceptedDate)</span>
+                            }
+                            else
+                            {
+                                <span class="badge badge-neutral">Brak akceptacji</span>
+                            }
+                        </dd>
+                    </div>
                 </dl>
             </div>
         </section>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Terms/Terms.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Terms/Terms.razor
@@ -1,0 +1,264 @@
+@page "/regulamin"
+@page "/terms"
+@attribute [AllowAnonymous]
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.Extensions.Options
+@using LotroKoniecDev.Frontend.Settings
+@inject IOptions<AuthSystemSettings> AuthSystemOptions
+
+<PageTitle>Regulamin — lotro-translator.pl</PageTitle>
+
+<HeadContent>
+    <meta name="description"
+          content="Regulamin serwisu lotro-translator.pl — zasady korzystania z platformy polskiego tłumaczenia The Lord of the Rings Online, licencja na wkład tłumaczeniowy i status projektu fanowskiego."/>
+</HeadContent>
+
+<section class="container page-head">
+    <div>
+        <p class="eyebrow">Dokument prawny</p>
+        <h1>Regulamin serwisu</h1>
+        <p class="lede">
+            Zasady korzystania z platformy lotro-translator.pl.
+            Ostatnia aktualizacja: <span class="mono">12 lipca 2026 r.</span>
+        </p>
+    </div>
+</section>
+
+<section class="container content-wrap">
+    <div class="legal-grid">
+        <article class="panel legal-doc">
+            <div class="panel-body">
+                <p class="legal-lede">
+                    Niniejszy regulamin określa zasady korzystania z serwisu lotro-translator.pl —
+                    społecznościowej, niekomercyjnej platformy polskiego tłumaczenia gry
+                    The Lord of the Rings Online. Rejestrując konto, akceptujesz postanowienia
+                    regulaminu, w tym licencję na wkład tłumaczeniowy opisaną w §&nbsp;5.
+                </p>
+
+                <section class="legal-sec" id="postanowienia-ogolne">
+                    <h2>§ 1. Postanowienia ogólne</h2>
+                    <ol>
+                        <li>
+                            Serwis lotro-translator.pl (dalej: <strong>Serwis</strong>) jest prowadzony przez
+                            społeczność lotro-translator.pl (dalej: <strong>Operator</strong>) — niekomercyjny,
+                            fanowski projekt polskiego tłumaczenia gry The Lord of the Rings Online.
+                            Kontakt z Operatorem: <a href="mailto:koniecdev@gmail.com">koniecdev@gmail.com</a>.
+                        </li>
+                        <li>
+                            Gra The Lord of the Rings Online, jej treści, znaki towarowe i pozostała własność
+                            intelektualna należą do Standing Stone Games LLC oraz Middle-earth Enterprises.
+                            <strong>Serwis nie jest powiązany ze Standing Stone Games, Middle-earth Enterprises
+                            ani żadnym oficjalnym podmiotem związanym z grą, nie jest przez nie wspierany ani
+                            autoryzowany.</strong>
+                        </li>
+                        <li>
+                            Serwis działa niekomercyjnie: korzystanie z niego jest bezpłatne, a Operator nie
+                            czerpie przychodów z tłumaczenia ani z jego dystrybucji.
+                        </li>
+                        <li>
+                            Korzystanie z Serwisu — w tym założenie konta i wnoszenie wkładu tłumaczeniowego —
+                            oznacza akceptację niniejszego regulaminu.
+                        </li>
+                    </ol>
+                </section>
+
+                <section class="legal-sec" id="definicje">
+                    <h2>§ 2. Definicje</h2>
+                    <ol>
+                        <li><strong>Gra</strong> — The Lord of the Rings Online.</li>
+                        <li><strong>Użytkownik</strong> — każda osoba korzystająca z Serwisu.</li>
+                        <li>
+                            <strong>Tłumacz</strong> — Użytkownik posiadający konto w Serwisie, wnoszący wkład
+                            tłumaczeniowy.
+                        </li>
+                        <li>
+                            <strong>Wkład tłumaczeniowy</strong> — teksty tłumaczeń, ich poprawki i inne treści
+                            wprowadzone przez Tłumacza do Serwisu.
+                        </li>
+                        <li>
+                            <strong>Plik spolszczenia</strong> — generowany przez Serwis plik z tłumaczeniami
+                            (<span class="mono">polish.txt</span>), udostępniany graczom do pobrania i do
+                            automatycznego pobierania przez narzędzia instalujące spolszczenie.
+                        </li>
+                    </ol>
+                </section>
+
+                <section class="legal-sec" id="zasady-korzystania">
+                    <h2>§ 3. Zasady korzystania z Serwisu</h2>
+                    <ol>
+                        <li>
+                            Serwis służy do wspólnego tłumaczenia tekstów Gry na język polski: przeglądania
+                            tekstów, proponowania tłumaczeń, ich weryfikacji i zatwierdzania oraz pobierania
+                            pliku spolszczenia.
+                        </li>
+                        <li>
+                            Niedozwolone jest: wprowadzanie treści bezprawnych, obraźliwych lub naruszających
+                            prawa osób trzecich (w tym treści skopiowanych z cudzych tłumaczeń bez uprawnienia),
+                            celowe wprowadzanie tłumaczeń błędnych lub szkodliwych, zautomatyzowane masowe
+                            pobieranie treści Serwisu poza udostępnionym plikiem spolszczenia, a także działania
+                            zakłócające pracę Serwisu lub próby nieuprawnionego dostępu.
+                        </li>
+                        <li>
+                            Obieg redakcyjny (w tym zatwierdzanie tłumaczeń, ich edycja i unieważnianie po
+                            aktualizacjach Gry) pozostaje w gestii Operatora i osób pełniących role redakcyjne.
+                            Wniesienie wkładu nie gwarantuje jego publikacji w pliku spolszczenia.
+                        </li>
+                        <li>
+                            Operator może ograniczyć lub zablokować konto naruszające regulamin; o ile to możliwe,
+                            wcześniej wezwie Użytkownika do zaprzestania naruszeń.
+                        </li>
+                    </ol>
+                </section>
+
+                <section class="legal-sec" id="konta">
+                    <h2>§ 4. Konta</h2>
+                    <ol>
+                        <li>
+                            Założenie konta wymaga podania nazwy użytkownika, adresu e-mail i hasła oraz
+                            potwierdzenia adresu e-mail. Konto jest osobiste — nie udostępniaj danych logowania
+                            innym osobom.
+                        </li>
+                        <li>
+                            Konto można usunąć samodzielnie w sekcji „Moje konto”. Usunięcie następuje po
+                            14-dniowym okresie ochronnym, w którym można je anulować linkiem otrzymanym
+                            e-mailem; szczegóły opisuje polityka prywatności.
+                        </li>
+                        <li>
+                            Po usunięciu konta dane osobowe są nieodwracalnie anonimizowane, a wkład
+                            tłumaczeniowy pozostaje w Serwisie w formie zanonimizowanej — na zasadach licencji
+                            z §&nbsp;5.
+                        </li>
+                    </ol>
+                </section>
+
+                <section class="legal-sec" id="licencja">
+                    <h2>§ 5. Licencja na wkład tłumaczeniowy</h2>
+                    <ol>
+                        <li>
+                            Tłumacz oświadcza, że wkład tłumaczeniowy jest wynikiem jego własnej pracy i nie
+                            narusza praw osób trzecich.
+                        </li>
+                        <li>
+                            Z chwilą wprowadzenia wkładu tłumaczeniowego do Serwisu Tłumacz udziela Operatorowi
+                            <strong>niewyłącznej, nieodpłatnej, nieograniczonej czasowo i terytorialnie oraz
+                            nieodwołalnej</strong> licencji na korzystanie z tego wkładu w zakresie:
+                            <ul>
+                                <li>utrwalania i przechowywania w infrastrukturze Serwisu,</li>
+                                <li>
+                                    opracowania — redakcji, korekty, modyfikacji i łączenia z wkładem innych
+                                    Tłumaczy w ramach obiegu weryfikacji,
+                                </li>
+                                <li>
+                                    włączania do pliku spolszczenia (<span class="mono">polish.txt</span>) i jego
+                                    rozpowszechniania, w tym publicznego udostępniania przez API Serwisu oraz
+                                    narzędzia instalujące spolszczenie,
+                                </li>
+                                <li>
+                                    udzielania dalszych licencji (sublicencji) graczom — w zakresie niezbędnym do
+                                    pobrania spolszczenia i korzystania z niego w Grze.
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <strong>Licencja pozostaje w mocy po usunięciu konta.</strong> Wkład tłumaczeniowy
+                            pozostaje wówczas w Serwisie i w pliku spolszczenia w formie zanonimizowanej —
+                            bez możliwości powiązania go z osobą Tłumacza.
+                        </li>
+                        <li>
+                            Tłumaczenie jest dziełem zbiorowym społeczności i jest rozpowszechniane bez
+                            oznaczania autorstwa poszczególnych fragmentów. Tłumacz zobowiązuje się nie
+                            wykonywać wobec Operatora i graczy autorskiego prawa osobistego do oznaczania
+                            wkładu swoim autorstwem oraz upoważnia Operatora do udostępniania wkładu
+                            anonimowo.
+                        </li>
+                        <li>
+                            Licencja jest nieodpłatna — Tłumaczowi nie przysługuje wynagrodzenie za korzystanie
+                            z wkładu przez Operatora ani graczy.
+                        </li>
+                    </ol>
+                </section>
+
+                <section class="legal-sec" id="dane-osobowe">
+                    <h2>§ 6. Dane osobowe</h2>
+                    <p>
+                        Zasady przetwarzania danych osobowych — w tym prawa Użytkownika, okresy retencji oraz
+                        przebieg usuwania konta — opisuje odrębna
+                        <a href="@PrivacyPolicyUrl" target="_blank" rel="noopener">polityka prywatności</a>.
+                        W razie rozbieżności w sprawach danych osobowych pierwszeństwo ma polityka prywatności.
+                    </p>
+                </section>
+
+                <section class="legal-sec" id="odpowiedzialnosc">
+                    <h2>§ 7. Odpowiedzialność, reklamacje i kontakt</h2>
+                    <ol>
+                        <li>
+                            Serwis i plik spolszczenia są udostępniane bezpłatnie, w stanie „tak jak są”
+                            (as&nbsp;is). Operator dokłada starań, aby Serwis działał poprawnie, ale nie
+                            gwarantuje nieprzerwanej dostępności ani wolności tłumaczenia od błędów i nie
+                            odpowiada za skutki użycia spolszczenia w Grze.
+                        </li>
+                        <li>
+                            Korzystanie ze spolszczenia odbywa się na własną odpowiedzialność Użytkownika,
+                            z poszanowaniem regulaminu Gry.
+                        </li>
+                        <li>
+                            Reklamacje i zgłoszenia dotyczące działania Serwisu kieruj na adres
+                            <a href="mailto:koniecdev@gmail.com">koniecdev@gmail.com</a>. Odpowiadamy bez
+                            zbędnej zwłoki, najpóźniej w terminie 14 dni.
+                        </li>
+                        <li>
+                            Postanowienia regulaminu nie wyłączają ani nie ograniczają praw, które przysługują
+                            konsumentom na mocy bezwzględnie obowiązujących przepisów prawa.
+                        </li>
+                    </ol>
+                </section>
+
+                <section class="legal-sec" id="postanowienia-koncowe">
+                    <h2>§ 8. Postanowienia końcowe</h2>
+                    <ol>
+                        <li>
+                            Operator może zmienić regulamin z ważnych przyczyn, w szczególności przy zmianie
+                            przepisów prawa, funkcji Serwisu lub zasad dystrybucji spolszczenia. O istotnych
+                            zmianach zarejestrowani Użytkownicy zostaną powiadomieni e-mailem co najmniej
+                            <strong>14 dni</strong> przed ich wejściem w życie. Użytkownik, który nie akceptuje
+                            zmian, może w tym czasie usunąć konto.
+                        </li>
+                        <li>
+                            Aktualna treść regulaminu jest zawsze dostępna pod adresem
+                            <span class="mono">lotro-translator.pl/regulamin</span> wraz z datą ostatniej
+                            aktualizacji.
+                        </li>
+                        <li>Prawem właściwym dla regulaminu jest prawo polskie.</li>
+                        <li>
+                            Jeżeli którekolwiek postanowienie regulaminu okaże się nieważne lub bezskuteczne,
+                            pozostałe postanowienia pozostają w mocy.
+                        </li>
+                    </ol>
+                </section>
+            </div>
+        </article>
+
+        <aside class="legal-side">
+            <div class="panel">
+                <div class="panel-head"><h2>Spis treści</h2></div>
+                <div class="panel-body">
+                    <nav class="legal-toc" aria-label="Spis treści regulaminu">
+                        <a href="#postanowienia-ogolne">§ 1. Postanowienia ogólne</a>
+                        <a href="#definicje">§ 2. Definicje</a>
+                        <a href="#zasady-korzystania">§ 3. Zasady korzystania z Serwisu</a>
+                        <a href="#konta">§ 4. Konta</a>
+                        <a href="#licencja">§ 5. Licencja na wkład tłumaczeniowy</a>
+                        <a href="#dane-osobowe">§ 6. Dane osobowe</a>
+                        <a href="#odpowiedzialnosc">§ 7. Odpowiedzialność, reklamacje i kontakt</a>
+                        <a href="#postanowienia-koncowe">§ 8. Postanowienia końcowe</a>
+                    </nav>
+                </div>
+            </div>
+        </aside>
+    </div>
+</section>
+
+@code {
+    private string PrivacyPolicyUrl =>
+        $"{AuthSystemOptions.Value.BaseUrl.TrimEnd('/')}/Account/PrivacyPolicy";
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -1767,3 +1767,94 @@ code {
         gap: 4px;
     }
 }
+
+/* ───────── Legal documents (terms) ───────── */
+.legal-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 260px;
+    gap: 20px;
+    align-items: start;
+    padding-bottom: 48px;
+}
+
+.legal-side {
+    position: sticky;
+    top: 20px;
+}
+
+.legal-toc {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.legal-toc a {
+    color: var(--text-dim);
+    font-size: 13px;
+    text-decoration: none;
+    transition: color .15s;
+}
+
+.legal-toc a:hover {
+    color: var(--accent-hi);
+}
+
+.legal-doc .panel-body {
+    display: flex;
+    flex-direction: column;
+    gap: 26px;
+}
+
+.legal-lede {
+    margin: 0;
+    color: var(--text-dim);
+    font-size: 14.5px;
+    line-height: 1.65;
+}
+
+.legal-sec h2 {
+    margin: 0 0 10px;
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: -0.005em;
+    color: var(--text);
+}
+
+.legal-sec p,
+.legal-sec li {
+    color: var(--text-dim);
+    font-size: 13.5px;
+    line-height: 1.7;
+}
+
+.legal-sec p {
+    margin: 0;
+}
+
+.legal-sec ol,
+.legal-sec ul {
+    margin: 0;
+    padding-left: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.legal-sec li strong {
+    color: var(--text);
+}
+
+.legal-sec a {
+    color: var(--accent-hi);
+}
+
+@media (max-width: 880px) {
+    .legal-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .legal-side {
+        position: static;
+        order: -1;
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Factories/UserFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Factories/UserFactory.cs
@@ -15,7 +15,8 @@ internal static class UserFactory
         faker.Internet.Email(),
         password ?? DefaultPassword,
         AcceptedPrivacyPolicy: true,
-        AcceptedDataProcessingConsent: true);
+        AcceptedDataProcessingConsent: true,
+        AcceptedTermsOfService: true);
 
     public static async Task<IdentityId> RegisterRandomUserAsync(
         TestApiClient apiClient,

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AccountDeletionFinalizerTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AccountDeletionFinalizerTests.cs
@@ -49,6 +49,8 @@ public sealed class AccountDeletionFinalizerTests : EndpointsTestBase
         user.DataProcessingConsentDate.ShouldBeNull();
         user.PrivacyPolicyAccepted.ShouldBeFalse();
         user.PrivacyPolicyAcceptedDate.ShouldBeNull();
+        user.TermsOfServiceAccepted.ShouldBeFalse();
+        user.TermsOfServiceAcceptedDate.ShouldBeNull();
         user.LockoutEnabled.ShouldBeTrue();
         user.LockoutEnd.ShouldBe(DateTimeOffset.MaxValue);
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConcurrencyEndpointsTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConcurrencyEndpointsTests.cs
@@ -25,7 +25,8 @@ public sealed class ConcurrencyEndpointsTests : EndpointsTestBase
                 sharedEmail,
                 sharedPassword,
                 AcceptedPrivacyPolicy: true,
-                AcceptedDataProcessingConsent: true))
+                AcceptedDataProcessingConsent: true,
+                AcceptedTermsOfService: true))
             .ToArray();
 
         // Act

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ExportAccountDataEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ExportAccountDataEndpointTests.cs
@@ -38,6 +38,8 @@ public sealed class ExportAccountDataEndpointTests : EndpointsTestBase
         authData.GetProperty("email").GetString().ShouldBe(registerRequest.Email);
         authData.GetProperty("dataProcessingConsentGiven").GetBoolean().ShouldBeTrue();
         authData.GetProperty("privacyPolicyAccepted").GetBoolean().ShouldBeTrue();
+        authData.GetProperty("termsOfServiceAccepted").GetBoolean().ShouldBeTrue();
+        authData.GetProperty("termsOfServiceAcceptedDate").ValueKind.ShouldNotBe(JsonValueKind.Null);
         authData.GetProperty("emailConfirmed").GetBoolean().ShouldBeTrue();
         authData.GetProperty("roles").GetArrayLength().ShouldBeGreaterThan(0);
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterEndpointTests.cs
@@ -40,7 +40,8 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
             existingRequest.Email,
             "TestPass1!",
             AcceptedPrivacyPolicy: true,
-            AcceptedDataProcessingConsent: true);
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: true);
 
         // Act
         HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
@@ -65,7 +66,8 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
             caseVariantEmail,
             "TestPass1!",
             AcceptedPrivacyPolicy: true,
-            AcceptedDataProcessingConsent: true);
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: true);
 
         // Act
         HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
@@ -89,7 +91,8 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
             Faker.Internet.Email(),
             "TestPass1!",
             AcceptedPrivacyPolicy: true,
-            AcceptedDataProcessingConsent: true);
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: true);
 
         // Act
         HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
@@ -114,7 +117,8 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
             Faker.Internet.Email(),
             "TestPass1!",
             AcceptedPrivacyPolicy: true,
-            AcceptedDataProcessingConsent: true);
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: true);
 
         // Act
         HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
@@ -144,7 +148,8 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
             Faker.Internet.Email(),
             "TestPass1!",
             AcceptedPrivacyPolicy: true,
-            AcceptedDataProcessingConsent: true);
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: true);
 
         // Act
         HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
@@ -169,7 +174,8 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
             Faker.Internet.Email(),
             "TestPass1!",
             AcceptedPrivacyPolicy: true,
-            AcceptedDataProcessingConsent: true);
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: true);
 
         // Act
         HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
@@ -189,7 +195,8 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
             Faker.Internet.Email(),
             "TestPass1!",
             AcceptedPrivacyPolicy: false,
-            AcceptedDataProcessingConsent: true);
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: true);
 
         // Act
         HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
@@ -197,6 +204,28 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Register_ShouldReturnBadRequest_WhenTermsOfServiceNotAccepted()
+    {
+        // Arrange
+        RegisterRequest request = new(
+            Faker.Random.AlphaNumeric(16),
+            Faker.Internet.Email(),
+            "TestPass1!",
+            AcceptedPrivacyPolicy: true,
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: false);
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/register", UriKind.Relative), request);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string content = await response.Content.ReadAsStringAsync();
+        content.ShouldContain("You must accept the terms of service to register.");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
@@ -81,6 +81,43 @@ public sealed partial class RegisterPageTests : EndpointsTestBase
         AccountConfirmationEmailSpy.LastEmail.ShouldBeNull();
     }
 
+    [Fact]
+    public async Task RegisterPage_ShouldShowError_WhenTermsOfServiceNotAccepted()
+    {
+        // Arrange
+        AccountConfirmationEmailSpy.Reset();
+        RegisterRequest request = UserFactory.GenerateRandomRegisterRequest(Faker);
+
+        // Act
+        HttpResponseMessage response = await PostToRegisterPageAsync(
+            BuildForm(request, request.Password, acceptedTermsOfService: false));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Musisz zaakceptować regulamin serwisu");
+        AccountConfirmationEmailSpy.LastEmail.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RegisterPage_ShouldRenderTermsConsentWithLink_WhenAccessed()
+    {
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.GetAsync(
+            new Uri("/Account/Register", UriKind.Relative));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("register-accept-terms");
+        // The frontend terms URL derives from the web client's first post-logout redirect URI
+        // (AuthSystemApiFactory configures https://localhost:5001) — a regression to the linkless
+        // fallback would ship a consent checkbox referencing terms the registrant cannot open.
+        html.ShouldContain("""<a href="https://localhost:5001/regulamin" target="_blank" rel="noopener">regulamin serwisu</a>""");
+    }
+
     [Theory]
     [InlineData("kasia 92")]
     [InlineData("kasia.92")]
@@ -132,14 +169,16 @@ public sealed partial class RegisterPageTests : EndpointsTestBase
         RegisterRequest request,
         string confirmPassword,
         bool acceptedPrivacyPolicy = true,
-        bool acceptedDataProcessingConsent = true) => new()
+        bool acceptedDataProcessingConsent = true,
+        bool acceptedTermsOfService = true) => new()
         {
             ["Username"] = request.Username,
             ["Email"] = request.Email,
             ["Password"] = request.Password,
             ["ConfirmPassword"] = confirmPassword,
             ["AcceptedPrivacyPolicy"] = acceptedPrivacyPolicy ? "true" : "false",
-            ["AcceptedDataProcessingConsent"] = acceptedDataProcessingConsent ? "true" : "false"
+            ["AcceptedDataProcessingConsent"] = acceptedDataProcessingConsent ? "true" : "false",
+            ["AcceptedTermsOfService"] = acceptedTermsOfService ? "true" : "false"
         };
 
     private async Task<HttpResponseMessage> PostToRegisterPageAsync(Dictionary<string, string> formFields)

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
@@ -26,6 +26,7 @@ internal static class AuthActions
         await page.GetByLabel(FieldLabels.ConfirmPassword).FillAsync(user.Password);
         await page.GetByTestId(TestIds.RegisterAcceptPrivacy).CheckViaLabelAsync();
         await page.GetByTestId(TestIds.RegisterAcceptDataProcessing).CheckViaLabelAsync();
+        await page.GetByTestId(TestIds.RegisterAcceptTerms).CheckViaLabelAsync();
         await page.GetByRole(AriaRole.Button, new() { Name = Buttons.Register, Exact = true }).ClickAsync();
 
         await page.GetByTestId(TestIds.RegisterSuccess).WaitForAsync(LongWait);

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/Locators.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/Locators.cs
@@ -10,6 +10,7 @@ internal static class TestIds
 {
     public const string RegisterAcceptPrivacy = "register-accept-privacy";
     public const string RegisterAcceptDataProcessing = "register-accept-data-processing";
+    public const string RegisterAcceptTerms = "register-accept-terms";
     public const string RegisterSuccess = "register-success";
     public const string ConfirmEmailSuccess = "confirm-email-success";
 }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountLoaderTests.cs
@@ -168,7 +168,8 @@ public sealed class AccountLoaderTests
     internal static AccountDataExportResponse CreateEnvelope(
         IReadOnlyList<string>? roles = null,
         DateTimeOffset? deletionScheduledAt = null,
-        List<LinkDto>? links = null)
+        List<LinkDto>? links = null,
+        bool termsOfServiceAccepted = true)
     {
         return new AccountDataExportResponse(
             new AuthDataExportDto(
@@ -182,6 +183,8 @@ public sealed class AccountLoaderTests
                 new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero),
                 PrivacyPolicyAccepted: true,
                 new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero),
+                termsOfServiceAccepted,
+                termsOfServiceAccepted ? new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero) : null,
                 deletionScheduledAt),
             IsComplete: true)
         {

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountTests.cs
@@ -45,6 +45,21 @@ public sealed class AccountTests : BunitContext
         component.Markup.ShouldContain("frodo@shire.me");
         component.Markup.ShouldContain("Tłumacz");
         component.Markup.ShouldContain("2026-06-01 12:00 UTC");
+        component.Markup.ShouldContain("Regulamin serwisu");
+        component.Markup.ShouldContain("Zaakceptowany");
+    }
+
+    [Fact]
+    public void Render_WhenTermsNotAccepted_ShowsTheGrandfatheredConsentState()
+    {
+        // Accounts registered before the terms shipped are grandfathered (spec 0010) — the row
+        // must render the neutral state, never a fake acceptance.
+        StubExport(AccountLoaderTests.CreateEnvelope(termsOfServiceAccepted: false));
+
+        IRenderedComponent<AccountComponent> component = Render<AccountComponent>();
+
+        component.Markup.ShouldContain("Regulamin serwisu");
+        component.Markup.ShouldContain("Brak akceptacji");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Terms/TermsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Terms/TermsTests.cs
@@ -1,0 +1,96 @@
+using System.Reflection;
+using AngleSharp.Dom;
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using TermsComponent = LotroKoniecDev.Frontend.Components.Pages.Terms.Terms;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Terms;
+
+/// <summary>
+/// Renders the terms-of-service page (#453). The page is the contractual anchor for the erasure
+/// design: the contribution-license section must name distribution in polish.txt and post-deletion
+/// retention of anonymized contributions, and the fan-project disclaimer must name the IP owners —
+/// a wording regression there would silently void what LEGAL-01 assumes.
+/// </summary>
+public sealed class TermsTests : BunitContext
+{
+    public TermsTests()
+    {
+        Services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new AuthSystemSettings
+        {
+            BaseUrl = "https://localhost:5003/",
+            Authority = "https://localhost:5003",
+            ClientId = "lotrokoniecdev-web",
+            CallbackPath = "/callback",
+            SignedOutCallbackPath = "/signout-callback-oidc",
+            Scopes = ["openid", "profile", "api"]
+        }));
+    }
+
+    [Fact]
+    public void Terms_IsAnonymousByContract()
+    {
+        // Registration links here for the consent checkbox — an anonymous visitor must never be
+        // bounced to login while reading what they are asked to accept.
+        typeof(TermsComponent).GetCustomAttribute<AllowAnonymousAttribute>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Render_ContributionLicenseSection_CoversDistributionAndPostDeletionRetention()
+    {
+        IRenderedComponent<TermsComponent> component = Render<TermsComponent>();
+
+        IElement licenseSection = component.Find("#licencja");
+        licenseSection.TextContent.ShouldContain("polish.txt");
+        licenseSection.TextContent.ShouldContain("nieodwołalnej");
+        licenseSection.TextContent.ShouldContain("Licencja pozostaje w mocy po usunięciu konta");
+        licenseSection.TextContent.ShouldContain("zanonimizowanej");
+        licenseSection.TextContent.ShouldContain("sublicencji");
+    }
+
+    [Fact]
+    public void Render_GeneralSection_CarriesTheNonAffiliationDisclaimer()
+    {
+        IRenderedComponent<TermsComponent> component = Render<TermsComponent>();
+
+        IElement generalSection = component.Find("#postanowienia-ogolne");
+        generalSection.TextContent.ShouldContain("Standing Stone Games");
+        generalSection.TextContent.ShouldContain("Middle-earth Enterprises");
+        generalSection.TextContent.ShouldContain("nie jest powiązany");
+    }
+
+    [Fact]
+    public void Render_PrivacyPolicyLink_PointsAtTheAuthServerFromSettings()
+    {
+        IRenderedComponent<TermsComponent> component = Render<TermsComponent>();
+
+        IElement link = component.Find("#dane-osobowe a[target=_blank]");
+        link.GetAttribute("href").ShouldBe("https://localhost:5003/Account/PrivacyPolicy");
+    }
+
+    [Fact]
+    public void Render_TableOfContents_LinksEverySection()
+    {
+        IRenderedComponent<TermsComponent> component = Render<TermsComponent>();
+
+        IReadOnlyList<IElement> tocLinks = component.FindAll(".legal-toc a");
+        tocLinks.Count.ShouldBe(8);
+        foreach (IElement tocLink in tocLinks)
+        {
+            string anchor = tocLink.GetAttribute("href")!.TrimStart('#');
+            component.Find($"#{anchor}").ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public void Render_FinalSection_StatesPolishLawAndTheChangeProcedure()
+    {
+        IRenderedComponent<TermsComponent> component = Render<TermsComponent>();
+
+        IElement finalSection = component.Find("#postanowienia-koncowe");
+        finalSection.TextContent.ShouldContain("prawo polskie");
+        finalSection.TextContent.ShouldContain("14 dni");
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
@@ -58,7 +58,8 @@ public abstract class E2ETestBase : IAsyncLifetime
             email,
             TranslatorPassword,
             AcceptedPrivacyPolicy: true,
-            AcceptedDataProcessingConsent: true);
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: true);
 
         IdentityId identityId = await AuthApi.RegisterAsync(request);
         TokenResponse token = await AuthApi.LoginAsync(email, TranslatorPassword);


### PR DESCRIPTION
Closes #453. Part of the legal & GDPR pack (epic #459).

## What

- **Agreed spec** `docs/specs/0010-terms-of-service.md` — owner decisions folded in: irrevocable non-exclusive license with sublicense to players, moral-rights non-exercise clause, required registration checkbox (existing accounts grandfathered), e-mail notice 14 days before material changes, Polish law.
- **`/regulamin` (+ `/terms` alias) on the frontend** — static SSR, `AllowAnonymous`, 8 sections + TOC. The contribution-license section explicitly covers distribution in `polish.txt` and post-deletion retention of anonymized contributions; the non-affiliation disclaimer names Standing Stone Games / Middle-earth Enterprises.
- **Footer** links the terms on every page; **"Moje konto"** shows the terms consent state.
- **Registration**: third required checkbox persisted as `TermsOfServiceAccepted(+Date)` end-to-end (page model, `RegisterUser` validator/handler, `RegisterRequest`, additive N-1-safe migration). The terms link on the auth page derives from the web client's first post-logout redirect URI — no new setting.
- **GDPR export + erasure** handle the new fields symmetrically with the two existing consents; seeded admin accepts them.

## Why

The LEGAL-01 erasure design keeps anonymized contributions after account deletion and distributes them in `polish.txt` — defensible only with an explicit license grant, which did not exist anywhere. The privacy policy already promised this retention without the contractual basis behind it.

## Tests

- Build zero-warnings; SSR-purity gate green.
- `Frontend.Tests.Unit` 380 ✓ (new `TermsTests`: license/disclaimer/law wording pinned, TOC anchors, `AllowAnonymous` contract; account row incl. grandfathered state).
- `AuthSystem.API.Tests.Integration` 275 ✓ (missing-consent 400 + page error, terms-link href pinned, export field, erasure wipe).
- `Tests.Unit` 277 ✓. E2E register flows updated (Playwright checks the new checkbox).
- Reviewed by the code-reviewer agent; all Major findings addressed (assertion gaps: link derivation, persistence proof, erasure wipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)