### PR TITLE
HETZ-00: ADR-0034 — Hetzner VPS instead of Azure Container Apps

### DIFF
--- a/docs/adr/0034-hetzner-vps-instead-of-azure-container-apps.md
+++ b/docs/adr/0034-hetzner-vps-instead-of-azure-container-apps.md
@@ -1,0 +1,162 @@
+# ADR-0034: Single Hetzner VPS instead of Azure Container Apps
+
+**Status:** Accepted
+**Date:** 2026-07-12
+**Decision-makers:** Solo maintainer
+**Related:** deployment (all of `iac/`, `compose.prod.yaml`, CD workflows), epic #486 (HETZ-01..06:
+#487–#492), ADR-0008 (cloud deployment), ADR-0018 (staging), ADR-0023/0024 (migrations), ADR-0027
+(warm window — made obsolete), ADR-0029 (revision sweep — made obsolete)
+
+## Context
+
+On 2026-07-12 the Azure for Students subscription hosting BOTH projects (LotroKoniecDev and
+TheKittySaver, prod + staging each) was disabled: `ReadOnlyDisabledSubscription` on every CD
+write, both prods serving ACA's "Container App is stopped" 404. Cost Management shows EUR 51.36
+burned 1–12 July (~EUR 6/day until the ADR-0027 FinOps fixes landed 9 July, ~EUR 1.8/day after —
+a week too late). The portal refuses renewal ("You are not eligible to renew Azure for Students")
+and offers only Students Starter, which has no credit and no Container Apps. Even if a retry
+succeeds, the platform re-dies every year the verification fails.
+
+Code facts that constrain the choice:
+
+- **Nothing stateful lives on Azure.** DBs are Neon (ADR-0023/0024 discipline, PITR, MIGR-04
+  snapshots), images are GHCR (built by `cd.yml`), secrets are reproducible
+  (`scripts/gen-openiddict-keys.sh`, Neon console, Brevo), DNS is at an external registrar.
+  Azure held only compute, Key Vault copies, and Log Analytics telemetry.
+- **`compose.prod.yaml` already is a single-node deployment.** It was built (ADR-0008 §4 / M6-07)
+  to reproduce the whole cloud topology on one machine: 4 app images + Caddy terminating TLS on
+  one origin per app + one-shot migrator + DP keyring volumes. Its only laptop-isms are the local
+  CA (`.docker/prod-https/`, `trust-ca-entrypoint.sh`) and an in-compose postgres — both of which
+  a real host with real domains makes unnecessary.
+- ACA-specific machinery that exists only to fight the platform: KEDA cron warm window +
+  mandatory `http_scale_rule` (ADR-0027), single-active-revision sweep (ADR-0029), measured
+  43–62 s cold starts with auth's 31 s dominating, LAW daily-quota juggling, the
+  "deployed is not running" revision trap.
+- CI images are `linux/amd64` only; no multi-arch buildx exists.
+- Two projects × (prod + staging) ≈ 16 .NET containers + Caddy. Idle RSS ~150–250 MB each →
+  a 4 GB box is a lie waiting to OOM; 8 GB fits comfortably.
+
+## Decision
+
+### 1. One Hetzner VPS hosts everything, split only on real users
+
+A single **CX32 (4 vCPU, 8 GB, amd64, Ubuntu 24.04 LTS, Falkenstein)** — ~EUR 7/month + ~20% for
+snapshot backups (verify price at checkout) — runs prod and staging of both projects. That is a
+flat ~EUR 8–9/month versus ~EUR 55–180/month of Azure burn, with zero cold starts. The split
+trigger is explicit: real player traffic on lotro-translator.pl, not a hypothetical. CX22 (4 GB)
+is rejected as the "cheapest" option — see Context; amd64 over ARM (CAX) because the images are
+amd64 and multi-arch buildx is pure added surface.
+
+### 2. `compose.hetzner.yaml` derived from `compose.prod.yaml`, minus the laptop-isms
+
+The Hetzner stack is the parity stack with three deletions and one swap: **delete** the local CA
++ `trust-ca-entrypoint.sh` mounts (Let's Encrypt certs are OS-trusted), **delete** the in-compose
+postgres (Neon stays the DB for prod AND staging — self-hosting the DB would trade a managed
+PITR story for owning backups), **delete** mailpit/aspire from the critical path (profiles stay
+optional), **swap** the Caddyfile to real domains with automatic ACME. `compose.prod.yaml` itself
+is untouched — it remains the laptop parity stack. Prod and staging are two compose projects
+(`-p lotro-prod` / `-p lotro-staging`) off one file, parametrized by env file + image tag.
+
+### 3. CD becomes ssh + compose; two-stage promotion survives
+
+`cd.yml`'s build→GHCR legs stay. The deploy legs become: ssh as the `deploy` user → migrator
+one-shot → `docker compose pull && up -d` → `scripts/smoke.sh` (fingerprint assertion included).
+Staging deploys automatically on merge; prod stays behind the same gated GitHub Environment as
+today (ADR-0018 flow, new target). Terraform (`iac/`), Key Vault, and the Azure workflow legs are
+retired. A deploy is seconds of container restart — acceptable pre-launch; zero-downtime rollouts
+are a real-users problem, and ADR-0023's forward-only, N-1-compatible migration discipline stays
+binding regardless (the migrator still runs before the new app containers).
+
+### 4. Secrets live in git-ignored env files on the server
+
+`/opt/lotro/.env.hetzner.{prod,staging}`, assembled once from: fresh Neon connection strings,
+regenerated OpenIddict keys (invalidates sessions — free pre-launch), Brevo SMTP key and admin
+seeds from the owner. `.env.hetzner.example` in-repo documents every variable; the runbook maps
+each to its source of truth and rotation command. No vault service replaces Key Vault — for a
+solo-maintainer single box, an 0600 env file plus the existing GitGuardian/gitleaks gates is the
+right-sized answer (YAGNI).
+
+### 5. LotroKoniecDev owns the server-level infra; TheKittySaver mounts alongside
+
+Bootstrap script, shared Caddy, and the runbook live in this repo (precedent: the shared Log
+Analytics workspace lived only in `iac/azure-law.tf`). TheKittySaver gets its own compose stack,
+CD tickets, and a twin ADR in its own repo, deployed to `/opt/tks` behind the same Caddy —
+after LOTRO prod is live.
+
+### 6. ADR-0027 and ADR-0029 are obsolete-by-platform
+
+The warm window, `http_scale_rule` rule, and revision sweep solved ACA economics and ACA revision
+semantics. On an always-on VPS they have no referent. Their Status lines get an
+"obsolete — platform retired by ADR-0034" note (HETZ-06); the daily GH Actions health ping stays
+(free, still a useful uptime signal).
+
+## Consequences
+
+### Positive
+
+- Flat ~EUR 8–9/month for everything; no annual credit-eligibility ruleta; no cold starts
+  (43–62 s → 0), which also shrinks the auth cold-start × Neon-resume race window.
+- The deployment model becomes the thing already proven on a laptop (`compose.prod.yaml`
+  exercised the same Dockerfiles, Caddy topology, forwarded headers, DP keyrings).
+- Terraform, Key Vault, KEDA, revision management, LAW quotas — all deleted, not maintained.
+
+### Negative / Accepted Trade-offs
+
+- Single point of failure: one box, one region. Accepted pre-launch; the split trigger is §1.
+- Self-managed OS security (ufw, fail2ban, unattended-upgrades — HETZ-01) replaces a managed
+  platform's patching.
+- Deploys cause seconds of downtime (no rolling revisions). Accepted; revisit with real users.
+- Observability shrinks: no LAW. OTLP endpoint stays configurable; aspire-dashboard remains an
+  optional profile. A real telemetry sink is a later, deliberate decision.
+- Neon stays a third-party dependency; its free-tier limits (storage cliff ~0.5 GB) are now the
+  binding infra constraint.
+
+## Alternatives Considered
+
+### A. Retry/renew Azure for Students
+
+Renewal currently refused; even on success it is a 12-month fuse with an eligibility check at the
+end, and the ADR-0027 hackery exists only to make ACA affordable. Rejected as the platform; a
+successful retry merely funds a calmer migration.
+
+### B. PaaS free tiers (Fly.io, Railway, Render, Koyeb)
+
+Free tiers are revocable marketing (both projects just experienced exactly that failure mode),
+multi-app + custom-domain TLS + one-shot migrators fit awkwardly, and per-app pricing crosses a
+VPS within months. Rejected.
+
+### C. ARM (CAX11/21) for the lower price
+
+Requires multi-arch buildx in CI and re-verifying native-dependency behavior for four images to
+save ~EUR 2/month. Rejected — wrong side of the effort/price curve.
+
+### D. Coolify/Dokploy on the VPS
+
+A deploy UI would replace the exact compose + ssh mechanics the repo already has proven and
+tested. New tool surface, same outcome. Rejected (YAGNI).
+
+### E. Self-hosted postgres in the compose stack
+
+compose.prod.yaml already carries the service, but it would trade Neon's PITR + MIGR-04 snapshot
+machinery (ADR-0025) for hand-rolled backups on the same failure domain as the apps. Rejected.
+
+## Implementation Notes
+
+- New: `scripts/hetzner/bootstrap.sh` (no `.ps1` twin — runs on the server, the twins rule
+  covers dev machines), `compose.hetzner.yaml`, `.docker/hetzner/Caddyfile`,
+  `.env.hetzner.example`, `docs/deployment/hetzner-runbook.md`
+- Changed: `cd.yml`/`deploy.yml` (ssh deploy legs), `docs/deployment/runbook.md` (rewritten),
+  `CLAUDE.md` (M6 section), ADR-0027/0029 status lines
+- Retired: `iac/` Azure resources, `seed-keyvault.{sh,ps1}`, `infra.yml`, local-CA mounts in the
+  Hetzner stack (parity stack keeps them)
+- Execution: epic #486, tickets #487–#492; owner-assisted bring-up is #491;
+  plan: `docs/deployment/hetzner-migration-plan.md`
+
+## References
+
+- Epic #486; tickets #487 (bootstrap), #488 (compose+Caddy), #489 (secrets), #490 (CD),
+  #491 (bring-up + DNS), #492 (Azure retirement)
+- ADR-0008 (cloud-agnostic deployment — its §4 parity stack is what made this migration cheap),
+  ADR-0018, ADR-0023, ADR-0024, ADR-0025, ADR-0027, ADR-0029
+- `docs/deployment/runbook.md` — env-var matrix the Hetzner stack must reproduce
+- Hetzner cloud pricing: https://www.hetzner.com/cloud/

--- a/docs/deployment/hetzner-migration-plan.md
+++ b/docs/deployment/hetzner-migration-plan.md
@@ -1,0 +1,86 @@
+# Hetzner migration plan — executable playbook
+
+> Decision: ADR-0034. Epic #486, tickets #487–#492. Written 2026-07-12, the day the Azure
+> subscription died — the goal of Phase 0 is **prods back up the same day**. This document is
+> the working script for the implementing session; tickets carry the acceptance criteria.
+
+## State snapshot (2026-07-12)
+
+- Azure subscription `Disabled` (credits exhausted, renewal refused). Both prods 404. Nothing
+  on Azure is billing; nothing needs rescuing from it (try `az keyvault secret show` once for
+  convenience — if it fails, every secret is reproducible, see §Secrets).
+- Safe and untouched: Neon DBs (prod + staging, both projects), GHCR images, repo + IaC history,
+  DNS zone at the external registrar, Brevo SMTP.
+- Deployment blueprint that already works: `compose.prod.yaml` + `.docker/caddy/Caddyfile`
+  (laptop parity stack — same Dockerfiles, Caddy TLS-per-origin topology, forwarded headers,
+  one-shot migrator, DP keyring volumes).
+
+## Phase 0 — TODAY: interactive bring-up (ticket #491, plus minimal #487/#488/#489 inline)
+
+Run in an **interactive** session with the owner (server purchase, DNS panel, and secrets are
+owner inputs — this phase is not loopable). Order matters; DNS early (ACME needs it resolving).
+
+1. **Owner:** create Hetzner account → buy **CX32, amd64, Ubuntu 24.04 LTS, Falkenstein**
+   (+ enable snapshots/backups) → add ssh public key → paste the server IP into the session.
+2. **Owner (parallel):** registrar DNS panel — A records → server IP, TTL 300:
+   apex `lotro-translator.pl` (+ `www` if configured today) and every app/staging hostname.
+   **Source of truth for the exact hostname list: the env matrix in
+   `docs/deployment/runbook.md`** (frontend/auth/tms × prod/staging — do not guess from memory,
+   read the matrix; keep the hostnames identical to the ACA setup so no appsettings change).
+3. **Session:** `scripts/hetzner/bootstrap.sh` over ssh (write it first if #487 hasn't landed —
+   spec in the ticket: Docker + compose plugin, ufw 22/80/443, fail2ban, unattended-upgrades,
+   `deploy` user, GHCR read-only PAT login).
+4. **Session:** land #488's files (`compose.hetzner.yaml`, `.docker/hetzner/Caddyfile`,
+   `.env.hetzner.example`) on a branch; scp/rsync to `/opt/lotro/`.
+5. **Session + owner:** assemble `/opt/lotro/.env.hetzner.prod` and `.env.hetzner.staging`
+   per §Secrets. `chmod 600`.
+6. **Bring-up sequence (per env, staging first as the rehearsal):**
+   migrator one-shot → apps → Caddy; watch ACME issue certs; then
+   `scripts/smoke.sh` against the public origins + a manual OIDC register/login round-trip,
+   translation list, `GET /translation-files/{lang}`.
+7. Note Neon-resume behavior on first cold hit (auth's 20 s connection-open vs ~31 s resume —
+   known pre-existing race; the always-on host shrinks the window but doesn't fix the bug).
+
+**Done when:** prod + staging serve with valid LE certs, smoke green from an external network.
+
+## Phase 1–6 — hardening the same thing into the repo (loopable after Phase 0)
+
+| Phase | Ticket | Content |
+|---|---|---|
+| 1 | #487 | bootstrap.sh idempotent + hetzner-runbook.md server section |
+| 2 | #488 | compose.hetzner.yaml + Caddyfile + .env.hetzner.example, PR-quality |
+| 3 | #489 | secrets matrix documented; KV read attempt recorded |
+| 4 | #490 | CD over ssh (staging auto, prod gated env), smoke in-pipeline, Azure legs disabled |
+| 5 | #491 | close out with the live verification evidence |
+| 6 | #492 | Azure retirement: iac/, seed-keyvault, workflows, runbook rewrite, ADR-0027/0029 status notes, CLAUDE.md M6 sweep |
+
+TheKittySaver: twin epic in its repo after LOTRO prod is live — same recipe, `/opt/tks`,
+uratujkota.pl vhosts appended to the same Caddy (slots pre-commented in #488's Caddyfile).
+
+## Secrets — source of truth and how to remint
+
+| Secret | Source | How |
+|---|---|---|
+| `ConnectionStrings__*` (TMS + Auth, prod + staging) | Neon | owner mints fresh in Neon console (or API; project/branch IDs in memory `neon-pitr-topology`). Prefer fresh over recovering KV copies. |
+| OpenIddict certs/keys (3 values) | regenerate | `scripts/gen-openiddict-keys.sh` → paste into env files. Invalidates old sessions — irrelevant pre-launch. |
+| Brevo SMTP key | owner | Brevo dashboard (GH secret holds a copy but is not readable back). Sender stays `SMTP_SENDER_EMAIL` GH var. |
+| `AUTH_ADMIN_*` seeds | owner | re-set on first bring-up (#210 flow). |
+| `SMOKE_CLIENT_SECRET` | regenerate | new value in env + GH secret (mind the `--body` gotcha, memory `staging-env-shared-aca`). |
+| `HETZNER_SSH_KEY` / host | new | generated for CD (#490); deploy-user key, not root. |
+
+## Explicitly NOT changing
+
+Neon as DB (ADR-0023/0024/0025 discipline intact) · GHCR image pipeline · Brevo · domain names
+and OIDC topology (same public origins → no appsettings churn) · `compose.prod.yaml` laptop
+parity stack · two-stage staging→prod promotion (ADR-0018 flow, new transport).
+
+## Gotchas for the implementing session
+
+- Images are amd64 — the box is amd64; never "fix" a pull error by enabling emulation.
+- ACME will fail until DNS propagates — start DNS first (step 2), certs come up on retry alone.
+- In Production, OpenIddict rejects plain HTTP: every authority/issuer URL must be the public
+  `https://` origin (same rule as the parity stack — runbook gotchas section).
+- `.github/workflows/*` pushes need the koniecdev token (memory `github-push-koniecdev-account`).
+- `GET / -> 200` proves nothing (house rule) — smoke's fingerprint leg is the real check.
+- Keep hostnames identical to ACA-era values; if the runbook matrix and reality disagree,
+  the code/config in the repo wins — fix the doc.

--- a/docs/deployment/hetzner-migration-plan.md
+++ b/docs/deployment/hetzner-migration-plan.md
@@ -56,6 +56,15 @@ owner inputs — this phase is not loopable). Order matters; DNS early (ACME nee
 
 TheKittySaver: twin epic in its repo after LOTRO prod is live — same recipe, `/opt/tks`,
 uratujkota.pl vhosts appended to the same Caddy (slots pre-commented in #488's Caddyfile).
+**One extra must-have LOTRO doesn't have: TKS stores cat gallery photos + announcement
+thumbnails in Azure Blob** (`Infrastructure/FileStorage/AzureBlob/`, provisioned by its
+`iac/storage.tf`; read links via `IImageReadLinkFactory`). The seam is interface + connection
+string (`AzureBlobFileStorageRegistration` takes `ConnectionString`/`ServiceUri`), so the
+decided path is a **fresh storage account on the owner's personal (pay-as-you-go) Azure
+account** — config-only swap, cents/month at portfolio scale. Existing blobs on the dead
+student subscription are test/seed data (retained ~90 days, recoverable only if the sub
+revives) — plan for re-seed, don't block on recovery. The same personal storage account also
+takes the nightly `pg_dump` backups + encrypted env copies (Neon free = 6 h PITR only).
 
 ## Secrets — source of truth and how to remint
 


### PR DESCRIPTION
Part of #486.

Records the decision (ADR-0034) and ships the executable migration playbook
(docs/deployment/hetzner-migration-plan.md): single CX32 (amd64) hosts prod+staging of both
projects, compose.prod.yaml is the blueprint minus laptop-isms, Neon/GHCR/Brevo/domains
unchanged, CD becomes ssh + compose with the staging→prod gate preserved. Docs only.

Execution: #487–#492; owner-assisted same-day bring-up is #491 / plan §Phase 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)