### PR TITLE
Add SECURITY.md (private vulnerability reporting)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Use GitHub's private vulnerability reporting instead:
+<https://github.com/koniecdev/LotroKoniecDev/security/advisories/new>
+
+Please include, when possible:
+
+- steps to reproduce,
+- the affected area (auth, TMS API, frontend, patcher CLI),
+- the impact you believe it has.
+
+You can expect an initial response within a few days.
+
+## Supported versions
+
+Only the latest version deployed from `main` is supported. There are no maintained release lines.


### PR DESCRIPTION
Adds a security policy file at the repo root.

Context: Dependabot alerts, Dependabot security updates and private vulnerability reporting were enabled in repository settings today. SECURITY.md points researchers to the private reporting flow instead of public issues.

Docs-only change — no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqgaD9zAwz4vnvrNDHJQ9h