### PR TITLE
LEGAL-11: ToS IP/takedown clause + named Operator (ToS §1.1, privacy policy §01)

### DIFF
--- a/docs/specs/0011-legal-risk-mitigation-pack.md
+++ b/docs/specs/0011-legal-risk-mitigation-pack.md
@@ -176,7 +176,7 @@ the public repo or platform hands a rightsholder an easy, high-value grievance.
       the official 2026 trademark ownership line.
 - [ ] Every frontend page renders the footer non-affiliation/trademark line (SSR-pure, no new
       interactivity; `check-ssr-purity` green).
-- [ ] ToS shows the new IP/takedown §, TOC updated, changelog date bumped.
+- [x] ToS shows the new IP/takedown §, TOC updated, changelog date bumped. (#477)
 - [ ] Home download CTA and CLI `patch`/`launch` output carry the agreed one-liner; CLI exit
       codes and all existing patcher tests unchanged.
 - [ ] `docs/legal/takedown-playbook.md` exists with the 48 h acknowledge flow + reply template.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
@@ -231,7 +231,7 @@
             <p>Niniejsza polityka opisuje, w jaki sposób serwis <strong>lotro-translator.pl</strong> przetwarza dane osobowe użytkowników zgodnie z Rozporządzeniem Parlamentu Europejskiego i Rady (UE) 2016/679 (RODO). Korzystając z serwisu, akceptujesz zasady opisane poniżej.</p>
 
             <h2><span class="sec-num">01</span> Administrator danych</h2>
-            <p>Administratorem Twoich danych osobowych jest społeczność <strong>lotro-translator.pl</strong> — niekomercyjny projekt polskiego tłumaczenia gry The Lord of the Rings Online. W sprawach dotyczących ochrony danych skontaktujesz się z nami pod adresem <a href="mailto:koniecdev@@gmail.com">koniecdev@@gmail.com</a>.</p>
+            <p>Administratorem Twoich danych osobowych jest <strong>Artur Koniec</strong>, prowadzący niekomercyjny projekt <strong>lotro-translator.pl</strong> — polskie tłumaczenie gry The Lord of the Rings Online. W sprawach dotyczących ochrony danych skontaktujesz się z nami pod adresem <a href="mailto:koniecdev@@gmail.com">koniecdev@@gmail.com</a>.</p>
 
             <h2><span class="sec-num">02</span> Zakres przetwarzanych danych</h2>
             <p>Przetwarzamy wyłącznie dane niezbędne do działania serwisu:</p>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Terms/Terms.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Terms/Terms.razor
@@ -39,9 +39,10 @@
                     <h2>§ 1. Postanowienia ogólne</h2>
                     <ol>
                         <li>
-                            Serwis lotro-translator.pl (dalej: <strong>Serwis</strong>) jest prowadzony przez
-                            społeczność lotro-translator.pl (dalej: <strong>Operator</strong>) — niekomercyjny,
-                            fanowski projekt polskiego tłumaczenia gry The Lord of the Rings Online.
+                            Operatorem serwisu lotro-translator.pl (dalej: <strong>Serwis</strong>) jest
+                            <strong>Artur Koniec</strong>, prowadzący niekomercyjny projekt lotro-translator.pl
+                            (dalej: <strong>Operator</strong>) — fanowski projekt polskiego tłumaczenia gry
+                            The Lord of the Rings Online.
                             Kontakt z Operatorem: <a href="mailto:koniecdev@gmail.com">koniecdev@gmail.com</a>.
                         </li>
                         <li>
@@ -213,8 +214,30 @@
                     </ol>
                 </section>
 
+                <section class="legal-sec" id="wlasnosc-intelektualna">
+                    <h2>§ 8. Własność intelektualna i zgłoszenia naruszeń</h2>
+                    <ol>
+                        <li>
+                            Operator respektuje prawa własności intelektualnej Standing Stone Games
+                            oraz Middle-earth Enterprises do Gry, jej treści i znaków towarowych.
+                        </li>
+                        <li>
+                            Angielskie teksty źródłowe Gry są przetwarzane w Serwisie wyłącznie w zakresie
+                            niezbędnym do stworzenia polskiego tłumaczenia i nie wchodzą w skład pliku
+                            spolszczenia. <strong>Plik spolszczenia zawiera wyłącznie polskie teksty
+                            stworzone przez społeczność</strong> — nigdy angielskie teksty źródłowe Gry.
+                        </li>
+                        <li>
+                            Uzasadnione żądania podmiotów uprawnionych z tytułu praw do Gry — w tym żądania
+                            usunięcia treści lub wstrzymania dystrybucji pliku spolszczenia — są realizowane
+                            niezwłocznie. Zgłoszenia naruszeń kieruj na adres
+                            <a href="mailto:koniecdev@gmail.com">koniecdev@gmail.com</a>.
+                        </li>
+                    </ol>
+                </section>
+
                 <section class="legal-sec" id="postanowienia-koncowe">
-                    <h2>§ 8. Postanowienia końcowe</h2>
+                    <h2>§ 9. Postanowienia końcowe</h2>
                     <ol>
                         <li>
                             Operator może zmienić regulamin z ważnych przyczyn, w szczególności przy zmianie
@@ -250,7 +273,8 @@
                         <a href="#licencja">§ 5. Licencja na wkład tłumaczeniowy</a>
                         <a href="#dane-osobowe">§ 6. Dane osobowe</a>
                         <a href="#odpowiedzialnosc">§ 7. Odpowiedzialność, reklamacje i kontakt</a>
-                        <a href="#postanowienia-koncowe">§ 8. Postanowienia końcowe</a>
+                        <a href="#wlasnosc-intelektualna">§ 8. Własność intelektualna i zgłoszenia naruszeń</a>
+                        <a href="#postanowienia-koncowe">§ 9. Postanowienia końcowe</a>
                     </nav>
                 </div>
             </div>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Terms/TermsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Terms/TermsTests.cs
@@ -71,12 +71,41 @@ public sealed class TermsTests : BunitContext
     }
 
     [Fact]
+    public void Render_GeneralSection_NamesTheOperator()
+    {
+        // UŚUDE art. 5 identification duty + the §5 contributor license grantee (LEGAL-11 / spec
+        // 0011 Q5): the Operator must be a named natural person, not the non-entity "społeczność".
+        IRenderedComponent<TermsComponent> component = Render<TermsComponent>();
+
+        IElement generalSection = component.Find("#postanowienia-ogolne");
+        generalSection.TextContent.ShouldContain("Artur Koniec");
+        generalSection.TextContent.ShouldContain("koniecdev@gmail.com");
+    }
+
+    [Fact]
+    public void Render_IpSection_StatesTakedownComplianceAndPolishOnlyPublishedFile()
+    {
+        // The "published file contains only community Polish text, never the English source"
+        // property is load-bearing (spec 0011 E6) — changing it is ADR-worthy, so a wording
+        // regression here must fail loudly.
+        IRenderedComponent<TermsComponent> component = Render<TermsComponent>();
+
+        IElement ipSection = component.Find("#wlasnosc-intelektualna");
+        ipSection.TextContent.ShouldContain("Standing Stone Games");
+        ipSection.TextContent.ShouldContain("Middle-earth Enterprises");
+        ipSection.TextContent.ShouldContain("wyłącznie polskie teksty");
+        ipSection.TextContent.ShouldContain("nigdy angielskie teksty źródłowe");
+        ipSection.TextContent.ShouldContain("niezwłocznie");
+        ipSection.TextContent.ShouldContain("koniecdev@gmail.com");
+    }
+
+    [Fact]
     public void Render_TableOfContents_LinksEverySection()
     {
         IRenderedComponent<TermsComponent> component = Render<TermsComponent>();
 
         IReadOnlyList<IElement> tocLinks = component.FindAll(".legal-toc a");
-        tocLinks.Count.ShouldBe(8);
+        tocLinks.Count.ShouldBe(9);
         foreach (IElement tocLink in tocLinks)
         {
             string anchor = tocLink.GetAttribute("href")!.TrimStart('#');


### PR DESCRIPTION
Closes #477

## What

- New ToS **§ 8 "Własność intelektualna i zgłoszenia naruszeń"** (before "Postanowienia końcowe", which becomes § 9; TOC updated): the Operator respects SSG/MEE IP; English source texts are processed solely to create the Polish translation and are not part of the published file; **the published file contains exclusively community-created Polish text — never the English source** (any future change to that property is ADR-worthy); justified rightsholder requests to koniecdev@gmail.com are honored promptly ("niezwłocznie", no public SLA).
- ToS **§ 1.1** and privacy policy **§ 01**: Operator / data controller is now **"Artur Koniec, prowadzący niekomercyjny projekt lotro-translator.pl"** + contact e-mail, no home address (spec 0011 Q5 decision, UŚUDE art. 5 + RODO art. 13(1)(a)).
- Last-updated date is already 12 lipca 2026 (today — LEGAL-03 landed today), so the dated changelog note is current; additive user/third-party-protective change ships immediately per § 8.2 (now § 9.2).
- Spec 0011 DoD box for LEGAL-11 ticked (spec stays Agreed — LEGAL-12/13 still open).

## Why

Exposures E6 + Q5 of spec 0011: the cooperative takedown posture was undocumented, and a "społeczność" has no legal personality — it failed the UŚUDE identification duty, weakened the RODO controller identification, and weakened the § 5 contributor license granted to a non-entity.

## Tests

- `TermsTests`: new guards `Render_GeneralSection_NamesTheOperator` and `Render_IpSection_StatesTakedownComplianceAndPolishOnlyPublishedFile`; TOC test bumped 8 → 9.
- Full solution build with zero warnings; Frontend unit suite 414/414 green; `check-ssr-purity.sh` green (content-only change, no interactivity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)