### PR TITLE
CI-04: Test coverage report in CI (Cobertura + ReportGenerator, report-only — no gate)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "dotnet-ef"
       ],
       "rollForward": true
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.10",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": true
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj', '.config/dotnet-tools.json') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 
@@ -89,6 +89,8 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       # See pr-verify.yml for why we target test projects by name rather than the solution.
+      # The same name-based selection scopes the coverage report (CI-04): only the suites
+      # that actually run here feed it — E2E projects never do.
       - name: Run Unit Tests
         run: |
           set -euo pipefail
@@ -96,7 +98,8 @@ jobs:
           while IFS= read -r proj; do
             found=1
             echo "::group::$(basename "$proj")"
-            dotnet test "$proj" --configuration Release --no-build --logger "console;verbosity=minimal"
+            dotnet test "$proj" --configuration Release --no-build --logger "console;verbosity=minimal" \
+              --collect "XPlat Code Coverage" --results-directory coverage-results
             echo "::endgroup::"
           done < <(find tests -name '*.Tests.Unit.csproj' | sort)
           if [ "$found" -eq 0 ]; then
@@ -113,10 +116,33 @@ jobs:
           while IFS= read -r proj; do
             found=1
             echo "::group::$(basename "$proj")"
-            dotnet test "$proj" --configuration Release --no-build --logger "console;verbosity=minimal"
+            dotnet test "$proj" --configuration Release --no-build --logger "console;verbosity=minimal" \
+              --collect "XPlat Code Coverage" --results-directory coverage-results
             echo "::endgroup::"
           done < <(find tests -name '*.Tests.Integration.csproj' | sort)
           if [ "$found" -eq 0 ]; then
             echo "::error::No *.Tests.Integration projects found — refusing to report a false green."
             exit 1
           fi
+
+      # Coverage is a REPORT, not a gate (CI-04 / #525) — deliberate decision, do not add a
+      # threshold "while at it". Coverage measures executed code, not verified behavior; the
+      # enforced quality signal stays the Stryker mutation score (mutation-test.yml, break: 67).
+      # Running it here too keeps a current coverage baseline artifact on every main build.
+      # No step here fails because of a coverage number.
+      - name: Coverage report (report-only, never a gate)
+        run: |
+          set -euo pipefail
+          dotnet tool restore
+          dotnet reportgenerator \
+            -reports:"coverage-results/**/coverage.cobertura.xml" \
+            -targetdir:"coverage-report" \
+            -reporttypes:"Html;MarkdownSummaryGithub"
+          cat coverage-report/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report-main-${{ github.run_number }}
+          path: coverage-report/
+          retention-days: 14

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -142,7 +142,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj', '.config/dotnet-tools.json') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 
@@ -159,7 +159,8 @@ jobs:
       # (LotroKoniecDev.Tests.Infrastructure) on the Linux runner, so target the
       # cross-platform test projects by naming convention. New suites are picked up
       # automatically; the Windows-only ones (.Tests.Infrastructure / .Tests.E2E) are
-      # excluded by name.
+      # excluded by name. The same name-based selection scopes the coverage report (CI-04):
+      # only the suites that actually run here feed it — E2E projects never do.
       - name: Run Unit Tests
         if: needs.changes.outputs.code == 'true'
         run: |
@@ -168,7 +169,8 @@ jobs:
           while IFS= read -r proj; do
             found=1
             echo "::group::$(basename "$proj")"
-            dotnet test "$proj" --configuration Release --no-build --logger "console;verbosity=minimal"
+            dotnet test "$proj" --configuration Release --no-build --logger "console;verbosity=minimal" \
+              --collect "XPlat Code Coverage" --results-directory coverage-results
             echo "::endgroup::"
           done < <(find tests -name '*.Tests.Unit.csproj' | sort)
           if [ "$found" -eq 0 ]; then
@@ -186,13 +188,38 @@ jobs:
           while IFS= read -r proj; do
             found=1
             echo "::group::$(basename "$proj")"
-            dotnet test "$proj" --configuration Release --no-build --logger "console;verbosity=minimal"
+            dotnet test "$proj" --configuration Release --no-build --logger "console;verbosity=minimal" \
+              --collect "XPlat Code Coverage" --results-directory coverage-results
             echo "::endgroup::"
           done < <(find tests -name '*.Tests.Integration.csproj' | sort)
           if [ "$found" -eq 0 ]; then
             echo "::error::No *.Tests.Integration projects found — refusing to report a false green."
             exit 1
           fi
+
+      # Coverage is a REPORT, not a gate (CI-04 / #525) — deliberate decision, do not add a
+      # threshold "while at it". Coverage measures executed code, not verified behavior; the
+      # enforced quality signal stays the Stryker mutation score (mutation-test.yml, break: 67).
+      # This report is a map of where tests are thin and where the Stryker scope could expand.
+      # No step here fails because of a coverage number.
+      - name: Coverage report (report-only, never a gate)
+        if: needs.changes.outputs.code == 'true'
+        run: |
+          set -euo pipefail
+          dotnet tool restore
+          dotnet reportgenerator \
+            -reports:"coverage-results/**/coverage.cobertura.xml" \
+            -targetdir:"coverage-report" \
+            -reporttypes:"Html;MarkdownSummaryGithub"
+          cat coverage-report/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        if: needs.changes.outputs.code == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report-pr-${{ github.event.pull_request.number }}-${{ github.run_number }}
+          path: coverage-report/
+          retention-days: 14
 
   # Packaging gate (CI-01 / #403): build the four SHIPPED images (cd.yml's exact matrix) on the PRs
   # that can change them — Dockerfile/.dockerignore edits, incl. Dependabot base-image digest bumps —


### PR DESCRIPTION
Closes #525

## What

- Both `dotnet test` legs (unit + integration) in `pr-verify.yml` and `ci.yml` now collect Cobertura coverage via `--collect "XPlat Code Coverage"` (coverlet.collector was already referenced by every test project).
- `dotnet-reportgenerator-globaltool` 5.5.10 is pinned in `.config/dotnet-tools.json`; a new step merges the per-project files, prints line + branch totals per assembly into the GitHub job summary (`MarkdownSummaryGithub`) and uploads the full HTML report as a workflow artifact with 14-day retention (same as the Stryker reports).
- NuGet cache key now includes `.config/dotnet-tools.json` so the tool restore is cached.

## Why

The 2026-07-25 audit found coverlet pinned but never used — we had no map of where tests are thin. This is deliberately a **report, not a gate** (comment in both workflows says so): coverage measures executed code, not verified behavior; the enforced signal stays the Stryker mutation score.

## Acceptance criteria

- Coverage totals in job summary + downloadable merged HTML artifact — the new `Coverage report` + `Upload coverage report` steps.
- No job ever fails because of a coverage number — ReportGenerator has no threshold configured; the workflow comment forbids adding one.
- Docs-only / guards-only PRs unaffected — every coverage step in pr-verify carries `if: needs.changes.outputs.code == 'true'`.
- `ci.yml` on main produces the same report (`coverage-report-main-<run>`), so main always has a current baseline.
- E2E projects excluded — the existing name-based `find` selects only `*.Tests.Unit` / `*.Tests.Integration`.

## Test

Chain proven locally: SharedKernel unit tests with `--collect` → `coverage.cobertura.xml` → `dotnet reportgenerator` → summary with per-assembly Line 88.2% / Branch 84.6% + HTML files. Full solution Release build green (0 warnings), patcher unit tests 277/277, classifier self-test 34/34, workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtB6NgAkz8TE5PXfMoDj79