### PR TITLE
fix: pin AngleSharp to 1.5.2 to clear GHSA-pgww-w46g-26qg

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,10 @@
          which carries advisory GHSA-v5pm-xwqc-g5wc (circular-schema stack overflow). Pin the first patched
          2.x release; the API projects reference it directly to force the fixed version into the graph. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.10.0" />
+    <!-- Security override: bunit 2.7.2 transitively pulls AngleSharp 1.4.0, which carries advisory
+         GHSA-pgww-w46g-26qg. Pin the first patched 1.x release; Frontend.Tests.Unit references it
+         directly to force the fixed version into the graph. -->
+    <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
@@ -9,6 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="bunit" />
+        <!-- Direct pin forces the patched AngleSharp (advisory GHSA-pgww-w46g-26qg) over the vulnerable
+             1.4.0 pulled transitively by bunit; version lives in Directory.Packages.props. -->
+        <PackageReference Include="AngleSharp" />
         <PackageReference Include="coverlet.collector">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- GitHub's advisory database just flagged AngleSharp 1.4.0 (transitively pulled by `bunit` 2.7.2) as moderate severity (GHSA-pgww-w46g-26qg). This repo's `NuGetAuditLevel=moderate` turns that into a restore error, which now fails on **every** branch including `main` (confirmed by reproducing it locally against `main`, and by CI failures on unrelated PRs #510/#511).
- Pins `AngleSharp` to the first patched release (1.5.2) via central package management, with a direct `PackageReference` in `Frontend.Tests.Unit` to force the fixed version into the graph — the same idiom already used for the `Microsoft.OpenApi` override.

## Test plan
- [x] `dotnet build tests/LotroKoniecDev.Frontend.Tests.Unit -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/LotroKoniecDev.Frontend.Tests.Unit -c Release` — 414/414 passed (bUnit still works against the bumped AngleSharp)
- [x] `dotnet build LotroKoniecDev.slnx -c Release` — full solution, 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjhXzREvfEREaP8bw6HJ43