### PR TITLE
LEGAL-05: Privacy policy accuracy pass + legal links in the frontend footer

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
@@ -246,7 +246,16 @@
             <h2><span class="sec-num">03</span> Cel i podstawa przetwarzania</h2>
             <p>Dane przetwarzamy w celu prowadzenia konta i umożliwienia współtworzenia tłumaczenia — zapisywania i zatwierdzania wpisów przypisanych do Twojego konta (art. 6 ust. 1 lit. b RODO — wykonanie umowy), a także zapewnienia bezpieczeństwa serwisu (lit. f — prawnie uzasadniony interes).</p>
 
-            <h2 id="cookies"><span class="sec-num">04</span> Pliki cookie</h2>
+            <h2 id="recipients"><span class="sec-num">04</span> Odbiorcy danych</h2>
+            <p>Nie sprzedajemy danych ani nie udostępniamy ich w celach marketingowych. Dane są powierzane wyłącznie dostawcom infrastruktury, z której korzysta serwis (podmiotom przetwarzającym w rozumieniu art. 28 RODO):</p>
+            <ul>
+                <li><strong>Microsoft (Azure)</strong> — hosting aplikacji serwisu oraz logów technicznych; centrum danych w regionie Polska Centralna (UE).</li>
+                <li><strong>Neon Inc.</strong> — zarządzana baza danych PostgreSQL, w której przechowujemy dane konta i wkład tłumaczeniowy; serwery we Frankfurcie (UE). Dostawca ma siedzibę w USA — transfer zabezpieczają standardowe klauzule umowne.</li>
+                <li><strong>Brevo (Sendinblue SAS, Francja)</strong> — wysyłka wiadomości transakcyjnych (np. potwierdzenie adresu e-mail, link anulowania usunięcia konta); przetwarza adres e-mail odbiorcy i treść wiadomości.</li>
+                <li><strong>Google LLC</strong> — strony logowania i rejestracji ładują czcionki webowe z serwerów Google (Google Fonts); przy ich pobraniu Google otrzymuje adres IP Twojej przeglądarki. Transfer do USA odbywa się na podstawie EU-U.S. Data Privacy Framework. Planujemy rezygnację z tej usługi na rzecz czcionek serwowanych bezpośrednio z serwisu.</li>
+            </ul>
+
+            <h2 id="cookies"><span class="sec-num">05</span> Pliki cookie</h2>
             <p>Korzystamy wyłącznie z niezbędnych plików cookie, koniecznych do prawidłowego i bezpiecznego działania serwisu. Nie wymagają one zgody, ponieważ bez nich serwis nie mógłby funkcjonować:</p>
             <ul>
                 <li><strong>Cookie sesji logowania</strong> — utrzymują Twoje zalogowanie po uwierzytelnieniu (<code>.lotrokoniecdev.auth</code> w aplikacji tłumaczy, <code>LotroKoniecDev.Auth</code> na serwerze logowania).</li>
@@ -256,7 +265,7 @@
             </ul>
             <p>Nie korzystamy z plików cookie analitycznych, marketingowych ani śledzących, ani z usług profilujących stron trzecich. Jeśli w przyszłości je wprowadzimy, najpierw poprosimy Cię o zgodę i zaktualizujemy niniejszą politykę.</p>
 
-            <h2><span class="sec-num">05</span> Twoje prawa</h2>
+            <h2><span class="sec-num">06</span> Twoje prawa</h2>
             <p>W każdej chwili możesz skorzystać z przysługujących Ci praw:</p>
             <ul>
                 <li><strong>Prawo dostępu</strong> — możesz uzyskać kopię swoich danych przechowywanych w serwisie.</li>
@@ -266,10 +275,14 @@
                 <li><strong>Prawo sprzeciwu</strong> — wycofasz zgodę na przetwarzanie w dowolnym momencie.</li>
             </ul>
 
-            <h2><span class="sec-num">06</span> Okres przechowywania</h2>
-            <p>Dane konta przechowujemy przez czas jego istnienia. Żądanie usunięcia konta uruchamia 14-dniowy okres ochronny, w którym konto jest zablokowane, a usunięcie można anulować linkiem z wiadomości e-mail; po jego upływie dane osobowe są anonimizowane, a wkład tłumaczeniowy pozostaje w serwisie wyłącznie z nieprzypisywalnym identyfikatorem. Dane techniczne usuwamy po wygaśnięciu uzasadnionego okresu bezpieczeństwa.</p>
+            <h2><span class="sec-num">07</span> Okres przechowywania</h2>
+            <p>Dane konta przechowujemy przez czas jego istnienia. Żądanie usunięcia konta uruchamia 14-dniowy okres ochronny, w którym konto jest zablokowane, a usunięcie można anulować linkiem z wiadomości e-mail; po jego upływie dane osobowe są anonimizowane, a wkład tłumaczeniowy pozostaje w serwisie wyłącznie z nieprzypisywalnym identyfikatorem.</p>
+            <ul>
+                <li><strong>Logi techniczne</strong> (w tym adresy IP) — przechowywane do <strong>30 dni</strong>.</li>
+                <li><strong>Kopie odzyskiwania bazy danych</strong> — mechanizm odtwarzania punktu w czasie obejmuje okres do <strong>6 godzin</strong> wstecz; dodatkowa migawka bazy tworzona przed wdrożeniem nowej wersji serwisu jest przechowywana najdłużej do kolejnego wdrożenia. Po upływie tych okien dane usunięte z bazy znikają również z kopii.</li>
+            </ul>
 
-            <h2><span class="sec-num">07</span> Kontakt</h2>
+            <h2><span class="sec-num">08</span> Kontakt</h2>
             <p>Pytania dotyczące przetwarzania danych lub realizacji praw kieruj na adres <a href="mailto:koniecdev@@gmail.com">koniecdev@@gmail.com</a>. Przysługuje Ci również prawo wniesienia skargi do Prezesa Urzędu Ochrony Danych Osobowych.</p>
 
             <div class="prose-card">

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
@@ -1,6 +1,9 @@
 @inherits LayoutComponentBase
 @using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession
+@using LotroKoniecDev.Frontend.Settings
+@using Microsoft.Extensions.Options
 @inject ISessionExpiryNotice SessionExpiryNotice
+@inject IOptions<AuthSystemSettings> AuthSystemOptions
 
 <div class="app">
     <NavMenu/>
@@ -34,6 +37,7 @@
             <p>© @DateTime.UtcNow.Year lotro-translator.pl — polskie tłumaczenie The Lord of the Rings Online</p>
             <p class="foot-links">
                 <a href="/regulamin">Regulamin</a>
+                <a href="@PrivacyPolicyUrl" target="_blank" rel="noopener">Polityka prywatności</a>
             </p>
         </div>
     </footer>
@@ -43,6 +47,9 @@
 
 @code {
     private bool _showSessionExpiredNotice;
+
+    private string PrivacyPolicyUrl =>
+        $"{AuthSystemOptions.Value.BaseUrl.TrimEnd('/')}/Account/PrivacyPolicy";
 
     // One-shot: consumed at render time (no JS, no interactivity). Clearing the marker here means the
     // banner shows exactly once after a forced logout and is gone on the next navigation.

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/MainLayoutTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/MainLayoutTests.cs
@@ -1,0 +1,74 @@
+using AngleSharp.Dom;
+using LotroKoniecDev.Frontend.Components.Layout;
+using LotroKoniecDev.Frontend.Infrastructure.Auth.DeadSession;
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Layout;
+
+/// <summary>
+/// Renders <see cref="MainLayout"/> through bUnit to lock the footer legal links down (LEGAL-05):
+/// every frontend page must offer the terms of service and the auth-hosted privacy policy — the
+/// single source of truth the cookie banner and the terms page already target. A regression here
+/// silently breaks the Art. 13 reachability requirement on the whole app.
+/// </summary>
+public sealed class MainLayoutTests : BunitContext
+{
+    private readonly ISessionExpiryNotice _sessionExpiryNotice = Substitute.For<ISessionExpiryNotice>();
+
+    public MainLayoutTests()
+    {
+        Services.AddAntiforgery();
+        Services.AddSingleton(_sessionExpiryNotice);
+
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(new DefaultHttpContext());
+        Services.AddSingleton(accessor);
+
+        Services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new AuthSystemSettings
+        {
+            BaseUrl = "https://localhost:5003/",
+            Authority = "https://localhost:5003",
+            ClientId = "lotrokoniecdev-web",
+            CallbackPath = "/callback",
+            SignedOutCallbackPath = "/signout-callback-oidc",
+            Scopes = ["openid", "profile", "api"]
+        }));
+
+        AddAuthorization().SetNotAuthorized();
+    }
+
+    [Fact]
+    public void Render_Footer_LinksTheTermsOfService()
+    {
+        IRenderedComponent<MainLayout> component = RenderMainLayout();
+
+        IElement termsLink = component.Find("footer .foot-links a[href='/regulamin']");
+        termsLink.TextContent.ShouldBe("Regulamin");
+    }
+
+    [Fact]
+    public void Render_Footer_LinksTheAuthServerPrivacyPolicyFromSettings()
+    {
+        IRenderedComponent<MainLayout> component = RenderMainLayout();
+
+        IElement policyLink = component.Find("footer .foot-links a[target=_blank]");
+        policyLink.GetAttribute("href").ShouldBe("https://localhost:5003/Account/PrivacyPolicy");
+        policyLink.GetAttribute("rel").ShouldBe("noopener");
+        policyLink.TextContent.ShouldBe("Polityka prywatności");
+    }
+
+    [Fact]
+    public void Render_Body_IsRenderedInsideMain()
+    {
+        IRenderedComponent<MainLayout> component = RenderMainLayout();
+
+        component.Find("main").TextContent.ShouldContain("page-body");
+    }
+
+    private IRenderedComponent<MainLayout> RenderMainLayout() =>
+        Render<MainLayout>(parameters => parameters
+            .Add(layout => layout.Body, builder => builder.AddContent(0, "page-body")));
+}


### PR DESCRIPTION
Closes #458

## What

- **Footer legal links on every frontend page** — `MainLayout` (the `DefaultLayout` of every routed page) now links the privacy policy next to the existing terms link. The link targets the auth-hosted policy built from `AuthSystemSettings.BaseUrl` — the same single-source-of-truth pattern the terms page (§6) and the cookie banner already use. No text fork.
- **Recipients/processors section (Art. 13(1)(e))** — the policy now names the actual processors: Microsoft Azure (hosting + technical logs, Poland Central/EU), Neon (managed PostgreSQL, Frankfurt/EU, US provider under SCCs), Brevo (transactional e-mail, France/EU), and Google Fonts (auth pages CDN — flagged as being phased out; remove the entry when #455 lands).
- **Concrete retention windows** — replaced the vague "technical data deleted after a reasonable security period" with reality, verified in the repo: technical logs 30 days (`iac/azure-law.tf`), DB point-in-time recovery up to 6 hours (runbook MIGR-01), pre-deploy snapshot branch kept at most until the next deploy (`deploy.yml` MIGR-04, max 1 per project).

## Already accurate (verified, no change needed)

- Two-phase deletion wording with the 14-day cancellation window — landed with #452.
- Cookie section consistent with the #454 banner (same cookie names, `#cookies` anchor preserved — the banner deep-links it).

## Tests

- New bUnit `MainLayoutTests`: both footer legal links (terms href, policy href from settings + `rel=noopener`), body rendering.
- `dotnet build` zero warnings; Frontend.Tests.Unit 406/406, Tests.Unit 277/277, AuthSystem.API.Tests.Unit 8/8 green; `check-ssr-purity.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)