### PR TITLE
LEGAL-07: Extend the GDPR data export with TMS contribution data

### DIFF
--- a/docs/adr/0032-gdpr-export-tms-leg-via-frontend-composition.md
+++ b/docs/adr/0032-gdpr-export-tms-leg-via-frontend-composition.md
@@ -1,0 +1,82 @@
+# ADR-0032: The GDPR Data Export Gains a TMS Leg, Composed by the Frontend with the User's Own Token
+
+**Status:** Accepted
+**Date:** 2026-07-12
+**Decision-makers:** Solo maintainer (ticket #456, legal & GDPR compliance pack #459)
+**Related:** `ExportAccountData` (AuthSystem), `ExportMyContributionData` (TranslationSystem),
+`AccountEndpointsExtensions` (Frontend, LEGAL-02), ADR-0031 (deletion needs no cross-context
+call), TKS ADR-0003 (service-to-service token pipeline — deliberately NOT lifted), tickets
+#456, #459
+
+## Context
+
+`GET auth/account/data-export` returns **auth data only**. While the account exists, the
+TranslationSystem holds personal data linked to the same identity (GDPR Art. 15 covers all
+of it):
+
+- the **Translator profile** (ADR-0004): `DisplayName`, `Email`, `IdentityId`,
+  `ProvisionedAt` — direct PII stored in the TMS context;
+- the **contribution attribution**: `Translation.SubmittedById` / `ApprovedById` rows.
+  The reference is an opaque `TranslatorId`, but it is linkable to the person for as long
+  as the account exists, so "auth-only is enough" cannot be justified (after erasure the
+  attribution becomes non-attributable — that is ADR-0031's argument, and it holds only
+  post-deletion).
+
+So the export must cover the TMS leg. Two sanctioned shapes existed (ticket #456):
+
+1. **auth-api aggregates (the TheKittySaver original).** TKS's `ExportAccountData` calls
+   the sibling context over a back-channel HTTP client authenticated with a
+   client-credentials **service token** (TKS ADR-0003: `AuthTokenClient`,
+   `AuthTokenDelegatingHandler`, `OnBehalfOf` header, `RequireServiceScope` policy).
+   LotroKoniecDev never lifted that pipeline — auth-api has **no** HTTP client to tms-api
+   today. Lifting it for this one GET means: the token client + delegating handler +
+   resilience pipeline, a `TranslationSystem BaseUrl` setting for auth-api in **every**
+   environment (dev hosts, prod-parity compose, staging, prod → terraform + runbook +
+   `.env` matrix churn), and a brand-new auth→tms coupling direction.
+2. **The frontend composes.** The user-facing export is already the frontend download
+   route (`/account/export`, LEGAL-02) — a server-side route that holds the caller's
+   access token and already talks to **both** APIs through typed clients. tms-api only
+   needs a plain **self-only** endpoint (identity from the caller's own bearer token via
+   `ICurrentUserAccessor`); the download route fetches both legs and merges them into the
+   exported JSON file.
+
+## Decision
+
+**Shape 2 — frontend composition.** tms-api ships
+`GET /api/v1/translators/me/data-export` (authorized, self-only, read models only); the
+frontend download route calls it with the user's own token and composes the file:
+
+- Auth leg fails → the export fails (unchanged — without auth data there is no export).
+- **TMS leg fails → the export still succeeds** with `translationData: null` and
+  `isComplete: false` (the acceptance criterion; NB the TKS original returns 503 here —
+  we deviate deliberately, a degraded export beats no export).
+- The TMS payload is a **contribution summary + row identifiers**, not full row bodies:
+  the Translator profile, per-status counts, and the `(TranslationId, FileId, GossipId,
+  Status)` identifier list per role (submitted / approved). Source/translated texts are
+  the catalog's content, not the user's personal data; identifiers prove exactly what is
+  attributed. First/last activity timestamps are **not** claimed — without
+  `TranslationHistory` (post-MVP) row timestamps do not reliably reflect *this user's*
+  activity, and a GDPR document must not guess.
+
+Rationale for the locus: YAGNI (house rule) — the service-token pipeline is real
+infrastructure with per-environment configuration for a hypothetical direct-API consumer
+that does not exist (no real users; the frontend is the only client). ADR-0031 set the
+precedent that cross-context back-channels are avoided until a real need appears. The
+seeded `lotrokoniecdev-api` client-credentials client and tms-api's `RequireServiceScope`
+policy stay dormant (they arrived with the auth-module lift) — if a future feature needs
+a genuine server-to-server call, lift TKS ADR-0003 then, via a new ADR.
+
+## Consequences
+
+- **`GET auth/account/data-export` alone stays auth-only.** The complete Art. 15 export
+  is the frontend download — which is the only export surface the product exposes to
+  users (LEGAL-02's "Moje konto" page). Acceptable while the frontend is the sole API
+  consumer; revisit if a public API programme ever ships.
+- The downloaded file's envelope changes from the raw auth response to a composed
+  `{ authData, translationData, isComplete }` document (HATEOAS links dropped — they were
+  transport metadata, not personal data). No back-compat concern: pre-launch, exports are
+  point-in-time documents.
+- tms-api gains one authorized read-only endpoint; no schema change, no new env vars, no
+  deployment changes.
+- A TMS outage degrades the export (`isComplete: false`) instead of failing it; the user
+  can retry later for a complete document.

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountDataExportFile.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountDataExportFile.cs
@@ -1,0 +1,16 @@
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.TranslationSystem.Contracts.Translators;
+
+namespace LotroKoniecDev.Frontend.Components.Pages.Account;
+
+/// <summary>
+/// The composed GDPR export document the download route serves (LEGAL-07, ADR-0032): the auth leg
+/// plus the TMS contribution leg, fetched with the caller's own token. <see cref="IsComplete"/> is
+/// <c>false</c> when the TMS leg could not be fetched — the export still succeeds with
+/// <see cref="TranslationData"/> <c>null</c>, because a degraded export beats no export; the auth
+/// leg failing fails the download instead (there is no export without the account data).
+/// </summary>
+internal sealed record AccountDataExportFile(
+    AuthDataExportDto AuthData,
+    TranslatorDataExportResponse? TranslationData,
+    bool IsComplete);

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
@@ -1,7 +1,10 @@
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Translators;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LotroKoniecDev.Frontend.Components.Pages.Account;
@@ -11,17 +14,23 @@ namespace LotroKoniecDev.Frontend.Components.Pages.Account;
 /// lands as a JSON <em>file</em> in the browser — a Blazor SSR page cannot return a file result, so
 /// this server route fetches the export envelope through the same loader seam the page uses and
 /// re-serves it with a <c>Content-Disposition</c> attachment header. Authorized like the upstream
-/// auth endpoint; the bearer of the caller's session flows through the typed client.
+/// auth endpoint; the bearer of the caller's session flows through the typed clients. The route
+/// composes the full Art. 15 document (ADR-0032): the auth leg plus the TMS contribution leg —
+/// a TMS failure degrades the file (<c>isComplete: false</c>) instead of failing the download.
 /// </summary>
 internal static class AccountEndpointsExtensions
 {
     /// <summary>The download URL — linked from the account page's export action.</summary>
     internal const string ExportDownloadPath = "/account/export";
 
+    /// <summary>The TMS leg — the caller's contribution export (self-only; LEGAL-07).</summary>
+    internal const string ContributionExportApiPath = "/api/v1/translators/me/data-export";
+
     private static readonly JsonSerializerOptions ExportSerializerOptions = new()
     {
         WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
     };
 
     extension(IEndpointRouteBuilder endpoints)
@@ -38,10 +47,12 @@ internal static class AccountEndpointsExtensions
     /// <summary>
     /// The download route's request delegate, exposed internally so it can be unit-tested without a
     /// web host: it returns a file result with the indented camelCase JSON dump on success, or a
-    /// problem result (the upstream's, or a 502 fallback) on failure.
+    /// problem result (the upstream's, or a 502 fallback) on failure. Only the auth leg can fail the
+    /// download; the TMS leg degrades to <c>translationData: null</c> + <c>isComplete: false</c>.
     /// </summary>
     internal static async Task<IResult> DownloadAccountExportAsync(
         AccountLoader loader,
+        ITranslationSystemClient translationSystemClient,
         CancellationToken cancellationToken)
     {
         ApiResult<AccountDataExportResponse> result = await loader.LoadExportAsync(cancellationToken);
@@ -55,7 +66,31 @@ internal static class AccountEndpointsExtensions
             });
         }
 
-        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(result.Value, ExportSerializerOptions);
+        TranslatorDataExportResponse? translationData = null;
+        try
+        {
+            ApiResult<TranslatorDataExportResponse> contributionResult =
+                await translationSystemClient.GetApiResultAsync<TranslatorDataExportResponse>(
+                    ContributionExportApiPath,
+                    cancellationToken);
+
+            if (contributionResult.IsSuccess)
+            {
+                translationData = contributionResult.Value;
+            }
+        }
+        catch (JsonException)
+        {
+            // A 200 whose body doesn't parse is still a failed TMS leg — degrade, don't fail
+            // the download (ADR-0032). The null-check above likewise covers a 200 empty body.
+        }
+
+        AccountDataExportFile exportFile = new(
+            result.Value.AuthData,
+            translationData,
+            IsComplete: translationData is not null && result.Value.IsComplete);
+
+        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(exportFile, ExportSerializerOptions);
         string fileName = string.Format(
             CultureInfo.InvariantCulture,
             "lotro-translator-moje-dane-{0:yyyyMMdd-HHmmss}.json",

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/ApiDependencyInjection.cs
@@ -23,6 +23,7 @@ using LotroKoniecDev.TranslationSystem.API.Features.Import;
 using LotroKoniecDev.TranslationSystem.API.Features.Progress;
 using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
 using LotroKoniecDev.TranslationSystem.API.Features.Translations;
+using LotroKoniecDev.TranslationSystem.API.Features.Translators;
 using LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
 using LotroKoniecDev.TranslationSystem.API.Hateoas.GameVersionAggregateFactories;
 using LotroKoniecDev.TranslationSystem.API.Hateoas.PaginationLinkFactories;
@@ -33,6 +34,7 @@ using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
 using LotroKoniecDev.TranslationSystem.Contracts.Import;
 using LotroKoniecDev.TranslationSystem.Contracts.Progress;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+using LotroKoniecDev.TranslationSystem.Contracts.Translators;
 
 namespace LotroKoniecDev.TranslationSystem.API;
 
@@ -87,6 +89,7 @@ internal static class ApiDependencyInjection
             services.AddImportFeature();
             services.AddProgressFeature();
             services.AddTranslationsFeature();
+            services.AddTranslatorsFeature();
             services.AddTranslationFilesFeature();
             services.AddGameVersionsFeature();
 
@@ -148,6 +151,13 @@ internal static class ApiDependencyInjection
             services.AddScoped<
                 ICommandHandler<BulkApproveTranslations.Command, Result<BulkApproveTranslationsResponse>>,
                 BulkApproveTranslations.Handler>();
+        }
+
+        private void AddTranslatorsFeature()
+        {
+            services.AddScoped<
+                IQueryHandler<ExportMyContributionData.Query, Result<TranslatorDataExportResponse>>,
+                ExportMyContributionData.Handler>();
         }
 
         private void AddTranslationFilesFeature()

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/EventIds.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/EventIds.cs
@@ -23,4 +23,8 @@ internal static class EventIds
     // Background workers (1400–1499)
     public const int TranslationFileRebuildCompleted = 1400;
     public const int TranslationFileRebuildFailed = 1401;
+
+    // GDPR (1500–1599)
+    public const int GdprContributionExportRequested = 1500;
+    public const int GdprContributionExportCompleted = 1501;
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translators/ExportMyContributionData.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translators/ExportMyContributionData.cs
@@ -1,0 +1,137 @@
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.API.Auth;
+using LotroKoniecDev.TranslationSystem.API.Auth.CurrentUserAccessing;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Extensions;
+using LotroKoniecDev.TranslationSystem.Contracts.Translators;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslatorAggregate;
+using Microsoft.EntityFrameworkCore;
+
+namespace LotroKoniecDev.TranslationSystem.API.Features.Translators;
+
+/// <summary>
+/// The TMS leg of the GDPR Art. 15 data export (LEGAL-07, ADR-0032): the caller's translator
+/// profile plus the attribution of every translation row they submitted or approved — identifiers
+/// and per-status counts, never the texts. Strictly self-only: the identity comes from the
+/// caller's own bearer token, no role required (GDPR self-access must not depend on being a
+/// translator today). Soft-removed rows stay included — the attribution is the caller's personal
+/// data regardless of whether the row still ships in the game catalog. The frontend download
+/// route composes this response into the exported file next to the auth leg.
+/// </summary>
+internal sealed partial class ExportMyContributionData : IEndpoint
+{
+    internal sealed record Query(IdentityId IdentityId) : IQuery<Result<TranslatorDataExportResponse>>;
+
+    internal sealed partial class Handler : IQueryHandler<Query, Result<TranslatorDataExportResponse>>
+    {
+        private static readonly ContributionSummaryDto EmptySummary = new(
+            SubmittedTotal: 0,
+            SubmittedDraft: 0,
+            SubmittedApproved: 0,
+            SubmittedNeedsReview: 0,
+            ApprovedTotal: 0,
+            SubmittedRows: [],
+            ApprovedRows: []);
+
+        private readonly IApplicationReadDbContext _readDbContext;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(IApplicationReadDbContext readDbContext, ILogger<Handler> logger)
+        {
+            _readDbContext = readDbContext;
+            _logger = logger;
+        }
+
+        public async ValueTask<Result<TranslatorDataExportResponse>> Handle(
+            Query query, CancellationToken cancellationToken)
+        {
+            LogGdprContributionExportRequested(_logger, query.IdentityId.Value);
+
+            TranslatorReadModel? translator = await _readDbContext.Translators
+                .FirstOrDefaultAsync(t => t.IdentityId == query.IdentityId, cancellationToken);
+
+            // The eager provisioning middleware (ADR-0004 amendment) normally creates the profile
+            // before this handler runs, so this branch fires only when that best-effort provisioning
+            // was skipped (e.g. a token whose claims can't produce a DisplayName). No profile means
+            // no attributed rows either, since attribution stamps a TranslatorId.
+            if (translator is null)
+            {
+                return Result.Success(new TranslatorDataExportResponse(null, EmptySummary));
+            }
+
+            List<ContributionRowDto> submittedRows = await _readDbContext.Translations
+                .Where(t => t.SubmittedById == translator.Id)
+                .OrderBy(t => t.FileId)
+                .ThenBy(t => t.GossipId)
+                .Select(t => new ContributionRowDto(t.Id, t.FileId, t.GossipId, t.Status))
+                .ToListAsync(cancellationToken);
+
+            List<ContributionRowDto> approvedRows = await _readDbContext.Translations
+                .Where(t => t.ApprovedById == translator.Id)
+                .OrderBy(t => t.FileId)
+                .ThenBy(t => t.GossipId)
+                .Select(t => new ContributionRowDto(t.Id, t.FileId, t.GossipId, t.Status))
+                .ToListAsync(cancellationToken);
+
+            ContributionSummaryDto summary = new(
+                SubmittedTotal: submittedRows.Count,
+                SubmittedDraft: submittedRows.Count(row => row.Status is TranslationStatus.Draft),
+                SubmittedApproved: submittedRows.Count(row => row.Status is TranslationStatus.Approved),
+                SubmittedNeedsReview: submittedRows.Count(row => row.Status is TranslationStatus.NeedsReview),
+                ApprovedTotal: approvedRows.Count,
+                SubmittedRows: submittedRows,
+                ApprovedRows: approvedRows);
+
+            TranslatorProfileExportDto profile = new(
+                translator.Id,
+                translator.IdentityId,
+                translator.DisplayName,
+                translator.Email,
+                translator.ProvisionedAt);
+
+            LogGdprContributionExportCompleted(
+                _logger, query.IdentityId.Value, submittedRows.Count, approvedRows.Count);
+
+            return Result.Success(new TranslatorDataExportResponse(profile, summary));
+        }
+
+        [LoggerMessage(EventId = EventIds.GdprContributionExportRequested, Level = LogLevel.Information,
+            Message = "GDPR contribution export requested for identity {IdentityId}")]
+        private static partial void LogGdprContributionExportRequested(ILogger logger, Guid identityId);
+
+        [LoggerMessage(EventId = EventIds.GdprContributionExportCompleted, Level = LogLevel.Information,
+            Message = "GDPR contribution export completed for identity {IdentityId}: {SubmittedCount} submitted, {ApprovedCount} approved rows")]
+        private static partial void LogGdprContributionExportCompleted(
+            ILogger logger, Guid identityId, int submittedCount, int approvedCount);
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapGet("/api/v1/translators/me/data-export", async (
+                ICurrentUserAccessor currentUserAccessor,
+                IQueryHandler<Query, Result<TranslatorDataExportResponse>> handler,
+                CancellationToken cancellationToken) =>
+            {
+                ValueMaybe<IdentityId> maybeIdentityId = currentUserAccessor.MaybeIdentityId;
+                if (maybeIdentityId.HasNoValue)
+                {
+                    return Results.Unauthorized();
+                }
+
+                Result<TranslatorDataExportResponse> result =
+                    await handler.Handle(new Query(maybeIdentityId.Value), cancellationToken);
+
+                return result.IsSuccess
+                    ? Results.Ok(result.Value)
+                    : Results.Problem(result.Error.ToProblemDetails());
+            })
+            .WithName(nameof(ExportMyContributionData))
+            .WithTags("Translators")
+            .RequireAuthorization(AuthorizationPolicies.RequireAuthenticatedUser)
+            .Produces<TranslatorDataExportResponse>(StatusCodes.Status200OK);
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translators/TranslatorDataExportResponse.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Translators/TranslatorDataExportResponse.cs
@@ -1,0 +1,48 @@
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.Contracts.Translators;
+
+/// <summary>
+/// The caller's TMS-side personal data for the GDPR Art. 15 export (LEGAL-07, ADR-0032): the
+/// lazily provisioned translator profile (ADR-0004) plus the contribution attribution — a
+/// per-status summary and the identifiers of every row attributed to the caller, per role.
+/// Row identifiers only, never the texts: the catalog content is not the user's personal data,
+/// the attribution link is. <see cref="Profile"/> is <c>null</c> when no translator profile was
+/// ever provisioned for the identity — the contribution lists are then empty by construction.
+/// </summary>
+public sealed record TranslatorDataExportResponse(
+    TranslatorProfileExportDto? Profile,
+    ContributionSummaryDto Contributions);
+
+/// <summary>The translator profile as stored in the TMS context (ADR-0004).</summary>
+public sealed record TranslatorProfileExportDto(
+    TranslatorId TranslatorId,
+    IdentityId IdentityId,
+    string DisplayName,
+    string? Email,
+    DateTimeOffset ProvisionedAt);
+
+/// <summary>
+/// Per-status counts over the rows the caller submitted, the count of rows the caller approved,
+/// and the identifier list per attribution role. A submitted row is never
+/// <see cref="TranslationStatus.Untranslated"/> (submitting Polish is what moves it out), so the
+/// three counters partition <see cref="SubmittedTotal"/>.
+/// </summary>
+public sealed record ContributionSummaryDto(
+    int SubmittedTotal,
+    int SubmittedDraft,
+    int SubmittedApproved,
+    int SubmittedNeedsReview,
+    int ApprovedTotal,
+    IReadOnlyList<ContributionRowDto> SubmittedRows,
+    IReadOnlyList<ContributionRowDto> ApprovedRows);
+
+/// <summary>One attributed row: the identifiers that pin it in the catalog, plus its status.</summary>
+public sealed record ContributionRowDto(
+    TranslationId Id,
+    int FileId,
+    long GossipId,
+    TranslationStatus Status);

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
@@ -8,8 +8,14 @@ using LotroKoniecDev.Frontend.Components.Pages.Account;
 using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.AuthSystemHttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
 using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.Contracts.Translators;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
@@ -20,12 +26,14 @@ namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Account;
 
 /// <summary>
 /// Drives the GDPR export download route's request delegate directly (no web host): on success it must
-/// re-serve the auth export envelope as an indented camelCase JSON file attachment, and on failure it
-/// must surface the upstream problem (or the defensive 502 fallback).
+/// compose the auth leg with the TMS contribution leg (ADR-0032) into an indented camelCase JSON file
+/// attachment, on an auth-leg failure it must surface the upstream problem (or the defensive 502
+/// fallback), and on a TMS-leg failure it must still serve the file with <c>isComplete: false</c>.
 /// </summary>
 public sealed class AccountEndpointsExtensionsTests
 {
     private const string BaseUrl = "https://localhost:5003/";
+    private const string TmsBaseUrl = "https://localhost:5002/";
     private const string ExportHref = "auth/account/data-export";
 
     private static readonly JsonSerializerOptions ApiJsonOptions = new(JsonSerializerDefaults.Web)
@@ -40,7 +48,8 @@ public sealed class AccountEndpointsExtensionsTests
     {
         AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
 
-        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(loader, CancellationToken.None);
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         file.ContentType.ShouldBe("application/json");
@@ -49,17 +58,100 @@ public sealed class AccountEndpointsExtensionsTests
     }
 
     [Fact]
-    public async Task DownloadAccountExportAsync_OnSuccess_SerializesTheEnvelopeAsIndentedCamelCaseJson()
+    public async Task DownloadAccountExportAsync_OnSuccess_SerializesTheComposedDocumentAsIndentedCamelCaseJson()
     {
         AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
 
-        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(loader, CancellationToken.None);
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
         json.ShouldContain("\"username\": \"frodo\"");
         json.ShouldContain("\"email\": \"frodo@shire.me\"");
         json.ShouldContain("\"isComplete\": true");
+    }
+
+    [Fact]
+    public async Task DownloadAccountExportAsync_WhenTmsLegSucceeds_TheFileCarriesTheContributionData()
+    {
+        AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
+
+        FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
+        string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
+        json.ShouldContain("\"displayName\": \"Frodo Baggins\"");
+        json.ShouldContain("\"submittedTotal\": 2");
+        json.ShouldContain("\"approvedTotal\": 1");
+        json.ShouldContain("\"status\": \"Draft\"");
+    }
+
+    [Fact]
+    public async Task DownloadAccountExportAsync_WhenTmsLegFails_StillServesTheAuthDataWithIsCompleteFalse()
+    {
+        AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
+        ITranslationSystemClient tmsClient = CreateTmsClient(StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.ServiceUnavailable,
+            """{ "title": "Usługa chwilowo niedostępna", "status": 503 }"""));
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, tmsClient, CancellationToken.None);
+
+        FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
+        string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
+        json.ShouldContain("\"username\": \"frodo\"");
+        json.ShouldContain("\"translationData\": null");
+        json.ShouldContain("\"isComplete\": false");
+    }
+
+    [Fact]
+    public async Task DownloadAccountExportAsync_WhenTmsLegFails_TheFileNameStaysTheExportAttachment()
+    {
+        AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
+        ITranslationSystemClient tmsClient = CreateTmsClient(StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.InternalServerError,
+            """{ "title": "Błąd serwera", "status": 500 }"""));
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, tmsClient, CancellationToken.None);
+
+        FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
+        file.ContentType.ShouldBe("application/json");
+        file.FileDownloadName!.ShouldStartWith("lotro-translator-moje-dane-");
+    }
+
+    [Fact]
+    public async Task DownloadAccountExportAsync_WhenTmsReturnsAMalformedBody_StillServesTheFileWithIsCompleteFalse()
+    {
+        AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
+        ITranslationSystemClient tmsClient = CreateTmsClient(
+            StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "this is not json"));
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, tmsClient, CancellationToken.None);
+
+        FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
+        string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
+        json.ShouldContain("\"translationData\": null");
+        json.ShouldContain("\"isComplete\": false");
+    }
+
+    [Fact]
+    public async Task DownloadAccountExportAsync_WhenTmsReturnsAnEmptyBody_StillServesTheFileWithIsCompleteFalse()
+    {
+        AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
+        ITranslationSystemClient tmsClient = CreateTmsClient(
+            StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, string.Empty));
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, tmsClient, CancellationToken.None);
+
+        FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
+        string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
+        json.ShouldContain("\"translationData\": null");
+        json.ShouldContain("\"isComplete\": false");
     }
 
     [Fact]
@@ -72,7 +164,8 @@ public sealed class AccountEndpointsExtensionsTests
                 HttpStatusCode.NotFound,
                 """{ "title": "Nie znaleziono użytkownika", "status": 404 }""")));
 
-        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(loader, CancellationToken.None);
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
 
         ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
         problem.ProblemDetails.Status.ShouldBe(404);
@@ -91,7 +184,8 @@ public sealed class AccountEndpointsExtensionsTests
             _discoveryCache,
             CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}")));
 
-        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(loader, CancellationToken.None);
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
 
         ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
         problem.ProblemDetails.Status.ShouldBe(503);
@@ -124,5 +218,42 @@ public sealed class AccountEndpointsExtensionsTests
             BaseAddress = new Uri(BaseUrl)
         };
         return new AuthSystemClient(httpClient);
+    }
+
+    private static ITranslationSystemClient CreateTmsClientReturningContribution()
+        => CreateTmsClient(StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(CreateContribution(), ApiJsonOptions)));
+
+    private static ITranslationSystemClient CreateTmsClient(StubHttpMessageHandler handler)
+    {
+        HttpClient httpClient = new(handler)
+        {
+            BaseAddress = new Uri(TmsBaseUrl)
+        };
+        return new TranslationSystemClient(httpClient);
+    }
+
+    private static TranslatorDataExportResponse CreateContribution()
+    {
+        TranslatorId translatorId = TranslatorId.Create();
+        ContributionRowDto draftRow = new(TranslationId.Create(), 620756992, 1001, TranslationStatus.Draft);
+        ContributionRowDto approvedRow = new(TranslationId.Create(), 620756992, 1002, TranslationStatus.Approved);
+
+        return new TranslatorDataExportResponse(
+            new TranslatorProfileExportDto(
+                translatorId,
+                IdentityId.Create(),
+                "Frodo Baggins",
+                "frodo@shire.me",
+                new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero)),
+            new ContributionSummaryDto(
+                SubmittedTotal: 2,
+                SubmittedDraft: 1,
+                SubmittedApproved: 1,
+                SubmittedNeedsReview: 0,
+                ApprovedTotal: 1,
+                SubmittedRows: [draftRow, approvedRow],
+                ApprovedRows: [approvedRow]));
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translators/ExportMyContributionDataTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translators/ExportMyContributionDataTests.cs
@@ -1,0 +1,207 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.Contracts.Translators;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translators;
+
+[Collection("TranslationApi")]
+public sealed class ExportMyContributionDataTests : IAsyncLifetime
+{
+    private const string ExportPath = "/api/v1/translators/me/data-export";
+    private const int FileId = 620756992;
+    private const string CallerDisplayName = "Frodo Baggins";
+    private const string CallerEmail = "frodo@shire.me";
+    private static readonly DateTimeOffset Now = new(2026, 7, 12, 0, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+    private Guid _callerIdentity;
+    private TranslatorId _callerId;
+    private TranslatorId _otherId;
+
+    public ExportMyContributionDataTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"Translators\" CASCADE;");
+
+        _callerIdentity = Guid.NewGuid();
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+
+        Translator caller = Translator.Create(
+            IdentityId.FromValue(_callerIdentity),
+            DisplayName.Create(CallerDisplayName).Value,
+            Email.Create(CallerEmail).Value,
+            Now).Value;
+        Translator other = Translator.Create(
+            IdentityId.Create(), DisplayName.Create("Samwise Gamgee").Value, email: null, Now).Value;
+        dbContext.Translators.AddRange(caller, other);
+
+        await dbContext.SaveChangesAsync();
+        _versionId = gameVersion.Id;
+        _callerId = caller.Id;
+        _otherId = other.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Export_WithoutToken_ShouldReturn401()
+    {
+        // Act
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync(ExportPath);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Export_WithNoContributions_ShouldReturnTheProfileWithAnEmptySummary()
+    {
+        // Act
+        TranslatorDataExportResponse export = await ExportAsync();
+
+        // Assert — the seeded profile is returned; nothing is attributed yet.
+        export.Profile.ShouldNotBeNull();
+        export.Profile.TranslatorId.ShouldBe(_callerId);
+        export.Profile.IdentityId.Value.ShouldBe(_callerIdentity);
+        export.Profile.DisplayName.ShouldBe(CallerDisplayName);
+        export.Profile.Email.ShouldBe(CallerEmail);
+        export.Contributions.SubmittedTotal.ShouldBe(0);
+        export.Contributions.ApprovedTotal.ShouldBe(0);
+        export.Contributions.SubmittedRows.ShouldBeEmpty();
+        export.Contributions.ApprovedRows.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Export_ShouldSummarizeAndListOnlyTheCallersAttribution()
+    {
+        // Arrange — caller submitted a draft (1001) and an approved row (1002), approved another
+        // translator's row (1003); rows 1004/1005 belong entirely to the other translator.
+        await SeedAsync(
+            SubmittedRow(1001, _callerId),
+            ApprovedRow(1002, submittedBy: _callerId, approvedBy: _otherId),
+            ApprovedRow(1003, submittedBy: _otherId, approvedBy: _callerId),
+            SubmittedRow(1004, _otherId),
+            ApprovedRow(1005, submittedBy: _otherId, approvedBy: _otherId));
+
+        // Act
+        TranslatorDataExportResponse export = await ExportAsync();
+
+        // Assert
+        export.Contributions.SubmittedTotal.ShouldBe(2);
+        export.Contributions.SubmittedDraft.ShouldBe(1);
+        export.Contributions.SubmittedApproved.ShouldBe(1);
+        export.Contributions.SubmittedNeedsReview.ShouldBe(0);
+        export.Contributions.ApprovedTotal.ShouldBe(1);
+        export.Contributions.SubmittedRows.Select(row => row.GossipId).ShouldBe([1001L, 1002L]);
+        export.Contributions.ApprovedRows.Select(row => row.GossipId).ShouldBe([1003L]);
+        export.Contributions.SubmittedRows.ShouldAllBe(row => row.FileId == FileId);
+    }
+
+    [Fact]
+    public async Task Export_ShouldCountAnInvalidatedSubmissionAsNeedsReview()
+    {
+        // Arrange — a game update reworded the source under the caller's translation.
+        Translation invalidated = SubmittedRow(1001, _callerId);
+        invalidated.ApplySourceChange(
+            TranslationSource.Create("Reworded source", null, null).Value, _versionId, Now);
+        await SeedAsync(invalidated);
+
+        // Act
+        TranslatorDataExportResponse export = await ExportAsync();
+
+        // Assert
+        export.Contributions.SubmittedTotal.ShouldBe(1);
+        export.Contributions.SubmittedNeedsReview.ShouldBe(1);
+        export.Contributions.SubmittedRows.Single().Status.ShouldBe(TranslationStatus.NeedsReview);
+    }
+
+    [Fact]
+    public async Task Export_ShouldIncludeSoftRemovedRows()
+    {
+        // Arrange — the attribution stays the caller's personal data even after the row left the
+        // game catalog (ADR-0032).
+        Translation removed = SubmittedRow(1001, _callerId);
+        removed.MarkRemoved(_versionId, Now);
+        await SeedAsync(removed);
+
+        // Act
+        TranslatorDataExportResponse export = await ExportAsync();
+
+        // Assert
+        export.Contributions.SubmittedTotal.ShouldBe(1);
+        export.Contributions.SubmittedRows.Single().GossipId.ShouldBe(1001L);
+    }
+
+    private async Task<TranslatorDataExportResponse> ExportAsync()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            TranslationSystemApiFactory.CreateAccessToken(
+                AuthConstants.Roles.Translator,
+                subject: _callerIdentity,
+                displayName: CallerDisplayName,
+                email: CallerEmail));
+
+        HttpResponseMessage response = await client.GetAsync(ExportPath);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        return (await response.Content.ReadFromJsonAsync<TranslatorDataExportResponse>(JsonOptions))!;
+    }
+
+    private async Task SeedAsync(params Translation[] rows)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+        dbContext.Translations.AddRange(rows);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private Translation SubmittedRow(int gossipId, TranslatorId submittedBy)
+    {
+        Translation row = CreateUntranslatedRow(gossipId);
+        row.ProvideTranslation("Polski tekst", submittedBy, Now);
+        return row;
+    }
+
+    private Translation ApprovedRow(int gossipId, TranslatorId submittedBy, TranslatorId approvedBy)
+    {
+        Translation row = CreateUntranslatedRow(gossipId);
+        row.ProvideTranslation("Polski tekst", submittedBy, Now);
+        row.Approve(approvedBy, Now);
+        return row;
+    }
+
+    private Translation CreateUntranslatedRow(int gossipId)
+        => Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create("Source text", null, null).Value,
+            _versionId,
+            Now).Value;
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/FakeReadDbContext.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Shared/FakeReadDbContext.cs
@@ -12,21 +12,25 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Shared;
 
 /// <summary>
 /// A pure in-memory <see cref="IApplicationReadDbContext"/> double for unit-testing read-side
-/// handlers: <see cref="Translations"/> is always populated, <see cref="GameVersions"/> optionally
-/// (the public progress snapshot reads both). EF Core's async operators run via
+/// handlers: <see cref="Translations"/> is always populated, <see cref="GameVersions"/> and
+/// <see cref="Translators"/> optionally (the public progress snapshot reads the former, the GDPR
+/// contribution export reads the latter). EF Core's async operators run via
 /// <see cref="TestAsyncQueryProvider{T}"/>.
 /// </summary>
 internal sealed class FakeReadDbContext : IApplicationReadDbContext
 {
     private readonly List<TranslationReadModel> _translations;
     private readonly List<GameVersionReadModel> _gameVersions;
+    private readonly List<TranslatorReadModel> _translators;
 
     public FakeReadDbContext(
         IEnumerable<TranslationReadModel> translations,
-        IEnumerable<GameVersionReadModel>? gameVersions = null)
+        IEnumerable<GameVersionReadModel>? gameVersions = null,
+        IEnumerable<TranslatorReadModel>? translators = null)
     {
         _translations = [.. translations];
         _gameVersions = [.. gameVersions ?? []];
+        _translators = [.. translators ?? []];
     }
 
     public DbSet<GameVersionReadModel> GameVersions => BuildSet(_gameVersions);
@@ -35,7 +39,7 @@ internal sealed class FakeReadDbContext : IApplicationReadDbContext
 
     public DbSet<PrecomputedTranslationFileReadModel> PrecomputedTranslationFiles => BuildSet(new List<PrecomputedTranslationFileReadModel>());
 
-    public DbSet<TranslatorReadModel> Translators => BuildSet(new List<TranslatorReadModel>());
+    public DbSet<TranslatorReadModel> Translators => BuildSet(_translators);
 
     private static DbSet<T> BuildSet<T>(List<T> source) where T : class
     {

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translators/ExportMyContributionDataHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translators/ExportMyContributionDataHandlerTests.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.API.Features.Translators;
+using LotroKoniecDev.TranslationSystem.API.Tests.Unit.Shared;
+using LotroKoniecDev.TranslationSystem.Contracts.Translators;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslatorAggregate;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Translators;
+
+public sealed class ExportMyContributionDataHandlerTests
+{
+    private const int FileId = 620756992;
+    private static readonly DateTimeOffset Now = new(2026, 7, 12, 0, 0, 0, TimeSpan.Zero);
+    private static readonly GameVersionId VersionId = GameVersionId.Create();
+
+    private readonly List<TranslationReadModel> _translations = [];
+    private readonly List<TranslatorReadModel> _translators = [];
+
+    [Fact]
+    public async Task Handle_WhenNoTranslatorProfileExists_ShouldReturnNullProfileWithAnEmptySummary()
+    {
+        // Arrange — the eager provisioning middleware is best-effort, so an identity can reach the
+        // handler without a profile; the export must still succeed with a defined empty document.
+        IdentityId unknownIdentity = IdentityId.Create();
+
+        // Act
+        TranslatorDataExportResponse export = await HandleAsync(unknownIdentity);
+
+        // Assert
+        export.Profile.ShouldBeNull();
+        export.Contributions.SubmittedTotal.ShouldBe(0);
+        export.Contributions.SubmittedDraft.ShouldBe(0);
+        export.Contributions.SubmittedApproved.ShouldBe(0);
+        export.Contributions.SubmittedNeedsReview.ShouldBe(0);
+        export.Contributions.ApprovedTotal.ShouldBe(0);
+        export.Contributions.SubmittedRows.ShouldBeEmpty();
+        export.Contributions.ApprovedRows.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithAttributedRows_ShouldSummarizeOnlyTheCallersAttribution()
+    {
+        // Arrange — caller submitted a draft, an approved and a needs-review row and approved one
+        // foreign row; the other translator's own rows must not leak into the caller's export.
+        IdentityId callerIdentity = IdentityId.Create();
+        TranslatorId callerId = GivenTranslator(callerIdentity, "Frodo Baggins", "frodo@shire.me");
+        TranslatorId otherId = GivenTranslator(IdentityId.Create(), "Samwise Gamgee", email: null);
+        GivenRow(1001, TranslationStatus.Draft, submittedBy: callerId);
+        GivenRow(1002, TranslationStatus.Approved, submittedBy: callerId, approvedBy: otherId);
+        GivenRow(1003, TranslationStatus.NeedsReview, submittedBy: callerId);
+        GivenRow(1004, TranslationStatus.Approved, submittedBy: otherId, approvedBy: callerId);
+        GivenRow(1005, TranslationStatus.Approved, submittedBy: otherId, approvedBy: otherId);
+
+        // Act
+        TranslatorDataExportResponse export = await HandleAsync(callerIdentity);
+
+        // Assert
+        export.Profile.ShouldNotBeNull();
+        export.Profile.TranslatorId.ShouldBe(callerId);
+        export.Profile.IdentityId.ShouldBe(callerIdentity);
+        export.Profile.DisplayName.ShouldBe("Frodo Baggins");
+        export.Profile.Email.ShouldBe("frodo@shire.me");
+        export.Contributions.SubmittedTotal.ShouldBe(3);
+        export.Contributions.SubmittedDraft.ShouldBe(1);
+        export.Contributions.SubmittedApproved.ShouldBe(1);
+        export.Contributions.SubmittedNeedsReview.ShouldBe(1);
+        export.Contributions.ApprovedTotal.ShouldBe(1);
+        export.Contributions.SubmittedRows.Select(row => row.GossipId).ShouldBe([1001L, 1002L, 1003L]);
+        export.Contributions.ApprovedRows.Select(row => row.GossipId).ShouldBe([1004L]);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldOrderRowsByFileIdThenGossipId()
+    {
+        // Arrange — rows land unsorted across two files; the export must order them for a stable,
+        // diffable document.
+        IdentityId callerIdentity = IdentityId.Create();
+        TranslatorId callerId = GivenTranslator(callerIdentity, "Frodo Baggins", "frodo@shire.me");
+        GivenRow(2000, TranslationStatus.Draft, submittedBy: callerId, fileId: FileId + 1);
+        GivenRow(1002, TranslationStatus.Draft, submittedBy: callerId);
+        GivenRow(1001, TranslationStatus.Draft, submittedBy: callerId);
+
+        // Act
+        TranslatorDataExportResponse export = await HandleAsync(callerIdentity);
+
+        // Assert
+        export.Contributions.SubmittedRows
+            .Select(row => (row.FileId, row.GossipId))
+            .ShouldBe([(FileId, 1001L), (FileId, 1002L), (FileId + 1, 2000L)]);
+    }
+
+    private async Task<TranslatorDataExportResponse> HandleAsync(IdentityId identityId)
+    {
+        ExportMyContributionData.Handler handler = new(
+            new FakeReadDbContext(_translations, translators: _translators),
+            NullLogger<ExportMyContributionData.Handler>.Instance);
+
+        Result<TranslatorDataExportResponse> result =
+            await handler.Handle(new ExportMyContributionData.Query(identityId), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        return result.Value;
+    }
+
+    private TranslatorId GivenTranslator(IdentityId identityId, string displayName, string? email)
+    {
+        TranslatorReadModel translator = new(TranslatorId.Create(), identityId, displayName, email, Now);
+        _translators.Add(translator);
+        return translator.Id;
+    }
+
+    private void GivenRow(
+        int gossipId,
+        TranslationStatus status,
+        TranslatorId submittedBy,
+        TranslatorId? approvedBy = null,
+        int fileId = FileId)
+        => _translations.Add(new TranslationReadModel(
+            TranslationId.Create(),
+            fileId,
+            gossipId,
+            $"source-{gossipId}",
+            null,
+            null,
+            "Polski tekst",
+            null,
+            submittedBy,
+            approvedBy,
+            status,
+            VersionId,
+            null,
+            null,
+            Now,
+            Now));
+}


### PR DESCRIPTION
Closes #456. Part of the legal & GDPR compliance pack (epic #459).

## What

The GDPR Art. 15 export now covers the user's TMS-side personal data. Decision recorded in **ADR-0032**: the frontend download route composes the export with the caller's own token — no auth→tms service back-channel is lifted (YAGNI; ADR-0031 precedent).

- **tms-api**: new self-only `GET /api/v1/translators/me/data-export` — translator profile (DisplayName/Email/IdentityId/ProvisionedAt) + contribution summary (per-status counts) + row identifiers per role (submitted/approved), soft-removed rows included. Identity comes exclusively from the token's `sub` claim; reads read models only.
- **frontend**: `/account/export` serves the composed `{ authData, translationData, isComplete }` document. Any TMS-leg failure (HTTP error, transport failure, malformed/empty 200 body) degrades the file to `translationData: null` + `isComplete: false` — the download itself still succeeds. An auth-leg failure still fails the download.

## Acceptance criteria

- **Export covers TMS contribution attribution** — met (endpoint + composition + ADR-0032 records the shape).
- **TMS-side failure yields `IsComplete = false`, not a failed export** — met; unit-tested for 5xx, transport, malformed body and empty body.

## Tests

- tms-api: 5 integration tests against real PostgreSQL (401, empty summary, cross-user isolation, NeedsReview bucket, soft-removed rows) + 3 handler unit tests (incl. the no-profile branch).
- frontend: download-route unit tests extended to 9 (composition, both failure legs, malformed/empty TMS body).
- auth-api unchanged — its existing export integration tests still cover the auth leg.
- `dotnet build` green with zero warnings; code-reviewer gate run at xhigh, all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)