### PR TITLE
#523: Keep the game's English name in the hero + hide auth-only navbar links from anonymous visitors

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Layout/NavMenu.razor
@@ -15,12 +15,13 @@
         <nav class="nav-links" aria-label="Nawigacja główna">
             <NavLink class="nav-link" href="/" Match="NavLinkMatch.All">Start</NavLink>
             <NavLink class="nav-link" href="/translations">Tłumaczenia</NavLink>
-            <NavLink class="nav-link" href="/import-export">Import / Eksport</NavLink>
-            <NavLink class="nav-link" href="/game-versions">Wersje gry</NavLink>
-            <NavLink class="nav-link" href="/dashboard">Panel</NavLink>
 
             <AuthorizeView>
                 <Authorized>
+                    @* These three pages are [Authorize]-gated — an anonymous click only bounces to login (#523). *@
+                    <NavLink class="nav-link" href="/import-export">Import / Eksport</NavLink>
+                    <NavLink class="nav-link" href="/game-versions">Wersje gry</NavLink>
+                    <NavLink class="nav-link" href="/dashboard">Panel</NavLink>
                     @* The privacy policy promises the self-service section under this exact name. *@
                     <NavLink class="nav-link" href="/account" data-testid="nav-account">Moje konto</NavLink>
                     <span class="nav-user">@(context.User.Identity?.Name)</span>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home/Home.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home/Home.razor
@@ -19,7 +19,7 @@
 <section class="hero home-hero">
     <div class="container">
         <p class="eyebrow">Polskie tłumaczenie LOTRO</p>
-        <h1>Władca Pierścieni Online — <span class="hero-accent">po polsku</span></h1>
+        <h1>The Lord of the Rings Online — <span class="hero-accent">po polsku</span></h1>
         <p class="lede">
             Społecznościowy projekt spolszczenia The Lord of the Rings Online: teksty prosto z plików
             gry, tłumaczenie w przeglądarce z obiegiem zatwierdzania i gotowe spolszczenie do pobrania

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/NavMenuTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Layout/NavMenuTests.cs
@@ -72,7 +72,7 @@ public sealed class NavMenuTests : BunitContext
     }
 
     [Fact]
-    public void Render_Always_ShowsTheCoreNavigationLinksInOrder()
+    public void Render_WhenAnonymous_ShowsOnlyThePublicNavigationLinksInOrder()
     {
         AddAuthorization().SetNotAuthorized();
 
@@ -83,11 +83,30 @@ public sealed class NavMenuTests : BunitContext
             .Select(anchor => anchor.GetAttribute("href")!)
             .ToArray();
 
-        // The topbar hosts the auth affordance in the same nav; anonymous renders the login link last.
+        // The [Authorize]-gated pages stay hidden from anonymous visitors (#523);
+        // the topbar hosts the auth affordance in the same nav, so the login link renders last.
         navTargets.ShouldBe(
         [
-            "/", "/translations", "/import-export", "/game-versions", "/dashboard",
+            "/", "/translations",
             AuthenticationDependencyInjectionExtensions.LoginPath
+        ]);
+    }
+
+    [Fact]
+    public void Render_WhenAuthenticated_ShowsTheAuthGatedNavigationLinksInOrder()
+    {
+        AddAuthorization().SetAuthorized("Frodo");
+
+        IRenderedComponent<NavMenu> component = RenderNavMenu();
+
+        string[] navTargets = component
+            .FindAll("nav.nav-links a")
+            .Select(anchor => anchor.GetAttribute("href")!)
+            .ToArray();
+
+        navTargets.ShouldBe(
+        [
+            "/", "/translations", "/import-export", "/game-versions", "/dashboard", "/account"
         ]);
     }
 


### PR DESCRIPTION
Closes #523

## What changed

**Hero title (`Home.razor`)** — "Władca Pierścieni Online — po polsku" → "The Lord of the Rings Online — po polsku". The game's official name stays in English, which the meta description and lede already did.

**Navbar (`NavMenu.razor`)** — `Import / Eksport`, `Wersje gry` and `Panel` moved inside the `<AuthorizeView><Authorized>` branch. All three pages are `[Authorize]`-gated, so anonymous visitors only bounced to the login page when clicking them. `Start` and `Tłumaczenia` stay public.

Audit result from the ticket: nothing in the navbar is **admin**-walled — admin-only operations (game-version register/delete, import) are gated by server-emitted HATEOAS rels inside the pages (#158), so hiding the auth-gated links is the full fix.

## Tests

`NavMenuTests` — the anonymous link-order test now expects only the public set; a new authenticated case locks the full link order. 415 FE unit tests green, Release build with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8x2iNCb8So7vLwRqzkJqT