### PR TITLE
fix: cookie bar copy height on mobile

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -1557,7 +1557,7 @@ code {
     align-items: center;
     gap: 12px;
     min-width: 0;
-    flex: 1 1 420px;
+    flex: 1 1 max-content;
 }
 
 .cookie-bar-ico {


### PR DESCRIPTION
On mobile (<=640px) `.cookie-bar-inner` switches to `flex-direction: column`, so the `flex: 1 1 420px` on `.cookie-bar-copy` applied its 420px basis to the vertical axis and made the copy block ~420px tall. Changed the basis to `max-content` so the block sizes to its content in both layouts. Desktop row layout keeps the same grow/shrink behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJCyYxiD8nLn1cjSbrcv16