### PR TITLE
HETZ-03: Secrets assembly — .env for Hetzner from Neon/Brevo/regenerated keys

### DIFF
--- a/.env.hetzner.example
+++ b/.env.hetzner.example
@@ -1,6 +1,9 @@
 # Template for the per-box env file of compose.hetzner.yaml (ADR-0034).
 # Copy to /opt/lotro/.env on the target box, fill in, chmod 600. NEVER commit a filled copy.
 #
+# Where each value comes from and how to rotate it (incl. the create-if-missing reseed traps):
+#   docs/deployment/hetzner-runbook.md — "Secrets and env vars".
+#
 # prod box  (lotro-prod):    DOMAIN_APP=lotro-translator.pl          COMPOSE_PROJECT_NAME=lotro-prod
 # staging box (lotro-staging): DOMAIN_APP=staging.lotro-translator.pl COMPOSE_PROJECT_NAME=lotro-staging
 

--- a/docs/deployment/hetzner-migration-plan.md
+++ b/docs/deployment/hetzner-migration-plan.md
@@ -68,6 +68,12 @@ takes the nightly `pg_dump` backups + encrypted env copies (Neon free = 6 h PITR
 
 ## Secrets — source of truth and how to remint
 
+> **Superseded by `docs/deployment/hetzner-runbook.md` §Secrets and env vars** (HETZ-03/#489), which
+> carries the full per-variable matrix, the rotation commands and the create-if-missing reseed traps.
+> The table below stays as the plan's summary. **The Key Vault shortcut was tried and is dead:**
+> `secret list` returns the names, `secret show` is `Forbidden` while the subscription is disabled —
+> no value is recoverable, everything was re-minted. Don't retry it.
+
 | Secret | Source | How |
 |---|---|---|
 | `ConnectionStrings__*` (TMS + Auth, prod + staging) | Neon | owner mints fresh in Neon console (or API; project/branch IDs in memory `neon-pitr-topology`). Prefer fresh over recovering KV copies. |

--- a/docs/deployment/hetzner-runbook.md
+++ b/docs/deployment/hetzner-runbook.md
@@ -9,11 +9,10 @@
 > `lotro-staging` hosts BOTH stagings. Everything the ADR/plan says about "the VPS" applies to
 > each box of the pair.
 >
-> Scope today: **server provisioning + facts** (HETZ-01/#487). The secrets matrix (HETZ-03/#489)
-> and the CD-over-ssh pipeline (HETZ-04/#490) extend this file when they land. Until HETZ-06/#492
-> retires the Azure content, `docs/deployment/runbook.md` remains the reference for the app-level
-> env-var matrix (service × environment) and the OIDC/issuer gotchas — those are
-> platform-independent and still binding.
+> Scope today: **server provisioning + facts** (HETZ-01/#487) and the **secrets matrix**
+> (HETZ-03/#489). The CD-over-ssh pipeline (HETZ-04/#490) extends this file when it lands. Until
+> HETZ-06/#492 retires the Azure content, `docs/deployment/runbook.md` remains the reference for the
+> OIDC/issuer gotchas — those are platform-independent and still binding.
 
 ## Server facts
 
@@ -45,6 +44,103 @@ The same layout exists on BOTH boxes; the single `/opt/lotro/.env` per box is wh
 them (`COMPOSE_PROJECT_NAME=lotro-prod` vs `lotro-staging`, domains, image tag) — see the header
 of `compose.hetzner.yaml`.
 
+## Secrets and env vars
+
+**`compose.hetzner.yaml` is the authoritative list** of what the stack consumes — a variable that
+does not appear there does nothing, whatever this table says. The live values sit in
+**`/opt/lotro/.env`** on each box (`chmod 600`, owner `deploy`): **one file per box**, because one
+box = one environment. (The migration plan drafted `.env.hetzner.prod` + `.env.hetzner.staging`
+side by side — that shape belonged to the single-CX32 design; with the two-CX23 fleet each box
+carries exactly one env file, named plainly `.env` so compose picks it up with no `--env-file`.)
+The tracked template carrying every key with placeholder values is **`.env.hetzner.example`**.
+
+**Nothing below was recovered from Azure — every value was re-minted, and it had to be**
+(see §Key Vault recovery attempt).
+
+### Secret material — source of truth and how to rotate
+
+| Variable | Consumed by | Source of truth | (Re)mint / rotate |
+|---|---|---|---|
+| `ConnectionStrings__AuthDatabase` | migrator, auth-api | **Neon** — the env's project (prod: `lotro-translator-prod`; staging has its own, ADR-0018), DB `lotro_auth` | Neon console → Roles → *Reset password* → rebuild the string by hand. **Keyword format only** — Npgsql does not parse `postgres://` URIs. Must carry `Ssl Mode=Require` and `Timeout=60` (rides out Neon's ~31 s scale-to-zero resume). |
+| `ConnectionStrings__TranslationDatabase` | migrator, tms-api | same Neon project, DB `lotro_translation` | same |
+| `OpenIddict__SigningKey__RsaPrivateKeyXml` | auth-api | **regenerate** — no canonical copy exists anywhere | `scripts/gen-openiddict-keys.sh` prints all three OpenIddict values as `KEY=VALUE` lines; append to the box `.env`. Pure config (never stored in the DB), so rotating just invalidates issued tokens → everyone re-logs in. Free pre-launch. |
+| `OpenIddict__EncryptionKey__Key` | auth-api | regenerate | same script, same blast radius. |
+| `OpenIddict__ApiClientSecret` | auth-api (**seeds** the `lotrokoniecdev-api` client row) | regenerate | same script — **but the DB row wins on restart; rotation needs the reseed below.** Must stay equal to the `SMOKE_CLIENT_SECRET` GitHub secret of the same environment. |
+| `Email__Username` | auth-api | **Brevo** dashboard → SMTP & API → SMTP keys | The SMTP **login**, shaped `<id>@smtp-brevo.com` — **not** the Brevo account e-mail, which fails the handshake with `535`. Read it off the Brevo dashboard; the value in use sits in the box `.env`. |
+| `Email__Password` | auth-api | **Brevo** (owner pastes) | Generate a new SMTP key in Brevo. Shown **once** and never readable back — the copies in the box `.env` and in GitHub secrets are both write-only, so a lost key is re-generated, never recovered. |
+| `AUTH_ADMIN_PASSWORD` (+ `AUTH_ADMIN_USERNAME`, `AUTH_ADMIN_EMAIL`) | auth-api → `AdminUser__*` seeder | **owner-chosen** | Seeded **only when missing**, so editing `.env` never rotates a live admin — see the reseed traps. `AUTH_ADMIN_USERNAME` must match `^[a-zA-Z0-9]+$` (ADR-0022) or auth-api fails at startup. |
+| `SMOKE_CLIENT_SECRET` *(GitHub secret, per environment — **not** a box var)* | `scripts/smoke.sh`, CD (#490) | == `OpenIddict__ApiClientSecret` of that env | `gh secret set SMOKE_CLIENT_SECRET --env <staging\|production> --body "$VALUE"` — **never `--body -`**: gh takes `-` literally and the candidate smoke then 401s. |
+| GHCR pull token *(not an env var — `docker login` state in `/home/deploy/.docker/config.json`)* | `docker compose pull` | **GitHub PAT**, scope `read:packages` **only** | Re-run `scripts/hetzner/bootstrap.sh` (its login leg prompts for user + PAT on a TTY). |
+| Deploy ssh key | CD over ssh (#490) | generated for CD | Lands with HETZ-04 — the `deploy` user's key, never `root`'s. |
+
+Not secrets, but they decide which environment a box *is* — full list with placeholders in
+`.env.hetzner.example`: `COMPOSE_PROJECT_NAME` (`lotro-prod` \| `lotro-staging`), `IMAGE_NAMESPACE`,
+`IMAGE_TAG`, `DOMAIN_APP` / `DOMAIN_AUTH` / `DOMAIN_TMS`, `ACME_EMAIL`, `TKS_DOMAIN_*` (the guest
+TheKittySaver vhosts), `Email__Host` / `Email__Port` / `Email__Mode` / `Email__SenderEmail` /
+`Email__Sender`, and `OTEL_EXPORTER_OTLP_ENDPOINT` (empty = exporter off).
+
+Two pieces of credential-ish material live **outside** `.env` and outside the DB: the
+`auth-keys` and `frontend-keys` **Data Protection keyring volumes**. They are not minted from
+anywhere — losing a volume simply invalidates every auth cookie and OIDC correlation state
+(everyone re-logs in), which is why they are named volumes and not bind mounts.
+
+### Reseed traps — the auth seeder is create-if-missing
+
+`SeedAuthDatabaseAsync` (`AuthSystem.API/Extensions/DatabaseSeederExtensions.cs`) creates only what
+is absent: the admin user is skipped when its e-mail **or** username already exists, and each
+OpenIddict client is skipped when its `client_id` already exists. The Neon DBs **outlived Azure**,
+so this is the normal case — and it means **editing `.env` and restarting silently changes nothing**:
+
+| You changed in `.env` | What silently keeps the OLD value | Symptom |
+|---|---|---|
+| `OpenIddict__ApiClientSecret` | the `lotrokoniecdev-api` client row | `client_credentials` with the new secret → **401**; smoke's token leg fails |
+| `AUTH_ADMIN_PASSWORD` | the admin `Users` row | the old password still logs in; the new one never works |
+| `DOMAIN_APP` | the `lotrokoniecdev-web` client's redirect + post-logout URIs (written **only at creation**) | login bounces with `invalid_redirect_uri` |
+
+Fix = delete the rows and let the seeder rebuild them from the current `.env`. Schema is
+**`authsystem`** and the Identity tables are **renamed** (`authsystem."Users"`, *not* `AspNetUsers`).
+Delete in FK order:
+
+```sql
+DELETE FROM authsystem."OpenIddictTokens";
+DELETE FROM authsystem."OpenIddictAuthorizations";
+DELETE FROM authsystem."OpenIddictApplications";
+-- only when rotating AUTH_ADMIN_* (UserRoles cascades with the user):
+DELETE FROM authsystem."Users" WHERE "Email" = '<admin e-mail>';
+```
+
+```bash
+docker compose -f compose.hetzner.yaml restart auth-api   # seeder runs at startup, recreates the rows
+```
+
+Every logged-in user is signed out by this (their tokens are gone) — free pre-launch, a real
+outage after launch.
+
+### Key Vault recovery attempt (recorded 2026-07-13 — do not retry)
+
+The plan allowed one shortcut attempt at reading the old secrets out of Azure Key Vault before
+re-minting. Result, from the owner's machine with `az` still logged in (subscription **Disabled**):
+
+| Call | Outcome |
+|---|---|
+| `az keyvault list` | **works** — all four vaults still enumerate (management-plane read) |
+| `az keyvault secret list --vault-name lotrotms-kv-{prod,staging}` | **works** — returns the 8 secret **names**: `admin-password`, `connection-string-auth`, `connection-string-translation`, `openiddict-api-client-secret`, `openiddict-encryption-key`, `openiddict-signing-key`, `smtp-password`, `smtp-username` |
+| `az keyvault secret show --name <any>` | **Forbidden** — `The subscription associated with this vault has been disabled.` |
+
+**Outcome: no secret value is recoverable from Key Vault.** The data plane serves metadata but
+refuses every *value* read while the subscription is disabled — so the vault tells you only what
+used to exist, never what it was. That is why every secret on the Hetzner boxes was re-minted from
+the table above. `scripts/seed-keyvault.sh` (whose name→env mapping is the historical index of what
+lived in the vaults) retires with the rest of the Azure surface in #492.
+
+### Hygiene
+
+- The box `.env` is the **only** live copy of the set → the owner keeps one encrypted off-box copy
+  (password manager). Losing it costs a re-mint plus the reseed above — never data.
+- `.gitignore` ignores `.env`, `.env.*` and `*.env`, whitelisting only the placeholder examples, so
+  a filled env file cannot be committed by accident; the required **GitGuardian** check on `main` is
+  the second net. Values travel to a box over ssh only — never through an issue, PR, or commit.
+
 ## (Re)provisioning a box
 
 1. **Owner:** Hetzner console → create the box (Ubuntu LTS, backups on for prod) with the
@@ -73,9 +169,8 @@ of `compose.hetzner.yaml`.
    script writes — bootstrap **overwrites** them (converges to the repo version), so any extra
    hand-tuned directive there is discarded. Fold anything worth keeping into the script first.
 4. **Stack files:** copy `compose.hetzner.yaml` + `.docker/hetzner/` to `/opt/lotro/` (as
-   `deploy`), assemble the box's `.env` per the secrets sources (`.env.hetzner.example` documents
-   every variable; sources of truth: migration plan §Secrets until #489 lands the full matrix
-   here), `chmod 600` it.
+   `deploy`), assemble the box's `.env` from `.env.hetzner.example` (every variable, its source of
+   truth and its rotation command: §Secrets and env vars above), `chmod 600` it.
 5. **Bring-up (staging box first as the rehearsal):** as `deploy`, on each box:
 
    ```bash
@@ -97,7 +192,7 @@ Each box is **fully disposable** — nothing on it is the source of truth for an
 | Databases | Neon (prod + staging, PITR + MIGR-04 snapshots) | nothing to do |
 | Images | GHCR (built by `cd.yml`) | nothing to do |
 | Config | this repo (`compose.hetzner.yaml`, Caddyfile) | scp again |
-| Secrets | `/opt/lotro/.env` per box — owner's backup + every value re-mintable (migration plan §Secrets) | restore or re-mint |
+| Secrets | `/opt/lotro/.env` per box — owner's backup + every value re-mintable (§Secrets and env vars) | restore or re-mint |
 | TLS certs | Caddy volume; Let's Encrypt re-issues | automatic on first bring-up |
 
 Recovery = **new VPS → bootstrap.sh → scp stack files → restore/re-mint the box's `.env` →


### PR DESCRIPTION
Closes #489

## What
Lands the secrets matrix for the Hetzner boxes in `docs/deployment/hetzner-runbook.md`: every env
var the stack consumes, with its source of truth and its rotation command.

## Why
The boxes run on re-minted secrets, but nothing wrote down *where each value comes from*. Rebuilding
a box (or rotating one key) meant re-deriving that from the compose file and tribal memory.

## Key Vault shortcut — tried once, recorded, dead
The ticket allowed one attempt at reading the old values out of Azure Key Vault:

- `az keyvault list` → works (management-plane read).
- `az keyvault secret list` → works, returns the 8 secret **names**.
- `az keyvault secret show` → **Forbidden**: `The subscription associated with this vault has been disabled.`

So the vault tells you what used to exist, never what it was. **No value is recoverable** — which is
why every secret was re-minted. The runbook records this so nobody spends time retrying it, and the
migration plan's §Secrets now points at the runbook.

## The part that was not in any doc
The auth seeder is **create-if-missing** (`DatabaseSeederExtensions.cs`), and the Neon DBs outlived
Azure — so on a surviving DB, changing `OpenIddict__ApiClientSecret`, `AUTH_ADMIN_PASSWORD` or
`DOMAIN_APP` in `.env` and restarting **silently changes nothing** (the client row / admin row / the
web client's redirect URIs are only written at creation). Documented with the symptom each one
produces and the FK-ordered delete + restart that actually rotates them. Table names and the
`UserRoles` cascade were verified against `20260627145210_InitialAuthSchema.cs`, not from memory.

## Deviation from the ticket body
The ticket says "assemble `.env.hetzner.prod` + `.env.hetzner.staging` on the server". That shape
belonged to the single-CX32 design; the fleet is two CX23 boxes, so **one box = one environment =
one `/opt/lotro/.env`** (already in place since the Phase-0 bring-up). The runbook documents the
real layout and says why.

## Test
Docs-only. `scripts/ci/classify-changes.sh` → `code=false guards=false images=false` (correctly
inert). No live secret value in the diff — only placeholder shapes; GitGuardian + the local
secret-detect hook pass.