### PR TITLE
chore(claude): reviews back to Fable 5 at high effort

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -3,8 +3,8 @@ name: code-reviewer
 description: Use this agent to review code changes against ticket acceptance criteria, find regressions, architecture violations, audit for unhandled edge cases (anti-happy-path gate), and verify test coverage. Invoke after implementing a feature or before creating a PR.
 tools: Read, Grep, Glob, Bash
 # model-policy: review
-model: claude-opus-4-8
-effort: xhigh
+model: claude-fable-5
+effort: high
 ---
 
 You are a senior code reviewer for the LotroKoniecDev project — a C# .NET Clean Architecture solution with 5 layers (CLI → Application → Domain ← Infrastructure, Primitives). Your job is to catch bugs, architectural violations, behavioral regressions, **unhandled edge cases**, and missing tests BEFORE code is merged. A change that demonstrably works on the happy path but has never been pushed off it is **not** done — proving it is hardened against edge cases is part of every review (Phase 6).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ scripts/claude/backlog-loop.sh 123 130                 # exactly these tickets, 
 caffeinate -is scripts/claude/backlog-loop.sh          # overnight run on macOS (blocks sleep)
 scripts/claude/next-ticket.sh                          # print the next READY ticket (priority + deps)
 scripts/claude/work-ticket.sh 123                      # one ticket, one fresh headless session
-# defaults: fable (Fable 5) · effort high (reviews at xhigh) · permission-mode auto — override via LOOP_MODEL /
+# defaults: fable (Fable 5) · effort high (reviews at high too) · permission-mode auto — override via LOOP_MODEL /
 # LOOP_EFFORT / LOOP_PERMISSION_MODE / LOOP_UNSAFE=1 · full manual: docs/claude-loop.md
 
 # TMS — EF Core migrations (write context owns them; --connection makes it work without appsettings/live DB)
@@ -369,12 +369,12 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 - **Right-size the design — YAGNI by default.** Before proposing an abstraction, cache, config
   knob, queue, or new infra, check it solves a **real, present** need from the current
   spec/ticket — not a hypothetical future. Pick the simple path and note the trade-off in one line.
-- **Agent fan-out is budgeted; reviews run on Opus 4.8 at xhigh effort, everything else at high**
-  (2026-07-13: reviews moved to Opus 4.8 for now via the central model policy; loop workers stay
-  on Fable 5 at high — history: Fable switch 2026-07-09→11, same-day Opus revert #497, Fable
-  re-enable #503). Hard cap:
+- **Agent fan-out is budgeted; everything runs on Fable 5 at high effort** (2026-07-17: reviews
+  moved back to Fable 5 + high via the central model policy, matching loop workers — history:
+  Fable switch 2026-07-09→11, same-day Opus revert #497, Fable re-enable #503, Opus for reviews
+  2026-07-13). Hard cap:
   **max 4 subagents in parallel**, no chained waves by default; a small diff gets reviewed
-  **inline, zero agents**. The `code-reviewer` agent runs with **model Opus 4.8 + effort xhigh**;
+  **inline, zero agents**. The `code-reviewer` agent runs with **model Fable 5 + effort high**;
   `/code-review` and `/security-review` follow the session model/effort; loop-mode worker
   sessions run at **effort high**
   (`LOOP_EFFORT` default) — unless the prompt for that run explicitly says otherwise. Applies to


### PR DESCRIPTION
## What

Move the `review` role from **Opus 4.8 + xhigh** back to **Fable 5 + high**, matching the loop worker.

- `.claude/agents/code-reviewer.md` — frontmatter re-stamped by `apply-model-policy.sh`
- `CLAUDE.md` — the two spots that restate the values in prose (loop-script defaults header + the fan-out house rule)

## Why

`~/.claude/model-policy.env` is the single source of truth for model+effort per agent role (#509); the stamper propagates it into every file carrying a `# model-policy: review` marker. This PR is the repo-side half of that change — the stamper leaves modified repo files for review rather than committing them.

Reviews have moved before (Fable 2026-07-09 → Opus revert #497 → Fable re-enable #503 → Opus 2026-07-13), so the house rule now points at the policy file as authoritative instead of trying to be a historical record.

Worker and audit roles are unchanged.

## How it was tested

Config + docs only, no product code. `apply-model-policy.sh --dry-run` before the run listed exactly the two `code-reviewer.md` files (this repo's and `~/.claude`'s); the real run stamped both and reported `0 skipped`. Working-tree diff on the agent file is the two frontmatter lines and nothing else. Pre-commit secret scan passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFnCtD5j36ZAx9usjY8dFF