### PR TITLE
LEGAL-10: Footer non-affiliation + trademark line on every page

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/MainLayout.razor
@@ -39,6 +39,7 @@
                 <a href="/regulamin">Regulamin</a>
                 <a href="@PrivacyPolicyUrl" target="_blank" rel="noopener">Polityka prywatności</a>
             </p>
+            <p class="foot-legal">Nieoficjalny, niekomercyjny projekt fanowski — niepowiązany ze Standing Stone Games ani Middle-earth Enterprises. The Lord of the Rings Online™ oraz nazwy postaci, przedmiotów, wydarzeń i miejsc są znakami towarowymi Middle-earth Enterprises, LLC.</p>
         </div>
     </footer>
 

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -1503,6 +1503,15 @@ code {
     color: var(--accent-hi);
 }
 
+/* .foot p wins on specificity (margin: 0), hence !important — same idiom as .foot-links */
+.foot-legal {
+    margin-top: 14px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    max-width: 720px;
+    line-height: 1.6;
+}
+
 /* ───────── Cookie consent bar ───────── */
 .cookie-bar {
     position: fixed;

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/MainLayoutTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/MainLayoutTests.cs
@@ -61,6 +61,18 @@ public sealed class MainLayoutTests : BunitContext
     }
 
     [Fact]
+    public void Render_Footer_ShowsTheNonAffiliationTrademarkLine()
+    {
+        IRenderedComponent<MainLayout> component = RenderMainLayout();
+
+        IElement legalLine = component.Find("footer .foot-legal");
+        legalLine.TextContent.ShouldBe(
+            "Nieoficjalny, niekomercyjny projekt fanowski — niepowiązany ze Standing Stone Games " +
+            "ani Middle-earth Enterprises. The Lord of the Rings Online™ oraz nazwy postaci, " +
+            "przedmiotów, wydarzeń i miejsc są znakami towarowymi Middle-earth Enterprises, LLC.");
+    }
+
+    [Fact]
     public void Render_Body_IsRenderedInsideMain()
     {
         IRenderedComponent<MainLayout> component = RenderMainLayout();


### PR DESCRIPTION
Closes #476

## What
Adds the non-affiliation/trademark sentence from spec 0011 (exposure E5) to the app footer in `MainLayout.razor`, under the existing legal links, so it renders on every frontend page.

## Why
The non-affiliation statement existed only inside the ToS (§1.2). Standard practice for fan projects is a visible trademark/non-affiliation line on every page.

## How
- `MainLayout.razor`: one `<p class="foot-legal">` with the exact sentence from the spec.
- `layout.css`: `.foot-legal` — inherits the footer's small muted mono style, adds a 720px readable measure (`!important` on margins matches the existing `.foot-links` idiom, since `.foot p { margin: 0 }` wins on specificity).
- `MainLayoutTests`: new bUnit test locking the line down.

## Tests
- `dotnet build` — 0 warnings.
- `scripts/check-ssr-purity.sh` — green (no new interactivity).
- Frontend unit suite 412/412 green (incl. the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)