### PR TITLE
HETZ-07: Segment the two compose stacks — own network for TKS, Caddy-only /32 trust

### DIFF
--- a/.docker/hetzner/Caddyfile
+++ b/.docker/hetzner/Caddyfile
@@ -24,8 +24,10 @@
 	reverse_proxy tms-api:8080
 }
 
-# --- TheKittySaver (its stack lives in /opt/tks and joins THIS stack's network; this Caddy
-# terminates TLS for its hostnames too). The TKS_DOMAIN_* values come from the per-box env
+# --- TheKittySaver (its stack lives in /opt/tks and joins the segregated `${project}_tks` network
+# this Caddy also sits on — #506; this Caddy terminates TLS for its hostnames too). Caddy resolves
+# these `tks-*` keys via the tks network and our own `frontend`/`auth-api`/`tms-api` via the default
+# network, so the two stacks share only Caddy. The TKS_DOMAIN_* values come from the per-box env
 # file; a box without the TKS stack keeps the compose defaults (*.localhost — internal cert,
 # no ACME, requests just 502) so this file stays valid everywhere.
 {$TKS_DOMAIN_APP} {

--- a/compose.hetzner.yaml
+++ b/compose.hetzner.yaml
@@ -14,6 +14,11 @@
 # hostnames to the in-stack Caddy, so one OIDC Authority serves the browser front-channel and the
 # container back-channel — same origin, real certificate, no hairpin dependency.
 #
+# Two segregated networks per box (#506, ADR-0034 amendment): our stack sits alone on `default`
+# (10.60.0.0/24); the guest TheKittySaver stack sits alone on `tks` (10.61.0.0/24). Caddy is the
+# ONLY shared component — it holds a pinned static IP on each network, and the apps trust
+# X-Forwarded-* from that single /32 only. See the `networks:` block at the bottom.
+#
 # Bring-up on a box (as the deploy user, files in /opt/lotro; scripts/hetzner/bootstrap.sh has
 # already done the one-time `docker login ghcr.io` as deploy with a read:packages PAT):
 #   docker compose -f compose.hetzner.yaml pull
@@ -37,9 +42,10 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: "http://+:8080"
-      # Trust X-Forwarded-* only from the pinned stack subnet (the Caddy hop) — #399. Keep in
-      # lockstep with the ipam subnet at the bottom of this file.
-      ForwardedHeaders__KnownNetworks__0: "10.60.0.0/24"
+      # Trust X-Forwarded-* only from Caddy's pinned static IP (the sole ingress hop) — #399,
+      # narrowed to a /32 by #506 so no other container on the network can spoof headers. Keep in
+      # lockstep with caddy's ipv4_address on the default network at the bottom of this file.
+      ForwardedHeaders__KnownNetworks__0: "10.60.0.100/32"
       ConnectionStrings__AuthDatabase: ${ConnectionStrings__AuthDatabase}
       OpenIddict__Issuer: "https://${DOMAIN_AUTH}"
       OpenIddict__SigningKey__RsaPrivateKeyXml: ${OpenIddict__SigningKey__RsaPrivateKeyXml}
@@ -76,7 +82,8 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: "http://+:8080"
-      ForwardedHeaders__KnownNetworks__0: "10.60.0.0/24"
+      # See the auth-api note: trust X-Forwarded-* only from Caddy's /32 (#399, #506).
+      ForwardedHeaders__KnownNetworks__0: "10.60.0.100/32"
       ConnectionStrings__TranslationDatabase: ${ConnectionStrings__TranslationDatabase}
       # Issuer = the public origin the tokens carry; Authority = where OIDC metadata + JWKS are
       # fetched. Both resolve to the in-stack Caddy via its network aliases below, serving the
@@ -102,7 +109,8 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: "http://+:8080"
-      ForwardedHeaders__KnownNetworks__0: "10.60.0.0/24"
+      # See the auth-api note: trust X-Forwarded-* only from Caddy's /32 (#399, #506).
+      ForwardedHeaders__KnownNetworks__0: "10.60.0.100/32"
       AuthSystem__Authority: "https://${DOMAIN_AUTH}"
       AuthSystem__BaseUrl: "https://${DOMAIN_AUTH}/"
       TranslationSystem__BaseUrl: "https://${DOMAIN_TMS}/"
@@ -141,14 +149,26 @@ services:
       - caddy-data:/data
       - caddy-config:/config
     networks:
+      # Caddy is the ONLY component on both networks — the single shared trust boundary between the
+      # LotroKoniecDev stack (default) and the guest TheKittySaver stack (tks). It holds a pinned
+      # static IP on each so the apps can trust X-Forwarded-* from exactly that hop (#506).
       default:
-        # In-stack containers resolve the public hostnames to this proxy (see the comment at the
-        # top of the file). Compose interpolates the per-env domains from the env file.
+        # Static so ForwardedHeaders__KnownNetworks__0 can pin it to a /32 (#506). Keep in lockstep
+        # with the KnownNetworks values on auth-api/tms-api/frontend above.
+        ipv4_address: 10.60.0.100
+        # LotroKoniecDev in-stack containers resolve OUR public hostnames to this proxy (see the
+        # comment at the top of the file). Compose interpolates the per-env domains from the env file.
         aliases:
           - ${DOMAIN_APP}
           - ${DOMAIN_AUTH}
           - ${DOMAIN_TMS}
-          # TKS in-stack back-channel: its containers resolve the public origins to this proxy.
+      tks:
+        # Static IP on the segregated TKS network — the only address the guest stack shares with us.
+        ipv4_address: 10.61.0.100
+        # TKS in-stack back-channel: the guest stack's containers (which join THIS network as
+        # external — twin ticket koniecdev/TheKittySaver#295) resolve their public origins to this
+        # proxy. Moved here from the default network by #506 so the two stacks no longer share one.
+        aliases:
           - ${TKS_DOMAIN_APP:-tks-app.localhost}
           - ${TKS_DOMAIN_AUTH:-tks-auth.localhost}
           - ${TKS_DOMAIN_API:-tks-api.localhost}
@@ -167,10 +187,23 @@ volumes:
   caddy-config:
 
 networks:
-  # Pinned subnet so the apps can restrict forwarded-header trust to the in-stack Caddy hop via
-  # ForwardedHeaders__KnownNetworks__0 above (#399). When the TheKittySaver stack joins the same
-  # box it picks its own subnet (e.g. 10.61.0.0/24) — never reuse this one.
+  # Two segregated networks per box (#506). Caddy is the only container on both; nothing else
+  # crosses. Pinned subnets so the apps can restrict forwarded-header trust to Caddy's static /32
+  # via ForwardedHeaders__KnownNetworks__0 above (#399).
+  #
+  # default (10.60.0.0/24): the LotroKoniecDev stack — auth-api, tms-api, frontend, migrator, Caddy.
+  #   Caddy sits at 10.60.0.100 (the value the /32 KnownNetworks pins).
   default:
     ipam:
       config:
         - subnet: 10.60.0.0/24
+  # tks (10.61.0.0/24): the shared boundary for the guest TheKittySaver stack. Only Caddy lives here
+  # (at 10.61.0.100); the TKS stack joins it as `external` (twin ticket koniecdev/TheKittySaver#295)
+  # instead of joining our default network. This keeps TKS containers OFF 10.60.0.0/24 — they can no
+  # longer reach our apps directly nor spoof X-Forwarded-* into them. `name:` mirrors the compose
+  # `${project}_default` convention so the guest can reference `${COMPOSE_PROJECT_NAME}_tks`.
+  tks:
+    name: ${COMPOSE_PROJECT_NAME}_tks
+    ipam:
+      config:
+        - subnet: 10.61.0.0/24

--- a/compose.hetzner.yaml
+++ b/compose.hetzner.yaml
@@ -25,6 +25,23 @@
 #   docker compose -f compose.hetzner.yaml up -d
 #   docker compose -f compose.hetzner.yaml logs -f migrator caddy
 
+# Caddy's environment, shared by the proxy itself and by the `caddy-validate` gate below. It is an
+# anchor and not two copies on purpose: the gate's whole job is to render the SAME Caddyfile the
+# proxy will run, so an env var added to one and forgotten in the other would leave a placeholder
+# empty in the gate only — and an empty site key makes Caddy read the block as a misplaced global
+# options block, i.e. the gate would pass a file that then fails to start.
+x-caddy-environment: &caddy-environment
+  DOMAIN_APP: ${DOMAIN_APP}
+  DOMAIN_AUTH: ${DOMAIN_AUTH}
+  DOMAIN_TMS: ${DOMAIN_TMS}
+  ACME_EMAIL: ${ACME_EMAIL}
+  # TheKittySaver hostnames (its stack lives in /opt/tks and joins the segregated `tks` network this
+  # Caddy also sits on — #506; this Caddy terminates TLS for it). Optional: a box without TKS keeps
+  # the *.localhost defaults — internal cert, no ACME, requests just 502.
+  TKS_DOMAIN_APP: ${TKS_DOMAIN_APP:-tks-app.localhost}
+  TKS_DOMAIN_AUTH: ${TKS_DOMAIN_AUTH:-tks-auth.localhost}
+  TKS_DOMAIN_API: ${TKS_DOMAIN_API:-tks-api.localhost}
+
 services:
   migrator:
     image: ghcr.io/${IMAGE_NAMESPACE:-koniecdev}/lotrokoniecdev-migrator:${IMAGE_TAG:-latest}
@@ -131,17 +148,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
-    environment:
-      DOMAIN_APP: ${DOMAIN_APP}
-      DOMAIN_AUTH: ${DOMAIN_AUTH}
-      DOMAIN_TMS: ${DOMAIN_TMS}
-      ACME_EMAIL: ${ACME_EMAIL}
-      # TheKittySaver hostnames (its stack lives in /opt/tks and joins THIS network; this Caddy
-      # terminates TLS for it). Optional: a box without TKS keeps the *.localhost defaults —
-      # internal cert, no ACME, requests just 502.
-      TKS_DOMAIN_APP: ${TKS_DOMAIN_APP:-tks-app.localhost}
-      TKS_DOMAIN_AUTH: ${TKS_DOMAIN_AUTH:-tks-auth.localhost}
-      TKS_DOMAIN_API: ${TKS_DOMAIN_API:-tks-api.localhost}
+    environment: *caddy-environment
     volumes:
       - ./.docker/hetzner/Caddyfile:/etc/caddy/Caddyfile:ro
       # /data holds the ACME account + issued certificates — losing it re-issues on next start
@@ -180,6 +187,23 @@ services:
       frontend:
         condition: service_started
 
+  # The Caddyfile syntax gate that scripts/hetzner/deploy.sh runs BEFORE it touches anything. It is a
+  # separate service and not `compose run caddy` on purpose: a one-off container inherits the whole
+  # service definition, including the static IPs the `caddy` service pins (#506) — which the RUNNING
+  # Caddy already holds. The first deploy would pass (no Caddy up yet) and every deploy after it would
+  # die with "failed to set up container networking: Address already in use" (reproduced on Docker
+  # 29.6.1, the engine the boxes run). Hence: same image, same Caddyfile, same environment (the anchor
+  # keeps it honest) — but NO network at all, and a profile so `up` never starts it.
+  caddy-validate:
+    image: caddy:2-alpine
+    profiles: ["validate"]
+    network_mode: none
+    environment: *caddy-environment
+    volumes:
+      - ./.docker/hetzner/Caddyfile:/etc/caddy/Caddyfile:ro
+    # The image has no caddy ENTRYPOINT — its CMD carries the binary, so an override must too.
+    command: ["caddy", "validate", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+
 volumes:
   auth-keys:
   frontend-keys:
@@ -203,7 +227,7 @@ networks:
   # longer reach our apps directly nor spoof X-Forwarded-* into them. `name:` mirrors the compose
   # `${project}_default` convention so the guest can reference `${COMPOSE_PROJECT_NAME}_tks`.
   tks:
-    name: ${COMPOSE_PROJECT_NAME}_tks
+    name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME must be set}_tks
     ipam:
       config:
         - subnet: 10.61.0.0/24

--- a/docs/adr/0034-hetzner-vps-instead-of-azure-container-apps.md
+++ b/docs/adr/0034-hetzner-vps-instead-of-azure-container-apps.md
@@ -1,6 +1,6 @@
 # ADR-0034: Single Hetzner VPS instead of Azure Container Apps
 
-**Status:** Accepted
+**Status:** Accepted (amended 2026-07-13 — see "Amendment: two segregated networks per box")
 **Date:** 2026-07-12
 **Decision-makers:** Solo maintainer
 **Related:** deployment (all of `iac/`, `compose.prod.yaml`, CD workflows), epic #486 (HETZ-01..06:
@@ -165,6 +165,35 @@ machinery (ADR-0025) for hand-rolled backups on the same failure domain as the a
   `iac/<file>` references throughout ADRs 0013/0016/0017/0019/0020/0027/0029 resolve there
 - Execution: epic #486, tickets #487–#492; owner-assisted bring-up is #491;
   plan: `docs/deployment/hetzner-migration-plan.md`
+
+## Amendment: two segregated networks per box — Caddy is the only shared trust boundary (2026-07-13, #506)
+
+§5 put the guest TheKittySaver stack "behind the same Caddy" but never stated the trust boundary
+between the two stacks, and the first implementation made them share **one** Docker network
+(`lotro-{env}_default`, `10.60.0.0/24`): TKS joined ours as `external` so the shared Caddy could
+reach it. That co-tenancy had two consequences the post-migration security review (2026-07-13)
+flagged: (1) **cross-stack pivot** — a TKS container sat inside our
+`ForwardedHeaders__KnownNetworks__0` and could reach `auth-api:8080` / `tms-api:8080` /
+`frontend:8080` directly, bypassing Caddy (and vice versa); (2) **header spoofing** — any container
+on the network could set `X-Forwarded-*` and be believed, because trust was scoped to the whole
+`/24`, not to the proxy.
+
+The trust boundary is now explicit and enforced by topology: **Caddy is the only component the two
+stacks share.** Each box runs two networks — `default` (`10.60.0.0/24`, our stack alone) and `tks`
+(`10.61.0.0/24`, `name: ${COMPOSE_PROJECT_NAME}_tks`, the guest stack alone). Caddy is the sole
+container on both, pinned to a static IP on each (`10.60.0.100` / `10.61.0.100`); the `TKS_DOMAIN_*`
+back-channel aliases move onto the `tks` network. The apps narrow
+`ForwardedHeaders__KnownNetworks__0` from the `/24` to Caddy's `10.60.0.100/32`, so a forged
+`X-Forwarded-*` from any non-Caddy container is no longer honoured, and no TKS container can address
+our apps at all (it is off `10.60.0.0/24` entirely). The static-IP↔KnownNetworks lockstep the
+existing subnet comment already mandated now extends to the exact host address.
+
+This is a `compose.hetzner.yaml` + docs change only; `compose.prod.yaml` (the laptop parity stack,
+which never co-tenants TKS) is untouched. The guest side is the twin ticket
+koniecdev/TheKittySaver#295 (re-point its `external` network from `${project}_default` to
+`${project}_tks`); deploying this ADR re-creates the lotro stack with the new topology, so the TKS
+stack must be re-pointed and re-upped (`down` + `up -d` in `/opt/tks`) right after the lotro deploy
+on each box — see the runbook's bring-up notes.
 
 ## References
 

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -51,6 +51,7 @@ staging.
 | Registry | `deploy` is `docker login`-ed to **ghcr.io** with a **read-only** (`read:packages`) PAT |
 | DB | none on the box — **Neon** is the database for prod AND staging (ADR-0034 §2) |
 | Ingress | **Caddy**, one vhost per app, automatic Let's Encrypt certificates |
+| Networks | **Two segregated Docker networks per box** (#506): `${project}_default` (`10.60.0.0/24`, our stack) and `${project}_tks` (`10.61.0.0/24`, the guest TheKittySaver stack). **Caddy is the only container on both** (static IPs `10.60.0.100` / `10.61.0.100`); nothing else crosses. The apps trust `X-Forwarded-*` from Caddy's `10.60.0.100/32` only — keep that /32 in lockstep with Caddy's `ipv4_address`. |
 
 Images are `linux/amd64` only (no multi-arch buildx) — the box is amd64 on purpose; never "fix" a
 pull error by enabling emulation.
@@ -132,7 +133,7 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 | `OpenIddict__WebClient__RedirectUris__0` | `https://localhost:7017/callback` | `https://lotro-translator.pl/callback` | ✅ non-dev | plain | MUST equal the Frontend callback (its public origin + `AuthSystem__CallbackPath`). Written to the DB **only at client creation** — see the reseed traps. |
 | `OpenIddict__WebClient__PostLogoutRedirectUris__0` | `https://localhost:7017` | `https://lotro-translator.pl` | ✅ non-dev | plain | Frontend post-logout return URL. |
 | `Cors__AllowedOrigins__0` | — (AllowAnyOrigin) | `https://lotro-translator.pl` | ✅ non-dev | plain | Bare origin = Frontend public URL. Lowercase, no port-if-default, no path/slash. |
-| `ForwardedHeaders__KnownNetworks__0` | — (dev skips `UseForwardedHeaders`) | `10.60.0.0/24` (the Caddy network) | optional | plain | Restricts `X-Forwarded-*` trust to the proxy hop (#399). Both deployed stacks set it. Malformed CIDR aborts boot. |
+| `ForwardedHeaders__KnownNetworks__0` | — (dev skips `UseForwardedHeaders`) | `10.60.0.100/32` (Caddy's pinned static IP) | optional | plain | Restricts `X-Forwarded-*` trust to Caddy's exact host address, not the whole subnet (#399, narrowed to a /32 by #506). Keep in lockstep with Caddy's `ipv4_address` on the default network in `compose.hetzner.yaml`. Both deployed stacks set it. Malformed CIDR aborts boot. |
 | `DataProtection__KeyRingPath` | — (host default) | `/keys` | ✅ non-dev | plain | Persistent volume (`auth-keys`); else logins/antiforgery/reset links break on every deploy. |
 | `Email__Host` | `localhost` (the compose mailpit, published on `:1025`) | `smtp-relay.brevo.com` | ✅ all | plain | SMTP host. Validated on start (every environment). |
 | `Email__Port` | `1025` | `587` | ✅ all | plain | 1–65535. |
@@ -155,7 +156,7 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 | `Auth__Authority` | — (unset → falls back to `Issuer`) | `https://auth.lotro-translator.pl` | optional² | plain | Back-channel for OIDC metadata + JWKS. ²Unset → falls back to `Issuer`; the dev host run relies on that fallback. Prod: must be `https` (OpenIddict rejects plain HTTP) and reachable from the container — i.e. the **public Caddy origin**, never `http://auth-api:8080`. |
 | `Auth__Audience` | `lotrokoniecdev-api` | `lotrokoniecdev-api` | ✅ all | plain | Default in base `appsettings.json`. |
 | `Cors__AllowedOrigins__0` | — (AllowAnyOrigin) | `https://lotro-translator.pl` | ✅ non-dev | plain | Bare origin = Frontend public URL. |
-| `ForwardedHeaders__KnownNetworks__0` | — (dev skips `UseForwardedHeaders`) | `10.60.0.0/24` (the Caddy network) | optional | plain | See the auth-api row. |
+| `ForwardedHeaders__KnownNetworks__0` | — (dev skips `UseForwardedHeaders`) | `10.60.0.100/32` (Caddy's pinned static IP) | optional | plain | See the auth-api row. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` | `http://localhost:4317` / `grpc` (launchSettings) | — (empty: no sink today) | optional | plain | Empty endpoint = export disabled. |
 | `Bootstrap__Enabled` | `false` | `false` | optional | plain | One-time DB seed of the first export (spec 0001). Off by default. |
 | `Bootstrap__GameVersion` / `Bootstrap__ExportedTextPath` / `Bootstrap__PolishTextPath` | — / — / `/app/translations/polish.txt` | as needed | optional | plain | Only consulted when `Bootstrap__Enabled=true`. |
@@ -178,7 +179,7 @@ Staging/Production.
 | `AuthSystem__Scopes` | `openid,email,profile,roles,api,offline_access` | same | ✅ all | plain | At least one scope. |
 | `TranslationSystem__BaseUrl` | `https://localhost:5002/` | `https://tms.lotro-translator.pl/` | ✅ all | plain | TMS API origin (trailing slash). |
 | `DataProtection__KeyRingPath` | — (host default) | `/keys` | ✅ non-dev | plain | Persistent volume (`frontend-keys`, ADR-0005); else antiforgery + auth cookies break on deploy. |
-| `ForwardedHeaders__KnownNetworks__0` | — (dev skips `UseForwardedHeaders`) | `10.60.0.0/24` (the Caddy network) | optional | plain | See the auth-api row. |
+| `ForwardedHeaders__KnownNetworks__0` | — (dev skips `UseForwardedHeaders`) | `10.60.0.100/32` (Caddy's pinned static IP) | optional | plain | See the auth-api row. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` | `http://localhost:4317` / `grpc` (launchSettings) | — (empty: no sink today) | optional | plain | Empty endpoint = export disabled. |
 
 ### migrator
@@ -403,9 +404,13 @@ The cross-service settings that are individually valid but break the system when
 
 5. **Behind the TLS-terminating proxy, forwarded headers are load-bearing.** Caddy MUST send
    `X-Forwarded-Proto` (and Host); all three apps read them (`UseForwardedHeaders`) to reconstruct the
-   `https` scheme used for `iss`, `redirect_uri`, and `Secure` cookies. Trust is scoped to the proxy's
-   subnet (#399): `ForwardedHeaders__KnownNetworks__0` = `10.60.0.0/24`, set for all three apps in
-   both `compose.hetzner.yaml` and `compose.prod.yaml`; a malformed CIDR aborts boot. Leaving it
+   `https` scheme used for `iss`, `redirect_uri`, and `Secure` cookies. Trust is scoped to Caddy's
+   exact host address (#399, narrowed from the `/24` to a `/32` by #506):
+   `ForwardedHeaders__KnownNetworks__0` = `10.60.0.100/32` in `compose.hetzner.yaml`
+   (`compose.prod.yaml` keeps the `/24` — it has no co-tenant stack to fence off), set for all three
+   apps; a malformed CIDR aborts boot. That value MUST stay in lockstep with Caddy's `ipv4_address`
+   on the default network (see [Topology](#topology)); moving Caddy's pinned IP without updating all
+   three apps silently drops forwarded-header trust and breaks `https` reconstruction. Leaving it
    unset trusts every upstream (with an explicit `ForwardLimit = 1`), which is safe **only** while the
    container port is unreachable except through the proxy — so **never publish `:8080`**. In prod the
    apps serve HTTP only; Caddy owns TLS.
@@ -1014,14 +1019,26 @@ Recovery = **new VPS → `bootstrap.sh` → scp stack files → restore/re-mint 
   `docker` + `docker compose` and installs `docker-ce` only when the box has no engine at all (fixed
   2026-07-13, #502). Do not "simplify" that guard away; the engine's vendor is irrelevant to us, its
   presence is not.
-- **Compose service KEYS must be globally unique on the shared network.** Compose registers the
-  service key itself as a Docker DNS alias on top of `container_name` — a guest stack (TKS) whose
-  compose also says `frontend:`/`auth-api:` collides with ours, and Caddy's
-  `reverse_proxy frontend:8080` then round-robins into the WRONG stack (2026-07-12 prod incident:
-  lotro-translator.pl served uratujkota.pl). Every TKS service key carries the `tks-` prefix; any new
-  stack joining this network must prefix its keys the same way. Detection:
+- **Two segregated networks per box; Caddy is the only shared component (#506).** Our stack lives
+  alone on `${project}_default` (`10.60.0.0/24`); the guest TheKittySaver stack lives alone on
+  `${project}_tks` (`10.61.0.0/24`, which our `compose.hetzner.yaml` defines and TKS joins as
+  `external` — its twin ticket koniecdev/TheKittySaver#295). Caddy sits on both at pinned static IPs
+  (`10.60.0.100` / `10.61.0.100`) and is the ONLY container that crosses. This fences off the
+  cross-stack pivot and the header-spoof that one shared network allowed (see the ADR-0034
+  amendment). **Coordinated bring-up:** deploying this topology change **re-creates the lotro stack**,
+  so the TKS containers keep running but lose the Caddy-side aliases on the old network — the TKS
+  stack must be re-pointed to `${project}_tks` and re-upped (`down` + `up -d` in `/opt/tks`) **right
+  after** the lotro deploy on each box (**staging first, then prod**; brief TKS downtime is fine
+  pre-launch).
+- **Compose service KEYS must still be globally unique per network.** Compose registers the service
+  key itself as a Docker DNS alias on top of `container_name`. Before #506 both stacks shared one
+  network, so a guest whose compose also said `frontend:`/`auth-api:` collided with ours and Caddy's
+  `reverse_proxy frontend:8080` round-robined into the WRONG stack (2026-07-12 prod incident:
+  lotro-translator.pl served uratujkota.pl). Segmentation removes that cross-stack collision, but the
+  `tks-` prefix on every TKS service key stays the rule — Caddy resolves `reverse_proxy tks-frontend:8080`
+  on the `tks` network, and the public-hostname aliases must remain unique there. Detection:
   `docker inspect -f '{{range $k,$v := .NetworkSettings.Networks}}{{$v.Aliases}}{{end}}' <ctr>` — no
-  alias may appear on two containers.
+  alias may appear on two containers of the same network.
 - **Docker bypasses ufw for published ports** (it programs iptables directly). Our stacks publish only
   Caddy's 80/443 — which ufw allows anyway. Never publish another service's port "just to debug";
   exec into the network instead

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -21,7 +21,7 @@
 - [Environment variable matrix](#environment-variable-matrix) — the single source of truth, per service × environment
 - [Secrets](#secrets) — where they live, how to generate them, how to rotate them
 - [Consistency rules that bite](#consistency-rules-that-bite) — issuer / redirect / authority / CORS
-- [Bringing the stack up](#bringing-the-stack-up) — dev, prod-parity, and (re)provisioning a box
+- [Bringing the stack up](#bringing-the-stack-up) — dev, prod-parity, (re)provisioning a box, and the one-time network cutover
 - [Continuous deployment (CD over ssh)](#continuous-deployment-cd-over-ssh) — build-once → auto staging → gated prod promotion
 - [Database migrations](#database-migrations) — strategy, running them, and recovering from a bad migration (Neon PITR + the MIGR-04 auto-snapshot)
 - [Post-deploy smoke test](#post-deploy-smoke-test) — one command verifies a deployed environment end-to-end
@@ -516,6 +516,52 @@ docker compose -f compose.prod.yaml --env-file .env.prod --profile local-smtp --
    remember `GET / -> 200` proves nothing; smoke's fingerprint leg is the real check.
 6. **Add swap on the prod box** and re-pin the CD host key (`ssh-keyscan`) — see
    [Gotchas](#gotchas) and [One-time setup per environment](#one-time-setup-per-environment).
+
+### One-time: cutting a live box over to the two segregated networks (#506)
+
+Both stacks are already running on these boxes, so #506 is a **migration of a live box**, not a fresh
+bring-up. The lotro deploy recreates our containers on the new topology and creates `${project}_tks`;
+the TKS containers keep running meanwhile, but on the old network and **without** the Caddy aliases
+they need — so they must be recreated straight after (compose cannot move a running container between
+networks). Do the whole sequence on **staging first**, prod only once staging is verified. A short TKS
+outage is expected and acceptable pre-launch.
+
+**Pre-flight** — record what you are changing, as `deploy` (`lotro-prod` shown; staging is
+`lotro-staging`):
+
+```bash
+docker network ls                                     # today: ONE shared network, both stacks on it
+docker network inspect lotro-prod_default \
+  --format '{{range .Containers}}{{.Name}} {{.IPv4Address}}{{"\n"}}{{end}}'
+```
+
+Everything that is **not** ours in that list (every `tks-*` container) is exactly what this change
+fences off. If Caddy already sits at `10.60.0.100` and a `lotro-prod_tks` network exists, the box has
+been cut over already — stop here.
+
+1. **Deploy lotro.** CD does it on merge; by hand: `IMAGE_TAG=<tag> bash /opt/lotro/deploy.sh`.
+2. **Verify the boundary before touching TKS** — Caddy must hold both pinned addresses, and nothing
+   but our four containers may remain on `10.60.0.0/24`:
+
+   ```bash
+   docker inspect lotro-prod-caddy-1 \
+     --format '{{range $n,$c := .NetworkSettings.Networks}}{{$n}} {{$c.IPAddress}}{{"\n"}}{{end}}'
+   docker network inspect lotro-prod_default \
+     --format '{{range .Containers}}{{.Name}}{{"\n"}}{{end}}'
+   ```
+
+3. **Recreate the TKS stack onto `${project}_tks`** (its compose change is the twin ticket,
+   koniecdev/TheKittySaver#295):
+
+   ```bash
+   cd /opt/tks
+   docker compose down          # NEVER -v: that would drop its DB/keyring volumes
+   docker compose up -d
+   ```
+
+4. **Verify both sites from outside the box** — ours with the [smoke test](#post-deploy-smoke-test),
+   TKS by loading its public origin. A 502 on TKS means its containers did not land on
+   `${project}_tks` (or lost their `tks-` service-key prefix) — Caddy itself is fine; re-check step 3.
 
 ## Continuous deployment (CD over ssh)
 

--- a/scripts/hetzner/deploy.sh
+++ b/scripts/hetzner/deploy.sh
@@ -111,15 +111,20 @@ compose config --quiet
 # undetected until the reload at the end of this script — or, worse, until the next reboot. Validate
 # it up front, while nothing has been touched: the running Caddy keeps serving its current config.
 #
-# It MUST go through `compose run` (not a bare `docker run --env-file .env`): the Caddyfile's
+# It MUST go through compose (not a bare `docker run --env-file .env`): the Caddyfile's
 # {$TKS_DOMAIN_*} placeholders are fed by compose's `${TKS_DOMAIN_APP:-tks-app.localhost}` defaults,
 # which live in compose.hetzner.yaml and NOT in .env — a box without the TheKittySaver stack leaves
 # those variables empty, and an empty site key makes Caddy read the block as a misplaced global
 # options block ("server block without any key…"). Only the composed environment renders the same
-# file Caddy will actually run. The doubled `caddy caddy` is deliberate: the first is the service,
-# the second is the binary (the image's entrypoint is not the caddy binary).
+# file Caddy will actually run.
+#
+# …but it must NOT be `compose run caddy`: since #506 that service pins static IPs (10.60.0.100 /
+# 10.61.0.100), and a one-off container built from it re-claims the very addresses the RUNNING Caddy
+# holds — "failed to set up container networking: Address already in use" on every deploy after the
+# first. `caddy-validate` is the same image + Caddyfile + environment (a YAML anchor keeps the env in
+# lockstep) with no network and its own profile, so it can never collide with the live proxy.
 log "Validating the Caddyfile"
-compose run --rm --no-deps caddy caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --profile validate run --rm --no-deps caddy-validate
 
 log "Pulling images from GHCR"
 compose pull --quiet

--- a/scripts/tests/hetzner-deploy.tests.sh
+++ b/scripts/tests/hetzner-deploy.tests.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPTS_DIR/.." && pwd)"
 DEPLOY_SH="$SCRIPTS_DIR/hetzner/deploy.sh"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -82,23 +83,27 @@ install_stub_docker() {
 printf '%s\n' "$*" >> "$STUB_LOG"
 
 if [ "$1" = compose ]; then
-    # docker compose -f <file> <verb> …
+    # docker compose [global flags] <verb> … — walk past `compose` and any global flag (`-f <file>`,
+    # `--profile <name>`, …) to find the verb. Flag-tolerant on purpose: the Caddyfile gate passes
+    # `--profile validate`, and a parser that mistook a flag for the verb would silently stop faking
+    # that step's outcome, which would make the failure cases below assert nothing.
     verb=""
-    seen_file=0
+    skip_next=0
     for arg in "$@"; do
+        if [ "$skip_next" = 1 ]; then skip_next=0; continue; fi
         case "$arg" in
             compose) continue ;;
-            -f) seen_file=1; continue ;;
-            *) if [ "$seen_file" = 1 ]; then seen_file=2; continue; fi
-               verb="$arg"; break ;;
+            -f | --file | -p | --project-name | --profile | --env-file) skip_next=1; continue ;;
+            -*) continue ;;
+            *) verb="$arg"; break ;;
         esac
     done
     case "$verb" in
         pull) [ -z "${STUB_PULL_FAIL:-}" ] || { echo 'stub: pull failed' >&2; exit 1; } ;;
         run)
             # Two distinct `compose run` calls — tell them apart by what they run:
-            #   `run --rm --no-deps caddy caddy validate …`  → the Caddyfile check
-            #   `run --rm --no-deps migrator`                → the migration gate
+            #   `--profile validate run --rm --no-deps caddy-validate`  → the Caddyfile check
+            #   `run --rm --no-deps migrator`                           → the migration gate
             case "$*" in
                 *validate*) [ -z "${STUB_CADDY_INVALID:-}" ] || { echo 'stub: Caddyfile invalid' >&2; exit 1; } ;;
                 *migrator*) [ -z "${STUB_MIGRATE_FAIL:-}" ] || { echo 'stub: migration failed' >&2; exit 1; } ;;
@@ -147,6 +152,31 @@ called() { grep -qF -- "$1" "$TMP_ROOT/calls.log"; }
 # Line number of the first docker call containing $1 (0 = never called).
 call_line() { grep -nF -- "$1" "$TMP_ROOT/calls.log" | head -1 | cut -d: -f1; }
 
+# Service keys that pin a static ipv4_address in the REAL compose.hetzner.yaml (service keys are the
+# only two-space-indented bare keys under `services:`).
+pinned_ip_services() {
+    awk '
+        /^services:/ { in_services = 1; next }
+        /^[^[:space:]#]/ { in_services = 0 }
+        in_services && /^  [A-Za-z0-9_.-]+:[[:space:]]*$/ { svc = $1; sub(/:$/, "", svc); next }
+        in_services && /ipv4_address:/ && svc != "" { print svc }
+    ' "$REPO_ROOT/compose.hetzner.yaml" | sort -u
+}
+
+# The service every recorded `compose … run …` call targets (the first non-flag word after `run`).
+run_targets() {
+    awk '{
+        seen = 0
+        for (i = 1; i <= NF; i++) {
+            if ($i == "run") { seen = 1; continue }
+            if (!seen) continue
+            if ($i ~ /^-/) continue
+            print $i
+            break
+        }
+    }' "$TMP_ROOT/calls.log"
+}
+
 install_stub_docker
 
 # --- Input validation: a bad tag must die before it can reach compose or a remote shell -----------
@@ -182,7 +212,7 @@ run_deploy "$stack" IMAGE_TAG=sha-abc1234 EXPECTED_DIGESTS="$(expected_digests "
 grep -q 'PREVIOUS_IMAGE_TAG=sha-0000000' <<<"$LAST_OUTPUT" || fail 'the previous tag was not printed for the rollback path'
 [ "$(env_tag "$stack")" = 'sha-abc1234' ] || fail 'IMAGE_TAG was not pinned in .env' "$(cat "$stack/.env")"
 grep -q 'supersecret' "$stack/.env" || fail 'rewriting .env dropped the other variables'
-called 'caddy validate' || fail 'the Caddyfile was never validated'
+called 'run --rm --no-deps caddy-validate' || fail 'the Caddyfile was never validated'
 called 'pull' || fail 'images were never pulled'
 called 'run --rm --no-deps migrator' || fail 'the migration gate never ran'
 called 'up -d --remove-orphans' || fail 'containers were never rolled'
@@ -199,6 +229,22 @@ up_at="$(call_line 'up -d --remove-orphans')"
 [ "$gate_at" -lt "$up_at" ] \
     || fail 'the migrator must run BEFORE up -d recreates the apps' "gate at call #$gate_at, up -d at call #$up_at"
 pass 'the migrator gate runs strictly BEFORE up -d recreates any app container'
+
+CASE='one-off gates vs static IPs'
+# THE regression test for the #506 review finding. `compose run <svc>` builds the one-off container
+# from the FULL service definition — static `ipv4_address` included — so targeting a service whose IP
+# the LIVE container already holds dies with "failed to set up container networking: Address already
+# in use" (reproduced on Docker 29.6.1, the engine the boxes run). It bites on the SECOND deploy, not
+# the first, which is precisely the failure a green first roll cannot reveal. Invariant: no service
+# that pins an IP in the real compose.hetzner.yaml may ever be a `compose run` target.
+pinned="$(pinned_ip_services)"
+[ -n "$pinned" ] || fail 'expected compose.hetzner.yaml to pin at least one static ipv4_address (Caddy)'
+for svc in $pinned; do
+    run_targets | grep -qxF "$svc" && fail \
+        "deploy.sh builds a one-off container from '$svc', which pins a static ipv4_address" \
+        "the running container already holds that address — every deploy after the first would die with 'Address already in use'"
+done
+pass "no one-off container is built from a static-IP service ($(echo "$pinned" | tr '\n' ' '))"
 
 CASE='.env mode'
 # SC2012: the path is ours and has no exotic characters; `ls -l` is the one mode probe whose output

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
@@ -28,6 +28,11 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.ForwardedHeaders
 public sealed class ForwardedHeadersTrustTests
 {
     private const string TrustedProxyCidr = "10.60.0.0/24";
+    /// <summary>
+    /// The value the deployed stack actually sets (#506): Caddy's pinned static IP, not its subnet.
+    /// Must stay in lockstep with <c>ForwardedHeaders__KnownNetworks__0</c> in compose.hetzner.yaml.
+    /// </summary>
+    private const string CaddyOnlyCidr = "10.60.0.100/32";
 
     private readonly AuthSystemApiFactory _appFactory;
 
@@ -75,6 +80,49 @@ public sealed class ForwardedHeadersTrustTests
         {
             Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
             uri!.Scheme.ShouldBe("https", $"href for rel='{link.Rel}' must honour the trusted proxy's X-Forwarded-Proto");
+        }
+    }
+
+    [Fact]
+    public async Task Discovery_ForwardedProtoFromCaddysPinnedIp_BuildsHttpsLinks()
+    {
+        // Arrange — the boundary the boxes actually run since #506: a single /32, and the peer IS it.
+        using WebApplicationFactory<Program> factory =
+            FactoryWithKnownNetworks(CaddyOnlyCidr, peerAddress: "10.60.0.100");
+        using HttpRequestMessage request = HateoasRequest();
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        DiscoveryResponse response = await SendDiscoveryAsync(factory, request);
+
+        // Assert — narrowing the CIDR to a host address must not break the real ingress hop.
+        response.Links.ShouldNotBeEmpty();
+        foreach (LinkDto link in response.Links)
+        {
+            Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+            uri!.Scheme.ShouldBe("https", $"href for rel='{link.Rel}' must honour X-Forwarded-Proto from Caddy's pinned IP");
+        }
+    }
+
+    [Fact]
+    public async Task Discovery_SpoofedForwardedProtoFromNeighbourInCaddysSubnet_KeepsHttpLinks()
+    {
+        // Arrange — 10.60.0.101 shares Caddy's /24 but is outside its /32. This is the whole point of
+        // #506: a co-tenant container on the box would have been BELIEVED under the old /24 trust.
+        using WebApplicationFactory<Program> factory =
+            FactoryWithKnownNetworks(CaddyOnlyCidr, peerAddress: "10.60.0.101");
+        using HttpRequestMessage request = HateoasRequest();
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        DiscoveryResponse response = await SendDiscoveryAsync(factory, request);
+
+        // Assert — same subnet is NOT enough; only Caddy's exact address is trusted.
+        response.Links.ShouldNotBeEmpty();
+        foreach (LinkDto link in response.Links)
+        {
+            Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+            uri!.Scheme.ShouldBe("http", $"href for rel='{link.Rel}' must ignore a same-subnet neighbour's X-Forwarded-Proto");
         }
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
@@ -33,6 +33,11 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Forwarded
 public sealed class ForwardedHeadersTrustTests : IAsyncLifetime
 {
     private const string TrustedProxyCidr = "10.60.0.0/24";
+    /// <summary>
+    /// The value the deployed stack actually sets (#506): Caddy's pinned static IP, not its subnet.
+    /// Must stay in lockstep with <c>ForwardedHeaders__KnownNetworks__0</c> in compose.hetzner.yaml.
+    /// </summary>
+    private const string CaddyOnlyCidr = "10.60.0.100/32";
     private const string Route = "/api/v1/game-versions";
     private static readonly DateTimeOffset Now = new(2026, 7, 10, 0, 0, 0, TimeSpan.Zero);
     private static readonly JsonSerializerOptions JsonOptions =
@@ -91,6 +96,47 @@ public sealed class ForwardedHeadersTrustTests : IAsyncLifetime
         LinkDto selfLink = response.Links.ShouldHaveSingleItem();
         Uri.TryCreate(selfLink.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
         uri!.Scheme.ShouldBe("https", "the self link must honour the trusted proxy's X-Forwarded-Proto");
+    }
+
+    [Fact]
+    public async Task GetResource_ForwardedProtoFromCaddysPinnedIp_BuildsHttpsLinks()
+    {
+        // Arrange — the boundary the boxes actually run since #506: a single /32, and the peer IS it.
+        GameVersionId id = await SeedAsync("48.2");
+        using WebApplicationFactory<Program> factory =
+            FactoryWithKnownNetworks(CaddyOnlyCidr, peerAddress: "10.60.0.100");
+        using HttpClient client = TranslatorClient(factory);
+        using HttpRequestMessage request = HateoasRequest($"{Route}/{id.Value}");
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        GameVersionResponse response = await SendHateoasAsync<GameVersionResponse>(client, request);
+
+        // Assert — narrowing the CIDR to a host address must not break the real ingress hop.
+        LinkDto selfLink = response.Links.ShouldHaveSingleItem();
+        Uri.TryCreate(selfLink.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+        uri!.Scheme.ShouldBe("https", "the self link must honour X-Forwarded-Proto from Caddy's pinned IP");
+    }
+
+    [Fact]
+    public async Task GetResource_SpoofedForwardedProtoFromNeighbourInCaddysSubnet_KeepsHttpLinks()
+    {
+        // Arrange — 10.60.0.101 shares Caddy's /24 but is outside its /32. This is the whole point of
+        // #506: a co-tenant container on the box would have been BELIEVED under the old /24 trust.
+        GameVersionId id = await SeedAsync("48.3");
+        using WebApplicationFactory<Program> factory =
+            FactoryWithKnownNetworks(CaddyOnlyCidr, peerAddress: "10.60.0.101");
+        using HttpClient client = TranslatorClient(factory);
+        using HttpRequestMessage request = HateoasRequest($"{Route}/{id.Value}");
+        request.Headers.Add("X-Forwarded-Proto", "https");
+
+        // Act
+        GameVersionResponse response = await SendHateoasAsync<GameVersionResponse>(client, request);
+
+        // Assert — same subnet is NOT enough; only Caddy's exact address is trusted.
+        LinkDto selfLink = response.Links.ShouldHaveSingleItem();
+        Uri.TryCreate(selfLink.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue();
+        uri!.Scheme.ShouldBe("http", "a /32 must not honour X-Forwarded-Proto from a same-subnet neighbour");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #506.

The two compose stacks on each Hetzner box shared ONE Docker network (`lotro-{env}_default`, 10.60.0.0/24): TKS joined ours as `external`, which let any container there reach `auth-api`/`tms-api`/`frontend` on :8080 *past Caddy* and spoof `X-Forwarded-*` into them. Finding #1 of the 2026-07-13 post-migration security review.

## What changes

- **Two segregated networks per box.** Our stack sits alone on `default` (10.60.0.0/24); the guest TheKittySaver stack gets its own `tks` network (`${COMPOSE_PROJECT_NAME}_tks`, 10.61.0.0/24). **Caddy is the only container on both** — pinned at `10.60.0.100` / `10.61.0.100` — so it stays the single shared trust boundary. The `TKS_DOMAIN_*` aliases moved onto `tks`.
- **Forwarded-header trust narrowed from the whole /24 to Caddy's `/32`** on all three apps (#399 → #506). A co-tenant container is no longer believed.
- TKS joins `${project}_tks` as `external` — twin ticket koniecdev/TheKittySaver#295.

## Review fixes (second commit)

`review-506` found a blocker in the deploy path: the Caddyfile gate ran `compose run --rm --no-deps caddy caddy validate`, and a one-off container is built from the **full** service definition — static IPs included. The running Caddy already holds them, so the **first deploy would pass and every deploy after it would die** with `failed to set up container networking: Address already in use` (reproduced on Docker 29.6.1, the engine the boxes run). The gate now targets a `caddy-validate` service: same image, same Caddyfile, same environment (a YAML anchor keeps the env in lockstep — a silent drift there would validate a *different* file than Caddy runs), but `network_mode: none` and its own profile.

## Verification

- The real gate against the real Caddyfile: `Valid configuration`, exit 0, **no network created**.
- `hetzner-deploy.tests.sh` pins the **invariant**, not today's string: no service that pins a static `ipv4_address` may ever be a `compose run` target. Proven to fail when violated. 14/14 green.
- `ForwardedHeadersTrustTests` (auth + tms): the `/32` is honoured from `10.60.0.100` and **rejected** from `10.60.0.101` — a same-/24 neighbour the old trust would have believed. Green against real PostgreSQL.
- Build 0 warnings; ssr-purity, dockerfile-restore-graph, classify-changes, shellcheck all clean.

## Rollout

This migrates a **live** box, so ordering matters and the runbook now carries the procedure (pre-flight → deploy → verify the boundary → recreate `/opt/tks` → verify both sites). **Staging first.** TheKittySaver#295 must be re-upped right after the deploy on each box, or uratujkota.pl 502s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)