### PR TITLE
LEGAL-12: Player-facing risk note (Home download CTA + CLI patch/launch notice)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+NOTICE — lotro-translator.pl (LotroKoniecDev)
+
+EN:
+The Polish translation patch modifies game files — formally, the LOTRO terms
+of service do not provide for such modifications, though over more than a
+decade of analogous projects (the Russian and the Spanish one) no bans have
+been recorded for them. You use it at your own risk.
+
+PL:
+Spolszczenie modyfikuje pliki gry — formalnie regulamin LOTRO nie przewiduje
+takich modyfikacji, choć przez ponad dekadę działania analogicznych projektów
+(rosyjskiego i hiszpańskiego) nie odnotowano za nie banów. Korzystasz na
+własną odpowiedzialność.
+
+Terms of service / Regulamin: https://lotro-translator.pl/regulamin

--- a/docs/specs/0011-legal-risk-mitigation-pack.md
+++ b/docs/specs/0011-legal-risk-mitigation-pack.md
@@ -177,8 +177,8 @@ the public repo or platform hands a rightsholder an easy, high-value grievance.
 - [ ] Every frontend page renders the footer non-affiliation/trademark line (SSR-pure, no new
       interactivity; `check-ssr-purity` green).
 - [x] ToS shows the new IP/takedown §, TOC updated, changelog date bumped. (#477)
-- [ ] Home download CTA and CLI `patch`/`launch` output carry the agreed one-liner; CLI exit
-      codes and all existing patcher tests unchanged.
+- [x] Home download CTA and CLI `patch`/`launch` output carry the agreed one-liner; CLI exit
+      codes and all existing patcher tests unchanged. (#478)
 - [ ] `docs/legal/takedown-playbook.md` exists with the 48 h acknowledge flow + reply template.
 - [ ] Q2's conscious accept (public EN corpus stays anonymous) and Q4's no-outreach stance are
       recorded here and require no code change; nothing in this pack touches endpoint auth.

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home/Home.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home/Home.razor
@@ -141,6 +141,12 @@
                     </a>
                     <a class="btn btn-ghost" href="@RepositoryUrl" rel="noopener">Patcher na GitHubie</a>
                 </div>
+                <p class="risk-note">
+                    Spolszczenie modyfikuje pliki gry — formalnie regulamin LOTRO nie przewiduje
+                    takich modyfikacji, choć przez ponad dekadę działania analogicznych projektów
+                    (rosyjskiego i hiszpańskiego) nie odnotowano za nie banów. Korzystasz na własną
+                    odpowiedzialność. Szczegóły w <a href="/regulamin">regulaminie</a>.
+                </p>
             </div>
         </section>
 

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -794,6 +794,23 @@ code {
     font-size: 12.5px;
 }
 
+.risk-note {
+    margin: 14px 0 0;
+    color: var(--text-dim);
+    font-size: 12.5px;
+    line-height: 1.6;
+}
+
+.risk-note a {
+    color: var(--text-dim);
+    text-decoration: underline;
+    transition: color .15s;
+}
+
+.risk-note a:hover {
+    color: var(--accent-hi);
+}
+
 .home-tech {
     text-align: center;
     padding: 6px 0 2px;

--- a/src/Patcher/LotroKoniecDev.Cli/Commands/LaunchCommand.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/Commands/LaunchCommand.cs
@@ -57,6 +57,8 @@ internal sealed class LaunchCommand : AsyncCommand<LaunchCommand.Settings>
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings,
         CancellationToken cancellationToken)
     {
+        ConsoleWriter.WriteNotice(RiskNotice.Text);
+
         // Auto-download the current translation file before launch (spec 0001 Q5, freeze exception):
         // skipped when disabled or no TMS URL is configured. Never blocks launch on the network — an
         // offline server with a cached file proceeds; only "offline + nothing cached" aborts here.

--- a/src/Patcher/LotroKoniecDev.Cli/Commands/PatchCommand.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/Commands/PatchCommand.cs
@@ -56,6 +56,8 @@ internal sealed class PatchCommand : AsyncCommand<PatchCommand.Settings>
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings,
         CancellationToken cancellationToken)
     {
+        ConsoleWriter.WriteNotice(RiskNotice.Text);
+
         (string TranslationsPath, string DatFilePath)? actualResolvedPaths = ResolveCommandPaths(settings);
         if (actualResolvedPaths is null)
         {

--- a/src/Patcher/LotroKoniecDev.Cli/ConsoleWriter.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/ConsoleWriter.cs
@@ -1,9 +1,14 @@
+using Spectre.Console;
+
 namespace LotroKoniecDev.Cli;
 
 internal static class ConsoleWriter
 {
     public static void WriteInfo(string message) =>
         Console.WriteLine(message);
+
+    public static void WriteNotice(string message) =>
+        AnsiConsole.MarkupLine($"[dim]{Markup.Escape(message)}[/]");
 
     public static void WriteSuccess(string message)
     {

--- a/src/Patcher/LotroKoniecDev.Cli/LotroKoniecDev.Cli.csproj
+++ b/src/Patcher/LotroKoniecDev.Cli/LotroKoniecDev.Cli.csproj
@@ -27,4 +27,9 @@
         <ProjectReference Include="..\LotroKoniecDev.Infrastructure\LotroKoniecDev.Infrastructure.csproj" />
     </ItemGroup>
 
+    <!-- LEGAL-12 (spec 0011): the player-facing risk NOTICE ships next to the published exe -->
+    <ItemGroup>
+        <None Include="..\..\..\NOTICE" Link="NOTICE" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/src/Patcher/LotroKoniecDev.Cli/RiskNotice.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/RiskNotice.cs
@@ -1,0 +1,13 @@
+namespace LotroKoniecDev.Cli;
+
+/// <summary>
+/// Player-facing risk note (spec 0011 / LEGAL-12) printed by <c>patch</c> and <c>launch</c>.
+/// Informational only — never a prompt, never affects behavior or exit codes.
+/// </summary>
+internal static class RiskNotice
+{
+    public const string Text =
+        "Spolszczenie modyfikuje pliki gry — formalnie regulamin LOTRO nie przewiduje takich modyfikacji, " +
+        "choć przez ponad dekadę działania analogicznych projektów (rosyjskiego i hiszpańskiego) " +
+        "nie odnotowano za nie banów. Korzystasz na własną odpowiedzialność.";
+}


### PR DESCRIPTION
Closes #478

## What

- **Home download section**: the agreed one-sentence risk note renders under the download CTA in the "Dla graczy" panel, with a link to the ToS (`/regulamin`). Static markup only — SSR purity gate green.
- **CLI**: `patch` and `launch` print the same message once at command start as a one-line dimmed Spectre.Console notice (`ConsoleWriter.WriteNotice` + shared `RiskNotice.Text` const). No confirmation prompt, no behavior or exit-code change.
- **NOTICE file** (EN + PL + ToS link) added at the repo root and copied next to the published exe via `CopyToPublishDirectory` (verified with a real `dotnet publish`).
- Spec 0011 acceptance item ticked.

The M4 epic (#472) gets a comment that the Avalonia app must ship the same text in its About/first-run screen.

## Why

Spec 0011 exposure E7: players got no honest, calm information that the patch modifies game files. Wording is the agreed one — states the formal rule and the empirical record, never promises safety, no scare-words.

## Tests

- `dotnet build LotroKoniecDev.slnx` — zero warnings.
- `dotnet test tests/LotroKoniecDev.Tests.Unit` — 277 passed, assertions untouched.
- `dotnet test tests/LotroKoniecDev.Frontend.Tests.Unit` — 414 passed.
- `scripts/check-ssr-purity.sh` — green.
- `dotnet publish` of the CLI — `NOTICE` present in the publish output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)