### PR TITLE
CD runs wait on the prod approval gate for days — expire stale deploy candidates

### DIFF
--- a/.github/workflows/cd-janitor.yml
+++ b/.github/workflows/cd-janitor.yml
@@ -1,0 +1,94 @@
+name: CD janitor (expire stale deploy candidates)
+
+# Cancels CD runs that have sat in `waiting` (the `production` environment approval gate in cd.yml)
+# for more than 24 hours (#527).
+#
+# Why: the prod gate pins the tested commit (head_sha), so approving a days-old run deploys a
+# days-old SHA — surprising and easy to do by accident. Unapproved runs also pile up until GitHub
+# expires them after 30 days, and their multi-day wall clock makes run-duration stats and the
+# Actions list unreadable. Approval wait is unbilled, so this is pure hygiene, not cost.
+#
+# A cancelled candidate is never lost work: the same commit can still be deployed on demand via
+# cd.yml's workflow_dispatch, and every newer green-CI commit produces a fresh candidate anyway.
+#
+# Cutoff is measured from startedAt, not createdAt — a re-run of an old run resets startedAt, so a
+# deliberately re-run candidate gets a fresh 24 h window instead of being culled immediately.
+#
+# Cron is UTC and deliberately off-hour (GitHub delays on-the-hour crons the most). Exact timing is
+# irrelevant here — anything roughly nightly keeps the queue clean.
+
+on:
+  schedule:
+    - cron: "25 4 * * *"
+  workflow_dispatch:
+
+# Least privilege: cancelling runs is the whole job. actions: write covers both the list and the
+# cancel; nothing here touches the repo contents.
+permissions:
+  actions: write
+
+concurrency:
+  group: cd-janitor
+  cancel-in-progress: false
+
+jobs:
+  expire:
+    name: cancel CD runs waiting > 24 h
+    # Never run on a fork: it would cull the fork owner's own deploy candidates.
+    if: github.repository == 'koniecdev/LotroKoniecDev'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Cancel stale waiting CD runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          cutoff="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
+          echo "Cutoff (UTC): runs started before ${cutoff} are stale."
+
+          # ISO-8601 UTC timestamps compare correctly as strings, so jq needs no date parsing.
+          stale="$(gh run list --workflow cd.yml --status waiting --limit 100 \
+            --json databaseId,startedAt,headSha,url \
+            | jq -r --arg cutoff "$cutoff" \
+              '.[] | select(.startedAt < $cutoff) | "\(.databaseId)\t\(.startedAt)\t\(.headSha[0:7])\t\(.url)"')"
+
+          echo '## CD janitor' >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "$stale" ]; then
+            echo "No CD run has been waiting for more than 24 h."
+            echo 'No stale deploy candidates — nothing cancelled.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          failed=0
+          # The backticks in the printf formats below are markdown for the job summary,
+          # not command substitution — nothing there is meant to expand.
+          # shellcheck disable=SC2016
+          while IFS=$'\t' read -r run_id started_at short_sha url; do
+            # Re-check right before cancelling: the run may have been approved (now in_progress)
+            # or completed since the list above — cancelling a rollout mid-flight is the one thing
+            # this janitor must never do.
+            # `|| echo unknown` keeps one vanished run (deleted since listing) from aborting the
+            # whole sweep under set -e; 'unknown' falls into the skip branch below.
+            status="$(gh run view "$run_id" --json status --jq .status || echo unknown)"
+            if [ "$status" != "waiting" ]; then
+              echo "Skipping run ${run_id} — status changed to '${status}' since listing."
+              printf -- '- SKIP run [%s](%s) — no longer waiting (now `%s`)\n' \
+                "$run_id" "$url" "$status" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            if gh run cancel "$run_id"; then
+              echo "Cancelled run ${run_id} (sha ${short_sha}, waiting since ${started_at})."
+              printf -- '- CANCELLED run [%s](%s) — sha `%s`, waiting since %s\n' \
+                "$run_id" "$url" "$short_sha" "$started_at" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "::error::Failed to cancel run ${run_id}: ${url}"
+              printf -- '- FAIL could not cancel run [%s](%s)\n' "$run_id" "$url" >> "$GITHUB_STEP_SUMMARY"
+              failed=1
+            fi
+          done <<< "$stale"
+
+          exit "$failed"

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -599,6 +599,13 @@ staging→prod promotion: the identical image that passed staging is what produc
 **The switches** (repo Variables): `CD_ENABLED=true` arms the deploy jobs at all; `STAGING_ENABLED=true`
 arms the staging leg and makes prod wait on it (ADR-0018).
 
+**Stale candidates expire after 24 h.** The gate pins the tested commit, so approving a days-old
+run would deploy a days-old SHA. [`cd-janitor.yml`](../../.github/workflows/cd-janitor.yml) (#527)
+cancels any CD run left `waiting` at the `production` gate for more than 24 hours (nightly cron,
+04:25 UTC; on demand: `gh workflow run cd-janitor.yml`). Nothing is lost — every newer green-CI
+merge produces a fresh candidate, and any older commit can still be deployed explicitly via
+`cd.yml`'s `workflow_dispatch`.
+
 ### What `deploy.yml` does
 
 On the runner it resolves the tag to **digests**, verifies each image's build provenance (fails

--- a/docs/tms-handbook.md
+++ b/docs/tms-handbook.md
@@ -1212,6 +1212,7 @@ containerized-OIDC problem dissolves in real production too.
 | `e2e` | manual + PRs touching package/Docker dependency manifests (so Dependabot bumps exercise it) | full-stack and browser E2E suites |
 | `smoke` | after deploys | health + a real OIDC token round-trip + file distribution |
 | `health-ping` | daily cron | probes the three public origins once a day (deep `/health`) — the only availability signal, and the one check that proves the (scale-to-zero) Neon database is reachable |
+| `cd-janitor` | nightly cron | cancels CD runs left `waiting` at the `production` approval gate for more than 24 h, so a stale-SHA candidate can never be approved by accident (#527) |
 | `codeql` | PRs + weekly schedule (no push — squash-merged code was already scanned on the PR, #526) | static security analysis |
 | `gitleaks` | PRs/pushes | secret scanning |
 | `actionlint` | every PR | lints `.github/workflows/` so workflow-only PRs cannot merge unparsed |


### PR DESCRIPTION
Closes #527

## What
Option A from the ticket (recommended there): a nightly janitor workflow, `.github/workflows/cd-janitor.yml`, that cancels CD runs left in `waiting` at the `production` approval gate for more than 24 hours. Runbook CD section and handbook workflow table document it.

## Why
The prod gate pins the tested commit (`head_sha`), so approving a days-old run deploys a days-old SHA — easy to do by accident. Stale candidates also pile up for 30 days and make run stats unreadable. Cancelling loses nothing: every newer green-CI merge is a fresh candidate, and any commit can still be deployed via `cd.yml` `workflow_dispatch`.

## How
- Nightly cron (04:25 UTC, off-hour) + `workflow_dispatch`; fork guard; least-privilege `actions: write` only.
- `gh run list --workflow cd.yml --status waiting` → jq filter on `startedAt` older than 24 h (ISO-8601 UTC strings compare correctly as strings; `startedAt` so a deliberate re-run gets a fresh window).
- Re-checks each run's status right before cancelling — never cancels a rollout that got approved between listing and cancel; a vanished run is skipped, not fatal.
- Every cancel/skip/failure lands in the job summary; a failed cancel fails the run (email signal).

## Test
- actionlint + shellcheck clean.
- Dry-run of the exact script body (cancel stubbed) against real repo data: correctly selected run 30163342621 (waiting since 2026-07-25, the very run the ticket complains about) and produced the expected summary.
- No .NET code touched — no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAyaF9mUWPkG88sw1Sb1L3