### PR TITLE
HETZ-05: Bring-up + DNS cutover — prods live on Hetzner

### DIFF
--- a/.env.hetzner.example
+++ b/.env.hetzner.example
@@ -30,10 +30,21 @@ OpenIddict__ApiClientSecret=
 OpenIddict__SigningKey__RsaPrivateKeyXml=
 
 # --- Email (Brevo SMTP; Username is the SMTP login from the Brevo dashboard, not the account email) ---
+#
+# Email__SenderEmail MUST be an address Brevo is authorised to send as — either the verified
+# *single sender*, or any address on a domain authenticated in Brevo (DKIM + SPF records published).
+# Anything else FAILS SILENTLY AND UNDETECTABLY: Brevo's relay ACCEPTS the message (so the app's
+# send succeeds, and the deep /health SMTP check stays green — it only proves connect + auth), and
+# the receiver then drops it for failing sender authentication. Nothing arrives, nothing errors, and
+# RegisterUser's auto-confirm fallback does NOT fire (it only triggers on a FAILED send), so users
+# are left stuck on "confirm your e-mail" forever. This is exactly how #491 shipped both prods with
+# an unroutable `no-reply@lotro-translator.pl`; the only way to catch it is to actually register and
+# read the inbox (docs/deployment/hetzner-runbook.md → "E-mail deliverability").
+# Leave BLANK on purpose: a wrong value is worse than a missing one.
 Email__Host=smtp-relay.brevo.com
 Email__Port=587
 Email__Mode=StartTls
-Email__SenderEmail=no-reply@lotro-translator.pl
+Email__SenderEmail=
 Email__Sender=LOTRO PL
 Email__Username=
 Email__Password=

--- a/docs/deployment/hetzner-runbook.md
+++ b/docs/deployment/hetzner-runbook.md
@@ -79,6 +79,38 @@ Not secrets, but they decide which environment a box *is* — full list with pla
 TheKittySaver vhosts), `Email__Host` / `Email__Port` / `Email__Mode` / `Email__SenderEmail` /
 `Email__Sender`, and `OTEL_EXPORTER_OTLP_ENDPOINT` (empty = exporter off).
 
+### E-mail deliverability — the sender must be one Brevo is authorised to send as
+
+`Email__SenderEmail` is not a free-text label. It must be either Brevo's verified **single sender**
+(today: `koniecdev@gmail.com`) or an address on a domain **authenticated in Brevo** — i.e. one whose
+DKIM + SPF records are published in DNS. Any other value fails in the one way no alarm can see:
+
+1. Brevo's relay **accepts** the message, so `IEmailService.SendAsync` returns success.
+2. The deep auth `/health` SMTP check stays **green** — it only proves connect + authenticate.
+3. The receiver (Gmail, etc.) sees mail claiming a domain with no SPF and no aligned DKIM, and
+   **silently drops it** — it does not even reach spam.
+4. `RegisterUser` auto-confirms a user only when the send **fails** (`RegisterUser.cs`, the
+   `emailResult.IsFailure` branch). A send that "succeeded" skips that net, so every new account is
+   stranded at *"potwierdź adres e-mail"* and **nobody can log in**.
+
+This shipped to **both** prods during the Hetzner cutover (#491): `.env.hetzner.example` seeded
+`no-reply@lotro-translator.pl`, and `lotro-translator.pl` has **no SPF, DKIM or DMARC records at
+all** (`dig +short TXT lotro-translator.pl` returns nothing). Fixed by pointing both boxes at the
+verified single sender.
+
+**The only check that works is an end-to-end one** — register a real account and read a real inbox;
+`smoke.sh` cannot cover this, and neither can a health probe:
+
+```bash
+dig +short TXT lotro-translator.pl            # SPF/DKIM/DMARC present at all? (today: nothing)
+# then actually register on the env and confirm the mail lands (Gmail plus-addressing works:
+# koniecdev+check@gmail.com), because only delivery proves delivery.
+```
+
+To move off the personal-gmail sender, authenticate the domain in Brevo (Senders → Domains → add
+`lotro-translator.pl`, publish the DKIM + SPF records it prints, add a DMARC record), *then* switch
+`Email__SenderEmail` to `no-reply@lotro-translator.pl` — and re-run the registration check above.
+
 Two pieces of credential-ish material live **outside** `.env` and outside the DB: the
 `auth-keys` and `frontend-keys` **Data Protection keyring volumes**. They are not minted from
 anywhere — losing a volume simply invalidates every auth cookie and OIDC correlation state


### PR DESCRIPTION
Closes #491.

## What this ticket actually found

Bring-up and DNS cutover were done in the 2026-07-12 interactive session. Verifying the remaining
acceptance criterion — **"login round-trip works"** — surfaced a **launch blocker on both prods**:
nobody could complete a registration, because activation e-mails were never delivered.

### Root cause

`.env.hetzner.example` seeded `Email__SenderEmail=no-reply@lotro-translator.pl`, and both boxes were
assembled from it. Brevo is not authorised to send as that address: `lotro-translator.pl` has **no
SPF, no DKIM and no DMARC records at all** (`dig +short TXT lotro-translator.pl` → nothing). The
Azure stack had sent as the Brevo-verified *single sender*, which is why this only appeared after the
cutover.

It fails in the one way nothing can see:

1. Brevo's relay **accepts** the message → `SendAsync` returns success.
2. The deep auth `/health` SMTP check stays **green** — it only proves connect + authenticate.
3. Gmail drops the mail for failing sender authentication — it does not even reach spam.
4. `RegisterUser` auto-confirms a user only when the send **fails**, so a send that "succeeded"
   skips that safety net and every new account is stranded on *"potwierdź adres e-mail"*.

### Fix

- **Both boxes** (applied live): `Email__SenderEmail` pointed at the verified Brevo sender, auth-api
  recreated.
- **This PR**: stop shipping a sender that cannot work — blank the value in `.env.hetzner.example`
  (a wrong sender is worse than a missing one) and document the failure mode, why no probe catches
  it, and the only check that does (register + read a real inbox) in the runbook, plus the path off
  the current sender.

## Verification (both environments, from an external network)

| Check | prod | staging |
|---|---|---|
| DNS → Hetzner box | resolves | resolves |
| Valid LE cert on all 3 vhosts | yes | yes |
| auth + tms `/health/ready` | 200 | 200 |
| Blazor asset fingerprint (#414 tell) | `blazor.web.<hash>.js` present | same |
| `GET /api/v1/translation-files/pl` | 200 + ETag, revalidate → 304 | 200 + ETag → 304 |
| **register → e-mail delivered → confirm → OIDC login → `/translations` + `/account`** | **green** | **green** |

The round-trip was driven end-to-end over plain HTTP (the auth pages are Razor and the frontend is
Static SSR, so no browser engine is needed), with the activation link read out of a real inbox.

## Notes / follow-ups (not in this PR)

- **Neon still autosuspends under the always-on host** — staging's compute suspended ~5 min after the
  last request, so the boxes do not hold it awake and compute burn stays traffic-shaped. Restarting
  auth-api against a *suspended* compute brought it up healthy in 8 s with no retry and no crash
  (the resume itself is ~1–2 s), so the ACA-era cold-start race — a ~31 s resume losing to auth's
  ~20 s connect timeout — **does not reproduce** on this host.
- Brevo **domain authentication** for `lotro-translator.pl`, so mail can leave a `no-reply@` address
  — owner-assisted follow-up.
- **CD over ssh is not operational yet**: the deploy path on the boxes and the per-environment
  deploy vars/secrets still need the HETZ-01 bootstrap + wiring. Owner-assisted follow-up; deploys
  remain manual until then.