### PR TITLE
CI hygiene: CodeQL scans every change twice (PR + push) — keep PR + weekly cron

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,11 @@
 name: CodeQL
 
-# Static analysis (SAST) for the C# codebase (audit #0001 / H1). Runs on every PR and on the
-# default branch (to seed the code-scanning baseline), plus a weekly scheduled scan so newly
-# published query packs catch latent issues. C# uses build-mode "none" — CodeQL analyses the
-# source directly, so the job needs no .NET SDK, restore, or compile step.
+# Static analysis (SAST) for the C# codebase (audit #0001 / H1). Runs on every PR, plus a weekly
+# scheduled scan that refreshes the default-branch code-scanning baseline and lets newly published
+# query packs catch latent issues. There is deliberately NO push trigger: main only receives
+# squash-merged PRs that were already scanned, so a push scan would analyse the same code twice
+# (#526 — CodeQL was ~40% of this repo's Actions compute). C# uses build-mode "none" — CodeQL
+# analyses the source directly, so the job needs no .NET SDK, restore, or compile step.
 #
 # paths-ignore mirrors that scope: this scan reads C# source and nothing else, so a change confined
 # to shell/PowerShell scripts, agent config (.claude/) or docs cannot produce or clear a C# alert.
@@ -12,16 +14,6 @@ name: CodeQL
 # alerts raised by an earlier run stay open regardless of what this PR touches.
 on:
   pull_request:
-    branches: ["main"]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.sh'
-      - '**/*.ps1'
-      - 'docs/**'
-      - '.claude/**'
-      - 'LICENSE'
-      - '.gitignore'
-  push:
     branches: ["main"]
     paths-ignore:
       - '**/*.md'

--- a/docs/tms-handbook.md
+++ b/docs/tms-handbook.md
@@ -1212,7 +1212,8 @@ containerized-OIDC problem dissolves in real production too.
 | `e2e` | manual + PRs touching package/Docker dependency manifests (so Dependabot bumps exercise it) | full-stack and browser E2E suites |
 | `smoke` | after deploys | health + a real OIDC token round-trip + file distribution |
 | `health-ping` | daily cron | probes the three public origins once a day (deep `/health`) — the only availability signal, and the one check that proves the (scale-to-zero) Neon database is reachable |
-| `codeql`, `gitleaks` | PRs/pushes/schedule | static security analysis; secret scanning |
+| `codeql` | PRs + weekly schedule (no push — squash-merged code was already scanned on the PR, #526) | static security analysis |
+| `gitleaks` | PRs/pushes | secret scanning |
 | `actionlint` | every PR | lints `.github/workflows/` so workflow-only PRs cannot merge unparsed |
 
 ### 11.2 How a release reaches production


### PR DESCRIPTION
Closes #526

## What
- `.github/workflows/codeql.yml`: removed the `push: branches ["main"]` trigger. `pull_request` stays untouched; the existing weekly cron (`27 4 * * 1`) already refreshes the default-branch code-scanning baseline, so nothing needed adding. Header comment updated to explain why there is deliberately no push trigger.
- `docs/tms-handbook.md`: split the `codeql, gitleaks` row in the checks table so each reflects its real triggers.

## Why
Every merge was scanned twice — once on the PR, again on the push to main. Main is squash-only, so the push scan re-analysed code the PR scan already covered. July 2026: 221 runs / ~785 min, ~40% of the repo's Actions compute. This roughly halves CodeQL runs with PR-level feedback unchanged.

## Test
- `actionlint` passes on the edited workflow.
- No .NET build inputs touched (workflow + docs only), so build/test suites are unaffected — `classify-changes` gives an all-false verdict for this path, pinned by `scripts/tests/classify-changes.tests.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StZVriWeWeECd9YL4nyhp5