### PR TITLE
refactor: consolidate all logging to source-generated LoggerMessage, enforce via CA1848

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -274,8 +274,9 @@ dotnet_diagnostic.CA1815.severity = none
 # CA1819: Properties should not return arrays
 dotnet_diagnostic.CA1819.severity = none
 
-# CA1848: Use the LoggerMessage delegates
-dotnet_diagnostic.CA1848.severity = none
+# CA1848: Use the LoggerMessage delegates — enforced since the 2026-07-12 consolidation;
+# TreatWarningsAsErrors turns any classic ILogger extension call into a failing build
+dotnet_diagnostic.CA1848.severity = warning
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = none

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -70,6 +70,9 @@ internal static class EventIds
     public const int OpenIddictPruneCompleted = 2310;
     public const int OpenIddictPruneFailed = 2311;
 
+    // Startup (2350–2359)
+    public const int StartupTransientDatabaseFailure = 2350;
+
     // Middleware (2400–2499)
     public const int UnauthorizedAccessAttempt = 2400;
     public const int ForbiddenAccessAttempt = 2401;

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/ColdStartRetry.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Extensions/ColdStartRetry.cs
@@ -10,7 +10,7 @@ namespace LotroKoniecDev.AuthSystem.API.Extensions;
 /// <c>RunAsync</c> and the container restarts. Worst case (4 attempts × ~20 s open timeout +
 /// 3 × 5 s delay ≈ 95 s) stays well under the 300 s ACA startup-probe budget.
 /// </summary>
-internal static class ColdStartRetry
+internal static partial class ColdStartRetry
 {
     internal const int DefaultMaxAttempts = 4;
     internal static readonly TimeSpan DefaultDelayBetweenAttempts = TimeSpan.FromSeconds(5);
@@ -36,12 +36,7 @@ internal static class ColdStartRetry
             }
             catch (Exception exception) when (attempt < maxAttempts && IsTransientDatabaseFailure(exception))
             {
-                logger.LogWarning(
-                    exception,
-                    "Transient database failure on startup attempt {Attempt}/{MaxAttempts}; retrying in {DelaySeconds}s",
-                    attempt,
-                    maxAttempts,
-                    delay.TotalSeconds);
+                LogTransientStartupFailure(logger, exception, attempt, maxAttempts, delay.TotalSeconds);
 
                 await Task.Delay(delay);
             }
@@ -62,4 +57,7 @@ internal static class ColdStartRetry
 
         return false;
     }
+
+    [LoggerMessage(EventId = EventIds.StartupTransientDatabaseFailure, Level = LogLevel.Warning, Message = "Transient database failure on startup attempt {Attempt}/{MaxAttempts}; retrying in {DelaySeconds}s")]
+    private static partial void LogTransientStartupFailure(ILogger logger, Exception exception, int attempt, int maxAttempts, double delaySeconds);
 }

--- a/src/Patcher/LotroKoniecDev.Application/EventIds.cs
+++ b/src/Patcher/LotroKoniecDev.Application/EventIds.cs
@@ -1,0 +1,39 @@
+namespace LotroKoniecDev.Application;
+
+/// <summary>
+/// Event ID ranges: TranslationSystem 1000–1999, AuthSystem 2000–2999, Shared 3000–3999,
+/// Hateoas 4000–4999, Patcher 5000–5999 (Application 5000–5499, Infrastructure 5500–5999).
+/// </summary>
+internal static class EventIds
+{
+    // Update Checking (5000–5099)
+    public const int ForumFetchFailed = 5000;
+    public const int ForumVersionParseFailed = 5001;
+
+    // Game Launching (5100–5199)
+    public const int LaunchStarted = 5100;
+    public const int LaunchDatFilePath = 5101;
+    public const int LaunchTranslationFilePath = 5102;
+    public const int LaunchGameVersionFilePath = 5103;
+    public const int LaunchBlockedGameAlreadyRunning = 5104;
+    public const int LaunchComputingTranslationHash = 5105;
+    public const int LaunchComputeHashFailed = 5106;
+    public const int LaunchCurrentTranslationHash = 5107;
+    public const int LaunchReadingStoredVersion = 5108;
+    public const int LaunchReadStoredVersionFailed = 5109;
+    public const int LaunchStoredVersionInfo = 5110;
+    public const int LaunchTranslationChangeEvaluated = 5111;
+    public const int LaunchPatchingTranslationChanged = 5112;
+    public const int LaunchApplyTranslationsFailed = 5113;
+    public const int LaunchTranslationsPatched = 5114;
+    public const int LaunchReadingDatVnum = 5115;
+    public const int LaunchReadVersionFailed = 5116;
+    public const int LaunchDatVnumRead = 5117;
+    public const int LaunchSaveVersionFailed = 5118;
+    public const int LaunchVersionSaved = 5119;
+    public const int LaunchSkippedTranslationUnchanged = 5120;
+    public const int LaunchStartingGame = 5121;
+    public const int LaunchGameLaunchFailed = 5122;
+    public const int LaunchLauncherStarted = 5123;
+    public const int LaunchEnded = 5124;
+}

--- a/src/Patcher/LotroKoniecDev.Application/Features/GameLaunching/SimplifiedGameLaunchingStrategy.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/GameLaunching/SimplifiedGameLaunchingStrategy.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace LotroKoniecDev.Application.Features.GameLaunching;
 
-internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
+internal sealed partial class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
 {
     private readonly IGameProcessDetector _gameProcessDetector;
     private readonly IFileHasher _fileHasher;
@@ -38,45 +38,45 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
     public ValueTask<Result<GameLaunchingResponse>> ExecuteAsync(
         GameLaunchingCommand command, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("=== SIMPLIFIED LAUNCH START ===");
-        _logger.LogInformation("DatFilePath: {DatFilePath}", command.DatFilePath);
-        _logger.LogInformation("TranslationFilePath: {TranslationFilePath}", command.TranslationFilePath);
-        _logger.LogInformation("GameVersionFilePath: {GameVersionFilePath}", command.GameVersionFilePath);
+        LogLaunchStarted(_logger);
+        LogDatFilePath(_logger, command.DatFilePath);
+        LogTranslationFilePath(_logger, command.TranslationFilePath);
+        LogGameVersionFilePath(_logger, command.GameVersionFilePath);
 
         // 1. Is the game already running?
         if (_gameProcessDetector.IsLotroRunning())
         {
-            _logger.LogWarning("BLOCKED: LOTRO already running");
+            LogBlockedGameAlreadyRunning(_logger);
             return ValueTask.FromResult(
                 Result.Failure<GameLaunchingResponse>(DomainErrors.GameLaunch.GameAlreadyRunning));
         }
 
         // 2. Has the translation file changed since last apply?
-        _logger.LogInformation("Step 1: Computing translation file hash...");
+        LogComputingTranslationHash(_logger);
         Result<string> hashResult = _fileHasher.ComputeHash(command.TranslationFilePath);
         if (hashResult.IsFailure)
         {
-            _logger.LogError("ComputeHash FAILED: {Error}", hashResult.Error.Message);
+            LogComputeHashFailed(_logger, hashResult.Error.Message);
             return ValueTask.FromResult(
                 Result.Failure<GameLaunchingResponse>(hashResult.Error));
         }
         string currentHash = hashResult.Value;
 
-        _logger.LogInformation("Current translation hash: {Hash}", currentHash);
+        LogCurrentTranslationHash(_logger, currentHash);
 
-        _logger.LogInformation("Step 2: Reading stored version info...");
+        LogReadingStoredVersion(_logger);
 
         Result<StoredVersionInfo?> storedResult = _gameVersionFileStore.ReadStoredVersion(command.GameVersionFilePath);
         if (storedResult.IsFailure)
         {
-            _logger.LogError("ReadStoredVersion FAILED: {Error}", storedResult.Error.Message);
+            LogReadStoredVersionFailed(_logger, storedResult.Error.Message);
             return ValueTask.FromResult(
                 Result.Failure<GameLaunchingResponse>(storedResult.Error));
         }
         StoredVersionInfo? storedInfo = storedResult.Value;
 
-        _logger.LogInformation(
-            "Stored info: ForumVersion={Forum}, VnumDat={VnumDat}, VnumGame={VnumGame}, Hash={Hash}",
+        LogStoredVersionInfo(
+            _logger,
             storedInfo?.ForumVersion ?? "(null)",
             storedInfo?.VnumDatFile?.ToString() ?? "(null)",
             storedInfo?.VnumGameData?.ToString() ?? "(null)",
@@ -85,7 +85,8 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
         bool translationChanged = storedResult.Value?.TranslationFileHash is null
             || !string.Equals(currentHash, storedResult.Value.TranslationFileHash, StringComparison.Ordinal);
 
-        _logger.LogInformation("Translation changed? {Changed} (stored hash null={IsNull}, match={Match})",
+        LogTranslationChangeEvaluated(
+            _logger,
             translationChanged,
             storedInfo?.TranslationFileHash is null,
             storedInfo?.TranslationFileHash is not null
@@ -97,13 +98,13 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
 
         if (translationChanged)
         {
-            _logger.LogInformation(">>> PATCHING: Translation file changed — applying patch");
+            LogPatchingTranslationChanged(_logger);
 
             Result<PatchSummaryResponse> patchResult =
                 _patchingService.ApplyTranslations(command.TranslationFilePath, command.DatFilePath);
             if (patchResult.IsFailure)
             {
-                _logger.LogError("ApplyTranslations FAILED: {Error}", patchResult.Error.Message);
+                LogApplyTranslationsFailed(_logger, patchResult.Error.Message);
                 return ValueTask.FromResult(
                     Result.Failure<GameLaunchingResponse>(
                         DomainErrors.GameLaunch.RepatchFailed(patchResult.Error.Message)));
@@ -115,23 +116,21 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
             appliedCount = patchSummary.AppliedTranslations;
             skippedCount = patchSummary.SkippedTranslations;
 
-            _logger.LogInformation("Patched translations: {Applied} applied, {Skipped} skipped",
-                appliedCount, skippedCount);
+            LogTranslationsPatched(_logger, appliedCount, skippedCount);
 
             // Save new hash + current vnum
-            _logger.LogInformation("Reading DAT vnum to save alongside hash...");
+            LogReadingDatVnum(_logger);
 
             Result<DatVersionInfo> vnumResult = _datVersionReader.ReadVersion(command.DatFilePath);
             if (vnumResult.IsFailure)
             {
-                _logger.LogError("ReadVersion FAILED: {Error}", vnumResult.Error.Message);
+                LogReadVersionFailed(_logger, vnumResult.Error.Message);
                 return ValueTask.FromResult(
                     Result.Failure<GameLaunchingResponse>(vnumResult.Error));
             }
             DatVersionInfo datVersion = vnumResult.Value;
 
-            _logger.LogInformation("DAT vnum: VnumDat={VnumDat}, VnumGame={VnumGame}",
-                datVersion.VnumDatFile, datVersion.VnumGameData);
+            LogDatVnumRead(_logger, datVersion.VnumDatFile, datVersion.VnumGameData);
 
             Result saveResult = _gameVersionFileStore.SaveVersion(
                 command.GameVersionFilePath,
@@ -141,29 +140,29 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
                 currentHash);
             if (saveResult.IsFailure)
             {
-                _logger.LogError("SaveVersion FAILED: {Error}", saveResult.Error.Message);
+                LogSaveVersionFailed(_logger, saveResult.Error.Message);
                 return ValueTask.FromResult(
                     Result.Failure<GameLaunchingResponse>(saveResult.Error));
             }
-            _logger.LogInformation("Version saved OK");
+            LogVersionSaved(_logger);
         }
         else
         {
-            _logger.LogInformation(">>> SKIP: Translation file unchanged — skipping patch");
+            LogSkippedTranslationUnchanged(_logger);
         }
 
         // 3. Launch (fire-and-forget)
-        _logger.LogInformation("Step 3: Launching game (fire-and-forget)...");
+        LogStartingGame(_logger);
         Result launchResult = _gameLauncher.Launch(command.DatFilePath);
         if (launchResult.IsFailure)
         {
-            _logger.LogError("Launch FAILED: {Error}", launchResult.Error.Message);
+            LogGameLaunchFailed(_logger, launchResult.Error.Message);
             return ValueTask.FromResult(
                 Result.Failure<GameLaunchingResponse>(launchResult.Error));
         }
 
-        _logger.LogInformation("Launcher started OK (fire-and-forget, not waiting for exit)");
-        _logger.LogInformation("=== SIMPLIFIED LAUNCH END ===");
+        LogLauncherStarted(_logger);
+        LogLaunchEnded(_logger);
 
         GameLaunchingResponse response = new(
             ForumVersion: null,
@@ -175,4 +174,79 @@ internal sealed class SimplifiedGameLaunchingStrategy : IGameLaunchingStrategy
 
         return ValueTask.FromResult(Result.Success(response));
     }
+
+    [LoggerMessage(EventId = EventIds.LaunchStarted, Level = LogLevel.Information, Message = "=== SIMPLIFIED LAUNCH START ===")]
+    private static partial void LogLaunchStarted(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchDatFilePath, Level = LogLevel.Information, Message = "DatFilePath: {DatFilePath}")]
+    private static partial void LogDatFilePath(ILogger logger, string datFilePath);
+
+    [LoggerMessage(EventId = EventIds.LaunchTranslationFilePath, Level = LogLevel.Information, Message = "TranslationFilePath: {TranslationFilePath}")]
+    private static partial void LogTranslationFilePath(ILogger logger, string translationFilePath);
+
+    [LoggerMessage(EventId = EventIds.LaunchGameVersionFilePath, Level = LogLevel.Information, Message = "GameVersionFilePath: {GameVersionFilePath}")]
+    private static partial void LogGameVersionFilePath(ILogger logger, string gameVersionFilePath);
+
+    [LoggerMessage(EventId = EventIds.LaunchBlockedGameAlreadyRunning, Level = LogLevel.Warning, Message = "BLOCKED: LOTRO already running")]
+    private static partial void LogBlockedGameAlreadyRunning(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchComputingTranslationHash, Level = LogLevel.Information, Message = "Step 1: Computing translation file hash...")]
+    private static partial void LogComputingTranslationHash(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchComputeHashFailed, Level = LogLevel.Error, Message = "ComputeHash FAILED: {Error}")]
+    private static partial void LogComputeHashFailed(ILogger logger, string error);
+
+    [LoggerMessage(EventId = EventIds.LaunchCurrentTranslationHash, Level = LogLevel.Information, Message = "Current translation hash: {Hash}")]
+    private static partial void LogCurrentTranslationHash(ILogger logger, string hash);
+
+    [LoggerMessage(EventId = EventIds.LaunchReadingStoredVersion, Level = LogLevel.Information, Message = "Step 2: Reading stored version info...")]
+    private static partial void LogReadingStoredVersion(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchReadStoredVersionFailed, Level = LogLevel.Error, Message = "ReadStoredVersion FAILED: {Error}")]
+    private static partial void LogReadStoredVersionFailed(ILogger logger, string error);
+
+    [LoggerMessage(EventId = EventIds.LaunchStoredVersionInfo, Level = LogLevel.Information, Message = "Stored info: ForumVersion={Forum}, VnumDat={VnumDat}, VnumGame={VnumGame}, Hash={Hash}")]
+    private static partial void LogStoredVersionInfo(ILogger logger, string forum, string vnumDat, string vnumGame, string hash);
+
+    [LoggerMessage(EventId = EventIds.LaunchTranslationChangeEvaluated, Level = LogLevel.Information, Message = "Translation changed? {Changed} (stored hash null={IsNull}, match={Match})")]
+    private static partial void LogTranslationChangeEvaluated(ILogger logger, bool changed, bool isNull, bool match);
+
+    [LoggerMessage(EventId = EventIds.LaunchPatchingTranslationChanged, Level = LogLevel.Information, Message = ">>> PATCHING: Translation file changed — applying patch")]
+    private static partial void LogPatchingTranslationChanged(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchApplyTranslationsFailed, Level = LogLevel.Error, Message = "ApplyTranslations FAILED: {Error}")]
+    private static partial void LogApplyTranslationsFailed(ILogger logger, string error);
+
+    [LoggerMessage(EventId = EventIds.LaunchTranslationsPatched, Level = LogLevel.Information, Message = "Patched translations: {Applied} applied, {Skipped} skipped")]
+    private static partial void LogTranslationsPatched(ILogger logger, int applied, int skipped);
+
+    [LoggerMessage(EventId = EventIds.LaunchReadingDatVnum, Level = LogLevel.Information, Message = "Reading DAT vnum to save alongside hash...")]
+    private static partial void LogReadingDatVnum(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchReadVersionFailed, Level = LogLevel.Error, Message = "ReadVersion FAILED: {Error}")]
+    private static partial void LogReadVersionFailed(ILogger logger, string error);
+
+    [LoggerMessage(EventId = EventIds.LaunchDatVnumRead, Level = LogLevel.Information, Message = "DAT vnum: VnumDat={VnumDat}, VnumGame={VnumGame}")]
+    private static partial void LogDatVnumRead(ILogger logger, int vnumDat, int vnumGame);
+
+    [LoggerMessage(EventId = EventIds.LaunchSaveVersionFailed, Level = LogLevel.Error, Message = "SaveVersion FAILED: {Error}")]
+    private static partial void LogSaveVersionFailed(ILogger logger, string error);
+
+    [LoggerMessage(EventId = EventIds.LaunchVersionSaved, Level = LogLevel.Information, Message = "Version saved OK")]
+    private static partial void LogVersionSaved(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchSkippedTranslationUnchanged, Level = LogLevel.Information, Message = ">>> SKIP: Translation file unchanged — skipping patch")]
+    private static partial void LogSkippedTranslationUnchanged(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchStartingGame, Level = LogLevel.Information, Message = "Step 3: Launching game (fire-and-forget)...")]
+    private static partial void LogStartingGame(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchGameLaunchFailed, Level = LogLevel.Error, Message = "Launch FAILED: {Error}")]
+    private static partial void LogGameLaunchFailed(ILogger logger, string error);
+
+    [LoggerMessage(EventId = EventIds.LaunchLauncherStarted, Level = LogLevel.Information, Message = "Launcher started OK (fire-and-forget, not waiting for exit)")]
+    private static partial void LogLauncherStarted(ILogger logger);
+
+    [LoggerMessage(EventId = EventIds.LaunchEnded, Level = LogLevel.Information, Message = "=== SIMPLIFIED LAUNCH END ===")]
+    private static partial void LogLaunchEnded(ILogger logger);
 }

--- a/src/Patcher/LotroKoniecDev.Application/Features/UpdateChecking/GameUpdateChecker.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/UpdateChecking/GameUpdateChecker.cs
@@ -45,14 +45,14 @@ public sealed partial class GameUpdateChecker : IGameUpdateChecker
         Result<string> fetchResult = await _forumPageFetcher.FetchReleaseNotesPageAsync();
         if (fetchResult.IsFailure)
         {
-            _logger.LogWarning("Forum fetch failed: {Error}", fetchResult.Error.Message);
+            LogForumFetchFailed(_logger, fetchResult.Error.Message);
             return Result.Success(new GameUpdateCheckSummary(null, storedInfo));
         }
 
         string? forumVersion = ParseLatestVersion(fetchResult.Value);
         if (forumVersion is null)
         {
-            _logger.LogWarning("Could not parse version from forum page");
+            LogForumVersionParseFailed(_logger);
             return Result.Success(new GameUpdateCheckSummary(null, storedInfo));
         }
 
@@ -82,4 +82,10 @@ public sealed partial class GameUpdateChecker : IGameUpdateChecker
     // future edits to a regex that runs on third-party HTML (AUDIT-SEC-07 / #397).
     [GeneratedRegex(@"Update\s+(\d+(?:\.\d+)*)\s+Release\s+Notes", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 1000)]
     private static partial Regex VersionRegex();
+
+    [LoggerMessage(EventId = EventIds.ForumFetchFailed, Level = LogLevel.Warning, Message = "Forum fetch failed: {Error}")]
+    private static partial void LogForumFetchFailed(ILogger logger, string error);
+
+    [LoggerMessage(EventId = EventIds.ForumVersionParseFailed, Level = LogLevel.Warning, Message = "Could not parse version from forum page")]
+    private static partial void LogForumVersionParseFailed(ILogger logger);
 }

--- a/src/Patcher/LotroKoniecDev.Infrastructure/Diagnostics/GameProcessDetector.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/Diagnostics/GameProcessDetector.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace LotroKoniecDev.Infrastructure.Diagnostics;
 
-public sealed class GameProcessDetector : IGameProcessDetector
+public sealed partial class GameProcessDetector : IGameProcessDetector
 {
     private static readonly string[] AllLotroProcessNames =
     [
@@ -45,8 +45,11 @@ public sealed class GameProcessDetector : IGameProcessDetector
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check for running LOTRO processes");
+            LogGameProcessCheckFailed(_logger, ex);
             return false;
         }
     }
+
+    [LoggerMessage(EventId = EventIds.GameProcessCheckFailed, Level = LogLevel.Debug, Message = "Failed to check for running LOTRO processes")]
+    private static partial void LogGameProcessCheckFailed(ILogger logger, Exception exception);
 }

--- a/src/Patcher/LotroKoniecDev.Infrastructure/EventIds.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/EventIds.cs
@@ -1,0 +1,11 @@
+namespace LotroKoniecDev.Infrastructure;
+
+/// <summary>
+/// Event ID ranges: TranslationSystem 1000–1999, AuthSystem 2000–2999, Shared 3000–3999,
+/// Hateoas 4000–4999, Patcher 5000–5999 (Application 5000–5499, Infrastructure 5500–5999).
+/// </summary>
+internal static class EventIds
+{
+    // Diagnostics (5500–5599)
+    public const int GameProcessCheckFailed = 5500;
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/EventIds.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/EventIds.cs
@@ -12,6 +12,9 @@ internal static class EventIds
     public const int ValidationFailure = 1140;
     public const int UnhandledException = 1150;
 
+    // Import (1200–1299)
+    public const int ImportPassesCompleted = 1200;
+
     // Middleware (1300–1399)
     public const int UnauthorizedAccessAttempt = 1300;
     public const int ForbiddenAccessAttempt = 1301;

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
@@ -37,7 +37,7 @@ namespace LotroKoniecDev.TranslationSystem.API.Features.Import;
 /// <c>COPY</c>, everything else mutates aggregates in bounded chunks, and the version flips to
 /// processed with the last save (all-or-nothing, idempotent re-upload).
 /// </summary>
-internal sealed class ImportExportedTexts : IEndpoint
+internal sealed partial class ImportExportedTexts : IEndpoint
 {
     /// <summary>
     /// <paramref name="FileStream"/> must be seekable — the import reads it once per pass. The
@@ -60,7 +60,7 @@ internal sealed class ImportExportedTexts : IEndpoint
         }
     }
 
-    internal sealed class Handler : ICommandHandler<Command, Result<ImportSummary>>
+    internal sealed partial class Handler : ICommandHandler<Command, Result<ImportSummary>>
     {
         /// <summary>
         /// An all-garbage 79 MB upload is rejected either way; the cap only bounds how many line
@@ -187,10 +187,8 @@ internal sealed class ImportExportedTexts : IEndpoint
 
             // Pass durations are the "Oś B" (async-import) trigger data (spec 0006): watching them
             // grow toward the request budget on staging/prod is what would justify that ADR.
-            _logger.LogInformation(
-                "Import passes for {IncomingRows} incoming row(s): upload pass {UploadPassMs} ms, "
-                + "diff pass {DiffPassMs} ms, apply pass {ApplyPassMs} ms "
-                + "(added {Added}, source-changed {SourceChanged}, removed {Removed}, restored {Restored}).",
+            LogImportPasses(
+                _logger,
                 incomingCount, uploadPassMilliseconds, diffPassMilliseconds, applyPassMilliseconds,
                 plan.AddedCount, plan.SourceChangedByKey.Count, plan.RemovedIds.Count, plan.RestoredIds.Count);
 
@@ -470,6 +468,9 @@ internal sealed class ImportExportedTexts : IEndpoint
                 Unchanged: plan.UnchangedCount,
                 Warnings: warnings);
         }
+
+        [LoggerMessage(EventId = EventIds.ImportPassesCompleted, Level = LogLevel.Information, Message = "Import passes for {IncomingRows} incoming row(s): upload pass {UploadPassMs} ms, diff pass {DiffPassMs} ms, apply pass {ApplyPassMs} ms (added {Added}, source-changed {SourceChanged}, removed {Removed}, restored {Restored}).")]
+        private static partial void LogImportPasses(ILogger logger, int incomingRows, long uploadPassMs, long diffPassMs, long applyPassMs, int added, int sourceChanged, int removed, int restored);
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/Utilities/LotroKoniecDev.Logging/TimedOperations/TimedOperation.cs
+++ b/src/Utilities/LotroKoniecDev.Logging/TimedOperations/TimedOperation.cs
@@ -4,6 +4,9 @@ using Microsoft.Extensions.Logging;
 namespace LotroKoniecDev.Logging.TimedOperations;
 
 #pragma warning disable CA2254 // Message template is composed at runtime by design (timer utility)
+#pragma warning disable CA1848 // LoggerMessage needs a compile-time template; this utility's template
+                               // is composed per operation, and a per-instance Define would re-parse
+                               // the template on every operation — slower than the plain Log call
 
 public sealed class TimedOperation : IDisposable
 {


### PR DESCRIPTION
## What

Five files still used classic `ILogger` extension calls while the rest of the repo uses the `LoggerMessage` source generator. This PR converts them 1:1 (same message templates, same levels) and flips `dotnet_diagnostic.CA1848.severity` from `none` to `warning` in `.editorconfig` — with repo-wide `TreatWarningsAsErrors`, any future classic logging call is now a failing build, so the drift cannot come back.

## Converted

- `GameUpdateChecker` (Patcher/Application) — 2 calls
- `SimplifiedGameLaunchingStrategy` (Patcher/Application) — 25 calls
- `GameProcessDetector` (Patcher/Infrastructure) — 1 call
- `ColdStartRetry` (AuthSystem) — 1 call
- `ImportExportedTexts` (TMS) — 1 call

The Patcher had no `EventIds` class, so it gets its own range **5000–5999** (Application 5000–5499, Infrastructure 5500–5999); Hateoas already occupies 4000–4999.

## Deliberate exception

`TimedOperation` (Utilities/Logging) composes its message template at runtime by design, so the source generator cannot apply and a per-instance `LoggerMessage.Define` would re-parse the template per operation — slower than the plain `Log` call. It keeps a scoped `#pragma warning disable CA1848` with the reason in-file, next to the existing `CA2254` suppression of the same nature. The enabled analyzer is what surfaced this file in the first place (raw `logger.Log(level, …)` calls a name-based grep misses).

## Patcher-stable compliance

Behavior-preserving: identical templates and levels, no flow changes; all existing tests pass with untouched assertions (277 + 8 + 172 unit tests green, zero warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)