### PR TITLE
loop: self-healing lock + a loud failure to start

### DIFF
--- a/docs/claude-loop.md
+++ b/docs/claude-loop.md
@@ -160,11 +160,16 @@ Per-ticket outcomes:
 - Default permission mode is `auto` plus a loop-scoped git/gh/dotnet/scripts `--allowedTools`
   allowlist (interactive sessions are unaffected). `LOOP_UNSAFE=1` trades that for
   zero-friction full autonomy — your call per run.
-- One loop at a time via `.claude/backlog-loop.lock`; a crashed run's lock is removed manually.
+- One loop at a time via `.claude/backlog-loop.lock`. The lock records its owner PID, so a crashed
+  run's lock is **reclaimed automatically** by the next conductor — a dead run can no longer block
+  the loop forever (it once ate a whole scheduled night). A lock whose owner is still alive is
+  still refused, and a refused *start* now fires the same macOS notification a finished run does,
+  so a scheduled loop can never fail silently into a log file.
 
 ## Troubleshooting
 
-- **"another loop appears to be running"** — stale lock after a crash: `rm -rf .claude/backlog-loop.lock`.
+- **"another loop is running (pid N)"** — a live conductor owns the lock; `ps -p N` to see it. A
+  *stale* lock (owner dead) is reclaimed automatically, so this message means a real second loop.
 - **Ticket ended `error` with no STATUS block** — read `logs/claude-loop/<run>/ticket-<n>.json`
   (`.result` field) and `.stderr`; usually a permission denial (extend `LOOP_ALLOWED_TOOLS`) or a
   mid-run crash.

--- a/scripts/claude/backlog-loop.sh
+++ b/scripts/claude/backlog-loop.sh
@@ -52,12 +52,48 @@ LIMIT_SLEEP_MIN="${LOOP_LIMIT_SLEEP_MIN:-60}"
 LIMIT_RETRIES="${LOOP_LIMIT_RETRIES:-8}"
 MAX_FAILURES="${LOOP_MAX_CONSECUTIVE_FAILURES:-2}"
 
+notify() {
+    command -v osascript >/dev/null 2>&1 && osascript -e \
+        "display notification \"$2\" with title \"$1\"" >/dev/null 2>&1 || true
+}
+
+# A bare mkdir mutex is not enough. A conductor killed without running its EXIT trap (terminal
+# closed, SIGKILL, power loss) leaves the directory behind, and every later run then refuses to
+# start — for a scheduled overnight run, silently into a log nobody reads. So the lock records its
+# owner and a lock whose owner is gone is reclaimed instead of blocking the loop forever.
 LOCK="$REPO_ROOT/.claude/backlog-loop.lock"
+LOCK_OWNER="$LOCK/pid"
+
+lock_owner_alive() {
+    local pid
+    pid="$(cat "$LOCK_OWNER" 2>/dev/null || true)"
+    [ -n "$pid" ] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    # The PID may have been recycled by an unrelated process — only a live conductor counts.
+    ps -p "$pid" -o command= 2>/dev/null | grep -q 'backlog-loop.sh'
+}
+
 if ! mkdir "$LOCK" 2>/dev/null; then
-    echo "another loop appears to be running — remove $LOCK if it is stale" >&2
-    exit 1
+    if lock_owner_alive; then
+        message="another loop is running (pid $(cat "$LOCK_OWNER" 2>/dev/null)) — refusing to start a second one"
+        echo "$message" >&2
+        notify "Claude backlog loop did NOT start" "$message"
+        exit 1
+    fi
+    echo "[conductor] stale lock (owner gone) — reclaiming $LOCK" >&2
+    # mv is atomic, so if two conductors race to reclaim, only one wins and the loser's mkdir fails.
+    if mv "$LOCK" "$LOCK.stale.$$" 2>/dev/null; then
+        rm -rf "$LOCK.stale.$$"
+    fi
+    if ! mkdir "$LOCK" 2>/dev/null; then
+        message="lost the race to reclaim the stale lock — another conductor got there first"
+        echo "$message" >&2
+        notify "Claude backlog loop did NOT start" "$message"
+        exit 1
+    fi
 fi
-trap 'rm -rf "$LOCK"' EXIT INT TERM
+echo "$$" > "$LOCK_OWNER"
+trap 'rm -rf "$LOCK"' EXIT INT TERM HUP
 
 RUN_DIR="$REPO_ROOT/logs/claude-loop/$(date +%Y%m%d-%H%M%S)"
 mkdir -p "$RUN_DIR"
@@ -123,6 +159,7 @@ while :; do
             ;;
         10)
             echo "[conductor] dirty working copy — stopping (nothing was touched)"
+            notify "Claude backlog loop stopped" "dirty working copy — nothing was touched"
             exit 10
             ;;
         *) failed=$((failed + 1)); consecutive_failures=$((consecutive_failures + 1)) ;;
@@ -150,6 +187,4 @@ echo "[conductor] done: $merged merged · $queued auto-merge queued · $blocked 
 [ "$blocked" -gt 0 ] && echo "[conductor] blocked tickets carry your questions as issue comments: gh issue list --label loop-blocked"
 echo "[conductor] raw session logs: $RUN_DIR"
 
-command -v osascript >/dev/null 2>&1 && osascript -e \
-    "display notification \"$merged merged, $blocked blocked, $failed failed (\$$total_cost)\" with title \"Claude backlog loop finished\"" \
-    >/dev/null 2>&1 || true
+notify "Claude backlog loop finished" "$merged merged, $blocked blocked, $failed failed (\$$total_cost)"


### PR DESCRIPTION
## Problem

The overnight scheduled loop run of 2026-07-12 did **zero** tickets. It fired correctly at 03:31, then:

```
another loop appears to be running — remove .../.claude/backlog-loop.lock if it is stale
```

The lock was a **two-day-old directory** left by a run that died on 2026-07-10 at 14:39 while waiting for PR checks. Two defects made a dead run poison every future one:

1. **The lock had no owner.** `mkdir` is an atomic mutex, but it records nothing — a stale lock is indistinguishable from a held one, so it blocks the loop forever until a human removes it by hand. The `EXIT INT TERM` trap also missed `HUP`, so closing the terminal leaked the lock in the first place.
2. **A failed start was silent.** The macOS notification only fires on a *finished* run, so a scheduled loop that never started reported nothing — the failure sat in a log file until someone noticed 0% usage the next morning.

## Fix

- The lock records its owner PID (`$LOCK/pid`). A lock whose owner is dead — or whose PID was recycled by a process that is not a conductor — is **reclaimed**; a live owner is still refused. Reclaim uses an atomic `mv`, so two conductors racing cannot both win.
- The trap covers `HUP`.
- A refused start and a dirty-working-copy stop fire the same notification a finished run does, via one `notify()` helper.

## Verification

Exercised against the real script:

| Scenario | Expected | Result |
|---|---|---|
| Lock owner dead (the 03:31 case) | reclaim, run, release | `stale lock (owner gone) — reclaiming`, loop ran, lock gone on exit |
| Lock owner alive | refuse, leave the lock alone | `another loop is running (pid N)`, exit 1, lock preserved |
| No lock | acquire, record owner | owner PID written |

🤖 Generated with [Claude Code](https://claude.com/claude-code)