### PR TITLE
ci: scope the PR gates to what the diff can actually break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,19 @@ name: CI
 # to catch anything that slipped past PR verification — direct pushes to main, or a PR that
 # went green against an older main. The integration suite spins up postgres:17-alpine via
 # Testcontainers; the ubuntu runner has Docker preinstalled.
+#
+# Unlike pr-verify, this workflow does NOT self-skip its .NET steps via scripts/ci/classify-changes.sh:
+# CD is triggered by THIS workflow concluding `success` (cd.yml, workflow_run), so "CI was green"
+# must keep meaning "the build and both suites actually ran on this commit". Cheap-change filtering
+# lives in `paths-ignore` instead — a push that matches it triggers no CI and therefore no CD, which
+# is the intended behavior for content that ships nothing (docs, agent config).
 on:
   push:
     branches: ["main"]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+      - '.claude/**'
       - 'LICENSE'
       - '.gitignore'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,19 +4,31 @@ name: CodeQL
 # default branch (to seed the code-scanning baseline), plus a weekly scheduled scan so newly
 # published query packs catch latent issues. C# uses build-mode "none" — CodeQL analyses the
 # source directly, so the job needs no .NET SDK, restore, or compile step.
+#
+# paths-ignore mirrors that scope: this scan reads C# source and nothing else, so a change confined
+# to shell/PowerShell scripts, agent config (.claude/) or docs cannot produce or clear a C# alert.
+# It is NOT a required check (unlike "Pull Request Verification"), so filtering it out of a PR
+# cannot deadlock the merge — but the merge gate still refuses any PR with open CodeQL alerts, and
+# alerts raised by an earlier run stay open regardless of what this PR touches.
 on:
   pull_request:
     branches: ["main"]
     paths-ignore:
       - '**/*.md'
+      - '**/*.sh'
+      - '**/*.ps1'
       - 'docs/**'
+      - '.claude/**'
       - 'LICENSE'
       - '.gitignore'
   push:
     branches: ["main"]
     paths-ignore:
       - '**/*.md'
+      - '**/*.sh'
+      - '**/*.ps1'
       - 'docs/**'
+      - '.claude/**'
       - 'LICENSE'
       - '.gitignore'
   schedule:

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -14,16 +14,25 @@ name: Pull Request Verification
 # checks with path filtering. CI (main) keeps its own paths-ignore on purpose: a docs-only push
 # must keep triggering no CI and therefore no CD (audit 0001 M2).
 #
-# Container images (CI-01 / #403): Dockerfiles stay `inert` for the .NET job — that classification
-# is literally right, a Dockerfile change cannot break `dotnet build`, the test suites or the SSR
-# guard (they sit in `force_build` only so the restore-graph guard re-checks their COPY lists).
-# But the shipped images used to be built for the first time in cd.yml, AFTER the merge — so a
-# Dependabot base-image digest bump could land on main without the image ever having been built or
-# scanned, and a fixable HIGH/CRITICAL in the new base surfaced only once main was already
-# un-deployable. The `changes` job therefore emits a second output, `images`, and the `images` job
-# below builds all four shipped images with `push: false` and Trivy-scans them ON the PR. cd.yml
-# keeps its own post-push scan of the exact published digest before cosign signs it; the PR scan is
-# an earlier, additional gate, not a replacement.
+# What runs is decided by scripts/ci/classify-changes.sh, which returns THREE independent verdicts —
+# `code` (the .NET gate: restore + Release build + unit + integration tests), `guards` (the cheap
+# bash gates CI executes) and `images` — because they have three different sets of inputs. The
+# earlier single `force_build` verdict conflated the first two: a change to a script that CI merely
+# EXECUTES (e.g. scripts/claude/work-ticket.sh, which the provenance self-test drives) forced the
+# whole .NET gate, so PR #497 — .claude/ + docs + two loop scripts, not one line of C# — paid for a
+# full Release build and both test suites. Now such a PR runs the guard steps only, in seconds, and
+# the .NET steps are skipped by their step-level `if:` — the job (and therefore the required check)
+# still reports. The classifier's self-test runs UNCONDITIONALLY in `changes`, before any verdict is
+# trusted: a classifier that mis-classifies real source as inert would skip the build silently, and
+# nothing else in the pipeline would notice.
+#
+# Container images (CI-01 / #403): the shipped images used to be built for the first time in cd.yml,
+# AFTER the merge — so a Dependabot base-image digest bump could land on main without the image ever
+# having been built or scanned, and a fixable HIGH/CRITICAL in the new base surfaced only once main
+# was already un-deployable. The `images` job below therefore builds all four shipped images with
+# `push: false` and Trivy-scans them ON the PR. cd.yml keeps its own post-push scan of the exact
+# published digest before cosign signs it; the PR scan is an earlier, additional gate, not a
+# replacement.
 on:
   pull_request:
     branches: ["main"]
@@ -43,6 +52,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       code: ${{ steps.diff.outputs.code }}
+      guards: ${{ steps.diff.outputs.guards }}
       images: ${{ steps.diff.outputs.images }}
     steps:
       # fetch-depth: 2 brings the PR merge commit plus both parents, so HEAD^1 (the base tip)
@@ -53,66 +63,25 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
-      # A PR that changes ONLY files which cannot affect the .NET build, the unit/integration tests
-      # or the SSR-purity guard skips the heavy job below. No untrusted input reaches this script
-      # (pure git against the checked-out merge commit). Fails OPEN (code=true) if the diff cannot be
-      # computed — a redundant build beats a false green.
+      # The classifier below decides what runs, so it is the one guard nothing else backstops:
+      # its self-test runs first, always, whatever the diff says. Pure bash, ~1 second.
+      - name: Change-classifier self-test
+        run: ./scripts/tests/classify-changes.tests.sh
+
+      # Three verdicts (code / guards / images) from the PR's own diff. No untrusted input reaches
+      # it — pure git against the checked-out merge commit. Fails OPEN (everything true) if the diff
+      # cannot be computed: a redundant build beats a false green.
       - name: Classify changed paths
         id: diff
-        run: |
-          set -euo pipefail
-          # Inert paths: docs, shell/PowerShell scripts, IaC (infra.yml gates it separately),
-          # Docker (only the flavors we actually ship — a NEW flavor safely triggers a redundant
-          # build until it is listed here, never a false skip) / compose, the .docker/ trust
-          # material, editor/run configs, .env examples, and everything under .github/ (workflows,
-          # issue/PR templates). A PR touching only these cannot break the .NET build, the tests, or
-          # the SSR guard. Workflow files are not unchecked, though: actionlint.yml (CI-02 / #404)
-          # parses .github/workflows/** on every PR. NEVER add a build input here (.editorconfig, Directory.*.props/.targets,
-          # global.json, nuget.config, test fixtures) — that would be a false green.
-          inert='\.md$|^docs/|^LICENSE$|^\.gitignore$|^\.gitattributes$|\.sh$|\.ps1$|^iac/|(^|/)Dockerfile(\.migrator(\.prod)?|\.tests)?$|^compose[^/]*\.ya?ml$|^\.docker/|^\.github/|^\.run/|^\.vscode/|^\.idea/|(^|/)\.env[^/]*\.example$'
-          # Build-relevant despite matching `inert`: check-ssr-purity.sh, the migration-safety
-          # guard + its self-test, the Docker restore-graph guard, and the backlog loop's
-          # provenance gate + its self-test are EXECUTED by the build job (the .ps1 twins run
-          # through the migration self-test's pwsh leg), and pr-verify/ci define the .NET gate
-          # itself — a change to any of them must run the gate so it validates its own new
-          # definition. Dockerfiles join them because the restore-graph guard now reads them: a
-          # Dockerfile-only PR that drops a COPY ["…csproj"] line must still face the gate that
-          # catches it.
-          force_build='^scripts/check-ssr-purity\.sh$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|^scripts/claude/(issue-trust|next-ticket|work-ticket)\.sh$|^scripts/tests/claude-loop-provenance\.tests\.sh$|(^|/)Dockerfile(\.migrator(\.prod)?|\.tests)?$|^\.github/workflows/pr-verify\.yml$|^\.github/workflows/ci\.yml$'
-          # Image-build inputs (CI-01 / #403): ANY Dockerfile flavor (a dev-only flavor costs a
-          # redundant image build, never a false skip), the build-context filter (.dockerignore),
-          # and this workflow itself — a change to the image job's definition must build the images
-          # so it validates itself. Fails open like `code` (images=true) if the diff is missing.
-          image_inputs='(^|/)Dockerfile[^/]*$|(^|/)\.dockerignore$|^\.github/workflows/pr-verify\.yml$'
-          code=true
-          images=true
-          if files="$(git diff --name-only HEAD^1 HEAD)"; then
-            build_relevant="$(printf '%s\n' "$files" | grep -vE "$inert" || true)"
-            forced="$(printf '%s\n' "$files" | grep -E "$force_build" || true)"
-            image_relevant="$(printf '%s\n' "$files" | grep -E "$image_inputs" || true)"
-            if [ -n "$files" ] && [ -z "$build_relevant" ] && [ -z "$forced" ]; then
-              code=false
-            fi
-            if [ -n "$files" ] && [ -z "$image_relevant" ]; then
-              images=false
-            fi
-            echo "Changed files:"
-            printf '%s\n' "$files" | sed 's/^/  /'
-            echo "Build-relevant files: ${build_relevant:-<none>}"
-            echo "Forced-build files:   ${forced:-<none>}"
-            echo "Image-relevant files: ${image_relevant:-<none>}"
-          else
-            echo "::warning::Could not compute the PR diff — running the full gate."
-          fi
-          printf 'code=%s\n' "$code" >> "$GITHUB_OUTPUT"
-          printf 'images=%s\n' "$images" >> "$GITHUB_OUTPUT"
+        run: ./scripts/ci/classify-changes.sh HEAD^1
 
   build:
     name: Pull Request Verification
     needs: changes
     # Inert-only PR ⇒ skipped, and a skipped job satisfies the required "Pull Request Verification"
-    # status check (see the header comment).
-    if: needs.changes.outputs.code == 'true'
+    # status check (see the header comment). A guards-only PR still runs the job — the bash gates
+    # below execute unconditionally, while every .NET step carries `if: …outputs.code == 'true'`.
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.guards == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
 
@@ -153,12 +122,16 @@ jobs:
       - name: Backlog-loop provenance gate self-test
         run: ./scripts/tests/claude-loop-provenance.tests.sh
 
+      # Everything below is the .NET gate: it runs only when the PR can actually affect it. A PR
+      # that merely edits a script CI executes (or a Dockerfile) stops here, green, in seconds.
       - name: Setup .NET
+        if: needs.changes.outputs.code == 'true'
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: '10.0.100'
 
       - name: Cache NuGet packages
+        if: needs.changes.outputs.code == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
@@ -167,10 +140,12 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Restore
+        if: needs.changes.outputs.code == 'true'
         run: dotnet restore
 
       # TreatWarningsAsErrors is repo-wide — a single warning fails this build.
       - name: Build
+        if: needs.changes.outputs.code == 'true'
         run: dotnet build --configuration Release --no-restore
 
       # Solution-wide `dotnet test` can't host the patcher's x86 native-interop suite
@@ -179,6 +154,7 @@ jobs:
       # automatically; the Windows-only ones (.Tests.Infrastructure / .Tests.E2E) are
       # excluded by name.
       - name: Run Unit Tests
+        if: needs.changes.outputs.code == 'true'
         run: |
           set -euo pipefail
           found=0
@@ -196,6 +172,7 @@ jobs:
       # Real PostgreSQL via Testcontainers (currently AuthSystem.API.Tests.Integration;
       # the TranslationSystem.API suite joins by the same convention when M2-15 lands).
       - name: Run Integration Tests
+        if: needs.changes.outputs.code == 'true'
         run: |
           set -euo pipefail
           found=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,18 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
   references only once it sees `.razor` files — never during the `.csproj`-only restore — so
   `--no-restore` there silently emits a static-web-assets manifest with no `_framework/*` and every
   asset 404s at runtime. Never add the flag back to that `dotnet build`; `publish` keeps it.
+- **CI runs what the diff can actually break — nothing more (`scripts/ci/classify-changes.sh`).**
+  Every PR gets three **independent** verdicts: `code` (restore + Release build + unit + integration
+  tests), `guards` (the cheap bash gates CI *executes*: SSR purity, Dockerfile restore graph,
+  migration safety, loop provenance) and `images`. Keep them independent — collapsing "CI executes
+  this script" into "run the whole .NET gate" is what made a `.claude/` + docs + loop-scripts PR pay
+  for a full Release build and both suites. The failure mode that matters is the other direction:
+  putting a **build input** (`.editorconfig`, `Directory.*.props`, `global.json`, a fixture) into the
+  inert list buys a silent false green, so `scripts/tests/classify-changes.tests.sh` pins both
+  directions and runs **unconditionally** in the `changes` job, before any verdict is trusted.
+  `ci.yml` (main) deliberately does **not** self-skip its .NET steps — CD is triggered by CI
+  concluding success, so "CI was green" must keep meaning the build and both suites really ran; it
+  filters cheap content with `paths-ignore` instead (no CI ⇒ no CD).
 - **`GET / -> 200` never proves the Blazor frontend works.** A `[StreamRendering]` page returns 200
   with its spinner frame before it fetches anything. The signature of a healthy image is the
   **fingerprint**: `@Assets[]` renders `_framework/blazor.web.<hash>.js` only when `MapStaticAssets`

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Decide WHICH gates a change must face. One classifier, three independent verdicts:
+#
+#   code=…    the .NET gate — restore + Release build (the repo-wide zero-warning gate)
+#             + unit tests + integration tests (real PostgreSQL). Minutes.
+#   guards=…  the cheap bash gates CI EXECUTES — SSR purity, Dockerfile restore graph,
+#             migration safety (+ its self-test), backlog-loop provenance self-test. Seconds.
+#   images=…  the four shipped OCI images — build + Trivy scan.
+#
+# Why three and not one: a change to a script that CI executes (say scripts/claude/work-ticket.sh)
+# must re-run the guard that executes it — but it cannot break `dotnet build`, the test suites or
+# the SSR guard. Collapsing the two into a single "run everything" verdict is what made a PR that
+# only touched .claude/ + docs + the loop scripts pay for a full .NET build + both test suites.
+#
+# Verdict rules:
+#   * A file is INERT unless it can affect one of the three gates. Everything under docs/, .claude/,
+#     .github/, .idea/, .run/, .vscode/, .docker/, iac/, every *.md / *.sh / *.ps1 / compose file,
+#     the Dockerfiles and .dockerignore.
+#   * code    = any NON-inert file (fail-safe default: an unrecognized path IS a build input), plus
+#               pr-verify.yml / ci.yml — they define the .NET gate, so a change to one must run the
+#               gate it just redefined.
+#   * guards  = anything the guard steps execute or read, plus everything `code` implies (a .NET PR
+#               faces the guards too).
+#   * images  = any Dockerfile flavor, .dockerignore, and pr-verify.yml (it defines the image job).
+#
+# NEVER add a build input (.editorconfig, Directory.*.props/.targets, global.json, nuget.config,
+# a test fixture) to the inert list — that is a false green, the one failure mode that matters here.
+# The reverse mistake (a redundant build) only costs minutes. `scripts/tests/classify-changes.tests.sh`
+# pins both directions and runs UNCONDITIONALLY in the job that calls this script, so a classifier
+# that starts skipping real builds goes red before it is ever trusted.
+#
+# Usage:
+#   classify-changes.sh <base-ref>   # classify `git diff --name-only <base-ref> HEAD`
+#   classify-changes.sh --files      # classify the newline-separated paths on stdin (test seam)
+#
+# Prints `key=value` lines to stdout (and appends them to $GITHUB_OUTPUT when set); the human
+# breakdown goes to stderr. Fails OPEN — every verdict true — when the diff cannot be computed.
+#
+# CI-only (Linux runners), so unlike the check-*.sh guards this one has no .ps1 twin.
+set -euo pipefail
+
+INERT='\.md$|^docs/|^LICENSE$|^\.gitignore$|^\.gitattributes$|\.sh$|\.ps1$|^iac/|(^|/)Dockerfile[^/]*$|(^|/)\.dockerignore$|^compose[^/]*\.ya?ml$|^\.docker/|^\.github/|^\.claude/|^\.run/|^\.vscode/|^\.idea/|(^|/)\.env[^/]*\.example$'
+
+# Executed or read by the guard steps of pr-verify/ci. The .ps1 twins are here because the
+# migration-safety self-test runs its pwsh leg; the Dockerfiles because the restore-graph guard
+# parses their COPY lists — a Dockerfile-only PR that drops a COPY ["…csproj"] line must still
+# face the guard that catches it (and the image job, which actually builds it).
+GUARD_INPUTS='^scripts/check-ssr-purity\.(sh|ps1)$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|^scripts/claude/(issue-trust|next-ticket|work-ticket)\.sh$|^scripts/tests/claude-loop-provenance\.tests\.sh$|(^|/)Dockerfile[^/]*$|^\.github/workflows/(pr-verify|ci)\.yml$'
+
+# Build-relevant despite matching INERT: the two workflows that DEFINE the .NET gate.
+CODE_INPUTS='^\.github/workflows/(pr-verify|ci)\.yml$'
+
+# Image-build inputs: ANY Dockerfile flavor (a dev-only flavor costs a redundant image build, never
+# a false skip), the build-context filter, and pr-verify.yml — the image job must validate its own
+# new definition.
+IMAGE_INPUTS='(^|/)Dockerfile[^/]*$|(^|/)\.dockerignore$|^\.github/workflows/pr-verify\.yml$'
+
+files=''
+diffable=1
+
+case "${1-}" in
+    --files)
+        files="$(cat)"
+        ;;
+    '' | -*)
+        echo "usage: $(basename "$0") <base-ref> | --files < paths" >&2
+        exit 2
+        ;;
+    *)
+        if ! files="$(git diff --name-only "$1" HEAD)"; then
+            diffable=0
+        fi
+        ;;
+esac
+
+code=true
+guards=true
+images=true
+
+if [ "$diffable" -eq 1 ] && [ -n "$files" ]; then
+    build_relevant="$(printf '%s\n' "$files" | grep -vE "$INERT" || true)"
+    forced_code="$(printf '%s\n' "$files" | grep -E "$CODE_INPUTS" || true)"
+    guard_relevant="$(printf '%s\n' "$files" | grep -E "$GUARD_INPUTS" || true)"
+    image_relevant="$(printf '%s\n' "$files" | grep -E "$IMAGE_INPUTS" || true)"
+
+    if [ -z "$build_relevant" ] && [ -z "$forced_code" ]; then
+        code=false
+    fi
+    if [ "$code" = false ] && [ -z "$guard_relevant" ]; then
+        guards=false
+    fi
+    if [ -z "$image_relevant" ]; then
+        images=false
+    fi
+
+    {
+        echo 'Changed files:'
+        printf '%s\n' "$files" | sed 's/^/  /'
+        echo "Build-relevant files: ${build_relevant:-<none>}"
+        echo "Forced-code files:    ${forced_code:-<none>}"
+        echo "Guard-relevant files: ${guard_relevant:-<none>}"
+        echo "Image-relevant files: ${image_relevant:-<none>}"
+    } >&2
+elif [ "$diffable" -eq 0 ]; then
+    echo '::warning::Could not compute the diff — running every gate.' >&2
+else
+    echo '::warning::Empty diff — running every gate.' >&2
+fi
+
+verdicts="$(printf 'code=%s\nguards=%s\nimages=%s\n' "$code" "$guards" "$images")"
+printf '%s\n' "$verdicts"
+if [ -n "${GITHUB_OUTPUT-}" ]; then
+    printf '%s\n' "$verdicts" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/tests/classify-changes.tests.sh
+++ b/scripts/tests/classify-changes.tests.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Offline self-test for scripts/ci/classify-changes.sh — the classifier that decides whether a PR
+# runs the .NET gate, the bash guards, the image build, or nothing at all.
+#
+# It runs UNCONDITIONALLY in the `changes` job, before the classifier is trusted to classify
+# anything: a classifier that mis-classifies real source as inert would silently skip the build and
+# the tests, and no other check would notice. The false-green half of the table below is therefore
+# the point of this file — the "skips the right things" half only guards the CI bill.
+#
+# Pure bash + git-free: every case feeds a path list on stdin through the --files seam.
+set -uo pipefail
+
+SCRIPTS_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+CLASSIFY="$SCRIPTS_DIR/ci/classify-changes.sh"
+
+failures=0
+cases=0
+
+# expect <expected-verdicts> <description> <path>...
+expect() {
+    local expected="$1" description="$2"
+    shift 2
+    local actual
+    actual="$(printf '%s\n' "$@" | "$CLASSIFY" --files 2>/dev/null | tr '\n' ' ')"
+    actual="${actual% }"
+    cases=$((cases + 1))
+    if [ "$actual" = "$expected" ]; then
+        printf 'PASS  %s\n' "$description"
+    else
+        printf 'FAIL  %s\n        expected: %s\n        actual:   %s\n' "$description" "$expected" "$actual"
+        failures=$((failures + 1))
+    fi
+}
+
+# expect_code <description> <path>  — the false-green half: this file MUST face the .NET gate.
+expect_code() {
+    local description="$1" path="$2"
+    local actual
+    actual="$(printf '%s\n' "$path" | "$CLASSIFY" --files 2>/dev/null | grep '^code=')"
+    cases=$((cases + 1))
+    if [ "$actual" = 'code=true' ]; then
+        printf 'PASS  %s\n' "$description"
+    else
+        printf 'FAIL  %s\n        expected: code=true\n        actual:   %s\n' "$description" "$actual"
+        failures=$((failures + 1))
+    fi
+}
+
+echo '── the .NET gate is never skipped for a real build input ─────────────────────────────────────'
+expect_code 'a C# source file'          'src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/Approve.cs'
+expect_code 'a Razor component'         'src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor.razor'
+expect_code 'a project file'            'src/Patcher/LotroKoniecDev.Cli/LotroKoniecDev.Cli.csproj'
+expect_code 'the solution file'         'LotroKoniecDev.slnx'
+expect_code 'central package versions'  'Directory.Packages.props'
+expect_code 'repo-wide build props'     'Directory.Build.props'
+expect_code 'the SDK pin'               'global.json'
+expect_code 'the NuGet config'          'nuget.config'
+expect_code 'the analyzer config'       '.editorconfig'
+expect_code 'a test source file'        'tests/LotroKoniecDev.Tests.Unit/FragmentTests.cs'
+expect_code 'a golden test fixture'     'tests/LotroKoniecDev.Tests.Unit/Fixtures/exported.txt'
+expect_code 'an EF migration'           'src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260713_Add.cs'
+expect_code 'appsettings'               'src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/appsettings.json'
+expect_code 'an unrecognized new path'  'tools/whatever/Program.cs'
+
+echo
+echo '── inert: nothing runs ───────────────────────────────────────────────────────────────────────'
+expect 'code=false guards=false images=false' 'agent config under .claude/'   '.claude/agents/code-reviewer.md' '.claude/settings.json'
+expect 'code=false guards=false images=false' 'project memory + docs'         'CLAUDE.md' 'docs/claude-loop.md'
+expect 'code=false guards=false images=false' 'the loop conductor script'     'scripts/claude/backlog-loop.sh'
+expect 'code=false guards=false images=false' 'IaC (infra.yml gates it)'      'iac/main.tf'
+expect 'code=false guards=false images=false' 'another workflow'              '.github/workflows/codeql.yml'
+expect 'code=false guards=false images=false' 'the dev compose stack'         'compose.yaml'
+expect 'code=false guards=false images=false' 'an env example'                '.env.example'
+
+echo
+echo '── guards only: the bash gates re-run, the .NET gate does not ────────────────────────────────'
+expect 'code=false guards=true images=false' 'a script the provenance self-test executes' 'scripts/claude/work-ticket.sh'
+expect 'code=false guards=true images=false' 'the provenance gate itself'                 'scripts/claude/issue-trust.sh'
+expect 'code=false guards=true images=false' 'the SSR-purity guard'                       'scripts/check-ssr-purity.sh'
+expect 'code=false guards=true images=false' 'the migration-safety guard'                 'scripts/check-migration-safety.sh'
+expect 'code=false guards=true images=false' 'a guard self-test'                          'scripts/tests/check-migration-safety.tests.sh'
+
+echo
+echo '── images ───────────────────────────────────────────────────────────────────────────────────'
+expect 'code=false guards=true images=true'  'a shipped Dockerfile (restore-graph guard reads it)' 'src/Frontend/LotroKoniecDev.Frontend/Dockerfile'
+expect 'code=false guards=true images=true'  'the migrator Dockerfile'                             'Dockerfile.migrator.prod'
+expect 'code=false guards=false images=true' 'the build-context filter'                            '.dockerignore'
+
+echo
+echo '── the gate definitions validate themselves ─────────────────────────────────────────────────'
+expect 'code=true guards=true images=true'  'pr-verify defines all three jobs' '.github/workflows/pr-verify.yml'
+expect 'code=true guards=true images=false' 'ci defines the .NET gate on main' '.github/workflows/ci.yml'
+
+echo
+echo '── fail open ────────────────────────────────────────────────────────────────────────────────'
+expect 'code=true guards=true images=true'  'an empty diff runs everything' ''
+expect 'code=true guards=true images=false' 'docs + source together still build' 'docs/adr/0035.md' 'src/Patcher/LotroKoniecDev.Domain/Result.cs'
+
+echo
+if [ "$failures" -gt 0 ]; then
+    printf '%d/%d cases FAILED\n' "$failures" "$cases"
+    exit 1
+fi
+printf 'all %d cases passed\n' "$cases"


### PR DESCRIPTION
## Problem

PR #497 touched `.claude/`, `CLAUDE.md`, `docs/` and two loop scripts — **zero lines of C#** — and ran the full .NET gate: restore, Release build, unit suite, integration suite (real PostgreSQL). Plus CodeQL.

Cause: pr-verify's `changes` gate had a single `force_build` verdict that mixed two unrelated questions:

1. *can this change break the .NET build/tests?*
2. *does CI **execute** this script, so the guard that executes it must re-run?*

`scripts/claude/work-ticket.sh` is in group 2 (the ADR-0026 provenance self-test drives it), so editing it forced group 1 as well.

## Fix

`scripts/ci/classify-changes.sh` — one classifier, three **independent** verdicts:

| verdict | what it gates | cost |
|---|---|---|
| `code` | restore + Release build + unit + integration tests | minutes |
| `guards` | SSR purity, Dockerfile restore graph, migration safety, loop provenance — the bash gates CI executes | seconds |
| `images` | build + Trivy-scan the four shipped images | minutes |

The bash guards run whenever the job runs; every .NET step now carries its own `if: needs.changes.outputs.code == 'true'`. A guards-only PR still runs the job — so the required **"Pull Request Verification"** check reports exactly as before — it just finishes in seconds. Re-classified on the way: `.claude/` and `.dockerignore` are inert; a Dockerfile means guards + images, not a .NET build.

Verdict for #497's six files under the new classifier:

```
code=false  guards=true  images=false
```

## The direction that actually matters

A redundant build costs minutes. A **build input mis-classified as inert** skips the build and the tests silently, and nothing else in the pipeline notices. So the classifier ships with `scripts/tests/classify-changes.tests.sh` (33 table-driven cases pinning both directions — `.cs`, `.razor`, `.csproj`, `Directory.*.props`, `global.json`, `nuget.config`, `.editorconfig`, fixtures, appsettings, and an unrecognized new path all MUST yield `code=true`), and that self-test runs **unconditionally** in the `changes` job, before any verdict is trusted.

## Other workflows

- **codeql.yml** — analyses C# with `build-mode: none`, so `**/*.sh`, `**/*.ps1` and `.claude/**` cannot raise or clear an alert → added to `paths-ignore`. Not a required check, so this cannot deadlock a merge; the merge gate still refuses any PR with open alerts.
- **ci.yml** (main) — deliberately **keeps** running its .NET steps unconditionally: CD is triggered by CI concluding `success` (`workflow_run`), so "CI was green" must keep meaning the build and both suites really ran on that commit. Cheap content is filtered with `paths-ignore` instead (no CI ⇒ no CD); `.claude/**` joins that list.

This PR touches `pr-verify.yml`, so it runs the full gate against its own new definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)