### PR TITLE
Bump Scalar.AspNetCore to 2.16.16 and add transitive pins (recut of #520)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.15" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.16" />
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <!-- Authentication & Identity -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
         <!-- Direct pin forces the patched Microsoft.OpenApi (advisory GHSA-v5pm-xwqc-g5wc) over the vulnerable
              2.0.0 pulled transitively by Microsoft.AspNetCore.OpenApi; version lives in Directory.Packages.props. -->
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <PackageReference Include="Microsoft.OpenApi" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
           <PrivateAssets>all</PrivateAssets>

--- a/src/Utilities/LotroKoniecDev.Logging/LotroKoniecDev.Logging.csproj
+++ b/src/Utilities/LotroKoniecDev.Logging/LotroKoniecDev.Logging.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
     
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     </ItemGroup>
 

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
@@ -16,6 +16,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />


### PR DESCRIPTION
Recut of #520: dependabot's group PR went DIRTY against main after #519 landed the same 31-package group (same failure mode as #517 — group PRs stuck DIRTY don't rebase). This branch carries only the remaining delta of #520 on top of current main:

- Scalar.AspNetCore 2.16.15 -> 2.16.16
- the direct PackageReference pins dependabot added for transitive deps: Microsoft.Extensions.Http.Resilience in AuthSystem.API (OpenIddict 7.6.0 SystemNetHttp packages require >= 10.8.0), Microsoft.Extensions.DependencyInjection.Abstractions in Logging, Microsoft.Extensions.Configuration.Json + Microsoft.Extensions.DependencyInjection in Frontend.Tests.Unit

One deliberate deviation from dependabot's commit: the `VersionOverride="10.8.0"` on Http.Resilience is replaced with a plain reference — the central version is already 10.8.0, and a stale override would silently hold the package back on future bumps.

Verified locally: full solution build 0 warnings, all unit suites green (1124 tests).

Supersedes #520 (to be closed after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJCyYxiD8nLn1cjSbrcv16