### PR TITLE
LEGAL-09: MIT LICENSE + THIRD-PARTY-NOTICES + README legal section fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+NOTE: This license covers the original code of this repository only. It does
+NOT cover bundled third-party binaries (notably datexport.dll) or any game
+content of The Lord of the Rings Online. See THIRD-PARTY-NOTICES.md for what
+the MIT License does not cover.
+
+MIT License
+
+Copyright (c) 2026 Artur Koniec
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,11 @@ milestones: GitHub issues (`M{milestone}-{nn}` titles).
 
 ## License & disclaimer
 
-Open-source fan project © Artur Koniec. *The Lord of the Rings Online* and all related names and
-content are trademarks of **Standing Stone Games**; this is an unofficial, non-commercial fan tool,
-not affiliated with or endorsed by SSG or Middle-earth Enterprises.
+The code of this project is licensed under the [MIT License](LICENSE) © Artur Koniec. MIT covers
+**our code only** — bundled third-party binaries (notably `datexport.dll`) and any game content are
+**not** covered; see [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) for details.
+
+This is an unofficial, non-commercial fan project, not affiliated with or endorsed by Standing
+Stone Games or Middle-earth Enterprises. Standing Stone Games and its marks are trademarks of
+**Daybreak Game Company LLC**. *The Lord of the Rings Online* and the characters, items, events and
+places therein are trademarks of **Middle-earth Enterprises, LLC**, used under license.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,56 @@
+# Third-party notices
+
+The MIT License in [`LICENSE`](LICENSE) covers the original code of this repository only.
+The third-party components listed below are included in the repository and are **not**
+covered by that license. Nothing in this repository grants, claims, or implies any license
+to these components beyond what their respective rightsholders allow.
+
+## datexport.dll
+
+Path: `src/Patcher/LotroKoniecDev.Infrastructure/datexport.dll`
+
+A proprietary library originally by Turbine, Inc. (rights today associated with Standing
+Stone Games / *The Lord of the Rings Online*), circulating in community fan tooling since
+approximately 2011. It is included here **solely for interoperability** with the game's
+DAT file format — this project does not claim and cannot grant any license to it. It will
+be **removed promptly upon request from the rightsholder** (contact: koniecdev@gmail.com).
+
+## Microsoft Visual C++ runtime libraries
+
+Paths: `src/Patcher/LotroKoniecDev.Infrastructure/msvcp71.dll`, `msvcr71.dll`,
+`msvcp90.dll`, `msvcr80.dll`
+
+Microsoft Visual C++ redistributable runtime libraries, © Microsoft Corporation. Included
+because `datexport.dll` requires them at runtime; distributed under Microsoft's
+redistribution terms for the Visual C++ runtime.
+
+## zlib1T.dll
+
+Path: `src/Patcher/LotroKoniecDev.Infrastructure/zlib1T.dll`
+
+A build of the zlib compression library by Jean-loup Gailly and Mark Adler, required by
+`datexport.dll` at runtime. zlib is distributed under the zlib license:
+
+> This software is provided 'as-is', without any express or implied warranty. In no event
+> will the authors be held liable for any damages arising from the use of this software.
+>
+> Permission is granted to anyone to use this software for any purpose, including
+> commercial applications, and to alter it and redistribute it freely, subject to the
+> following restrictions:
+>
+> 1. The origin of this software must not be misrepresented; you must not claim that you
+>    wrote the original software. If you use this software in a product, an acknowledgment
+>    in the product documentation would be appreciated but is not required.
+> 2. Altered source versions must be plainly marked as such, and must not be
+>    misrepresented as being the original software.
+> 3. This notice may not be removed or altered from any source distribution.
+
+## Game content and trademarks
+
+This repository and the lotro-translator.pl platform process text from *The Lord of the
+Rings Online* solely to enable the creation of a community Polish translation. No game
+content is licensed under the repository license. Standing Stone Games and its marks are
+trademarks of Daybreak Game Company LLC. *The Lord of the Rings Online* and the
+characters, items, events and places therein are trademarks of Middle-earth Enterprises,
+LLC, used under license. This is an unofficial, non-commercial fan project, not
+affiliated with or endorsed by Standing Stone Games or Middle-earth Enterprises.


### PR DESCRIPTION
Closes #475

## What

- **`LICENSE`** — MIT © Artur Koniec covering our code only, with a preamble note pointing to `THIRD-PARTY-NOTICES.md` for what MIT does NOT cover.
- **`THIRD-PARTY-NOTICES.md`** — `datexport.dll` (proprietary Turbine/SSG library circulating in fan tooling since ~2011, included solely for interoperability, not covered by the repo license, removed promptly on rightsholder request — no license claimed); `msvcp71/msvcr71/msvcp90/msvcr80.dll` (Microsoft Visual C++ redistributables); `zlib1T.dll` (zlib license, text included).
- **README "License & disclaimer"** — MIT for code + carve-outs + the official 2026 trademark ownership line (SSG marks — Daybreak Game Company LLC; *The Lord of the Rings Online* and the characters, items, events and places therein — Middle-earth Enterprises, LLC, used under license).

## Why

Exposures E1 + E4 in spec 0011 (Agreed): README claimed "open-source" with no LICENSE file (legally all-rights-reserved), and the repo redistributes `datexport.dll` with no notices. Owner decisions Q1/Q3: keep the DLL, MIT for our code, honest boundaries.

## Test

Docs-only change — no code touched, no build/test impact. Verified LICENSE, THIRD-PARTY-NOTICES.md and README are mutually consistent; the datexport.dll notice states provenance + interoperability purpose + removal-on-request and nothing more (spec rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)