### PR TITLE
fix(hetzner): bootstrap must adopt the box's Docker engine, not swap it

### DIFF
--- a/docs/deployment/hetzner-runbook.md
+++ b/docs/deployment/hetzner-runbook.md
@@ -200,6 +200,20 @@ lived in the vaults) retires with the rest of the Azure surface in #492.
    `/etc/ssh/sshd_config.d/00-hardening.conf` and `/etc/fail2ban/jail.local` against what the
    script writes — bootstrap **overwrites** them (converges to the repo version), so any extra
    hand-tuned directive there is discarded. Fold anything worth keeping into the script first.
+
+   **The Docker leg adopts, it does not install** (fixed 2026-07-13, wiring CD to the live pair).
+   The live pair runs **Ubuntu's** `docker.io` + `containerd` + `docker-compose-v2`, not Docker's
+   `docker-ce` stack — and the two CONFLICT. An unguarded `apt-get install docker-ce containerd.io`
+   on such a box is an engine **swap**: apt removes the running engine, dockerd restarts, and every
+   container on the host goes with it — *both* stacks, `/opt/lotro` **and** `/opt/tks`. So the
+   script now probes for `docker` + `docker compose` and installs `docker-ce` only when the box has
+   no engine at all. Do not "simplify" that guard away; the engine's vendor is irrelevant to us,
+   its presence is not.
+
+   **The GHCR login is optional today** — the four images are **public** packages, so `deploy`
+   pulls them anonymously and the PAT prompt can be skipped (the script warns and carries on). It
+   stays in the script because the login is what a *private* package would need; if you ever flip
+   the packages to private, that prompt is suddenly load-bearing.
 4. **Stack files:** copy `compose.hetzner.yaml` + `.docker/hetzner/` to `/opt/lotro/` (as
    `deploy`), assemble the box's `.env` from `.env.hetzner.example` (every variable, its source of
    truth and its rotation command: §Secrets and env vars above), `chmod 600` it.
@@ -272,7 +286,14 @@ TheKittySaver, which it proxies.
 
 ### One-time setup per environment
 
-CD fails closed with an explicit "not wired for ssh deploys" error until each environment
+**Precondition — the box needs a `deploy` user that owns the stack.** CD connects as `deploy` and
+scp's over `/opt/lotro`, so a box brought up by hand as root is not deployable: there is no `deploy`
+to log in as, and even once created it cannot read the root-owned `0600` `.env` nor overwrite the
+root-owned stack files. `bootstrap.sh` provisions the user *and* converges the ownership of
+`/opt/lotro` + `/opt/tks` recursively — that is the fix, not a `chown` by hand. (The Phase-0 pair
+was brought up inline without it; CD could not run until the user existed — 2026-07-13.)
+
+CD then fails closed with an explicit "not wired for ssh deploys" error until each environment
 (`staging`, `production`) carries these. Values for the boxes are in §Server facts.
 
 | Kind | Name | Value |
@@ -288,6 +309,15 @@ CD fails closed with an explicit "not wired for ssh deploys" error until each en
 
 Repo-level `CD_ENABLED=true` arms the deploy jobs at all; `STAGING_ENABLED=true` arms the staging leg
 (ADR-0018).
+
+> ⚠️ **A stale `SMOKE_CLIENT_SECRET` looks exactly like a broken deploy.** It is the one value here
+> that lives in *two* places — the box `.env` and the GitHub secret — and nothing reconciles them. Roll
+> the OpenIddict keys on a box (HETZ-03 did, for both) without re-setting the secret and CD still
+> deploys perfectly: images pull, the migration gate passes, the containers come up — and then smoke's
+> `client_credentials` leg **401s**, CD judges the rollout red and **automatically rolls it back**. The
+> log accuses the release; the fault is the secret. Whenever you rotate `OpenIddict__ApiClientSecret`,
+> re-set this in the same breath. There is no `SMOKE_CLIENT_SECRET` on `production` at env level ⇒ it
+> silently falls back to the **repo-level** secret, which is an Azure-era leftover — set it per env.
 
 **Mint a CD deploy key per box** — one key per environment, so a staging compromise cannot touch prod.
 It is the `deploy` user's key, never `root`'s:

--- a/scripts/hetzner/bootstrap.sh
+++ b/scripts/hetzner/bootstrap.sh
@@ -11,7 +11,8 @@
 #   ssh root@<ip> 'GHCR_USER=<user> GHCR_TOKEN=<pat> bash -s' < scripts/hetzner/bootstrap.sh
 #
 # What it sets up:
-#   * Docker Engine + compose plugin (official Docker apt repo — Ubuntu's docker.io is stale)
+#   * Docker Engine + compose plugin — ADOPTS whatever working engine the box already has, and
+#     installs docker-ce from Docker's apt repo only when there is none (see the leg below)
 #   * ufw: deny incoming except 22/80/443, allow outgoing
 #   * fail2ban with the systemd backend (24.04 ships no /var/log/auth.log without rsyslog)
 #   * unattended-upgrades (security patches apply themselves)
@@ -73,19 +74,38 @@ apt-get update -q
 # Upgrades are unattended-upgrades' job (security) or a deliberate operator action.
 apt-get install -qy --no-upgrade ca-certificates curl ufw fail2ban unattended-upgrades python3-systemd
 
-log "Docker Engine + compose plugin (official Docker apt repo)"
-install -m 0755 -d /etc/apt/keyrings
-if [ ! -f /etc/apt/keyrings/docker.asc ]; then
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-    chmod a+r /etc/apt/keyrings/docker.asc
-fi
-if write_file /etc/apt/sources.list.d/docker.list 0644 <<EOF
+log "Docker Engine + compose plugin"
+# ADOPT an engine that is already there; install docker-ce ONLY on a box that has none.
+#
+# The live CX23 pair (and any box provisioned from Ubuntu's own archive) runs docker.io +
+# containerd + docker-compose-v2. Those packages CONFLICT with Docker's docker-ce stack, so
+# `apt-get install docker-ce containerd.io …` on such a box is not an install — it is an engine
+# SWAP: apt removes the running docker.io/containerd and dockerd restarts, bouncing every container
+# on the host (BOTH compose stacks — /opt/lotro and /opt/tks). `--no-upgrade` does not save us
+# here; it only skips packages that are already installed, and docker-ce is not one of them.
+#
+# The script needs an engine and the compose plugin — not a specific vendor's packaging of them.
+# So: probe for the capability, and touch apt only when the capability is missing. This is what
+# makes the "safe to re-run on the hand-hardened Phase-0 boxes" promise in the header actually true.
+# Found the hard way on 2026-07-13, wiring CD to the live pair (#491 follow-up).
+if command -v docker > /dev/null 2>&1 && docker compose version > /dev/null 2>&1; then
+    echo "Engine + compose plugin already present ($(docker --version)) — adopting it."
+    echo "NOT installing docker-ce: it conflicts with Ubuntu's docker.io and the swap would restart every container."
+else
+    echo "No Docker engine (or no compose plugin) — installing docker-ce from Docker's apt repo."
+    install -m 0755 -d /etc/apt/keyrings
+    if [ ! -f /etc/apt/keyrings/docker.asc ]; then
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        chmod a+r /etc/apt/keyrings/docker.asc
+    fi
+    if write_file /etc/apt/sources.list.d/docker.list 0644 <<EOF
 deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${CODENAME} stable
 EOF
-then
-    apt-get update -q
+    then
+        apt-get update -q
+    fi
+    apt-get install -qy --no-upgrade docker-ce docker-ce-cli containerd.io docker-compose-plugin
 fi
-apt-get install -qy --no-upgrade docker-ce docker-ce-cli containerd.io docker-compose-plugin
 systemctl enable --now docker
 
 log "deploy user (docker group, key-only ssh, locked password)"
@@ -107,7 +127,14 @@ if [ ! -s /home/deploy/.ssh/authorized_keys ]; then
 fi
 
 log "stack directories (/opt/lotro for LotroKoniecDev, /opt/tks for TheKittySaver — ADR-0034 §5)"
+# -R, not just `install -d`: on a box where the stack was landed BEFORE the deploy user existed (the
+# Phase-0 pair — root scp'd the files in by hand), `install -d` chowns only the directory and leaves
+# every file inside it root-owned. Bootstrap then reports success while CD still cannot deploy: `.env`
+# is 0600 root, so deploy cannot read it (no compose run at all), and scp of compose.hetzner.yaml /
+# the Caddyfile / deploy.sh cannot truncate a root-owned file in a deploy-owned directory. Converging
+# the CONTENTS is what makes the deploy user real. Modes are left alone — only ownership moves.
 install -d -m 0755 -o deploy -g deploy /opt/lotro /opt/tks
+chown -R deploy:deploy /opt/lotro /opt/tks
 
 log "sshd hardening (PasswordAuthentication no)"
 # Lockout guard: never disable password auth on a box where NO key-based path exists (a box


### PR DESCRIPTION
## What

`scripts/hetzner/bootstrap.sh` says in its own header that it is *"Safe to re-run at any time — including on the Phase-0 boxes that were hardened by hand"*. It is not. Two defects, found while wiring CD to the live boxes.

### 1. The Docker leg is an engine swap, not an install

The boxes run Ubuntu's `docker.io` + `containerd` + `docker-compose-v2`. The script installs `docker-ce` + `containerd.io` + `docker-compose-plugin` from Docker's apt repo. Those packages **conflict**: apt would remove the running engine and install the other one, restarting `dockerd` — and with it **every container on the host**, both compose stacks (`/opt/lotro` and `/opt/tks`).

`--no-upgrade` does not protect against this. It skips packages that are *already installed*, and `docker-ce` is not one of them.

The script needs *an* engine and *a* compose plugin — the vendor is irrelevant. So it now probes for the capability and only installs `docker-ce` on a box that has no engine at all.

### 2. `install -d` leaves the stack contents root-owned

On a box where the stack landed **before** the `deploy` user existed, `install -d -o deploy` chowned the directory and nothing inside it. Bootstrap then reported success while CD still could not deploy:

- `.env` is `0600 root` → `deploy` cannot read it, so no compose command runs at all;
- `scp` of `compose.hetzner.yaml` / the Caddyfile / `deploy.sh` cannot truncate a root-owned file, even in a deploy-owned directory.

Ownership is now converged recursively. Modes are untouched.

## Docs

The runbook gains three notes: the adopt-don't-install rule, the `deploy`-user precondition for CD, and the trap that a **stale `SMOKE_CLIENT_SECRET` looks exactly like a broken deploy** — the rollout succeeds, smoke's `client_credentials` leg 401s, CD auto-rolls-back, and the log blames the release instead of the secret.

## Verification

`shellcheck` clean. The live boxes were converged by hand to the state this script now produces (deploy user, docker group, recursively-owned `/opt/lotro`), with zero container restarts — which is exactly the property the old script would have violated.