### PR TITLE
fix: pin System.Security.Cryptography.Xml to 10.0.10 to clear CVE-2026-50648

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,11 @@
          GHSA-pgww-w46g-26qg. Pin the first patched 1.x release; Frontend.Tests.Unit references it
          directly to force the fixed version into the graph. -->
     <PackageVersion Include="AngleSharp" Version="1.5.2" />
+    <!-- Security override: OpenIddict.*.DataProtection 7.5.0 transitively pulls System.Security.Cryptography.Xml
+         10.0.7, which carries CVE-2026-50648 (GHSA-23rf-6693-g89p and four sibling advisories, all fixed in
+         10.0.10). Pin the patched release; the AuthSystem test projects reference it directly to force the fixed
+         version into the graph (the APIs get it from the shared framework, so only test graphs carry the package). -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj
@@ -17,6 +17,9 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
+        <!-- Direct pin forces the patched System.Security.Cryptography.Xml (CVE-2026-50648) over the vulnerable
+             10.0.7 pulled transitively by OpenIddict.*.DataProtection; version lives in Directory.Packages.props. -->
+        <PackageReference Include="System.Security.Cryptography.Xml" />
         <PackageReference Include="Testcontainers" />
         <PackageReference Include="Testcontainers.PostgreSql"/>
         <PackageReference Include="xunit" />

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/LotroKoniecDev.AuthSystem.API.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/LotroKoniecDev.AuthSystem.API.Tests.Unit.csproj
@@ -15,6 +15,9 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
+        <!-- Direct pin forces the patched System.Security.Cryptography.Xml (CVE-2026-50648) over the vulnerable
+             10.0.7 pulled transitively by OpenIddict.*.DataProtection; version lives in Directory.Packages.props. -->
+        <PackageReference Include="System.Security.Cryptography.Xml" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Fresh advisories (GHSA-23rf-6693-g89p + four siblings, all patched in 10.0.10) flag the transitive `System.Security.Cryptography.Xml` 10.0.7 pulled by `OpenIddict.*.DataProtection`. With `NuGetAudit=all` + warnings-as-errors this fails restore of both AuthSystem test projects on **every** branch — it broke CI on the rebased dependabot PR #516 and will break any future run, blocking merges and CD.

Fix follows the established recipe (AngleSharp #514, Microsoft.OpenApi): central pin in `Directory.Packages.props` + direct references in the two affected test projects. The API projects are unaffected (shared-framework assembly, package pruned from their graphs).

Verified locally: restore clean (no NU1903), full solution build 0 warnings, AuthSystem unit tests green, resolved graph version now 10.0.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJCyYxiD8nLn1cjSbrcv16