### PR TITLE
chore(loop): re-enable Fable 5 for reviews + loop worker

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Use this agent to review code changes against ticket acceptance criteria, find regressions, architecture violations, audit for unhandled edge cases (anti-happy-path gate), and verify test coverage. Invoke after implementing a feature or before creating a PR.
 tools: Read, Grep, Glob, Bash
-model: opus
+model: fable
 effort: xhigh
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ scripts/claude/backlog-loop.sh 123 130                 # exactly these tickets, 
 caffeinate -is scripts/claude/backlog-loop.sh          # overnight run on macOS (blocks sleep)
 scripts/claude/next-ticket.sh                          # print the next READY ticket (priority + deps)
 scripts/claude/work-ticket.sh 123                      # one ticket, one fresh headless session
-# defaults: opus (Opus 4.8) · effort high (reviews at xhigh) · permission-mode auto — override via LOOP_MODEL /
+# defaults: fable (Fable 5) · effort high (reviews at xhigh) · permission-mode auto — override via LOOP_MODEL /
 # LOOP_EFFORT / LOOP_PERMISSION_MODE / LOOP_UNSAFE=1 · full manual: docs/claude-loop.md
 
 # TMS — EF Core migrations (write context owns them; --connection makes it work without appsettings/live DB)
@@ -368,14 +368,14 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 - **Right-size the design — YAGNI by default.** Before proposing an abstraction, cache, config
   knob, queue, or new infra, check it solves a **real, present** need from the current
   spec/ticket — not a hypothetical future. Pick the simple path and note the trade-off in one line.
-- **Agent fan-out is budgeted; reviews run on Opus 4.8 at xhigh effort, everything else at high**
-  (2026-07-13; reverted the 2026-07-09→11 Fable 5 experiment back to Opus 4.8, keeping the
-  xhigh-reviews / high-everything-else effort split). Hard cap: **max 4 subagents in parallel**,
-  no chained waves by default; a small diff gets reviewed **inline, zero agents**. The
-  `code-reviewer` agent, `/code-review` and `/security-review` run with **model Opus 4.8 + effort
-  xhigh**; loop-mode worker sessions run at **effort high** (`LOOP_EFFORT` default) — unless the
-  prompt for that run explicitly says otherwise. Applies to interactive sessions and loop-mode
-  workers alike.
+- **Agent fan-out is budgeted; reviews run on Fable 5 at xhigh effort, everything else at high**
+  (2026-07-13; re-enabled Fable 5 after the same-day Opus revert #497 — the xhigh-reviews /
+  high-everything-else effort split is unchanged; original Fable switch 2026-07-09→11). Hard cap:
+  **max 4 subagents in parallel**, no chained waves by default; a small diff gets reviewed
+  **inline, zero agents**. The `code-reviewer` agent, `/code-review` and `/security-review` run
+  with **model Fable 5 + effort xhigh**; loop-mode worker sessions run at **effort high**
+  (`LOOP_EFFORT` default) — unless the prompt for that run explicitly says otherwise. Applies to
+  interactive sessions and loop-mode workers alike.
 - **Frontend is Static SSR — enforced, not just documented.** No WebAssembly, no SignalR circuit,
   no per-user server state; forms post via `<form method="post" @formname @onsubmit>` (the SSR
   `@onsubmit` special-case) or `<EditForm OnValidSubmit>` — never interactive `@on*` handlers,

--- a/docs/claude-loop.md
+++ b/docs/claude-loop.md
@@ -97,7 +97,7 @@ one ticket with `LOOP_TRUST_GATE=0`, or add the commenter to `LOOP_TRUSTED_LOGIN
 | Var | Default | Meaning |
 |---|---|---|
 | `LOOP_EFFORT` | `high` | claude effort per ticket (reviews inside the session run at `xhigh` via the `code-reviewer` agent definition) |
-| `LOOP_MODEL` | `opus` | Opus 4.8 with its native 1M-token context window (the 2026-07-09→11 Fable 5 experiment was reverted 2026-07-13) |
+| `LOOP_MODEL` | `fable` | Fable 5 (re-enabled 2026-07-13 after a same-day Opus revert; original switch 2026-07-09) |
 | `LOOP_PERMISSION_MODE` | `auto` | headless permission mode |
 | `LOOP_CONFIG_DIR` | `~/.claude-account1` | Claude config dir = which account runs the loop (exported as `CLAUDE_CONFIG_DIR`) |
 | `LOOP_ALLOWED_TOOLS` | git/gh/dotnet/scripts | loop-scoped Bash allowlist passed via `--allowedTools` |

--- a/scripts/claude/backlog-loop.sh
+++ b/scripts/claude/backlog-loop.sh
@@ -12,7 +12,7 @@
 #   caffeinate -is scripts/claude/backlog-loop.sh   # overnight on macOS (blocks sleep)
 #
 # Env (all forwarded to work-ticket.sh): LOOP_EFFORT (default high; reviews run at xhigh via the
-#   code-reviewer agent definition), LOOP_MODEL (default opus),
+#   code-reviewer agent definition), LOOP_MODEL (default fable),
 #   LOOP_CONFIG_DIR (default ~/.claude-account1 — which account runs the loop),
 #   LOOP_PERMISSION_MODE (default auto), LOOP_UNSAFE, LOOP_MAX_BUDGET_USD,
 #   LOOP_TICKET_TIMEOUT_MIN, LOOP_CHECKS_TIMEOUT_MIN, LOOP_SKIP_LABELS,

--- a/scripts/claude/work-ticket.sh
+++ b/scripts/claude/work-ticket.sh
@@ -10,8 +10,8 @@
 # Env:
 #   LOOP_EFFORT             claude effort level (default: high — reviews inside the session run
 #                           at xhigh via the code-reviewer agent definition)
-#   LOOP_MODEL              model (default: opus — Opus 4.8 with its native 1M-token context
-#                           window; the 2026-07-09→11 Fable 5 experiment was reverted 2026-07-13)
+#   LOOP_MODEL              model (default: fable — Fable 5; re-enabled 2026-07-13 after a
+#                           same-day Opus revert)
 #   LOOP_CONFIG_DIR         Claude config dir = which account runs the loop
 #                           (default: ~/.claude-account1)
 #   LOOP_GH_USER            gh account whose token backs the loop's gh write calls — PR merge,
@@ -44,7 +44,7 @@ RUN_DIR="${2:-$REPO_ROOT/logs/claude-loop/adhoc-$(date +%Y%m%d-%H%M%S)}"
 mkdir -p "$RUN_DIR"
 
 EFFORT="${LOOP_EFFORT:-high}"
-MODEL="${LOOP_MODEL:-opus}"
+MODEL="${LOOP_MODEL:-fable}"
 export CLAUDE_CONFIG_DIR="${LOOP_CONFIG_DIR:-$HOME/.claude-account1}"
 PERMISSION_MODE="${LOOP_PERMISSION_MODE:-auto}"
 TIMEOUT_MIN="${LOOP_TICKET_TIMEOUT_MIN:-90}"
@@ -103,7 +103,7 @@ salvage() {
         git add -A >/dev/null 2>&1 || true
         git commit --quiet --no-verify \
             -m "claude-loop: salvage uncommitted work for #$ISSUE" \
-            -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>" >/dev/null 2>&1 || true
+            -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>" >/dev/null 2>&1 || true
         log "leftover changes committed on branch $salvage_branch"
     fi
     git checkout main --quiet 2>/dev/null || true


### PR DESCRIPTION
Re-enables **Fable 5** for the code-review reviewers and the loop worker, undoing the same-day Opus revert in #497 (per owner decision). Target state:

- **Reviewers** (`code-reviewer` agent → `/code-review`, `/security-review`, and the `/ticket` review gate): **Fable 5 + xhigh** — effort was already `xhigh`, only the model flips.
- **Main loop worker** (`LOOP_MODEL`): **Fable 5 + high** — effort stays `high`.

## Changes
- `.claude/agents/code-reviewer.md` — `model: opus` → `fable` (effort `xhigh` unchanged).
- `scripts/claude/work-ticket.sh` — `LOOP_MODEL` default `opus` → `fable`; salvage `Co-Authored-By` trailer → `Claude Fable 5`.
- `scripts/claude/backlog-loop.sh` + `docs/claude-loop.md` + `CLAUDE.md` — align the documented defaults and the dated standing-rule note (now: re-enabled 2026-07-13 after the same-day #497 revert; original switch 2026-07-09→11).

## Deliberately out of scope
- The unrelated #497 conductor-intervention doc (`.claude/commands/backlog.md`) is **left untouched** — this is why it's a targeted re-apply, not a whole-PR revert.
- `scripts/claude/audit.sh` is **git-ignored / local-only**; its `AUDIT_MODEL` default was flipped to `claude-fable-5` on the local machine but is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)