### PR TITLE
HETZ-06 follow-up: entomb the Azure IaC in docs/deployment/azure-graveyard/ instead of deleting it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -510,9 +510,10 @@ intel/
 # Stryker.NET mutation testing output
 StrykerOutput/
 
-# Terraform — the IaC itself was retired with Azure (ADR-0034 / #492), so nothing here is tracked
-# any more. These rules stay as a net: leftover local artifacts (iac/.terraform/, iac/tfplan) must
-# never be swept into a commit by `git add -A` — a plan file can embed secrets in plaintext.
+# Terraform — the IaC itself was retired with Azure (ADR-0034 / #492); the only Terraform left in
+# the repo is the dead, never-to-be-applied copy under docs/deployment/azure-graveyard/. These rules
+# stay as a net: leftover local artifacts (.terraform/, tfplan) must never be swept into a commit by
+# `git add -A` — a plan file can embed secrets in plaintext.
 **/.terraform/*
 
 *.tfstate
@@ -523,6 +524,9 @@ crash.*.log
 
 *.tfvars
 *.tfvars.json
+# Exception: the graveyard's staging overrides. They are part of the tombstone, not live config, and
+# carry no secrets by design (ADR-0017 — env_id / public domain / Key Vault + identity NAMES only).
+!docs/deployment/azure-graveyard/**/*.tfvars
 
 *.tfplan
 tfplan

--- a/docs/adr/0034-hetzner-vps-instead-of-azure-container-apps.md
+++ b/docs/adr/0034-hetzner-vps-instead-of-azure-container-apps.md
@@ -160,7 +160,9 @@ machinery (ADR-0025) for hand-rolled backups on the same failure domain as the a
 - Changed: `cd.yml`/`deploy.yml` (ssh deploy legs), `docs/deployment/runbook.md` (rewritten),
   `CLAUDE.md` (M6 section), ADR-0027/0029 status lines
 - Retired: `iac/` Azure resources, `seed-keyvault.{sh,ps1}`, `infra.yml`, local-CA mounts in the
-  Hetzner stack (parity stack keeps them)
+  Hetzner stack (parity stack keeps them). The Terraform root and the Key Vault seeders are not
+  deleted but **entombed** in `docs/deployment/azure-graveyard/` (read-only, never runnable) — the
+  `iac/<file>` references throughout ADRs 0013/0016/0017/0019/0020/0027/0029 resolve there
 - Execution: epic #486, tickets #487–#492; owner-assisted bring-up is #491;
   plan: `docs/deployment/hetzner-migration-plan.md`
 

--- a/docs/deployment/azure-graveyard/README.md
+++ b/docs/deployment/azure-graveyard/README.md
@@ -1,0 +1,72 @@
+# Azure graveyard — the retired Azure Container Apps deployment
+
+**Status: DEAD. Nothing in this folder is wired to anything, and nothing here should be run.**
+It is a read-only record of how the platform was hosted between M6 and 2026-07-13, kept next to
+the docs that talk about it.
+
+The live deployment is a Hetzner VPS + Neon: read [`../runbook.md`](../runbook.md), and see
+[ADR-0034](../../adr/0034-hetzner-vps-instead-of-azure-container-apps.md) for why the move
+happened (the Azure for Students subscription ran out of credits, both prods went dark, renewal
+was refused). Epic #486 executed it; #492 (HETZ-06) took the Terraform out of the build.
+
+## Why keep it at all
+
+Two reasons, both about reading — not about running:
+
+1. **The ADRs still point here.** ADRs 0013, 0016, 0017, 0019, 0020, 0027 and 0029 argue
+   line-by-line about `iac/monitoring.tf`, `iac/observability.tf`, `iac/setup.tf` and friends.
+   Those decisions are still part of the project's history, and a decision record whose subject
+   file cannot be opened is half a record. Their `iac/<file>` references resolve to
+   `docs/deployment/azure-graveyard/iac/<file>`.
+2. **The topology is reusable thinking.** The alert rules, the SLO probes, the Key-Vault-only
+   secret path and the per-environment parametrization were designed against real production pain.
+   If this project ever lands on a managed platform again, this is the starting point — not a
+   blank page.
+
+## DO NOT run this
+
+- The subscription is **disabled**. `terraform apply` cannot work, and the state blob it wants
+  lives in a storage account inside that same dead subscription.
+- The state file is **not** here (it never was — it lived in Azure Blob Storage), so this
+  configuration has no memory of what it created.
+- The secrets are **not** here and never were: Key Vault held the values (ADR-0013), Terraform
+  only data-read them into versionless URIs.
+- `scripts/seed-keyvault.{sh,ps1}` were restored **without the executable bit**, on purpose.
+
+## What is here
+
+```
+iac/
+  setup.tf                    Terraform + azurerm/azapi provider pins, partial azurerm backend
+  backend-config/{prod,staging}.hcl   the state blob key per environment (ADR-0017)
+  env/staging.tfvars          staging's non-secret overrides (ADR-0017 — env_id, domain, names)
+  vars.tf, locals.tf          the variables and the derived public origins (issuer/redirect/CORS)
+  resource-group.tf           rg-lotrotms-<env>-polc-001
+  azure_container_app_env.tf  the shared ACA environment (one per subscription — the staging squeeze)
+  azure-law.tf                the shared Log Analytics workspace
+  azure-container-apps.tf     the three apps: auth-api, tms-api, frontend
+  migrator-job.tf             the EF Core migration job that ran before each rollout
+  keyvault.tf                 the Vault + the app identity's read role (values seeded out-of-band)
+  storage.tf                  the Data Protection keyring blob container (ADR-0005)
+  observability.tf            App Insights + the ACA managed OTel agent (ADR-0016)
+  monitoring.tf               Azure Monitor: alert rules, action groups, the SLO web tests (ADR-0019)
+scripts/
+  seed-keyvault.sh / .ps1     seeded the 8 Key Vault secrets out-of-band (ADR-0013)
+```
+
+`iac/.terraform.lock.hcl` was deliberately **not** restored — it is a machine artifact (provider
+hashes for an init that will never run again). Git history has it, as it has every file above:
+the last commit where this tree was live is the parent of `72e1a4b` (PR #504).
+
+## Where each Azure piece went
+
+| Azure | Now |
+|---|---|
+| Container Apps (3 apps + revisions) | `compose.hetzner.yaml` on one VPS per environment, `/opt/lotro` |
+| Container App job (migrator) | the migrator container, run first by `scripts/hetzner/deploy.sh` |
+| ACA ingress + managed certs | Caddy on the box (Let's Encrypt) |
+| Key Vault + seeders | a `chmod 600` `/opt/lotro/.env` per box, written by CD from GitHub secrets |
+| Terraform + `infra.yml` | nothing — a box is bootstrapped once by `scripts/hetzner/bootstrap.sh` |
+| App Insights / LAW / Monitor alerts | container logs + the daily `health-ping.yml` (ADR-0027's probe outlived its platform) |
+| Blob-backed DP keyring | a docker volume per app (ADR-0005 still applies) |
+| Scale-to-zero + warm window | nothing — the containers run 24/7; only Neon still suspends |

--- a/docs/deployment/azure-graveyard/iac/azure-container-apps.tf
+++ b/docs/deployment/azure-graveyard/iac/azure-container-apps.tf
@@ -1,0 +1,588 @@
+resource "azurerm_container_app" "auth_api" {
+  name                         = "lotrotms-auth-api-${var.env_id}"
+  container_app_environment_id = local.app_env_id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Multiple"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [data.azurerm_user_assigned_identity.aca.id]
+  }
+
+  # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
+  # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
+  # bootstrap tag (var.image_tag). See ADR-0012 §2.
+  #
+  # Traffic weights are likewise owned by the CD health-gated rollout (ADR-0012 §5 amendment, audit
+  # 0001 H7): each deploy creates a candidate revision at 0% traffic, smokes it, then shifts 100% to
+  # it. Terraform only seeds the initial weight below (latest_revision = true) so a freshly-created
+  # app serves its first revision; it must NOT revert the pipeline's per-deploy traffic decisions.
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image,
+      ingress[0].traffic_weight,
+    ]
+  }
+
+  # Secrets resolve from Key Vault at runtime through the user-assigned identity (ADR-0013) — no
+  # plaintext value enters this configuration or the Terraform state.
+  secret {
+    name                = "connection-string-auth"
+    key_vault_secret_id = local.kv_secret_id["connection-string-auth"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+  secret {
+    name                = "openiddict-signing-key"
+    key_vault_secret_id = local.kv_secret_id["openiddict-signing-key"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+  secret {
+    name                = "openiddict-encryption-key"
+    key_vault_secret_id = local.kv_secret_id["openiddict-encryption-key"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+  secret {
+    name                = "openiddict-api-client-secret"
+    key_vault_secret_id = local.kv_secret_id["openiddict-api-client-secret"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+  secret {
+    name                = "smtp-username"
+    key_vault_secret_id = local.kv_secret_id["smtp-username"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+  secret {
+    name                = "smtp-password"
+    key_vault_secret_id = local.kv_secret_id["smtp-password"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+  secret {
+    name                = "admin-password"
+    key_vault_secret_id = local.kv_secret_id["admin-password"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+
+  template {
+    # ADR-0027 replaces the always-warm floor of ADR-0012 R8 with a SCHEDULE. min_replicas is 0 in
+    # every environment; prod's warm replica now comes from the cron rule below, so the apps hold a
+    # replica only during the hours a recruiter opens the CV link and cost nothing overnight. The
+    # health-gated rollout stays valid at 0: deploy.yml's readiness polls (60×10s) wake the
+    # 0%-traffic candidate and warm the public auth origin before smoke, and the rollout still
+    # deactivates superseded revisions so no idle replica accumulates.
+    min_replicas = var.app_min_replicas
+    max_replicas = 1
+
+    # The platform's implicit HTTP scale rule exists ONLY while no rule is declared ("If you don't
+    # create a scale rule, the default scale rule is applied" — Azure "Scaling in Container Apps").
+    # Declaring the cron rule below therefore REPLACES it, and an app sitting at zero replicas would
+    # be left with no trigger to start on: a request outside the warm window would reach nothing.
+    # This rule is the 0→1 activation that keeps off-hours a cold start, never an outage.
+    http_scale_rule {
+      name                = "http"
+      concurrent_requests = "10"
+    }
+
+    # Warm window (ADR-0027). KEDA evaluates every scaler and takes max(metrics), so inside the
+    # window this rule acts as a dynamic minimum of one replica; outside it the app returns to
+    # min_replicas after the platform's 300 s cool-down. Staging passes null and runs pure
+    # scale-to-zero (ADR-0020), which is why the rule is a dynamic block rather than a literal.
+    dynamic "custom_scale_rule" {
+      for_each = var.app_warm_window == null ? [] : [var.app_warm_window]
+
+      content {
+        name             = "warm-window"
+        custom_rule_type = "cron"
+
+        metadata = {
+          timezone        = custom_scale_rule.value.timezone
+          start           = custom_scale_rule.value.start
+          end             = custom_scale_rule.value.end
+          desiredReplicas = "1"
+        }
+      }
+    }
+
+    container {
+      name   = "auth-api"
+      image  = "ghcr.io/koniecdev/lotrokoniecdev-auth-api:${var.image_tag}"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 8080
+        path      = "/health/live"
+
+        initial_delay           = 5
+        interval_seconds        = 30
+        timeout                 = 5
+        failure_count_threshold = 3
+      }
+
+      readiness_probe {
+        transport = "HTTP"
+        port      = 8080
+        path      = "/health/ready"
+
+        interval_seconds        = 30
+        timeout                 = 5
+        failure_count_threshold = 3
+        success_count_threshold = 1
+      }
+
+      startup_probe {
+        transport = "HTTP"
+        port      = 8080
+        path      = "/health/live"
+
+        interval_seconds        = 10
+        timeout                 = 5
+        failure_count_threshold = 30
+      }
+
+      env {
+        name  = "ASPNETCORE_ENVIRONMENT"
+        value = "Production"
+      }
+      env {
+        name  = "ASPNETCORE_URLS"
+        value = "http://+:8080"
+      }
+      env {
+        name        = "ConnectionStrings__AuthDatabase"
+        secret_name = "connection-string-auth"
+      }
+      env {
+        name  = "OpenIddict__Issuer"
+        value = local.auth_origin
+      }
+      env {
+        name        = "OpenIddict__SigningKey__RsaPrivateKeyXml"
+        secret_name = "openiddict-signing-key"
+      }
+      env {
+        name        = "OpenIddict__EncryptionKey__Key"
+        secret_name = "openiddict-encryption-key"
+      }
+      env {
+        name        = "OpenIddict__ApiClientSecret"
+        secret_name = "openiddict-api-client-secret"
+      }
+      env {
+        name  = "OpenIddict__WebClient__RedirectUris__0"
+        value = local.callback_url
+      }
+      env {
+        name  = "OpenIddict__WebClient__PostLogoutRedirectUris__0"
+        value = local.apex_origin
+      }
+      env {
+        name  = "Cors__AllowedOrigins__0"
+        value = local.apex_origin
+      }
+      env {
+        name  = "DataProtection__KeyRingPath"
+        value = "/keys"
+      }
+      env {
+        name  = "Email__Host"
+        value = "smtp-relay.brevo.com"
+      }
+      env {
+        name  = "Email__Port"
+        value = "587"
+      }
+      env {
+        name  = "Email__Mode"
+        value = "StartTls"
+      }
+      env {
+        name  = "Email__SenderEmail"
+        value = var.smtp_sender_email
+      }
+      env {
+        name  = "Email__Sender"
+        value = "LOTRO PL"
+      }
+      env {
+        name        = "Email__Username"
+        secret_name = "smtp-username"
+      }
+      env {
+        name        = "Email__Password"
+        secret_name = "smtp-password"
+      }
+      env {
+        name  = "AdminUser__Username"
+        value = var.admin_username
+      }
+      env {
+        name  = "AdminUser__Email"
+        value = var.admin_email
+      }
+      env {
+        name        = "AdminUser__Password"
+        secret_name = "admin-password"
+      }
+
+      volume_mounts {
+        name = "keys"
+        path = "/keys"
+      }
+    }
+
+    volume {
+      name         = "keys"
+      storage_type = "AzureFile"
+      storage_name = azurerm_container_app_environment_storage.auth_keys.name
+    }
+  }
+
+  ingress {
+    external_enabled           = true
+    target_port                = 8080
+    transport                  = "auto"
+    allow_insecure_connections = false
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+resource "azurerm_container_app" "tms_api" {
+  name                         = "lotrotms-tms-api-${var.env_id}"
+  container_app_environment_id = local.app_env_id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Multiple"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [data.azurerm_user_assigned_identity.aca.id]
+  }
+
+  # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
+  # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
+  # bootstrap tag (var.image_tag). See ADR-0012 §2.
+  #
+  # Traffic weights are likewise owned by the CD health-gated rollout (ADR-0012 §5 amendment, audit
+  # 0001 H7): each deploy creates a candidate revision at 0% traffic, smokes it, then shifts 100% to
+  # it. Terraform only seeds the initial weight below (latest_revision = true) so a freshly-created
+  # app serves its first revision; it must NOT revert the pipeline's per-deploy traffic decisions.
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image,
+      ingress[0].traffic_weight,
+    ]
+  }
+
+  # Secret resolves from Key Vault at runtime through the user-assigned identity (ADR-0013).
+  secret {
+    name                = "connection-string-translation"
+    key_vault_secret_id = local.kv_secret_id["connection-string-translation"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+
+  template {
+    # ADR-0027 replaces the always-warm floor of ADR-0012 R8 with a SCHEDULE. min_replicas is 0 in
+    # every environment; prod's warm replica now comes from the cron rule below, so the apps hold a
+    # replica only during the hours a recruiter opens the CV link and cost nothing overnight. The
+    # health-gated rollout stays valid at 0: deploy.yml's readiness polls (60×10s) wake the
+    # 0%-traffic candidate and warm the public auth origin before smoke, and the rollout still
+    # deactivates superseded revisions so no idle replica accumulates.
+    min_replicas = var.app_min_replicas
+    max_replicas = 1
+
+    # The platform's implicit HTTP scale rule exists ONLY while no rule is declared ("If you don't
+    # create a scale rule, the default scale rule is applied" — Azure "Scaling in Container Apps").
+    # Declaring the cron rule below therefore REPLACES it, and an app sitting at zero replicas would
+    # be left with no trigger to start on: a request outside the warm window would reach nothing.
+    # This rule is the 0→1 activation that keeps off-hours a cold start, never an outage.
+    http_scale_rule {
+      name                = "http"
+      concurrent_requests = "10"
+    }
+
+    # Warm window (ADR-0027). KEDA evaluates every scaler and takes max(metrics), so inside the
+    # window this rule acts as a dynamic minimum of one replica; outside it the app returns to
+    # min_replicas after the platform's 300 s cool-down. Staging passes null and runs pure
+    # scale-to-zero (ADR-0020), which is why the rule is a dynamic block rather than a literal.
+    dynamic "custom_scale_rule" {
+      for_each = var.app_warm_window == null ? [] : [var.app_warm_window]
+
+      content {
+        name             = "warm-window"
+        custom_rule_type = "cron"
+
+        metadata = {
+          timezone        = custom_scale_rule.value.timezone
+          start           = custom_scale_rule.value.start
+          end             = custom_scale_rule.value.end
+          desiredReplicas = "1"
+        }
+      }
+    }
+
+    container {
+      name  = "tms-api"
+      image = "ghcr.io/koniecdev/lotrokoniecdev-tms-api:${var.image_tag}"
+      # Sizing is per-env (vars.tf): the full exported.txt import (~79 MB, ~792k rows) retains
+      # ~1.2 GB managed at peak and OOMs the 0.5Gi size at its ~384 MB GC cap (75% of the cgroup
+      # limit; incident 2026-07-02), so STAGING overrides to the max Consumption size for QA while
+      # PROD deliberately stays small — the real fix is the #290 streaming import, and the staging
+      # override is removed with #290's DoD.
+      cpu    = var.tms_api_cpu
+      memory = var.tms_api_memory
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 8080
+        path      = "/health/live"
+
+        initial_delay           = 5
+        interval_seconds        = 30
+        timeout                 = 5
+        failure_count_threshold = 3
+      }
+
+      readiness_probe {
+        transport = "HTTP"
+        port      = 8080
+        path      = "/health/ready"
+
+        interval_seconds        = 30
+        timeout                 = 5
+        failure_count_threshold = 3
+        success_count_threshold = 1
+      }
+
+      startup_probe {
+        transport = "HTTP"
+        port      = 8080
+        path      = "/health/live"
+
+        interval_seconds        = 10
+        timeout                 = 5
+        failure_count_threshold = 30
+      }
+
+      env {
+        name  = "ASPNETCORE_ENVIRONMENT"
+        value = "Production"
+      }
+      env {
+        name  = "ASPNETCORE_URLS"
+        value = "http://+:8080"
+      }
+      env {
+        name        = "ConnectionStrings__TranslationDatabase"
+        secret_name = "connection-string-translation"
+      }
+      env {
+        name  = "Auth__Issuer"
+        value = local.auth_origin
+      }
+      env {
+        name  = "Auth__Authority"
+        value = local.auth_origin
+      }
+      env {
+        name  = "Auth__Audience"
+        value = "lotrokoniecdev-api"
+      }
+      env {
+        name  = "Cors__AllowedOrigins__0"
+        value = local.apex_origin
+      }
+      env {
+        name  = "Bootstrap__Enabled"
+        value = "false"
+      }
+    }
+  }
+
+  ingress {
+    external_enabled           = true
+    target_port                = 8080
+    transport                  = "auto"
+    allow_insecure_connections = false
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+resource "azurerm_container_app" "frontend" {
+  name                         = "lotrotms-frontend-${var.env_id}"
+  container_app_environment_id = local.app_env_id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Multiple"
+
+  # The rolling image is owned by the CD pipeline (az containerapp update by commit SHA), not
+  # Terraform. Ignore image drift so `terraform apply` never reverts a deployed revision back to the
+  # bootstrap tag (var.image_tag). See ADR-0012 §2.
+  #
+  # Traffic weights are likewise owned by the CD health-gated rollout (ADR-0012 §5 amendment, audit
+  # 0001 H7): each deploy creates a candidate revision at 0% traffic, smokes it, then shifts 100% to
+  # it. Terraform only seeds the initial weight below (latest_revision = true) so a freshly-created
+  # app serves its first revision; it must NOT revert the pipeline's per-deploy traffic decisions.
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image,
+      ingress[0].traffic_weight,
+    ]
+  }
+
+  template {
+    # ADR-0027 replaces the always-warm floor of ADR-0012 R8 with a SCHEDULE. min_replicas is 0 in
+    # every environment; prod's warm replica now comes from the cron rule below, so the apps hold a
+    # replica only during the hours a recruiter opens the CV link and cost nothing overnight. The
+    # health-gated rollout stays valid at 0: deploy.yml's readiness polls (60×10s) wake the
+    # 0%-traffic candidate and warm the public auth origin before smoke, and the rollout still
+    # deactivates superseded revisions so no idle replica accumulates.
+    min_replicas = var.app_min_replicas
+    max_replicas = 1
+
+    # The platform's implicit HTTP scale rule exists ONLY while no rule is declared ("If you don't
+    # create a scale rule, the default scale rule is applied" — Azure "Scaling in Container Apps").
+    # Declaring the cron rule below therefore REPLACES it, and an app sitting at zero replicas would
+    # be left with no trigger to start on: a request outside the warm window would reach nothing.
+    # This rule is the 0→1 activation that keeps off-hours a cold start, never an outage.
+    http_scale_rule {
+      name                = "http"
+      concurrent_requests = "10"
+    }
+
+    # Warm window (ADR-0027). KEDA evaluates every scaler and takes max(metrics), so inside the
+    # window this rule acts as a dynamic minimum of one replica; outside it the app returns to
+    # min_replicas after the platform's 300 s cool-down. Staging passes null and runs pure
+    # scale-to-zero (ADR-0020), which is why the rule is a dynamic block rather than a literal.
+    dynamic "custom_scale_rule" {
+      for_each = var.app_warm_window == null ? [] : [var.app_warm_window]
+
+      content {
+        name             = "warm-window"
+        custom_rule_type = "cron"
+
+        metadata = {
+          timezone        = custom_scale_rule.value.timezone
+          start           = custom_scale_rule.value.start
+          end             = custom_scale_rule.value.end
+          desiredReplicas = "1"
+        }
+      }
+    }
+
+    container {
+      name   = "frontend"
+      image  = "ghcr.io/koniecdev/lotrokoniecdev-frontend:${var.image_tag}"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 8080
+        path      = "/health/live"
+
+        initial_delay           = 5
+        interval_seconds        = 30
+        timeout                 = 5
+        failure_count_threshold = 3
+      }
+
+      readiness_probe {
+        transport = "HTTP"
+        port      = 8080
+        path      = "/health/ready"
+
+        interval_seconds        = 30
+        timeout                 = 5
+        failure_count_threshold = 3
+        success_count_threshold = 1
+      }
+
+      startup_probe {
+        transport = "HTTP"
+        port      = 8080
+        path      = "/health/live"
+
+        interval_seconds        = 10
+        timeout                 = 5
+        failure_count_threshold = 30
+      }
+
+      env {
+        name  = "ASPNETCORE_ENVIRONMENT"
+        value = "Production"
+      }
+      env {
+        name  = "ASPNETCORE_URLS"
+        value = "http://+:8080"
+      }
+      env {
+        name  = "AuthSystem__Authority"
+        value = local.auth_origin
+      }
+      env {
+        name  = "AuthSystem__BaseUrl"
+        value = "${local.auth_origin}/"
+      }
+      env {
+        name  = "AuthSystem__ClientId"
+        value = "lotrokoniecdev-web"
+      }
+      env {
+        name  = "TranslationSystem__BaseUrl"
+        value = "${local.tms_origin}/"
+      }
+      env {
+        name  = "DataProtection__KeyRingPath"
+        value = "/keys"
+      }
+
+      volume_mounts {
+        name = "keys"
+        path = "/keys"
+      }
+    }
+
+    volume {
+      name         = "keys"
+      storage_type = "AzureFile"
+      storage_name = azurerm_container_app_environment_storage.frontend_keys.name
+    }
+  }
+
+  ingress {
+    external_enabled           = true
+    target_port                = 8080
+    transport                  = "auto"
+    allow_insecure_connections = false
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}

--- a/docs/deployment/azure-graveyard/iac/azure-law.tf
+++ b/docs/deployment/azure-graveyard/iac/azure-law.tf
@@ -1,0 +1,42 @@
+resource "azurerm_log_analytics_workspace" "law" {
+  count               = local.create_env ? 1 : 0
+  location            = azurerm_resource_group.main.location
+  name                = "lotrotmslaw${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  # This one workspace ingests BOTH projects (lotrotms + tks, prod + staging) — they share the
+  # `lotrotmsenvprod` Container Apps environment, so there is exactly one LAW in the subscription.
+  #
+  # 0.16 pinned ingestion to the 5 GB/month free grant (5 / 31 = 0.161) and was hit EVERY day around
+  # 20:00 UTC, leaving the workspace blind from then until the 12:00 UTC reset — 16 h/day, and the
+  # hole covers the 05:00 UTC cron warm-window scale-up (ADR-0027), which is precisely when the
+  # cold-start replica restarts we need to diagnose happen. Raised to 0.5 to reopen that window.
+  #
+  # Raising the cap does not by itself cost anything: billing is per GB ingested, and the cap only
+  # truncates. Measured burn is ~0.168 GB/day at 24/7 uptime and ~0.105 GB/day (~3.3 GB/month) since
+  # scale-to-zero — still inside the free grant. ~65% of it is /health/live + /health/ready probe
+  # telemetry; filtering those out of OpenTelemetry is the durable fix, after which this drops back.
+  daily_quota_gb = 0.5
+
+  lifecycle {
+    # Audit 0001 / H11 (ADR-0017): losing this workspace drops all log history. Guard against a stray
+    # rename / -target slip during multi-env work.
+    prevent_destroy = true
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# M6-22: law gained a count for shared-environment mode (staging reuses prod's workspace), shifting
+# its address to [0]. For prod (create_env = true) the workspace is otherwise unchanged, so this is a
+# pure state-address move — never a destroy/recreate.
+moved {
+  from = azurerm_log_analytics_workspace.law
+  to   = azurerm_log_analytics_workspace.law[0]
+}

--- a/docs/deployment/azure-graveyard/iac/azure_container_app_env.tf
+++ b/docs/deployment/azure-graveyard/iac/azure_container_app_env.tf
@@ -1,0 +1,31 @@
+resource "azurerm_container_app_environment" "app_env" {
+  count                      = local.create_env ? 1 : 0
+  location                   = azurerm_resource_group.main.location
+  name                       = "lotrotmsenv${var.env_id}"
+  resource_group_name        = azurerm_resource_group.main.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.law[0].id
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Shared-environment mode (M6-22): when var.aca_environment_name is set, this env deploys its apps
+# into that EXISTING managed environment (the subscription caps Container App Environments at one,
+# held by prod) instead of creating its own above. Read-only; surfaced to every app/job/storage via
+# local.app_env_id.
+data "azurerm_container_app_environment" "shared" {
+  count               = local.create_env ? 0 : 1
+  name                = var.aca_environment_name
+  resource_group_name = var.aca_environment_resource_group
+}
+
+# M6-22: app_env gained a count for shared-environment mode, shifting its address to [0]. For prod
+# (create_env = true) the resource is otherwise unchanged, so this is a pure state-address move
+# (terraform plan shows a `moved`, never a destroy/recreate) — same pattern as resource-group.tf.
+moved {
+  from = azurerm_container_app_environment.app_env
+  to   = azurerm_container_app_environment.app_env[0]
+}

--- a/docs/deployment/azure-graveyard/iac/backend-config/prod.hcl
+++ b/docs/deployment/azure-graveyard/iac/backend-config/prod.hcl
@@ -1,0 +1,4 @@
+# Prod Terraform state blob (audit 0001 / H5, ADR-0017). The azurerm backend in setup.tf is partial;
+# select this key at init:
+#   terraform init -reconfigure -backend-config=backend-config/prod.hcl
+key = "prod.terraform.tfstate"

--- a/docs/deployment/azure-graveyard/iac/backend-config/staging.hcl
+++ b/docs/deployment/azure-graveyard/iac/backend-config/staging.hcl
@@ -1,0 +1,4 @@
+# Staging Terraform state blob (audit 0001 / H5, ADR-0017) — a separate blob from prod in the same
+# backend container, so a botched staging apply can never corrupt prod state. Select this key at init:
+#   terraform init -reconfigure -backend-config=backend-config/staging.hcl
+key = "staging.terraform.tfstate"

--- a/docs/deployment/azure-graveyard/iac/env/staging.tfvars
+++ b/docs/deployment/azure-graveyard/iac/env/staging.tfvars
@@ -1,0 +1,30 @@
+# Staging environment overrides (audit 0001 / H2+H5, ADR-0017). Apply with:
+#   terraform init -reconfigure -backend-config=backend-config/staging.hcl
+#   terraform apply -var-file=env/staging.tfvars
+#
+# Prerequisites (out-of-band, ADR-0017 §7): a SEPARATE lotrotms-kv-staging Key Vault with freshly
+# generated secrets (never the prod vault — audit §C5), a lotrotms-aca-staging identity, and a Neon
+# `staging` branch (audit §H13). The required secret-free inputs (subscription_id, smtp_sender_email,
+# admin_username, admin_email) still arrive as TF_VAR_*, not from this file.
+# See docs/deployment/runbook.md §"Staging bring-up" for the ordered first-time bring-up sequence.
+env_id             = "staging"
+public_base_domain = "staging.lotro-translator.pl"
+key_vault_name     = "lotrotms-kv-staging"
+aca_identity_name  = "lotrotms-aca-staging"
+
+# Shared-environment mode (M6-22): the subscription allows only ONE Container App Environment total,
+# held by prod, so staging deploys its apps INTO prod's managed environment instead of creating its
+# own. These point at prod's environment (name + resource group); see iac/locals.tf (create_env).
+aca_environment_name           = "lotrotmsenvprod"
+aca_environment_resource_group = "rg-lotrotms-prod-polc-001"
+
+# Scale-to-zero (ADR-0020 FinOps): staging serves no steady traffic — no synthetic probes (staging
+# creates no monitoring, ADR-0018/M6-22) and no users between rollouts/QA — so three always-on
+# 0.25 vCPU / 0.5 GiB replicas were pure idle spend (~$15-18/month). First request after idle pays a
+# cold start (~10-20 s incl. Neon wake); accepted for QA. Prod is now 0 too (ADR-0027) — it buys its
+# warm replica from a schedule instead of a floor.
+app_min_replicas = 0
+
+# No warm window on staging (ADR-0027): nobody is looking at it outside a rollout or a QA session,
+# and both wake it through the http_scale_rule. Prod keeps the default schedule.
+app_warm_window = null

--- a/docs/deployment/azure-graveyard/iac/keyvault.tf
+++ b/docs/deployment/azure-graveyard/iac/keyvault.tf
@@ -1,0 +1,35 @@
+# Azure Key Vault is the single source of truth for the production app secrets (ADR-0013). The Vault,
+# its secrets, the user-assigned identity, and the identity's "Key Vault Secrets User" role assignment
+# are foundational infrastructure — seeded out-of-band by scripts/seed-keyvault.{sh,ps1} (like the
+# tfstate backend storage account), so the CI deploy principal never needs RBAC-admin and no plaintext
+# secret value ever enters this configuration or the Terraform state. Here Terraform only data-reads
+# them and builds the versionless secret URIs that the ACA apps + migrator job reference via the
+# identity.
+
+data "azurerm_key_vault" "secrets" {
+  name                = var.key_vault_name
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+data "azurerm_user_assigned_identity" "aca" {
+  name                = var.aca_identity_name
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+locals {
+  # Versionless Key Vault secret URIs. ACA resolves the current version on each revision, so a
+  # rotation (a new secret version set by the seed script) is picked up on the next deployment
+  # without touching Terraform. Names must match the secrets seeded by scripts/seed-keyvault.{sh,ps1}.
+  kv_secret_id = {
+    for name in [
+      "connection-string-translation",
+      "connection-string-auth",
+      "openiddict-signing-key",
+      "openiddict-encryption-key",
+      "openiddict-api-client-secret",
+      "smtp-username",
+      "smtp-password",
+      "admin-password",
+    ] : name => "${data.azurerm_key_vault.secrets.vault_uri}secrets/${name}"
+  }
+}

--- a/docs/deployment/azure-graveyard/iac/locals.tf
+++ b/docs/deployment/azure-graveyard/iac/locals.tf
@@ -1,0 +1,25 @@
+locals {
+  # Single source of truth for the platform's public origins (audit 0001 / H2, ADR-0017). Every OIDC
+  # issuer, redirect, CORS allow-list and base URL in azure-container-apps.tf derives from
+  # var.public_base_domain, so a new environment is one variable away. For prod
+  # (var.public_base_domain = "lotro-translator.pl") each value below is byte-identical to the literal
+  # it replaced — the OIDC `iss` and redirect_uri must match exactly (audit G15). Staging sets
+  # public_base_domain = "staging.lotro-translator.pl", yielding auth.staging.… / tms.staging.… /
+  # staging.… (the origins audit §6 prescribes).
+  apex_origin  = "https://${var.public_base_domain}"
+  auth_origin  = "https://auth.${var.public_base_domain}"
+  tms_origin   = "https://tms.${var.public_base_domain}"
+  callback_url = "${local.apex_origin}/callback"
+}
+
+locals {
+  # Shared-environment mode (M6-22). The Azure subscription allows only ONE Container App Environment
+  # total, and prod holds it. When var.aca_environment_name is set this env (staging) deploys its apps
+  # INTO that existing managed environment instead of creating its own: create_env is false, so the
+  # managed-environment + its workspace / app-insights / OTel-agent / monitoring singletons are skipped
+  # and the shared environment is data-read instead. For prod the vars are empty -> create_env = true
+  # -> every singleton is created exactly as before (byte-identical plan). app_env_id is the single
+  # knob every container app, the migrator job, and the keyring storage point at.
+  create_env = var.aca_environment_name == ""
+  app_env_id = local.create_env ? azurerm_container_app_environment.app_env[0].id : data.azurerm_container_app_environment.shared[0].id
+}

--- a/docs/deployment/azure-graveyard/iac/migrator-job.tf
+++ b/docs/deployment/azure-graveyard/iac/migrator-job.tf
@@ -1,0 +1,68 @@
+resource "azurerm_container_app_job" "migrator" {
+  name                         = "lotrotms-migrator-${var.env_id}"
+  location                     = azurerm_resource_group.main.location
+  resource_group_name          = azurerm_resource_group.main.name
+  container_app_environment_id = local.app_env_id
+
+  replica_timeout_in_seconds = 1800
+  replica_retry_limit        = 1
+
+  manual_trigger_config {
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [data.azurerm_user_assigned_identity.aca.id]
+  }
+
+  # Secrets resolve from Key Vault at runtime through the user-assigned identity (ADR-0013) — no
+  # plaintext value enters this configuration or the Terraform state.
+  secret {
+    name                = "connection-string-translation"
+    key_vault_secret_id = local.kv_secret_id["connection-string-translation"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+
+  secret {
+    name                = "connection-string-auth"
+    key_vault_secret_id = local.kv_secret_id["connection-string-auth"]
+    identity            = data.azurerm_user_assigned_identity.aca.id
+  }
+
+  template {
+    container {
+      name   = "migrator"
+      image  = "ghcr.io/koniecdev/lotrokoniecdev-migrator:${var.image_tag}"
+      cpu    = 0.5
+      memory = "1Gi"
+
+      env {
+        name  = "ASPNETCORE_ENVIRONMENT"
+        value = "Production"
+      }
+      env {
+        name        = "ConnectionStrings__TranslationDatabase"
+        secret_name = "connection-string-translation"
+      }
+      env {
+        name        = "ConnectionStrings__AuthDatabase"
+        secret_name = "connection-string-auth"
+      }
+    }
+  }
+
+  # The rolling image is owned by the CD pipeline (az containerapp job update by commit SHA), not
+  # Terraform. Ignore image drift so `terraform apply` never reverts the job to the bootstrap tag
+  # (var.image_tag). See ADR-0012.
+  lifecycle {
+    ignore_changes = [template[0].container[0].image]
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}

--- a/docs/deployment/azure-graveyard/iac/monitoring.tf
+++ b/docs/deployment/azure-graveyard/iac/monitoring.tf
@@ -1,0 +1,510 @@
+# Azure Monitor alerting (audit 0001 §C3). Production was operationally blind: zero monitor
+# resources existed, so a crash-loop, an error storm, a stopped log pipeline, or an auth outage
+# (token issuance is the platform SPOF) surfaced only when the owner or a user noticed.
+#
+# Most alerts deliberately stand on signals that ALREADY exist — ACA platform metrics
+# (Microsoft.App/containerApps) and the Log Analytics workspace the apps already stream console logs
+# to. The auth latency alert additionally reads Application Insights (the OTel-reconstructed request
+# metrics, observability.tf). The external availability SLO that used to live here was retired by
+# ADR-0027 — see the comment above the auth_role_name local. Everything is parametrized by var.env_id
+# so a future staging inherits alerting for free.
+#
+# Delivery is EMAIL ONLY (owner decision): one action group with a single email receiver
+# (var.admin_email). No SMS, no webhook. Every alert below references that action group.
+#
+# Plan-on-PR caveat: Terraform `plan` does not validate metric names, log-table schemas, KQL, or the
+# auth cloud_RoleName against the live Azure catalog — those are checked
+# server-side at `apply` (or observed only once telemetry flows). The metric names used here
+# (RestartCount / Requests / UsageNanoCores / WorkingSetBytes / KeyVault Availability / requests-
+# duration) and the log tables (ContainerAppConsoleLogs_CL / Operation) are the documented
+# Container Apps + Key Vault + App Insights + LAW signals.
+
+locals {
+  # All three container apps share one resource type, region and sizing (0.25 vCPU / 0.5 GiB,
+  # ≤1 replica), so each metric alert below is a single rule fanned out per app via for_each.
+  # Single-scope alerts are universally supported by Azure Monitor (multi-resource metric alerts are
+  # only allowed for a small allowlist of resource types that does NOT include Container Apps), need
+  # no target_resource_type/location, and keep the config DRY. The app key is folded into each alert
+  # name so the three instances stay uniquely identifiable.
+  monitored_container_apps = {
+    "auth-api" = azurerm_container_app.auth_api.id
+    "tms-api"  = azurerm_container_app.tms_api.id
+    "frontend" = azurerm_container_app.frontend.id
+  }
+
+  # Per-container limits (mirror azure-container-apps.tf): 0.25 vCPU, 0.5 GiB. Saturation
+  # thresholds below derive from these so they track any future sizing change in one place.
+  container_cpu_cores    = 0.25
+  container_memory_bytes = 0.5 * 1024 * 1024 * 1024 # 0.5 GiB = 536870912 bytes
+
+  # Alert at 80% sustained utilisation — high enough to be a real signal, low enough to act before
+  # CPU throttling or an OOM kill (memory saturation is the usual precursor to a replica restart).
+  cpu_saturation_nanocores  = local.container_cpu_cores * 1000 * 1000 * 1000 * 0.8 # 200,000,000 ncores
+  memory_saturation_bytes   = floor(local.container_memory_bytes * 0.8)            # 429,496,729 bytes (80% of 0.5 GiB)
+  http_server_error_floor   = 5                                                    # 5xx responses in a 5-minute window before the request alert fires
+  log_error_spike_threshold = 10                                                   # Error/Fatal log entries (per app) in 5 minutes = an error storm
+
+  # Daily cold-start suppression window (the alert processing rule at the end of this file). Derived
+  # from var.app_warm_window.start (5-field cron: minute hour …) so moving the warm window moves the
+  # suppression with it — minute-of-day arithmetic, wrapping across midnight. 5 minutes of lead-in,
+  # 35 minutes of tail: the observed noise fires within ~3 minutes of the wake-up and auto-resolves
+  # within ~20 (2026-07-11: fired 05:03 UTC, resolved 05:10/05:19).
+  warm_start_minute_of_day            = var.app_warm_window == null ? 0 : tonumber(split(" ", trimspace(var.app_warm_window.start))[1]) * 60 + tonumber(split(" ", trimspace(var.app_warm_window.start))[0])
+  cold_start_suppression_from_minute  = (local.warm_start_minute_of_day + 1435) % 1440
+  cold_start_suppression_until_minute = (local.warm_start_minute_of_day + 35) % 1440
+  cold_start_suppression_start_time   = format("%02d:%02d:00", floor(local.cold_start_suppression_from_minute / 60), local.cold_start_suppression_from_minute % 60)
+  cold_start_suppression_end_time     = format("%02d:%02d:00", floor(local.cold_start_suppression_until_minute / 60), local.cold_start_suppression_until_minute % 60)
+
+  # Alert processing rules take a WINDOWS time-zone id, unlike KEDA's IANA name in app_warm_window.
+  # Extend this map if the warm window ever moves to another zone — lookup fails loudly on a miss.
+  windows_time_zone_by_iana = {
+    "Europe/Warsaw" = "Central European Standard Time"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------
+# Action group — the single delivery channel for every alert. Email only (owner decision); no SMS.
+# ---------------------------------------------------------------------------------------------------
+resource "azurerm_monitor_action_group" "alerts" {
+  count               = local.create_env ? 1 : 0
+  name                = "lotrotmsag${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  # short_name shows up in the notification subject and is capped by Azure at 12 characters, so it
+  # cannot simply carry the full env-qualified name — substr keeps it env-aware within the cap
+  # (e.g. prod -> "lotrotmsprod", staging -> "lotrotmsstag").
+  short_name = substr("lotrotms${var.env_id}", 0, 12)
+
+  email_receiver {
+    name                    = "admin-email"
+    email_address           = var.admin_email
+    use_common_alert_schema = true
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# M6-22: the action group gained a count for shared-environment mode — alerting belongs to the env
+# that owns the workspace, so staging (which reuses prod's environment + workspace) inherits prod's
+# alerts and creates none of its own. This shifts the address to [0]. For prod (create_env = true)
+# the resource is otherwise unchanged, so this is a pure state-address move.
+moved {
+  from = azurerm_monitor_action_group.alerts
+  to   = azurerm_monitor_action_group.alerts[0]
+}
+
+# ---------------------------------------------------------------------------------------------------
+# Metric alerts — ACA platform metrics (Microsoft.App/containerApps). Each metric is one rule fanned
+# out per app (for_each over local.monitored_container_apps), single-scope — see the local for why.
+# ---------------------------------------------------------------------------------------------------
+
+# Crash-loop detector. Any replica restart is a strong signal something is wrong (OOM, failed
+# readiness, unhandled crash). Threshold > 0 is intentionally sensitive per the audit; Maximum
+# aggregation means the alert stays active for the lifetime of the affected revision (a fresh, clean
+# revision resets the metric and auto-mitigates it) — read it as "this revision restarted,
+# investigate", not "restarting right now".
+resource "azurerm_monitor_metric_alert" "replica_restart" {
+  for_each            = local.create_env ? local.monitored_container_apps : {}
+  name                = "lotrotms-alert-replica-restart-${each.key}-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [each.value]
+  description         = "Container app ${each.key} restarted a replica (crash-loop signal). Fires by email."
+  severity            = 1 # Error
+  frequency           = "PT1M"
+  window_size         = "PT5M"
+
+  criteria {
+    metric_namespace = "Microsoft.App/containerApps"
+    metric_name      = "RestartCount"
+    aggregation      = "Maximum"
+    operator         = "GreaterThan"
+    threshold        = 0
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Server-error spike. 4xx is deliberately NOT alerted: on the auth server 401/400 are normal control
+# flow (bad credentials, expired tokens) and would only create noise. 5xx is the app failing to serve
+# — the user-visible signal worth waking up for.
+resource "azurerm_monitor_metric_alert" "http_server_errors" {
+  for_each            = local.create_env ? local.monitored_container_apps : {}
+  name                = "lotrotms-alert-http-5xx-${each.key}-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [each.value]
+  description         = "Spike of HTTP 5xx responses from container app ${each.key}. Fires by email."
+  severity            = 1 # Error
+  frequency           = "PT1M"
+  window_size         = "PT5M"
+
+  criteria {
+    metric_namespace = "Microsoft.App/containerApps"
+    metric_name      = "Requests"
+    aggregation      = "Total"
+    operator         = "GreaterThan"
+    threshold        = local.http_server_error_floor
+
+    dimension {
+      name     = "statusCodeCategory"
+      operator = "Include"
+      values   = ["5xx"]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Sustained CPU saturation (>80% of the 0.25-vCPU limit over 15 minutes). Informational: at
+# max_replicas = 1 there is no horizontal headroom, so this is a capacity signal — investigate or
+# raise the CPU request before it throttles.
+resource "azurerm_monitor_metric_alert" "cpu_saturation" {
+  for_each            = local.create_env ? local.monitored_container_apps : {}
+  name                = "lotrotms-alert-cpu-high-${each.key}-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [each.value]
+  description         = "Container app ${each.key} CPU sustained above 80% of its limit. Fires by email."
+  severity            = 3 # Informational (capacity signal)
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.App/containerApps"
+    metric_name      = "UsageNanoCores"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = local.cpu_saturation_nanocores
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Sustained memory saturation (>80% of the 0.5-GiB limit over 15 minutes). Warning, not
+# informational: hitting the memory limit triggers an OOM kill and a replica restart, so this is the
+# usual leading indicator of the crash-loop alert above.
+resource "azurerm_monitor_metric_alert" "memory_saturation" {
+  for_each            = local.create_env ? local.monitored_container_apps : {}
+  name                = "lotrotms-alert-memory-high-${each.key}-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [each.value]
+  description         = "Container app ${each.key} memory sustained above 80% of its limit (OOM precursor). Fires by email."
+  severity            = 2 # Warning
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.App/containerApps"
+    metric_name      = "WorkingSetBytes"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = local.memory_saturation_bytes
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------
+# Log alerts — scheduled queries over the Log Analytics workspace the apps already stream to.
+# ---------------------------------------------------------------------------------------------------
+
+# Error/Fatal log spike. In Production all three apps log via Serilog's CompactJsonFormatter (see
+# appsettings.Production.json), so each console line in ContainerAppConsoleLogs_CL is a JSON document
+# whose level is the "@l" field — present for Warning/Error/Fatal, omitted for Information. The query
+# parses that field and counts Error/Fatal entries per app over the window; the rule fires for any
+# app whose count crosses the spike threshold. This complements the metric alerts by catching
+# logged failures that never become a 5xx or a restart (e.g. a background job throwing).
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_error_spike" {
+  count               = local.create_env ? 1 : 0
+  name                = "lotrotms-alert-log-error-spike-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Spike of Error/Fatal Serilog entries in a container app's console logs. Fires by email."
+  severity            = 2 # Warning
+
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [azurerm_log_analytics_workspace.law[0].id]
+  # The *_CL custom-log tables only materialise once the apps have emitted those records, which lags
+  # a fresh environment's first apply. Skip create-time KQL schema validation so the alert can be
+  # provisioned before any logs flow — letting a future staging inherit alerting without a
+  # chicken-and-egg apply failure.
+  skip_query_validation = true
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppConsoleLogs_CL
+      | extend entry = parse_json(Log_s)
+      | where tostring(entry['@l']) in ('Error', 'Fatal')
+      | summarize ErrorCount = count() by ContainerAppName_s
+    KQL
+    time_aggregation_method = "Maximum"
+    metric_measure_column   = "ErrorCount"
+    threshold               = local.log_error_spike_threshold
+    operator                = "GreaterThan"
+
+    dimension {
+      name     = "ContainerAppName_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  auto_mitigation_enabled = true
+
+  action {
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# LAW daily-cap reached (audit M9). The workspace runs a deliberately small daily ingestion cap
+# (azure-law.tf, daily_quota_gb) to bound cost; the failure mode is that once the cap is hit, log
+# ingestion STOPS — exactly during an error storm, when logs matter most. Azure records that event
+# in the Operation table ("Data collection stopped due to daily limit reached" / OverQuota), so this
+# rule turns a silent blind-spot into an email. Checked hourly because the cap is a daily event.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "law_daily_cap" {
+  count               = local.create_env ? 1 : 0
+  name                = "lotrotms-alert-law-daily-cap-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Log Analytics daily ingestion cap reached — log collection has stopped. Fires by email."
+  severity            = 2 # Warning
+
+  evaluation_frequency = "PT1H"
+  window_duration      = "PT1H"
+  scopes               = [azurerm_log_analytics_workspace.law[0].id]
+  # The *_CL custom-log tables only materialise once the apps have emitted those records, which lags
+  # a fresh environment's first apply. Skip create-time KQL schema validation so the alert can be
+  # provisioned before any logs flow — letting a future staging inherit alerting without a
+  # chicken-and-egg apply failure.
+  skip_query_validation = true
+
+  criteria {
+    query                   = <<-KQL
+      Operation
+      | where OperationCategory =~ "Data collection Status"
+      | where Detail has "OverQuota"
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  auto_mitigation_enabled = true
+
+  action {
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------
+# The synthetic availability probes of ADR-0019 (three azurerm_application_insights_standard_web_test +
+# their location-availability alerts) were REMOVED here by ADR-0027, and the removal is not a cost tweak
+# but a correctness one: an external probe hitting the public origin every 15 minutes from three regions
+# is itself a request, so it would wake a scaled-to-zero app around the clock and cancel the very saving
+# the warm window exists to make. A probe cannot both watch an app and let it sleep.
+#
+# The replacement lives outside Azure: .github/workflows/health-ping.yml probes the same three public
+# origins once a day, just before the warm window opens, on free GitHub-hosted minutes. It costs nothing,
+# wakes the apps once, and a failed run emails the owner. The trade is deliberate — detection latency
+# goes from ~20 minutes to ~24 hours, which is the right shape for a pre-release platform with zero users
+# whose real requirement is "tell me in the morning if it died overnight". Restore the web tests (git
+# history) the day real users arrive: at that point an always-warm prod is justified anyway, and the
+# probe/warm-window conflict dissolves.
+locals {
+  # cloud_RoleName as the apps tag it via OTel (service.name = IHostEnvironment.ApplicationName = the
+  # entry-assembly name; each Program.cs ConfigureResource). Scopes the auth latency alert below.
+  # Confirm against live App Insights on first apply (managed OTel agent → AI role-name mapping).
+  auth_role_name = "LotroKoniecDev.AuthSystem.API"
+}
+
+# Key Vault availability (audit 0001 §M14). KV is the secret-resolution SPOF — every app + the migrator
+# resolve their connection strings / OpenIddict keys from it at revision start (ADR-0013), so a KV outage
+# is a platform outage that today surfaces only as a hard boot failure. The vault publishes an
+# Availability percentage; alert when it drops below 99% (a small buffer over a single transient throttle).
+resource "azurerm_monitor_metric_alert" "key_vault_availability" {
+  count               = local.create_env ? 1 : 0
+  name                = "lotrotms-alert-keyvault-availability-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [data.azurerm_key_vault.secrets.id]
+  description         = "Key Vault availability dropped below 99% (secret-resolution SPOF). Fires by email."
+  severity            = 1 # Error
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.KeyVault/vaults"
+    metric_name      = "Availability"
+    aggregation      = "Average"
+    operator         = "LessThan"
+    threshold        = 99
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Auth latency — a LEADING indicator (Sev2), not an outage. Sustained high server response time on the
+# token-issuance SPOF precedes readiness failures and user-visible slowness. Reads App Insights request
+# duration (the managed OTel agent reconstructs request metrics from traces, observability.tf) scoped to
+# the auth role. Auth-only by intent (ADR-0019 §4); a for_each extends it to tms/frontend if a need appears.
+resource "azurerm_monitor_metric_alert" "auth_latency" {
+  count               = local.create_env ? 1 : 0
+  name                = "lotrotms-alert-auth-latency-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [azurerm_application_insights.app_insights[0].id]
+  description         = "Auth-api server response time sustained above 2s (degradation leading indicator). Fires by email."
+  severity            = 2 # Warning (leading indicator)
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "microsoft.insights/components"
+    metric_name      = "requests/duration"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 2000 # milliseconds
+
+    dimension {
+      name     = "cloud/roleName"
+      operator = "Include"
+      values   = [local.auth_role_name]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# M6-22: the three log alerts gained a count for shared-environment mode — they query the workspace,
+# which staging reuses from prod, so staging inherits prod's log alerts and creates none of its own.
+# Each address shifts to [0]; for prod (create_env = true) the rules are otherwise unchanged, so these
+# are pure state-address moves.
+moved {
+  from = azurerm_monitor_scheduled_query_rules_alert_v2.log_error_spike
+  to   = azurerm_monitor_scheduled_query_rules_alert_v2.log_error_spike[0]
+}
+
+moved {
+  from = azurerm_monitor_scheduled_query_rules_alert_v2.law_daily_cap
+  to   = azurerm_monitor_scheduled_query_rules_alert_v2.law_daily_cap[0]
+}
+
+# ---------------------------------------------------------------------------------------------------
+# Alert processing rule — mute the daily cold-start false positives (#448, owner decision 2026-07-11).
+# ADR-0027's warm-up cron wakes the scaled-to-zero apps every morning at app_warm_window.start, and
+# the wake-up itself trips two alerts within minutes: auth-api restarts a replica once during its
+# cold start (known, open investigation) and tms-api's warm-up burst crosses the 80% CPU threshold.
+# Both auto-resolve, so the owner got four e-mails a day carrying zero information. This rule
+# suppresses NOTIFICATIONS for exactly those two alert rules in a short daily window around the
+# wake-up (the alerts still fire and stay visible in the portal); everything else — 5xx, memory,
+# log-error spike, the other apps' restart alerts — keeps e-mailing even inside the window.
+#
+# Accepted trade-off: processing rules apply at FIRE time and the replica-restart alert
+# auto-mitigates only when a fresh revision resets RestartCount, so a REAL auth-api crash-loop that
+# starts inside the window would fire once, be suppressed, and never re-notify. The unsuppressed 5xx
+# and log-error-spike alerts plus the daily health-ping cover that gap — the right shape for a
+# pre-release platform with zero users.
+resource "azurerm_monitor_alert_processing_rule_suppression" "cold_start_noise" {
+  count               = local.create_env && var.app_warm_window != null ? 1 : 0
+  name                = "lotrotms-apr-cold-start-noise-${var.env_id}"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [azurerm_resource_group.main.id]
+  description         = "Suppress the known warm-up cold-start alert noise (auth-api replica restart + tms-api CPU burst) around the daily ADR-0027 wake-up."
+
+  condition {
+    alert_rule_id {
+      operator = "Equals"
+      values = [
+        azurerm_monitor_metric_alert.replica_restart["auth-api"].id,
+        azurerm_monitor_metric_alert.cpu_saturation["tms-api"].id,
+      ]
+    }
+  }
+
+  schedule {
+    time_zone = local.windows_time_zone_by_iana[var.app_warm_window.timezone]
+
+    recurrence {
+      daily {
+        start_time = local.cold_start_suppression_start_time
+        end_time   = local.cold_start_suppression_end_time
+      }
+    }
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}

--- a/docs/deployment/azure-graveyard/iac/observability.tf
+++ b/docs/deployment/azure-graveyard/iac/observability.tf
@@ -1,0 +1,105 @@
+# Cloud telemetry for the three web apps (audit 0001 H3, ADR-0016).
+#
+# All three apps already emit clean, vendor-neutral OTLP (traces + Serilog->OTLP logs), but no
+# Container App sets OTEL_EXPORTER_OTLP_ENDPOINT, so in the cloud the telemetry goes nowhere. The
+# Container Apps *managed* OpenTelemetry agent closes that gap with zero app change: enabled at the
+# environment level it injects OTEL_EXPORTER_OTLP_ENDPOINT into every container automatically and
+# forwards traces + logs to Application Insights. The app code stays cloud-agnostic (ADR-0008 §2 —
+# only this infra couples to Azure).
+
+# Workspace-based Application Insights, backed by the existing Log Analytics workspace (audit 0001
+# H3 — reuse the LAW, never create a second workspace). Classic (non-workspace) AI is retired by
+# Azure, so workspace_id is mandatory.
+resource "azurerm_application_insights" "app_insights" {
+  count               = local.create_env ? 1 : 0
+  name                = "lotrotmsappinsights${var.env_id}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  workspace_id        = azurerm_log_analytics_workspace.law[0].id
+  application_type    = "web"
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# M6-22: app_insights gained a count for shared-environment mode (it backs the OTel agent on the
+# environment we create, which staging skips), shifting its address to [0]. For prod (create_env =
+# true) the resource is otherwise unchanged, so this is a pure state-address move.
+moved {
+  from = azurerm_application_insights.app_insights
+  to   = azurerm_application_insights.app_insights[0]
+}
+
+# Enable the Container Apps managed OpenTelemetry agent on the managed environment. azurerm 4.7.0 has
+# no native block for this (hashicorp/terraform-provider-azurerm#28217), so it is patched on with
+# azapi: azapi_update_resource PATCHes only the properties in its body, and azurerm — which has no
+# schema for these OTel fields — leaves them untouched, the augmentation pattern the azapi docs
+# recommend for filling azurerm gaps.
+#
+# Metrics are intentionally NOT a destination: the managed agent forwards metrics only to
+# OTLP/Datadog sinks, never to App Insights (traces + logs only). Platform metrics (sibling audit
+# 0001 C3 ticket) cover that gap, and App Insights still reconstructs request metrics from the traces.
+#
+# Tradeoff — the App Insights connection string is wired straight from its TF-native attribute into
+# the agent config rather than routed through Key Vault. Unlike the app secrets (ADR-0013) it is an
+# ingestion key for a telemetry sink, not a KV-class credential (no data access, blast radius is only
+# skewed telemetry) and it is already materialized in state; direct wiring is simpler and acceptable.
+# It is passed via sensitive_body so it never surfaces in plan/console output.
+#
+# api-version: a *preview* version is required, not the stable 2024-03-01/2025-01-01 — the OTel-agent
+# properties (appInsightsConfiguration + openTelemetryConfiguration) are not yet in the stable ARM
+# surface (verified against the azapi 2.10.0 embedded schema: stable rejects them, the preview line
+# accepts them). 2024-10-02-preview is the version Microsoft's ACA managed-OTel docs use. Revisit to a
+# stable version once Azure GAs the agent (azapi schema-validates the body at plan, so a wrong version
+# fails the infra.yml gate loudly rather than drifting).
+resource "azapi_update_resource" "app_env_otel" {
+  count       = local.create_env ? 1 : 0
+  type        = "Microsoft.App/managedEnvironments@2024-10-02-preview"
+  resource_id = azurerm_container_app_environment.app_env[0].id
+
+  body = {
+    properties = {
+      openTelemetryConfiguration = {
+        tracesConfiguration = {
+          destinations = ["appInsights"]
+        }
+        logsConfiguration = {
+          destinations = ["appInsights"]
+        }
+      }
+    }
+  }
+
+  sensitive_body = {
+    properties = {
+      # #246 fix (M6-23): the 2024-10-02-preview managedEnvironments PATCH re-validates the WHOLE
+      # resource, and the environment's existing appLogsConfiguration round-trips without the
+      # write-only logAnalyticsConfiguration.sharedKey — so a body that omits it fails apply with
+      # `400 LogAnalyticsConfiguration is invalid. Must provide a valid LogAnalyticsConfiguration`.
+      # Re-supply the SAME workspace (customerId + sharedKey) so the existing log-analytics destination
+      # stays valid while the OTel agent is added; this changes no destination, only re-asserts it.
+      appLogsConfiguration = {
+        destination = "log-analytics"
+        logAnalyticsConfiguration = {
+          customerId = azurerm_log_analytics_workspace.law[0].workspace_id
+          sharedKey  = azurerm_log_analytics_workspace.law[0].primary_shared_key
+        }
+      }
+      appInsightsConfiguration = {
+        connectionString = azurerm_application_insights.app_insights[0].connection_string
+      }
+    }
+  }
+}
+
+# M6-22: app_env_otel gained a count for shared-environment mode — we patch the OTel agent only onto
+# the environment we create (staging never reconfigures prod's shared environment), shifting its
+# address to [0]. For prod (create_env = true) the patch is otherwise unchanged, so this is a pure
+# state-address move.
+moved {
+  from = azapi_update_resource.app_env_otel
+  to   = azapi_update_resource.app_env_otel[0]
+}

--- a/docs/deployment/azure-graveyard/iac/resource-group.tf
+++ b/docs/deployment/azure-graveyard/iac/resource-group.tf
@@ -1,0 +1,18 @@
+resource "azurerm_resource_group" "main" {
+  location = "polandcentral"
+  name     = "rg-lotrotms-${var.env_id}-polc-001"
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+# Audit 0001 / H2 (ADR-0017): the symbol was renamed rg-lotrotms-prod-polc-001 -> main and the name is
+# now env_id-derived. For env_id = "prod" the name is unchanged, so this is a pure state-address move
+# (terraform plan shows a `moved`, never a destroy/recreate).
+moved {
+  from = azurerm_resource_group.rg-lotrotms-prod-polc-001
+  to   = azurerm_resource_group.main
+}

--- a/docs/deployment/azure-graveyard/iac/setup.tf
+++ b/docs/deployment/azure-graveyard/iac/setup.tf
@@ -1,0 +1,45 @@
+terraform {
+  # Pin the Terraform core version band (audit #0001 / M15) so a stray CLI version can't silently
+  # apply against this state. Matches the 1.15.7 pinned in the CI workflow (.github/workflows/infra.yml).
+  required_version = "~> 1.15"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.7.0"
+    }
+    # azapi patches the Container Apps managed OpenTelemetry agent onto the managed environment
+    # (iac/observability.tf, ADR-0016): azurerm 4.7.0 has no native block for it
+    # (hashicorp/terraform-provider-azurerm#28217). Exact-pinned like azurerm above (audit 0001 G20);
+    # multi-platform hashes are tracked in .terraform.lock.hcl.
+    azapi = {
+      source  = "Azure/azapi"
+      version = "2.10.0"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "rg-lotrotms-tfstate"
+    storage_account_name = "sttflotrotms23957"
+    container_name       = "tfstate"
+    # Per-environment state key (audit 0001 / H5, ADR-0017): partial backend — the key is supplied at
+    # init via `-backend-config=backend-config/<env>.hcl` (prod.hcl / staging.hcl), so prod and staging
+    # live in separate blobs in this one container and a botched staging apply can never touch prod
+    # state. CI passes prod.hcl; see .github/workflows/infra.yml and docs/deployment/runbook.md.
+  }
+}
+
+provider "azurerm" {
+  features {
+
+  }
+
+  subscription_id = var.subscription_id
+}
+
+# Used only by iac/observability.tf to patch the managed environment's OpenTelemetry config. Shares
+# the azurerm OIDC Azure CLI session in CI (use_cli default, established by azure/login); the
+# subscription mirrors the azurerm provider above.
+provider "azapi" {
+  subscription_id = var.subscription_id
+}

--- a/docs/deployment/azure-graveyard/iac/storage.tf
+++ b/docs/deployment/azure-graveyard/iac/storage.tf
@@ -1,0 +1,56 @@
+resource "azurerm_storage_account" "keys" {
+  name                     = "lotrotmskeys${var.env_id}"
+  resource_group_name      = azurerm_resource_group.main.name
+  location                 = azurerm_resource_group.main.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+
+  lifecycle {
+    # Audit 0001 / H11 (ADR-0017): the Data Protection keyring lives in this account — destroying it
+    # logs every user out. Guard against a stray rename / -target slip during multi-env work.
+    prevent_destroy = true
+  }
+
+  tags = {
+    environment = var.env_id
+    src         = var.src_key
+    project     = "lotrotms"
+  }
+}
+
+resource "azurerm_storage_share" "auth_keys" {
+  name                 = "auth-keys"
+  storage_account_name = azurerm_storage_account.keys.name
+  quota                = 5
+}
+
+resource "azurerm_storage_share" "frontend_keys" {
+  name                 = "frontend-keys"
+  storage_account_name = azurerm_storage_account.keys.name
+  quota                = 5
+}
+
+# Both envs create their own DP-keyring storage account + shares (above, unchanged), but the
+# environment-storage link is attached to the (possibly shared) managed environment via
+# local.app_env_id. On the shared env the link name must be env-unique so staging's mount doesn't
+# collide with prod's — hence the env_id suffix when create_env is false. For prod (create_env = true)
+# the name stays "auth-keys"/"frontend-keys" and the env id is identical, so neither attribute changes
+# (no moved block needed).
+resource "azurerm_container_app_environment_storage" "auth_keys" {
+  name                         = local.create_env ? "auth-keys" : "auth-keys-${var.env_id}"
+  container_app_environment_id = local.app_env_id
+  account_name                 = azurerm_storage_account.keys.name
+  share_name                   = azurerm_storage_share.auth_keys.name
+  access_key                   = azurerm_storage_account.keys.primary_access_key
+  access_mode                  = "ReadWrite"
+}
+
+resource "azurerm_container_app_environment_storage" "frontend_keys" {
+  name                         = local.create_env ? "frontend-keys" : "frontend-keys-${var.env_id}"
+  container_app_environment_id = local.app_env_id
+  account_name                 = azurerm_storage_account.keys.name
+  share_name                   = azurerm_storage_share.frontend_keys.name
+  access_key                   = azurerm_storage_account.keys.primary_access_key
+  access_mode                  = "ReadWrite"
+}

--- a/docs/deployment/azure-graveyard/iac/vars.tf
+++ b/docs/deployment/azure-graveyard/iac/vars.tf
@@ -1,0 +1,121 @@
+variable "env_id" {
+  type        = string
+  description = "The environment id"
+  default     = "prod"
+}
+
+variable "public_base_domain" {
+  type        = string
+  description = "Public apex domain for this environment. Every OIDC issuer/redirect/CORS/base URL derives from it via iac/locals.tf (audit 0001 / H2). The default keeps prod byte-identical; staging sets \"staging.lotro-translator.pl\"."
+  default     = "lotro-translator.pl"
+}
+
+variable "src_key" {
+  type        = string
+  description = "The infrastructure source"
+  default     = "terraform"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Bootstrap image tag for the four GHCR images. Only consumed when a Container App / Job is first created; afterwards the rolling tag is owned solely by the CD pipeline (az containerapp update by commit SHA) and Terraform ignores image drift via lifecycle.ignore_changes."
+  default     = "latest"
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "The Azure subscription id"
+}
+
+variable "key_vault_name" {
+  type        = string
+  description = "Name of the Key Vault that holds the production app secrets (ADR-0013). Seeded out-of-band by scripts/seed-keyvault.{sh,ps1}; Terraform only data-references it."
+  default     = "lotrotms-kv-prod"
+}
+
+variable "aca_identity_name" {
+  type        = string
+  description = "Name of the user-assigned managed identity the ACA apps + migrator job assume to read secrets from the Key Vault. Seeded out-of-band by scripts/seed-keyvault.{sh,ps1}; Terraform only data-references it."
+  default     = "lotrotms-aca-prod"
+}
+
+variable "smtp_sender_email" {
+  type        = string
+  description = "Verified sender email address"
+}
+
+variable "admin_username" {
+  type        = string
+  description = "Seeded admin username. Letters + digits only (ADR-0022) — Identity's AllowedUserNameCharacters rejects anything else and auth-api fails at startup."
+
+  validation {
+    condition     = var.admin_username == "" || can(regex("^[a-zA-Z0-9]+$", var.admin_username))
+    error_message = "admin_username must match ^[a-zA-Z0-9]+$ (ASCII letters and digits only, no spaces or special characters); empty skips seeding."
+  }
+}
+
+variable "admin_email" {
+  type        = string
+  description = "Seeded admin email"
+}
+
+variable "aca_environment_name" {
+  type        = string
+  description = "Name of an EXISTING managed Container Apps environment to deploy this env's apps into (shared-environment mode, M6-22). Empty = create our own. Set because the Azure subscription allows only ONE Container App Environment total, held by prod — staging runs its apps inside the prod environment."
+  default     = ""
+}
+
+variable "aca_environment_resource_group" {
+  type        = string
+  description = "Resource group of the existing managed environment named by var.aca_environment_name. Empty = our own resource group."
+  default     = ""
+}
+
+variable "app_min_replicas" {
+  type        = number
+  description = "min_replicas for the three container apps. Every environment now defaults to 0 (ADR-0027): prod's warm replica is no longer a floor but a SCHEDULE (var.app_warm_window), and staging has run at 0 since ADR-0020. The health-gated rollout stays valid at 0 because deploy.yml's readiness polls wake the candidates and warm the public auth origin before smoke."
+  default     = 0
+
+  validation {
+    condition     = var.app_min_replicas >= 0 && var.app_min_replicas <= 1
+    error_message = "app_min_replicas must be 0 or 1 (max_replicas is fixed at 1)."
+  }
+}
+
+variable "app_warm_window" {
+  type = object({
+    timezone = string
+    start    = string
+    end      = string
+  })
+  nullable    = true
+  description = "Daily window during which a KEDA cron scale rule holds one warm replica per app (ADR-0027). Outside it the apps fall back to app_min_replicas and an explicit http_scale_rule wakes them on the first request. `timezone` is an IANA name (KEDA handles DST); `start`/`end` are 5-field cron expressions. Prod keeps the default — the hours a recruiter opens the CV link. Set to null (staging) for pure scale-to-zero with no schedule."
+
+  default = {
+    timezone = "Europe/Warsaw"
+    start    = "0 7 * * *"
+    end      = "0 22 * * *"
+  }
+
+  validation {
+    condition     = var.app_warm_window == null || try(trimspace(var.app_warm_window.start) != trimspace(var.app_warm_window.end), false)
+    error_message = "app_warm_window.start and app_warm_window.end must differ — KEDA's cron scaler rejects an identical start/end."
+  }
+
+  validation {
+    condition     = var.app_warm_window == null || try(length(split(" ", trimspace(var.app_warm_window.start))) == 5 && length(split(" ", trimspace(var.app_warm_window.end))) == 5, false)
+    error_message = "app_warm_window.start and app_warm_window.end must be 5-field cron expressions (minute hour day-of-month month day-of-week)."
+  }
+}
+
+variable "tms_api_cpu" {
+  type        = number
+  description = "vCPU for the tms-api container. Every environment keeps the default 0.25: the exported.txt import OOM (incident 2026-07-02) was fixed by the #290 streaming two-pass import (spec 0006), and the temporary staging 2-vCPU bridge (#300) was removed with #290's DoD. Kept as a knob for future per-env sizing."
+  default     = 0.25
+}
+
+variable "tms_api_memory" {
+  type        = string
+  description = "Memory for the tms-api container, paired with tms_api_cpu (ACA Consumption allows only fixed pairs: 0.25/0.5Gi, 0.5/1Gi, 1/2Gi, 1.5/3Gi, 2/4Gi). Every environment keeps the default 0.5Gi — see tms_api_cpu."
+  default     = "0.5Gi"
+}

--- a/docs/deployment/azure-graveyard/scripts/seed-keyvault.ps1
+++ b/docs/deployment/azure-graveyard/scripts/seed-keyvault.ps1
@@ -1,0 +1,130 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Seeds Azure Key Vault as the single source of truth for the TMS production secrets (ADR-0013).
+    PowerShell twin of scripts/seed-keyvault.sh — keep the two in lock-step.
+
+.DESCRIPTION
+    Idempotent — safe to re-run for bring-up AND for rotation. Ensures, in order:
+      1. the Key Vault                    (RBAC-authorization mode, soft-delete on)
+      2. a user-assigned managed identity (the one the ACA apps + migrator job assume)
+      3. "Key Vault Secrets User"   on the Vault for that identity   (data-plane read at runtime)
+      4. "Key Vault Secrets Officer" on the Vault for the caller     (so this script can set secrets)
+      5. the 8 secret values
+
+    Terraform (iac/) only data-references the Vault + identity and wires the ACA secret references;
+    it never receives a plaintext value, so nothing secret rests on disk or in the Terraform state.
+
+    Secret VALUES come from environment variables (never an argument, never a committed file):
+      SEED_CONNECTION_STRING_TRANSLATION  -> connection-string-translation
+      SEED_CONNECTION_STRING_AUTH         -> connection-string-auth
+      SEED_OPENIDDICT_SIGNING_KEY         -> openiddict-signing-key
+      SEED_OPENIDDICT_ENCRYPTION_KEY      -> openiddict-encryption-key
+      SEED_OPENIDDICT_API_CLIENT_SECRET   -> openiddict-api-client-secret
+      SEED_SMTP_USERNAME                  -> smtp-username
+      SEED_SMTP_PASSWORD                  -> smtp-password
+      SEED_ADMIN_PASSWORD                 -> admin-password
+
+    Usage (one-time bring-up + every rotation):
+      az login                                       # an Owner / User Access Administrator on the sub
+      $env:SEED_CONNECTION_STRING_TRANSLATION = '…'   # … set all 8 SEED_* …
+      ./scripts/seed-keyvault.ps1
+
+    Overridable (defaults match iac/): KV_RESOURCE_GROUP, KV_LOCATION, KV_NAME, KV_IDENTITY_NAME.
+
+    Requires: az (Azure CLI), logged in to the prod subscription.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$ResourceGroup = if ($env:KV_RESOURCE_GROUP) { $env:KV_RESOURCE_GROUP } else { 'rg-lotrotms-prod-polc-001' }
+$Location      = if ($env:KV_LOCATION)       { $env:KV_LOCATION }       else { 'polandcentral' }
+$VaultName     = if ($env:KV_NAME)           { $env:KV_NAME }           else { 'lotrotms-kv-prod' }
+$IdentityName  = if ($env:KV_IDENTITY_NAME)  { $env:KV_IDENTITY_NAME }  else { 'lotrotms-aca-prod' }
+
+# KV secret name -> SEED_* env var holding its value. Keep the names in sync with the ACA
+# `secret { name = ... }` blocks in iac/azure-container-apps.tf + iac/migrator-job.tf.
+$Secrets = [ordered]@{
+    'connection-string-translation' = 'SEED_CONNECTION_STRING_TRANSLATION'
+    'connection-string-auth'        = 'SEED_CONNECTION_STRING_AUTH'
+    'openiddict-signing-key'        = 'SEED_OPENIDDICT_SIGNING_KEY'
+    'openiddict-encryption-key'     = 'SEED_OPENIDDICT_ENCRYPTION_KEY'
+    'openiddict-api-client-secret'  = 'SEED_OPENIDDICT_API_CLIENT_SECRET'
+    'smtp-username'                 = 'SEED_SMTP_USERNAME'
+    'smtp-password'                 = 'SEED_SMTP_PASSWORD'
+    'admin-password'                = 'SEED_ADMIN_PASSWORD'
+}
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) { throw 'Azure CLI (az) is not installed.' }
+az account show 1>$null 2>$null
+if ($LASTEXITCODE -ne 0) { throw "Not logged in — run 'az login' against the prod subscription." }
+
+$missing = $Secrets.Values | Where-Object { -not [Environment]::GetEnvironmentVariable($_) }
+if ($missing) { throw "Missing secret env var(s): $($missing -join ', ')" }
+
+Write-Host "==> Subscription: $(az account show --query name -o tsv) ($(az account show --query id -o tsv))"
+Write-Host "==> Resource group: $ResourceGroup | Vault: $VaultName | Identity: $IdentityName"
+
+# 1. Key Vault (idempotent). RBAC authorization is the current best practice.
+az keyvault show -n $VaultName -g $ResourceGroup 1>$null 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "==> Vault $VaultName already exists — skipping create."
+}
+else {
+    Write-Host "==> Creating Vault $VaultName …"
+    az keyvault create -n $VaultName -g $ResourceGroup -l $Location --sku standard `
+        --enable-rbac-authorization true --retention-days 90 -o none
+}
+$VaultId = az keyvault show -n $VaultName -g $ResourceGroup --query id -o tsv
+
+# 2. User-assigned managed identity (idempotent).
+az identity show -n $IdentityName -g $ResourceGroup 1>$null 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "==> Identity $IdentityName already exists — skipping create."
+}
+else {
+    Write-Host "==> Creating user-assigned identity $IdentityName …"
+    az identity create -n $IdentityName -g $ResourceGroup -l $Location -o none
+}
+$IdentityPrincipalId = az identity show -n $IdentityName -g $ResourceGroup --query principalId -o tsv
+$IdentityResourceId  = az identity show -n $IdentityName -g $ResourceGroup --query id -o tsv
+
+# 3 + 4. Role assignments (idempotent — az is a no-op when the assignment already exists).
+Write-Host "==> Granting 'Key Vault Secrets User' to the identity …"
+az role assignment create --assignee-object-id $IdentityPrincipalId --assignee-principal-type ServicePrincipal `
+    --role 'Key Vault Secrets User' --scope $VaultId -o none
+
+$CallerObjectId = az ad signed-in-user show --query id -o tsv 2>$null
+if ($CallerObjectId) {
+    Write-Host "==> Granting 'Key Vault Secrets Officer' to the caller (to set secrets) …"
+    az role assignment create --assignee-object-id $CallerObjectId --assignee-principal-type User `
+        --role 'Key Vault Secrets Officer' --scope $VaultId -o none
+}
+else {
+    Write-Warning "Could not resolve the caller object id (service principal?). Ensure the caller holds 'Key Vault Secrets Officer' on $VaultName before secrets can be set."
+}
+
+# 5. Set the secrets. Data-plane RBAC can take a minute to propagate after the role assignment above,
+#    so the first set is retried until it is authorized.
+function Set-KvSecret([string]$Name, [string]$Value) {
+    foreach ($attempt in 1..18) {
+        az keyvault secret set --vault-name $VaultName --name $Name --value $Value -o none 2>$null
+        if ($LASTEXITCODE -eq 0) { return }
+        Write-Host "   …waiting for data-plane RBAC to propagate (attempt $attempt) …"
+        Start-Sleep -Seconds 10
+    }
+    throw "Could not set secret '$Name' — the caller still lacks data-plane access on $VaultName."
+}
+
+foreach ($name in $Secrets.Keys) {
+    $value = [Environment]::GetEnvironmentVariable($Secrets[$name])
+    Write-Host "==> Setting secret $name …"
+    Set-KvSecret $name $value
+}
+
+Write-Host ''
+Write-Host 'Done. Key Vault is seeded.'
+Write-Host "  key_vault_name    = $VaultName"
+Write-Host "  aca_identity_name = $IdentityName"
+Write-Host "  identity id       = $IdentityResourceId"
+Write-Host 'Terraform reads these via the data sources in iac/keyvault.tf (defaults already match).'

--- a/docs/deployment/azure-graveyard/scripts/seed-keyvault.sh
+++ b/docs/deployment/azure-graveyard/scripts/seed-keyvault.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Seeds Azure Key Vault as the single source of truth for the TMS production secrets (ADR-0013).
+#
+# Idempotent — safe to re-run for bring-up AND for rotation. Ensures, in order:
+#   1. the Key Vault                    (RBAC-authorization mode, soft-delete on)
+#   2. a user-assigned managed identity (the one the ACA apps + migrator job assume)
+#   3. "Key Vault Secrets User"  on the Vault for that identity   (data-plane read at runtime)
+#   4. "Key Vault Secrets Officer" on the Vault for the caller    (so this script can set secrets)
+#   5. the 8 secret values
+#
+# Terraform (iac/) only data-references the Vault + identity and wires the ACA secret references;
+# it never receives a plaintext value, so nothing secret rests on disk or in the Terraform state.
+#
+# Secret VALUES come from environment variables (never an argument, never a committed file):
+#   SEED_CONNECTION_STRING_TRANSLATION  -> connection-string-translation
+#   SEED_CONNECTION_STRING_AUTH         -> connection-string-auth
+#   SEED_OPENIDDICT_SIGNING_KEY         -> openiddict-signing-key
+#   SEED_OPENIDDICT_ENCRYPTION_KEY      -> openiddict-encryption-key
+#   SEED_OPENIDDICT_API_CLIENT_SECRET   -> openiddict-api-client-secret
+#   SEED_SMTP_USERNAME                  -> smtp-username
+#   SEED_SMTP_PASSWORD                  -> smtp-password
+#   SEED_ADMIN_PASSWORD                 -> admin-password
+#
+# Usage (one-time bring-up + every rotation):
+#   az login                                       # an Owner / User Access Administrator on the sub
+#   export SEED_CONNECTION_STRING_TRANSLATION=...   # … export all 8 SEED_* …
+#   scripts/seed-keyvault.sh
+#
+# Overridable (defaults match iac/): KV_RESOURCE_GROUP, KV_LOCATION, KV_NAME, KV_IDENTITY_NAME.
+# The PowerShell twin scripts/seed-keyvault.ps1 must stay in lock-step with this file.
+#
+# Requires: az (Azure CLI), logged in to the prod subscription.
+
+set -euo pipefail
+
+RESOURCE_GROUP="${KV_RESOURCE_GROUP:-rg-lotrotms-prod-polc-001}"
+LOCATION="${KV_LOCATION:-polandcentral}"
+VAULT_NAME="${KV_NAME:-lotrotms-kv-prod}"
+IDENTITY_NAME="${KV_IDENTITY_NAME:-lotrotms-aca-prod}"
+
+# KV secret name  <-  SEED_* env var holding its value. Keep the names in sync with the ACA
+# `secret { name = ... }` blocks in iac/azure-container-apps.tf + iac/migrator-job.tf.
+SECRETS=(
+  "connection-string-translation:SEED_CONNECTION_STRING_TRANSLATION"
+  "connection-string-auth:SEED_CONNECTION_STRING_AUTH"
+  "openiddict-signing-key:SEED_OPENIDDICT_SIGNING_KEY"
+  "openiddict-encryption-key:SEED_OPENIDDICT_ENCRYPTION_KEY"
+  "openiddict-api-client-secret:SEED_OPENIDDICT_API_CLIENT_SECRET"
+  "smtp-username:SEED_SMTP_USERNAME"
+  "smtp-password:SEED_SMTP_PASSWORD"
+  "admin-password:SEED_ADMIN_PASSWORD"
+)
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+command -v az >/dev/null 2>&1 || die "Azure CLI (az) is not installed."
+az account show >/dev/null 2>&1 || die "Not logged in — run 'az login' against the prod subscription."
+
+missing=()
+for pair in "${SECRETS[@]}"; do
+  var="${pair#*:}"
+  [ -n "${!var:-}" ] || missing+=("$var")
+done
+[ "${#missing[@]}" -eq 0 ] || die "Missing secret env var(s): ${missing[*]}"
+
+echo "==> Subscription: $(az account show --query name -o tsv) ($(az account show --query id -o tsv))"
+echo "==> Resource group: ${RESOURCE_GROUP} | Vault: ${VAULT_NAME} | Identity: ${IDENTITY_NAME}"
+
+# 1. Key Vault (idempotent: create only if absent). RBAC authorization is the current best practice.
+if az keyvault show -n "$VAULT_NAME" -g "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "==> Vault ${VAULT_NAME} already exists — skipping create."
+else
+  echo "==> Creating Vault ${VAULT_NAME} …"
+  az keyvault create \
+    -n "$VAULT_NAME" \
+    -g "$RESOURCE_GROUP" \
+    -l "$LOCATION" \
+    --sku standard \
+    --enable-rbac-authorization true \
+    --retention-days 90 \
+    -o none
+fi
+VAULT_ID="$(az keyvault show -n "$VAULT_NAME" -g "$RESOURCE_GROUP" --query id -o tsv)"
+
+# 2. User-assigned managed identity (idempotent).
+if az identity show -n "$IDENTITY_NAME" -g "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "==> Identity ${IDENTITY_NAME} already exists — skipping create."
+else
+  echo "==> Creating user-assigned identity ${IDENTITY_NAME} …"
+  az identity create -n "$IDENTITY_NAME" -g "$RESOURCE_GROUP" -l "$LOCATION" -o none
+fi
+IDENTITY_PRINCIPAL_ID="$(az identity show -n "$IDENTITY_NAME" -g "$RESOURCE_GROUP" --query principalId -o tsv)"
+IDENTITY_RESOURCE_ID="$(az identity show -n "$IDENTITY_NAME" -g "$RESOURCE_GROUP" --query id -o tsv)"
+
+# 3 + 4. Role assignments (idempotent — az is a no-op when the assignment already exists).
+echo "==> Granting 'Key Vault Secrets User' to the identity …"
+az role assignment create \
+  --assignee-object-id "$IDENTITY_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --role "Key Vault Secrets User" \
+  --scope "$VAULT_ID" \
+  -o none
+
+CALLER_OBJECT_ID="$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)"
+if [ -n "$CALLER_OBJECT_ID" ]; then
+  echo "==> Granting 'Key Vault Secrets Officer' to the caller (to set secrets) …"
+  az role assignment create \
+    --assignee-object-id "$CALLER_OBJECT_ID" \
+    --assignee-principal-type User \
+    --role "Key Vault Secrets Officer" \
+    --scope "$VAULT_ID" \
+    -o none
+else
+  echo "WARNING: could not resolve the caller object id (service principal?). Ensure the caller holds" >&2
+  echo "         'Key Vault Secrets Officer' on ${VAULT_NAME} before secrets can be set." >&2
+fi
+
+# 5. Set the secrets. Data-plane RBAC can take a minute to propagate after the role assignment above,
+#    so the first set is retried until it is authorized.
+set_secret() {
+  local name="$1" value="$2" attempt
+  for attempt in $(seq 1 18); do
+    if az keyvault secret set --vault-name "$VAULT_NAME" --name "$name" --value "$value" -o none 2>/dev/null; then
+      return 0
+    fi
+    echo "   …waiting for data-plane RBAC to propagate (attempt ${attempt}) …"
+    sleep 10
+  done
+  die "Could not set secret '${name}' — the caller still lacks data-plane access on ${VAULT_NAME}."
+}
+
+for pair in "${SECRETS[@]}"; do
+  name="${pair%%:*}"
+  var="${pair#*:}"
+  echo "==> Setting secret ${name} …"
+  set_secret "$name" "${!var}"
+done
+
+echo ""
+echo "Done. Key Vault is seeded."
+echo "  key_vault_name    = ${VAULT_NAME}"
+echo "  aca_identity_name = ${IDENTITY_NAME}"
+echo "  identity id       = ${IDENTITY_RESOURCE_ID}"
+echo "Terraform reads these via the data sources in iac/keyvault.tf (defaults already match)."

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -1058,8 +1058,11 @@ Key Vault secrets, Log Analytics + Application Insights, scale-to-zero with a sc
 The Azure for Students subscription was disabled that day — credits exhausted, renewal refused — and
 both prods went dark. [ADR-0034](../adr/0034-hetzner-vps-instead-of-azure-container-apps.md) records
 the decision to move; [`hetzner-migration-plan.md`](hetzner-migration-plan.md) is the executed
-playbook; epic #486 tracked it. The Terraform root, the Key Vault seeders and the ACA-specific
-workflow legs were removed from the repo by #492 — git history keeps them.
+playbook; epic #486 tracked it. The ACA-specific workflow legs were removed from the repo by #492.
+The Terraform root and the Key Vault seeders were taken out of the build but **kept as a read-only
+tombstone** in [`azure-graveyard/`](azure-graveyard/README.md) — the ADRs of the Azure era argue
+about those files line-by-line, so they stay readable. Nothing in there is runnable: the
+subscription is disabled and the Terraform state died with it.
 
 **Recorded so nobody retries it:** with the subscription disabled, Key Vault serves secret *metadata*
 but refuses every *value* read (`az keyvault secret list` works and returns the 8 names;

--- a/docs/tms-handbook.md
+++ b/docs/tms-handbook.md
@@ -1641,7 +1641,9 @@ deletes the whole FinOps problem class the ADRs above had been fighting (scale-t
 windows, revision sweeps). Accepted: no blue/green (a 4 GB box cannot hold a second live set, so a
 deploy costs seconds of downtime, guarded by a migration gate + automatic rollback); observability
 shrank to logs + a daily health ping until a real sink is chosen; the box is now a thing to patch.
-Retired with it: the Terraform root, Key Vault, and ADRs 0013/0016/0017/0020/0027/0029.
+Retired with it: the Terraform root, Key Vault, and ADRs 0013/0016/0017/0020/0027/0029 — the
+Terraform and the Key Vault seeders survive as a read-only tombstone in
+`docs/deployment/azure-graveyard/`, so the `iac/*.tf` those ADRs argue about can still be opened.
 
 ---
 


### PR DESCRIPTION
Follow-up to #492 (PR #504). That ticket allowed either option — delete the Azure IaC, or move it
to a graveyard folder with a tombstone. It deleted. This PR takes the other option.

## Why

The ADRs of the Azure era argue about those files **line by line** — ADR-0013 (Key Vault as the
single source of truth), 0016 (`iac/observability.tf`), 0017 (`iac/locals.tf`, `backend-config/`),
0019 (`iac/monitoring.tf` SLO probes), 0020, 0027, 0029. After #492 every one of those references
dangles. A decision record whose subject file cannot be opened is half a record, and "it's in git
history" is not a link anybody follows.

## What

- Restores `iac/**` and `scripts/seed-keyvault.{sh,ps1}` under `docs/deployment/azure-graveyard/`,
  byte-identical to their last live state (the parent of `72e1a4b`).
- Adds a README tombstone: what this is (dead), why it is kept, and a **DO NOT RUN** section — the
  subscription is disabled, the Terraform state lived in a storage account inside it, the secrets
  were never in the tree. Plus a table mapping each Azure piece to its Hetzner replacement.
- `iac/.terraform.lock.hcl` is **not** restored — a machine artifact (provider hashes) for an init
  that will never run again.
- The seeder scripts come back **without the executable bit**, on purpose.
- `.gitignore`: an exception for the graveyard's `staging.tfvars` (the blanket `*.tfvars` rule came
  back with #492). It carries no secrets by design — ADR-0017: `env_id`, public domain, Key Vault
  and identity *names* only.
- Runbook, ADR-0034 and the handbook now point at the graveyard instead of saying "git history
  keeps them".

## Verification

- Everything lands under `docs/` → `scripts/ci/classify-changes.sh` returns `code=false
  guards=false images=false`. No .NET gate, no guards, no image builds — nothing here is a build
  input.
- The secret-detection pre-commit hook passes: the restored `.tf` files contain secret *names* and
  versionless Key Vault URIs, never values.

Refs #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)