### PR TITLE
LEGAL-04: Cookie information banner (SSR, essential-cookies disclosure)

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
@@ -228,7 +228,7 @@
         <div class="prose-main prose">
             <p class="auth-eyebrow">Ochrona danych · RODO</p>
             <h1>Polityka prywatności</h1>
-            <p class="updated">Ostatnia aktualizacja: 8 czerwca 2026</p>
+            <p class="updated">Ostatnia aktualizacja: 12 lipca 2026</p>
 
             <p>Niniejsza polityka opisuje, w jaki sposób serwis <strong>lotro-translator.pl</strong> przetwarza dane osobowe użytkowników zgodnie z Rozporządzeniem Parlamentu Europejskiego i Rady (UE) 2016/679 (RODO). Korzystając z serwisu, akceptujesz zasady opisane poniżej.</p>
 
@@ -246,7 +246,17 @@
             <h2><span class="sec-num">03</span> Cel i podstawa przetwarzania</h2>
             <p>Dane przetwarzamy w celu prowadzenia konta i umożliwienia współtworzenia tłumaczenia — zapisywania i zatwierdzania wpisów przypisanych do Twojego konta (art. 6 ust. 1 lit. b RODO — wykonanie umowy), a także zapewnienia bezpieczeństwa serwisu (lit. f — prawnie uzasadniony interes).</p>
 
-            <h2><span class="sec-num">04</span> Twoje prawa</h2>
+            <h2 id="cookies"><span class="sec-num">04</span> Pliki cookie</h2>
+            <p>Korzystamy wyłącznie z niezbędnych plików cookie, koniecznych do prawidłowego i bezpiecznego działania serwisu. Nie wymagają one zgody, ponieważ bez nich serwis nie mógłby funkcjonować:</p>
+            <ul>
+                <li><strong>Cookie sesji logowania</strong> — utrzymują Twoje zalogowanie po uwierzytelnieniu (<code>.lotrokoniecdev.auth</code> w aplikacji tłumaczy, <code>LotroKoniecDev.Auth</code> na serwerze logowania).</li>
+                <li><strong>Cookie zabezpieczające (CSRF / antyfałszerstwo)</strong> — chronią formularze przed atakami typu cross-site request forgery.</li>
+                <li><strong>Cookie zgody na pliki cookie</strong> — zapamiętuje, że zapoznałeś się z informacją o plikach cookie, dzięki czemu baner nie pojawia się ponownie (<code>.lotrokoniecdev.cookie-consent</code>, ważne rok).</li>
+                <li><strong>Cookie techniczne krótkotrwałe</strong> — jednorazowe znaczniki stanu, np. informacja o wygaśnięciu sesji (<code>.lotrokoniecdev.session-expired</code>, ważne kilkadziesiąt sekund).</li>
+            </ul>
+            <p>Nie korzystamy z plików cookie analitycznych, marketingowych ani śledzących, ani z usług profilujących stron trzecich. Jeśli w przyszłości je wprowadzimy, najpierw poprosimy Cię o zgodę i zaktualizujemy niniejszą politykę.</p>
+
+            <h2><span class="sec-num">05</span> Twoje prawa</h2>
             <p>W każdej chwili możesz skorzystać z przysługujących Ci praw:</p>
             <ul>
                 <li><strong>Prawo dostępu</strong> — możesz uzyskać kopię swoich danych przechowywanych w serwisie.</li>
@@ -256,10 +266,10 @@
                 <li><strong>Prawo sprzeciwu</strong> — wycofasz zgodę na przetwarzanie w dowolnym momencie.</li>
             </ul>
 
-            <h2><span class="sec-num">05</span> Okres przechowywania</h2>
+            <h2><span class="sec-num">06</span> Okres przechowywania</h2>
             <p>Dane konta przechowujemy przez czas jego istnienia. Żądanie usunięcia konta uruchamia 14-dniowy okres ochronny, w którym konto jest zablokowane, a usunięcie można anulować linkiem z wiadomości e-mail; po jego upływie dane osobowe są anonimizowane, a wkład tłumaczeniowy pozostaje w serwisie wyłącznie z nieprzypisywalnym identyfikatorem. Dane techniczne usuwamy po wygaśnięciu uzasadnionego okresu bezpieczeństwa.</p>
 
-            <h2><span class="sec-num">06</span> Kontakt</h2>
+            <h2><span class="sec-num">07</span> Kontakt</h2>
             <p>Pytania dotyczące przetwarzania danych lub realizacji praw kieruj na adres <a href="mailto:koniecdev@@gmail.com">koniecdev@@gmail.com</a>. Przysługuje Ci również prawo wniesienia skargi do Prezesa Urzędu Ochrony Danych Osobowych.</p>
 
             <div class="prose-card">

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
@@ -37,6 +37,8 @@
             </p>
         </div>
     </footer>
+
+    <CookieConsent/>
 </div>
 
 @code {

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Shared/CookieConsent.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Shared/CookieConsent.razor
@@ -1,0 +1,60 @@
+@using Microsoft.AspNetCore.Http
+@using Microsoft.Extensions.Options
+@using LotroKoniecDev.Frontend.Infrastructure.CookieConsent
+@using LotroKoniecDev.Frontend.Settings
+@inject IOptions<AuthSystemSettings> AuthSystemOptions
+@inject IHttpContextAccessor HttpContextAccessor
+
+@if (!_accepted)
+{
+    <div class="cookie-bar" role="region" aria-label="Informacja o plikach cookie">
+        <div class="container cookie-bar-inner">
+            <div class="cookie-bar-copy">
+                <span class="cookie-bar-ico" aria-hidden="true">
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M12 2a10 10 0 1 0 10 10 4 4 0 0 1-5-5 4 4 0 0 1-5-5Z"/>
+                        <path d="M8.5 8.5h.01M15 9.5h.01M9.5 15h.01M14 14.5h.01"/>
+                    </svg>
+                </span>
+                <p class="cookie-bar-text">
+                    Używamy wyłącznie niezbędnych plików cookie, koniecznych do bezpiecznego działania
+                    serwisu — nie stosujemy śledzenia ani reklam. Szczegóły znajdziesz w
+                    <a href="@PrivacyPolicyCookiesUrl" target="_blank" rel="noopener">polityce prywatności</a>.
+                </p>
+            </div>
+            <form class="cookie-bar-form" method="post" action="@CookieConsentEndpointsExtensions.AcceptPath">
+                <AntiforgeryToken/>
+                <input type="hidden" name="returnPath" value="@CurrentPath()"/>
+                <button type="submit" class="btn btn-primary">Akceptuję</button>
+            </form>
+        </div>
+    </div>
+}
+
+@code {
+    private bool _accepted;
+
+    private string PrivacyPolicyCookiesUrl =>
+        $"{AuthSystemOptions.Value.BaseUrl.TrimEnd('/')}/Account/PrivacyPolicy#cookies";
+
+    // Server-side, one-shot decision (no JS, no interactivity): the banner is hidden the moment
+    // the consent cookie is present on the request. HttpOnly does not affect this server read.
+    protected override void OnInitialized()
+    {
+        string? cookieValue = HttpContextAccessor.HttpContext?.Request.Cookies[CookieConsentCookie.Name];
+        _accepted = CookieConsentCookie.IsAccepted(cookieValue);
+    }
+
+    private string CurrentPath()
+    {
+        HttpContext? httpContext = HttpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            return "/";
+        }
+
+        string path = httpContext.Request.Path.HasValue ? httpContext.Request.Path.Value! : "/";
+        string queryString = httpContext.Request.QueryString.Value ?? string.Empty;
+        return $"{path}{queryString}";
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/CookieConsent/CookieConsentCookie.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/CookieConsent/CookieConsentCookie.cs
@@ -1,0 +1,22 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.CookieConsent;
+
+internal static class CookieConsentCookie
+{
+    internal const string Name = ".lotrokoniecdev.cookie-consent";
+
+    // The show/hide decision is made server-side from the request cookie header — the app is pure
+    // SSR with no client-side script reading this cookie, and HttpOnly does not affect server
+    // reads. Secure mirrors the request scheme (like the session-expired marker) so the cookie
+    // still round-trips on the plain-http dev profile; it carries no sensitive value.
+    internal static CookieOptions BuildOptions(bool isHttps) => new()
+    {
+        HttpOnly = true,
+        Secure = isHttps,
+        SameSite = SameSiteMode.Lax,
+        IsEssential = true,
+        Expires = DateTimeOffset.UtcNow.AddYears(1),
+        Path = "/"
+    };
+
+    internal static bool IsAccepted(string? cookieValue) => !string.IsNullOrWhiteSpace(cookieValue);
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/CookieConsent/CookieConsentEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/CookieConsent/CookieConsentEndpointsExtensions.cs
@@ -1,0 +1,47 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.CookieConsent;
+
+/// <summary>
+/// Maps the cookie-consent acknowledgement route (LEGAL-04). The banner posts here as a plain HTML
+/// form — no JS, no interactivity — so acceptance works with JavaScript disabled; the antiforgery
+/// token is validated by the form-binding minimal-API pipeline.
+/// </summary>
+internal static class CookieConsentEndpointsExtensions
+{
+    internal const string AcceptPath = "/cookie-consent/accept";
+
+    extension(IEndpointRouteBuilder endpoints)
+    {
+        public IEndpointRouteBuilder MapCookieConsentEndpoints()
+        {
+            endpoints.MapPost(AcceptPath, AcceptCookieConsent).AllowAnonymous();
+            return endpoints;
+        }
+    }
+
+    /// <summary>
+    /// The accept route's request delegate, exposed internally so it can be unit-tested without a
+    /// web host: persists the consent cookie and redirects back to the page the form was posted
+    /// from, guarding against open redirects.
+    /// </summary>
+    internal static IResult AcceptCookieConsent(HttpContext context, IFormCollection form)
+    {
+        string returnPath = form["returnPath"].ToString();
+
+        context.Response.Cookies.Append(
+            CookieConsentCookie.Name,
+            "true",
+            CookieConsentCookie.BuildOptions(context.Request.IsHttps));
+
+        string safeReturn = IsLocalPath(returnPath) ? returnPath : "/";
+        return Results.Redirect(safeReturn);
+    }
+
+    // Control characters are rejected because the WHATWG URL parser strips ASCII tab/newline —
+    // "/\t/evil.example" would reach the browser as the protocol-relative "//evil.example"
+    // (mirrors ASP.NET Core's UrlHelper.IsLocalUrl hardening).
+    private static bool IsLocalPath(string path) =>
+        path.StartsWith('/')
+        && !path.StartsWith("//", StringComparison.Ordinal)
+        && !path.StartsWith("/\\", StringComparison.Ordinal)
+        && !path.Any(char.IsControl);
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -5,6 +5,7 @@ using LotroKoniecDev.Frontend.Components;
 using LotroKoniecDev.Frontend.Components.Pages.Account;
 using LotroKoniecDev.Frontend.Components.Pages.ImportExport;
 using LotroKoniecDev.Frontend.Infrastructure.Auth;
+using LotroKoniecDev.Frontend.Infrastructure.CookieConsent;
 using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.Security;
 using LotroKoniecDev.Frontend.Settings;
@@ -210,6 +211,7 @@ try
     app.MapAuthEndpoints();
     app.MapImportExportEndpoints();
     app.MapAccountEndpoints();
+    app.MapCookieConsentEndpoints();
     app.MapRazorComponents<App>();
 
     await app.RunAsync();

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -8,8 +8,8 @@
      warning 85 (≈ gold)    → orange 60 (kept distinct from the accent)
      success (mint = accent) → green 150 (decoupled: approved ≠ accent)
      danger 25              → unchanged
-   Cat-only sections (photo slider, wizard, gallery, cookie bar, legacy
-   block) are deliberately not ported.
+   Cat-only sections (photo slider, wizard, gallery, legacy block) are
+   deliberately not ported; the cookie bar arrived with LEGAL-04.
    ═════════════════════════════════════════════════════════════════════ */
 
 /* ───────── Tokens ───────── */
@@ -1501,6 +1501,80 @@ code {
 
 .foot-links a:hover {
     color: var(--accent-hi);
+}
+
+/* ───────── Cookie consent bar ───────── */
+.cookie-bar {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 60;
+    border-top: 1px solid var(--border-hi);
+    background: oklch(0.20 0.013 80 / 0.94);
+    backdrop-filter: blur(14px) saturate(140%);
+    box-shadow: 0 -8px 24px -14px rgba(0, 0, 0, 0.6);
+}
+
+.cookie-bar-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+    flex-wrap: wrap;
+}
+
+.cookie-bar-copy {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+    flex: 1 1 420px;
+}
+
+.cookie-bar-ico {
+    flex: 0 0 auto;
+    display: inline-flex;
+    color: var(--accent);
+}
+
+.cookie-bar-text {
+    margin: 0;
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--text-mute);
+}
+
+.cookie-bar-text a {
+    color: var(--accent-hi);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.cookie-bar-text a:hover {
+    color: var(--accent);
+}
+
+.cookie-bar-form {
+    flex: 0 0 auto;
+}
+
+.cookie-bar-form .btn {
+    white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+    .cookie-bar-inner {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+
+    .cookie-bar-form .btn {
+        width: 100%;
+    }
 }
 
 /* ───────── Utilities ───────── */

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/AccountGdprSelfServiceTests.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/AccountGdprSelfServiceTests.cs
@@ -34,6 +34,10 @@ public sealed class AccountGdprSelfServiceTests : E2ETestBase
         await AuthActions.ConfirmEmailAsync(Page, Fixture, user);
         await AuthActions.LoginAsync(Page, Fixture, user);
 
+        // Accept the cookie banner up front — its fixed bottom bar would otherwise cover the
+        // submit buttons of the change-password/delete forms this flow clicks (LEGAL-04).
+        await AuthActions.AcceptCookieBannerAsync(Page);
+
         // The nav offers "Moje konto" (the privacy-policy wording) and it lands on the account page
         // showing the live auth data.
         await Page.GetByTestId("nav-account").ClickAsync();

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/CookieConsentBannerTests.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/CookieConsentBannerTests.cs
@@ -1,0 +1,52 @@
+using LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
+using Microsoft.Playwright;
+using Shouldly;
+
+namespace LotroKoniecDev.Frontend.E2E.Tests.Flows;
+
+/// <summary>
+/// LEGAL-04 — the cookie information banner's acceptance criteria, pinned in a real browser with
+/// <em>JavaScript disabled</em>: a new visitor sees the banner on any page, accepting it (a plain
+/// SSR form post — no script) hides it everywhere, and the consent survives navigation. Needs no
+/// account and no seeded database — the banner is anonymous by design.
+/// </summary>
+public sealed class CookieConsentBannerTests : E2ETestBase
+{
+    public CookieConsentBannerTests(PlaywrightStackFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task Banner_shows_for_new_visitor_and_accepting_without_javascript_hides_it_across_navigation()
+    {
+        // Arrange — a dedicated JS-less context: the acceptance path must be pure SSR.
+        await using IBrowserContext jsLessContext = await Fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true,
+            JavaScriptEnabled = false,
+            ViewportSize = new ViewportSize { Width = 1366, Height = 900 }
+        });
+        jsLessContext.SetDefaultTimeout(20_000);
+        IPage page = await jsLessContext.NewPageAsync();
+
+        // A brand-new visitor sees the banner on the home page…
+        await page.GotoAsync($"{Fixture.FrontendBaseUrl}/");
+        ILocator banner = page.GetByRole(AriaRole.Region, new() { Name = "Informacja o plikach cookie" });
+        await banner.WaitForAsync();
+
+        // …and on any other page.
+        await page.GotoAsync($"{Fixture.FrontendBaseUrl}/regulamin");
+        (await banner.IsVisibleAsync()).ShouldBeTrue();
+
+        // Accepting is a plain form post that works without JavaScript.
+        await page.GetByRole(AriaRole.Button, new() { Name = "Akceptuję", Exact = true }).ClickAsync();
+        await banner.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Detached });
+
+        // The accept redirect returns to the page the form was posted from.
+        page.Url.ShouldContain("/regulamin");
+
+        // The consent cookie survives navigation — the banner stays gone everywhere.
+        await page.GotoAsync($"{Fixture.FrontendBaseUrl}/");
+        (await banner.IsVisibleAsync()).ShouldBeFalse();
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
@@ -56,6 +56,18 @@ internal static class AuthActions
         await page.GetByRole(AriaRole.Button, new() { Name = Buttons.Logout, Exact = true }).WaitForAsync(LongWait);
     }
 
+    /// <summary>
+    /// Accepts the LEGAL-04 cookie banner so its fixed bottom overlay never covers the controls a
+    /// flow clicks lower on the page. Call once after the first Frontend page load of a fresh
+    /// browser context.
+    /// </summary>
+    public static async Task AcceptCookieBannerAsync(IPage page)
+    {
+        await page.GetByRole(AriaRole.Button, new() { Name = "Akceptuję", Exact = true }).ClickAsync();
+        await page.GetByRole(AriaRole.Region, new() { Name = "Informacja o plikach cookie" })
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Detached, Timeout = 30_000 });
+    }
+
     public static async Task LogoutAsync(IPage page)
     {
         await page.GetByRole(AriaRole.Button, new() { Name = Buttons.Logout, Exact = true }).ClickAsync();

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Shared/CookieConsentTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Shared/CookieConsentTests.cs
@@ -1,0 +1,105 @@
+using AngleSharp.Dom;
+using LotroKoniecDev.Frontend.Components.Shared;
+using LotroKoniecDev.Frontend.Infrastructure.CookieConsent;
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Shared;
+
+/// <summary>
+/// Renders the cookie information banner (LEGAL-04). The show/hide decision is a one-shot
+/// server-side read of the request cookie — no JS, no interactivity — so these tests lock down the
+/// SSR wiring: the plain-HTML accept form (action + hidden returnPath), the privacy-policy link
+/// with the <c>#cookies</c> anchor, and the banner disappearing once the consent cookie rides the
+/// request. The full accept round-trip is the endpoint's unit tests plus the browser E2E.
+/// </summary>
+public sealed class CookieConsentTests : BunitContext
+{
+    private readonly DefaultHttpContext _httpContext = new();
+
+    public CookieConsentTests()
+    {
+        Services.AddAntiforgery();
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(_httpContext);
+        Services.AddSingleton(accessor);
+        Services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new AuthSystemSettings
+        {
+            BaseUrl = "https://localhost:5003/",
+            Authority = "https://localhost:5003",
+            ClientId = "lotrokoniecdev-web",
+            CallbackPath = "/callback",
+            SignedOutCallbackPath = "/signout-callback-oidc",
+            Scopes = ["openid", "profile", "api"]
+        }));
+    }
+
+    [Fact]
+    public void Render_WhenConsentCookieAbsent_ShowsTheBanner()
+    {
+        IRenderedComponent<CookieConsent> component = Render<CookieConsent>();
+
+        component.Find(".cookie-bar").ShouldNotBeNull();
+        component.Markup.ShouldContain("niezbędnych plików cookie");
+    }
+
+    [Fact]
+    public void Render_WhenConsentCookiePresent_RendersNothing()
+    {
+        _httpContext.Request.Headers.Cookie = $"{CookieConsentCookie.Name}=true";
+
+        IRenderedComponent<CookieConsent> component = Render<CookieConsent>();
+
+        component.Markup.Trim().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_AcceptForm_PostsToTheAcceptEndpointWithTheCurrentPathAndQuery()
+    {
+        _httpContext.Request.Path = "/translations";
+        _httpContext.Request.QueryString = new QueryString("?page=2");
+
+        IRenderedComponent<CookieConsent> component = Render<CookieConsent>();
+
+        IElement form = component.Find("form.cookie-bar-form");
+        form.GetAttribute("method").ShouldBe("post");
+        form.GetAttribute("action").ShouldBe(CookieConsentEndpointsExtensions.AcceptPath);
+        component.Find("input[name=returnPath]").GetAttribute("value").ShouldBe("/translations?page=2");
+    }
+
+    [Fact]
+    public void Render_PolicyLink_TargetsTheAuthServerPolicyCookieSection()
+    {
+        IRenderedComponent<CookieConsent> component = Render<CookieConsent>();
+
+        component.Find(".cookie-bar-text a")
+            .GetAttribute("href")
+            .ShouldBe("https://localhost:5003/Account/PrivacyPolicy#cookies");
+    }
+
+    [Fact]
+    public void Render_Banner_ContainsNoInteractiveHandlers()
+    {
+        // The SSR-purity contract: acceptance must work with JavaScript disabled, so the accept
+        // control is a plain form submit — never an @on* handler.
+        IRenderedComponent<CookieConsent> component = Render<CookieConsent>();
+
+        component.Find("button[type=submit]").TextContent.Trim().ShouldBe("Akceptuję");
+        component.Markup.ShouldNotContain("blazor:onclick");
+        component.Markup.ShouldNotContain("blazor:onsubmit");
+    }
+
+    [Fact]
+    public void Render_WhenHttpContextUnavailable_FallsBackToHomeReturnPath()
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+        Services.AddSingleton(accessor);
+
+        IRenderedComponent<CookieConsent> component = Render<CookieConsent>();
+
+        component.Find("input[name=returnPath]").GetAttribute("value").ShouldBe("/");
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/CookieConsent/CookieConsentCookieTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/CookieConsent/CookieConsentCookieTests.cs
@@ -1,0 +1,17 @@
+using LotroKoniecDev.Frontend.Infrastructure.CookieConsent;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.CookieConsent;
+
+public sealed class CookieConsentCookieTests
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("true", true)]
+    [InlineData("anything", true)]
+    public void IsAccepted_TreatsAnyNonBlankValueAsConsent(string? cookieValue, bool expected)
+    {
+        CookieConsentCookie.IsAccepted(cookieValue).ShouldBe(expected);
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/CookieConsent/CookieConsentEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/CookieConsent/CookieConsentEndpointsExtensionsTests.cs
@@ -1,0 +1,102 @@
+using LotroKoniecDev.Frontend.Infrastructure.CookieConsent;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Primitives;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.CookieConsent;
+
+/// <summary>
+/// Drives the accept route's request delegate directly (no web host): acceptance must persist the
+/// year-long consent cookie and bounce the visitor back to the page the plain-HTML form was posted
+/// from — with the open-redirect guard collapsing any non-local target to the home page (LEGAL-04).
+/// </summary>
+public sealed class CookieConsentEndpointsExtensionsTests
+{
+    [Fact]
+    public void AcceptCookieConsent_AppendsTheConsentCookie()
+    {
+        DefaultHttpContext httpContext = new();
+
+        CookieConsentEndpointsExtensions.AcceptCookieConsent(httpContext, CreateForm("/translations"));
+
+        string setCookie = httpContext.Response.Headers.SetCookie.ToString();
+        setCookie.ShouldContain(CookieConsentCookie.Name);
+        setCookie.ShouldContain("httponly", Case.Insensitive);
+        setCookie.ShouldContain("path=/", Case.Insensitive);
+        setCookie.ShouldContain("samesite=lax", Case.Insensitive);
+        // A persistent expiry is the "survives navigation" contract — a session cookie would
+        // re-show the banner on the next browser start.
+        setCookie.ShouldContain("expires=", Case.Insensitive);
+    }
+
+    [Fact]
+    public void AcceptCookieConsent_WhenReturnPathIsLocal_RedirectsBackToIt()
+    {
+        DefaultHttpContext httpContext = new();
+
+        IResult result = CookieConsentEndpointsExtensions.AcceptCookieConsent(
+            httpContext, CreateForm("/translations?page=2"));
+
+        RedirectHttpResult redirect = result.ShouldBeOfType<RedirectHttpResult>();
+        redirect.Url.ShouldBe("/translations?page=2");
+    }
+
+    [Theory]
+    [InlineData("https://evil.example")]
+    [InlineData("//evil.example")]
+    [InlineData("/\\evil.example")]
+    [InlineData("/\t/evil.example")]
+    [InlineData("/\r\n/evil.example")]
+    [InlineData("evil")]
+    [InlineData("")]
+    public void AcceptCookieConsent_WhenReturnPathIsNotLocal_RedirectsHome(string returnPath)
+    {
+        DefaultHttpContext httpContext = new();
+
+        IResult result = CookieConsentEndpointsExtensions.AcceptCookieConsent(
+            httpContext, CreateForm(returnPath));
+
+        RedirectHttpResult redirect = result.ShouldBeOfType<RedirectHttpResult>();
+        redirect.Url.ShouldBe("/");
+    }
+
+    [Fact]
+    public void AcceptCookieConsent_WhenReturnPathIsMissing_RedirectsHome()
+    {
+        DefaultHttpContext httpContext = new();
+        FormCollection emptyForm = new(new Dictionary<string, StringValues>());
+
+        IResult result = CookieConsentEndpointsExtensions.AcceptCookieConsent(httpContext, emptyForm);
+
+        RedirectHttpResult redirect = result.ShouldBeOfType<RedirectHttpResult>();
+        redirect.Url.ShouldBe("/");
+    }
+
+    [Fact]
+    public void AcceptCookieConsent_WhenRequestIsHttps_MarksTheCookieSecure()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.IsHttps = true;
+
+        CookieConsentEndpointsExtensions.AcceptCookieConsent(httpContext, CreateForm("/"));
+
+        httpContext.Response.Headers.SetCookie
+            .ToString()
+            .ShouldContain("secure", Case.Insensitive);
+    }
+
+    [Fact]
+    public void AcceptCookieConsent_WhenRequestIsPlainHttp_LeavesTheCookieNonSecure()
+    {
+        DefaultHttpContext httpContext = new();
+
+        CookieConsentEndpointsExtensions.AcceptCookieConsent(httpContext, CreateForm("/"));
+
+        string setCookie = httpContext.Response.Headers.SetCookie.ToString();
+        setCookie.ShouldContain(CookieConsentCookie.Name);
+        setCookie.ShouldNotContain("secure", Case.Insensitive);
+    }
+
+    private static FormCollection CreateForm(string returnPath) =>
+        new(new Dictionary<string, StringValues> { ["returnPath"] = returnPath });
+}


### PR DESCRIPTION
Closes #454

## What

- **Frontend:** SSR cookie information banner rendered from `MainLayout` on every page — ported from TheKittySaver's `CookieConsent.razor` + consent-cookie infrastructure, de-localized (Polish-only copy, no localizer indirection). Acceptance is a plain `<form method="post">` with an antiforgery token to `POST /cookie-consent/accept`, which persists `.lotrokoniecdev.cookie-consent` for a year and redirects back to the posting page.
- **Auth server:** new "Pliki cookie" section in the privacy policy (`/Account/PrivacyPolicy#cookies`, linked from the banner) listing every essential cookie by name and lifetime; sections renumbered, date bumped.
- **Hardening beyond the TKS source:** the accept endpoint's open-redirect guard also rejects control characters — an encoded tab (`/%09/evil.example`) would otherwise pass the `//` check and reach the browser as a protocol-relative redirect. TKS has the same hole (follow-up to port back).

## Why

Essential cookies need no consent under ePrivacy/RODO, but visitors must still be informed. Part of the LEGAL/GDPR pack (epic #459).

## Acceptance criteria → proof

- *New visitors see the banner on any page; accepting hides it everywhere and survives navigation* — new Playwright E2E flow `CookieConsentBannerTests` (home → /regulamin → accept → gone after navigation).
- *Works with JavaScript disabled* — that E2E flow runs in a `JavaScriptEnabled = false` browser context.
- *No interactive render mode* — `check-ssr-purity` green; a bUnit test additionally asserts no `blazor:on*` handlers in the banner markup.

## Tests

- Build: 0 warnings. Frontend unit: 403/403. Patcher unit: 277/277.
- Frontend Playwright E2E suite run locally against the full Docker stack: **10/10** (the GDPR flow now accepts the banner up front so the fixed bottom overlay never covers its submit buttons).
- code-reviewer (Fable 5, xhigh) ran; its critical finding (control-char redirect bypass) and both test-shape nits are fixed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)