### PR TITLE
auth-api restarts once on the daily cold start: retry the pre-listen seed against a suspended Neon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -477,7 +477,8 @@ structure.
 - Platform honesty: tests must pass on macOS AND Windows — `Path.Combine`, never hardcoded `C:\`.
 - **TMS test projects mirror KittySaver naming.** Unit (pure):
   `TranslationSystem.Domain.Tests.Unit`, `TranslationSystem.API.Tests.Unit`,
-  `SharedKernel.Tests.Unit`, `Logging.Tests.Unit`, `Frontend.Tests.Unit`. Integration (real
+  `AuthSystem.API.Tests.Unit`, `SharedKernel.Tests.Unit`, `Logging.Tests.Unit`,
+  `Frontend.Tests.Unit`. Integration (real
   PostgreSQL — never in a Unit project): `TranslationSystem.API.Tests.Integration`,
   `AuthSystem.API.Tests.Integration`. Browser/E2E (Testcontainers + Playwright — ADR-0009;
   Docker-required, off the PR gate by name): `TranslationSystem.E2E.Tests`,

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -113,6 +113,7 @@
     <Project Path="tests/LotroKoniecDev.TranslationSystem.E2E.Tests/LotroKoniecDev.TranslationSystem.E2E.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/AuthSystem/">
+    <Project Path="tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/LotroKoniecDev.AuthSystem.API.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj" />
   </Folder>
   <Folder Name="/tests/Frontend/">

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/ColdStartRetry.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/ColdStartRetry.cs
@@ -1,0 +1,65 @@
+using Npgsql;
+
+namespace LotroKoniecDev.AuthSystem.API.Extensions;
+
+/// <summary>
+/// Bounded retry for pre-listen database work (#451): on the daily scale-from-zero cold start the
+/// Neon compute resumes slower (~31 s measured) than Npgsql's connection-open timeout, so the
+/// first physical open fails transiently. EF's <c>EnableRetryOnFailure</c> retries commands, not
+/// that initial open — without this wrapper the unhandled exception kills the process before
+/// <c>RunAsync</c> and the container restarts. Worst case (4 attempts × ~20 s open timeout +
+/// 3 × 5 s delay ≈ 95 s) stays well under the 300 s ACA startup-probe budget.
+/// </summary>
+internal static class ColdStartRetry
+{
+    internal const int DefaultMaxAttempts = 4;
+    internal static readonly TimeSpan DefaultDelayBetweenAttempts = TimeSpan.FromSeconds(5);
+
+    internal static async Task ExecuteAsync(
+        Func<Task> operation,
+        ILogger logger,
+        int maxAttempts = DefaultMaxAttempts,
+        TimeSpan? delayBetweenAttempts = null)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxAttempts, 1);
+
+        TimeSpan delay = delayBetweenAttempts ?? DefaultDelayBetweenAttempts;
+
+        for (int attempt = 1; ; attempt++)
+        {
+            try
+            {
+                await operation();
+                return;
+            }
+            catch (Exception exception) when (attempt < maxAttempts && IsTransientDatabaseFailure(exception))
+            {
+                logger.LogWarning(
+                    exception,
+                    "Transient database failure on startup attempt {Attempt}/{MaxAttempts}; retrying in {DelaySeconds}s",
+                    attempt,
+                    maxAttempts,
+                    delay.TotalSeconds);
+
+                await Task.Delay(delay);
+            }
+        }
+    }
+
+    internal static bool IsTransientDatabaseFailure(Exception? exception)
+    {
+        while (exception is not null)
+        {
+            if (exception is NpgsqlException { IsTransient: true })
+            {
+                return true;
+            }
+
+            exception = exception.InnerException;
+        }
+
+        return false;
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/DatabaseSeederExtensions.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/DatabaseSeederExtensions.cs
@@ -20,14 +20,25 @@ internal static class DatabaseSeederExtensions
 
     internal static async Task SeedAuthDatabaseAsync(IServiceProvider services, IWebHostEnvironment environment)
     {
-        using IServiceScope scope = services.CreateScope();
+        ILogger logger = services.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(DatabaseSeederExtensions));
 
-        AuthDbContext dbContext = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
-        await dbContext.Database.MigrateAsync();
+        // The whole seed is idempotent, so replaying it after a transient failure is safe. Each
+        // attempt gets a fresh scope (and thus a fresh AuthDbContext) — a context that failed
+        // mid-migration must not be reused.
+        await ColdStartRetry.ExecuteAsync(
+            async () =>
+            {
+                using IServiceScope scope = services.CreateScope();
 
-        await SeedRolesAsync(scope.ServiceProvider);
-        await SeedAdminUserAsync(scope.ServiceProvider);
-        await SeedOAuthApplicationsAsync(scope.ServiceProvider, environment);
+                AuthDbContext dbContext = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+                await dbContext.Database.MigrateAsync();
+
+                await SeedRolesAsync(scope.ServiceProvider);
+                await SeedAdminUserAsync(scope.ServiceProvider);
+                await SeedOAuthApplicationsAsync(scope.ServiceProvider, environment);
+            },
+            logger);
     }
 
     private static async Task SeedRolesAsync(IServiceProvider serviceProvider)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj
@@ -48,6 +48,7 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="LotroKoniecDev.AuthSystem.API.Tests.Integration" />
+        <InternalsVisibleTo Include="LotroKoniecDev.AuthSystem.API.Tests.Unit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -12,7 +12,7 @@ dotnet test tests/LotroKoniecDev.Frontend.E2E.Tests          # browser stack via
 dotnet test --filter "FullyQualifiedName~Fragment"     # filter by name
 ```
 
-Full project inventory (12 projects):
+Full project inventory (13 projects):
 
 | Project | Kind | Needs |
 |---|---|---|
@@ -22,6 +22,7 @@ Full project inventory (12 projects):
 | `LotroKoniecDev.TranslationSystem.Domain.Tests.Unit` | TMS domain unit | nothing (pure); Stryker target |
 | `LotroKoniecDev.TranslationSystem.API.Tests.Unit` | TMS handler/auth/endpoint unit (fake read-DbContext, stub accessor/provisioner) | nothing (pure) |
 | `LotroKoniecDev.Frontend.Tests.Unit` | Blazor SSR component + infrastructure unit (bUnit-style) | nothing (pure) |
+| `LotroKoniecDev.AuthSystem.API.Tests.Unit` | auth-api unit (cold-start seed retry policy) | nothing (pure) |
 | `LotroKoniecDev.TranslationSystem.API.Tests.Integration` | in-process API against real PostgreSQL (Testcontainers; forged test tokens) | Docker |
 | `LotroKoniecDev.AuthSystem.API.Tests.Integration` | in-process auth-api against real PostgreSQL (Testcontainers) | Docker |
 | `LotroKoniecDev.TranslationSystem.E2E.Tests` | real-process TMS stack over HTTP | Docker (3 images) |

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Extensions/ColdStartRetryTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Extensions/ColdStartRetryTests.cs
@@ -1,0 +1,141 @@
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NSubstitute;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Extensions;
+
+public sealed class ColdStartRetryTests
+{
+    private readonly ILogger _logger = Substitute.For<ILogger>();
+
+    [Fact]
+    public async Task ExecuteAsync_SucceedingOperation_InvokesOperationOnce()
+    {
+        int attempts = 0;
+
+        await ColdStartRetry.ExecuteAsync(
+            () =>
+            {
+                attempts++;
+                return Task.CompletedTask;
+            },
+            _logger,
+            delayBetweenAttempts: TimeSpan.Zero);
+
+        attempts.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TransientFailuresThenSuccess_RetriesUntilSuccess()
+    {
+        int attempts = 0;
+
+        await ColdStartRetry.ExecuteAsync(
+            () =>
+            {
+                attempts++;
+                return attempts < 3
+                    ? Task.FromException(CreateTransientNpgsqlException())
+                    : Task.CompletedTask;
+            },
+            _logger,
+            delayBetweenAttempts: TimeSpan.Zero);
+
+        attempts.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PersistentTransientFailure_RethrowsAfterMaxAttempts()
+    {
+        const int maxAttempts = 4;
+        int attempts = 0;
+
+        NpgsqlException thrown = await Should.ThrowAsync<NpgsqlException>(() =>
+            ColdStartRetry.ExecuteAsync(
+                () =>
+                {
+                    attempts++;
+                    return Task.FromException(CreateTransientNpgsqlException());
+                },
+                _logger,
+                maxAttempts,
+                TimeSpan.Zero));
+
+        attempts.ShouldBe(maxAttempts);
+        thrown.IsTransient.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonTransientFailure_DoesNotRetry()
+    {
+        int attempts = 0;
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            ColdStartRetry.ExecuteAsync(
+                () =>
+                {
+                    attempts++;
+                    return Task.FromException(new InvalidOperationException("Admin user seeding failed"));
+                },
+                _logger,
+                delayBetweenAttempts: TimeSpan.Zero));
+
+        attempts.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonTransientNpgsqlFailure_DoesNotRetry()
+    {
+        int attempts = 0;
+
+        await Should.ThrowAsync<NpgsqlException>(() =>
+            ColdStartRetry.ExecuteAsync(
+                () =>
+                {
+                    attempts++;
+                    return Task.FromException(new NpgsqlException("password authentication failed"));
+                },
+                _logger,
+                delayBetweenAttempts: TimeSpan.Zero));
+
+        attempts.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TransientFailureWrappedInOuterException_RetriesUntilSuccess()
+    {
+        int attempts = 0;
+
+        await ColdStartRetry.ExecuteAsync(
+            () =>
+            {
+                attempts++;
+                return attempts < 2
+                    ? Task.FromException(new InvalidOperationException(
+                        "Migration failed",
+                        CreateTransientNpgsqlException()))
+                    : Task.CompletedTask;
+            },
+            _logger,
+            delayBetweenAttempts: TimeSpan.Zero);
+
+        attempts.ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task ExecuteAsync_MaxAttemptsBelowOne_ThrowsArgumentOutOfRangeException(int maxAttempts)
+    {
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            ColdStartRetry.ExecuteAsync(
+                () => Task.CompletedTask,
+                _logger,
+                maxAttempts,
+                TimeSpan.Zero));
+    }
+
+    private static NpgsqlException CreateTransientNpgsqlException() =>
+        new("The operation has timed out", new TimeoutException());
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/LotroKoniecDev.AuthSystem.API.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/LotroKoniecDev.AuthSystem.API.Tests.Unit.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+        <Using Include="Shouldly" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\AuthSystem\LotroKoniecDev.AuthSystem.API\LotroKoniecDev.AuthSystem.API.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes #451

## What
`SeedAuthDatabaseAsync` runs before `RunAsync`, and on the daily 05:00 UTC scale-from-zero cold start the Neon compute resume (~31 s measured) outlasts Npgsql's connection-open timeout (~20 s). The unhandled `NpgsqlException` killed the process and ACA restarted the container — a guaranteed daily restart + Sev1 alert.

The fix wraps the idempotent seed in a bounded cold-start retry (`ColdStartRetry`, new internal helper in `AuthSystem.API/Extensions`):
- retries only transient Npgsql failures (`NpgsqlException.IsTransient`, walking the inner-exception chain, so wrapped failures are caught too);
- 4 attempts, 5 s apart — worst case ~95 s wall clock, well under the existing 300 s ACA startup-probe budget (`iac/azure-container-apps.tf`), so no infra change is needed;
- each attempt runs in a fresh DI scope, so a `DbContext` that failed mid-migration is never reused;
- non-transient failures (bad credentials, admin-seed errors) still fail fast — configuration bugs are not masked.

## Options weighed (per the ticket)
- **Bounded retry around the seed — chosen.** Self-contained in code, covers every transient failure mode (not just the open timeout), testable.
- **Larger `Timeout` in the connection string — rejected as the primary fix.** The connection string is a Key Vault secret owned by infra; a code deploy could not carry the fix, and it would only stretch the single first attempt instead of surviving arbitrary transient failures. It can still be layered on later if ever needed.
- **ACA startup probe — already in place** (10 s × 30 failures = 300 s), so a longer seed cannot trip liveness; nothing to add.
- EF's `EnableRetryOnFailure` cannot cover this case: it retries transient commands, not the initial physical connection open exceeding its own timeout.

## Tests
- New `tests/LotroKoniecDev.AuthSystem.API.Tests.Unit` (pure; joins CI automatically via the `*.Tests.Unit.csproj` convention): first-try success, transient retry-then-success, rethrow after max attempts, fail-fast on non-transient failures (incl. a non-transient `NpgsqlException`), transient detection through the inner-exception chain, argument guards. 8/8 green.
- `LotroKoniecDev.AuthSystem.API.Tests.Integration`: 275/275 green locally (the factory drives the same retried seed path).
- Full solution build: zero warnings.

## Acceptance criteria mapping
- **First-attempt `RestartCount = 0` on the 05:00 UTC cold start** — verifiable only post-merge in LAW console logs; needs a check after the next deploy.
- **Covered by a test at the right seam** — unit tests on the retry policy + the integration suite exercising the wrapped seed.
- **Port to TheKittySaver** — follow-up issue to be filed in that repo (same lifted `DatabaseSeederExtensions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)