### PR TITLE
chore(loop): revert reviews + loop default to Opus 4.8; conductor may intervene

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Use this agent to review code changes against ticket acceptance criteria, find regressions, architecture violations, audit for unhandled edge cases (anti-happy-path gate), and verify test coverage. Invoke after implementing a feature or before creating a PR.
 tools: Read, Grep, Glob, Bash
-model: fable
+model: opus
 effort: xhigh
 ---
 

--- a/.claude/commands/backlog.md
+++ b/.claude/commands/backlog.md
@@ -9,6 +9,8 @@ You are the loop **conductor's assistant**, not the orchestra. The actual loop i
 context — your only jobs are launch, wait, and report. (The old pattern — spawning ticket
 subagents from this session — piled every worker's results into one growing context; never do it.)
 
+You are ALLOWED to intervene if you see loop failing, so it can actually run and work.
+
 ## 1. Launch
 
 Map `$ARGUMENTS` onto the script:
@@ -20,11 +22,14 @@ Map `$ARGUMENTS` onto the script:
 Run it via Bash with `run_in_background: true`. If it exits immediately with a dirty-working-copy
 or stale-lock message, surface that to the user and stop — never force it.
 
+We should technically caffeinate these commands unless the user explicitly says not to do it.
+
 ## 2. While it runs
 
 Stay thin. Do not read diffs, do not implement, do not review, do not poll in a tight loop — you
 are re-invoked when the background script exits. If the user asks for progress, check the
 background task's console output and relay the last few `[loop]`/`[conductor]` lines.
+You basically only intervene if the script fails somehow. 
 
 ## 3. Report the roll-up
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ scripts/claude/backlog-loop.sh 123 130                 # exactly these tickets, 
 caffeinate -is scripts/claude/backlog-loop.sh          # overnight run on macOS (blocks sleep)
 scripts/claude/next-ticket.sh                          # print the next READY ticket (priority + deps)
 scripts/claude/work-ticket.sh 123                      # one ticket, one fresh headless session
-# defaults: fable (Fable 5) · effort high (reviews at xhigh) · permission-mode auto — override via LOOP_MODEL /
+# defaults: opus (Opus 4.8) · effort high (reviews at xhigh) · permission-mode auto — override via LOOP_MODEL /
 # LOOP_EFFORT / LOOP_PERMISSION_MODE / LOOP_UNSAFE=1 · full manual: docs/claude-loop.md
 
 # TMS — EF Core migrations (write context owns them; --connection makes it work without appsettings/live DB)
@@ -368,13 +368,14 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 - **Right-size the design — YAGNI by default.** Before proposing an abstraction, cache, config
   knob, queue, or new infra, check it solves a **real, present** need from the current
   spec/ticket — not a hypothetical future. Pick the simple path and note the trade-off in one line.
-- **Agent fan-out is budgeted; reviews run on Fable 5 at xhigh effort, everything else at high**
-  (2026-07-11; supersedes the 2026-07-09 all-xhigh switch; previous standing rule was Opus 4.8 +
-  effort max). Hard cap: **max 4 subagents in parallel**, no chained waves by default; a small
-  diff gets reviewed **inline, zero agents**. The `code-reviewer` agent, `/code-review` and
-  `/security-review` run with **model Fable 5 + effort xhigh**; loop-mode worker sessions run at
-  **effort high** (`LOOP_EFFORT` default) — unless the prompt for that run explicitly says
-  otherwise. Applies to interactive sessions and loop-mode workers alike.
+- **Agent fan-out is budgeted; reviews run on Opus 4.8 at xhigh effort, everything else at high**
+  (2026-07-13; reverted the 2026-07-09→11 Fable 5 experiment back to Opus 4.8, keeping the
+  xhigh-reviews / high-everything-else effort split). Hard cap: **max 4 subagents in parallel**,
+  no chained waves by default; a small diff gets reviewed **inline, zero agents**. The
+  `code-reviewer` agent, `/code-review` and `/security-review` run with **model Opus 4.8 + effort
+  xhigh**; loop-mode worker sessions run at **effort high** (`LOOP_EFFORT` default) — unless the
+  prompt for that run explicitly says otherwise. Applies to interactive sessions and loop-mode
+  workers alike.
 - **Frontend is Static SSR — enforced, not just documented.** No WebAssembly, no SignalR circuit,
   no per-user server state; forms post via `<form method="post" @formname @onsubmit>` (the SSR
   `@onsubmit` special-case) or `<EditForm OnValidSubmit>` — never interactive `@on*` handlers,

--- a/docs/claude-loop.md
+++ b/docs/claude-loop.md
@@ -97,7 +97,7 @@ one ticket with `LOOP_TRUST_GATE=0`, or add the commenter to `LOOP_TRUSTED_LOGIN
 | Var | Default | Meaning |
 |---|---|---|
 | `LOOP_EFFORT` | `high` | claude effort per ticket (reviews inside the session run at `xhigh` via the `code-reviewer` agent definition) |
-| `LOOP_MODEL` | `fable` | Fable 5 (temporary switch 2026-07-09; previously `opus` — Opus 4.8 with its native 1M-token context window) |
+| `LOOP_MODEL` | `opus` | Opus 4.8 with its native 1M-token context window (the 2026-07-09→11 Fable 5 experiment was reverted 2026-07-13) |
 | `LOOP_PERMISSION_MODE` | `auto` | headless permission mode |
 | `LOOP_CONFIG_DIR` | `~/.claude-account1` | Claude config dir = which account runs the loop (exported as `CLAUDE_CONFIG_DIR`) |
 | `LOOP_ALLOWED_TOOLS` | git/gh/dotnet/scripts | loop-scoped Bash allowlist passed via `--allowedTools` |

--- a/scripts/claude/backlog-loop.sh
+++ b/scripts/claude/backlog-loop.sh
@@ -12,7 +12,7 @@
 #   caffeinate -is scripts/claude/backlog-loop.sh   # overnight on macOS (blocks sleep)
 #
 # Env (all forwarded to work-ticket.sh): LOOP_EFFORT (default high; reviews run at xhigh via the
-#   code-reviewer agent definition), LOOP_MODEL (default fable),
+#   code-reviewer agent definition), LOOP_MODEL (default opus),
 #   LOOP_CONFIG_DIR (default ~/.claude-account1 — which account runs the loop),
 #   LOOP_PERMISSION_MODE (default auto), LOOP_UNSAFE, LOOP_MAX_BUDGET_USD,
 #   LOOP_TICKET_TIMEOUT_MIN, LOOP_CHECKS_TIMEOUT_MIN, LOOP_SKIP_LABELS,

--- a/scripts/claude/work-ticket.sh
+++ b/scripts/claude/work-ticket.sh
@@ -10,8 +10,8 @@
 # Env:
 #   LOOP_EFFORT             claude effort level (default: high — reviews inside the session run
 #                           at xhigh via the code-reviewer agent definition)
-#   LOOP_MODEL              model (default: fable — Fable 5; temporary switch 2026-07-09,
-#                           previously opus — Opus 4.8 with its native 1M-token context window)
+#   LOOP_MODEL              model (default: opus — Opus 4.8 with its native 1M-token context
+#                           window; the 2026-07-09→11 Fable 5 experiment was reverted 2026-07-13)
 #   LOOP_CONFIG_DIR         Claude config dir = which account runs the loop
 #                           (default: ~/.claude-account1)
 #   LOOP_GH_USER            gh account whose token backs the loop's gh write calls — PR merge,
@@ -44,7 +44,7 @@ RUN_DIR="${2:-$REPO_ROOT/logs/claude-loop/adhoc-$(date +%Y%m%d-%H%M%S)}"
 mkdir -p "$RUN_DIR"
 
 EFFORT="${LOOP_EFFORT:-high}"
-MODEL="${LOOP_MODEL:-fable}"
+MODEL="${LOOP_MODEL:-opus}"
 export CLAUDE_CONFIG_DIR="${LOOP_CONFIG_DIR:-$HOME/.claude-account1}"
 PERMISSION_MODE="${LOOP_PERMISSION_MODE:-auto}"
 TIMEOUT_MIN="${LOOP_TICKET_TIMEOUT_MIN:-90}"
@@ -103,7 +103,7 @@ salvage() {
         git add -A >/dev/null 2>&1 || true
         git commit --quiet --no-verify \
             -m "claude-loop: salvage uncommitted work for #$ISSUE" \
-            -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>" >/dev/null 2>&1 || true
+            -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>" >/dev/null 2>&1 || true
         log "leftover changes committed on branch $salvage_branch"
     fi
     git checkout main --quiet 2>/dev/null || true


### PR DESCRIPTION
Two small, independent changes to the autonomous-loop / review tooling (`.claude/` + `scripts/claude/` + loop docs), one logical commit each.

## 1. Reviews + loop default: Fable 5 → Opus 4.8
The 2026-07-09→11 Fable 5 experiment is reverted to **Opus 4.8** (native 1M-token context). Effort split unchanged: reviews **xhigh**, everything else **high**.

The model is set in **code/config**, not just prose — so the sweep touches what actually runs, and CLAUDE.md is aligned to match (no doc-vs-code drift):
- `.claude/agents/code-reviewer.md` → `model: opus` (drives `code-reviewer`, `/code-review`, `/security-review`)
- `scripts/claude/work-ticket.sh` → `LOOP_MODEL` default `opus`; salvage-commit trailer → `Claude Opus 4.8`
- `CLAUDE.md`, `docs/claude-loop.md`, `scripts/claude/backlog-loop.sh` → documented defaults + dated standing-rule note

`scripts/claude/audit.sh` is in `.git/info/exclude` (locally untracked) so its `AUDIT_MODEL` default isn't part of the repo — changed locally only.

## 2. `/backlog` conductor may intervene
Owner edits to the `/backlog` command: the otherwise-thin conductor may step in when it sees the loop failing (so it actually runs), and commands should be caffeinated unless told otherwise.

## Notes
No compiled code changed; `.md`/`.sh` only. Unrelated to HETZ-01 (#496) — kept on its own branch.