### PR TITLE
SEO crawler control: noindex the staging trio + serve robots.txt on prod

### DIFF
--- a/.docker/caddy/Caddyfile
+++ b/.docker/caddy/Caddyfile
@@ -9,17 +9,26 @@
 # the apps is plain HTTP on :8080 with X-Forwarded-Proto/Host/For set, exercising UseForwardedHeaders
 # (M6-02). Explicit `tls` files make Caddy serve our cert and skip ACME — no internet needed.
 
+# SEO crawler control (#531) — parity with .docker/hetzner/Caddyfile. The parity stack passes no
+# XROBOTS env, so this always renders the `all` default (an explicit no-op header).
+(seo_headers) {
+	header X-Robots-Tag "{$XROBOTS:all}"
+}
+
 app.lotro.test {
 	tls /etc/caddy/certs/proxy.crt /etc/caddy/certs/proxy.key
+	import seo_headers
 	reverse_proxy frontend:8080
 }
 
 auth.lotro.test {
 	tls /etc/caddy/certs/proxy.crt /etc/caddy/certs/proxy.key
+	import seo_headers
 	reverse_proxy auth-api:8080
 }
 
 tms.lotro.test {
 	tls /etc/caddy/certs/proxy.crt /etc/caddy/certs/proxy.key
+	import seo_headers
 	reverse_proxy tms-api:8080
 }

--- a/.docker/hetzner/Caddyfile
+++ b/.docker/hetzner/Caddyfile
@@ -12,15 +12,27 @@
 	email {$ACME_EMAIL}
 }
 
+# SEO crawler control (#531): every LOTRO vhost stamps X-Robots-Tag from the per-box XROBOTS env
+# var — prod keeps the `all` default (an explicit no-op), the staging box sets `noindex, nofollow`
+# in /opt/lotro/.env so the deliberately-public staging trio never gets indexed as duplicate
+# content of prod. Deliberately NOT imported into the TKS vhosts below: TKS stamps the header
+# app-side (koniecdev/TheKittySaver#390), and a Caddy-level set would override it.
+(seo_headers) {
+	header X-Robots-Tag "{$XROBOTS:all}"
+}
+
 {$DOMAIN_APP} {
+	import seo_headers
 	reverse_proxy frontend:8080
 }
 
 {$DOMAIN_AUTH} {
+	import seo_headers
 	reverse_proxy auth-api:8080
 }
 
 {$DOMAIN_TMS} {
+	import seo_headers
 	reverse_proxy tms-api:8080
 }
 

--- a/.env.hetzner.example
+++ b/.env.hetzner.example
@@ -19,6 +19,11 @@ DOMAIN_AUTH=auth.lotro-translator.pl
 DOMAIN_TMS=tms.lotro-translator.pl
 ACME_EMAIL=you@example.com
 
+# --- SEO crawler control (#531) — Caddy stamps this as X-Robots-Tag on every LOTRO vhost ---
+# prod box:    leave unset/blank (defaults to `all`, an explicit no-op)
+# staging box: XROBOTS="noindex, nofollow" — keeps the deliberately-public staging trio unindexed
+XROBOTS=
+
 # --- Neon (keyword format — Npgsql does NOT parse postgres:// URIs).
 # Timeout=60 rides out Neon's scale-to-zero resume (~31 s) on the first cold connection.
 ConnectionStrings__AuthDatabase=Host=<neon-endpoint>;Database=lotro_auth;Username=<user>;Password=<password>;Ssl Mode=Require;Timeout=60

--- a/compose.hetzner.yaml
+++ b/compose.hetzner.yaml
@@ -41,6 +41,10 @@ x-caddy-environment: &caddy-environment
   TKS_DOMAIN_APP: ${TKS_DOMAIN_APP:-tks-app.localhost}
   TKS_DOMAIN_AUTH: ${TKS_DOMAIN_AUTH:-tks-auth.localhost}
   TKS_DOMAIN_API: ${TKS_DOMAIN_API:-tks-api.localhost}
+  # SEO crawler control (#531): the Caddyfile stamps this on every LOTRO vhost response as
+  # X-Robots-Tag. Prod leaves it unset (`all` = explicit no-op); the staging box sets
+  # `noindex, nofollow` so the public staging trio never gets indexed as duplicate content.
+  XROBOTS: ${XROBOTS:-all}
 
 services:
   migrator:

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -198,7 +198,11 @@ for the full strategy):
 These decide **which environment a box is** — full list with placeholders in `.env.hetzner.example`:
 `COMPOSE_PROJECT_NAME` (`lotro-prod` | `lotro-staging`), `IMAGE_NAMESPACE`, `IMAGE_TAG`,
 `DOMAIN_APP` / `DOMAIN_AUTH` / `DOMAIN_TMS`, `ACME_EMAIL`, `TKS_DOMAIN_*` (the guest TheKittySaver
-vhosts).
+vhosts), `XROBOTS` (SEO crawler control, #531 — Caddy stamps it as `X-Robots-Tag` on every LOTRO
+vhost response; prod leaves it unset → `all` (explicit no-op), the **staging box sets
+`XROBOTS="noindex, nofollow"`** so the deliberately-public staging trio never gets indexed as
+duplicate content of prod. The TKS vhosts are excluded on purpose — TKS stamps the header
+app-side, koniecdev/TheKittySaver#390).
 
 ## Secrets
 

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/robots.txt
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/robots.txt
@@ -1,0 +1,13 @@
+# One file serves prod AND staging (identical-image promotion, ADR-0018): allow-all with the
+# authenticated areas crawl-blocked. Staging's noindex comes from the Caddy-level X-Robots-Tag
+# (#531), which crawlers only see when the pages stay crawlable — so no Disallow: / here.
+# Deliberately NO Sitemap: line — staging must not advertise one, and nothing public is worth
+# a sitemap yet (revisit when the M7 catalog browser goes public).
+User-agent: *
+Disallow: /dashboard
+Disallow: /translations
+Disallow: /editor/
+Disallow: /import-export
+Disallow: /game-versions
+Disallow: /account
+Disallow: /auth/


### PR DESCRIPTION
Closes #531

## What

- **Staging noindex, Caddy-level:** the three LOTRO vhosts in `.docker/hetzner/Caddyfile` import a shared `seo_headers` snippet — `header X-Robots-Tag "{$XROBOTS:all}"`. Prod keeps the `all` default (explicit no-op); the staging box sets `XROBOTS="noindex, nofollow"` in `/opt/lotro/.env`. `XROBOTS` joins the `x-caddy-environment` anchor (shared with the `caddy-validate` gate), `.env.hetzner.example` and the runbook's box-identity list.
- **TKS vhosts deliberately skipped** per the coordination note on the issue: TKS stamps the header app-side (koniecdev/TheKittySaver#390); a Caddy-level set would override it.
- **Parity stack** (`.docker/caddy/Caddyfile`) mirrors the snippet; `compose.prod.yaml` passes no `XROBOTS`, so it always renders `all` — no behavior change beyond the header default.
- **Prod robots.txt:** static `wwwroot/robots.txt` served by `MapStaticAssets` — allow-all with `Disallow` for `/dashboard`, `/translations`, `/editor/`, `/import-export`, `/game-versions`, `/account`, `/auth/`. No `Sitemap:` line (staging must not advertise one; nothing public is worth a sitemap yet). One file serves both environments — staging's noindex comes from the header, so no `Disallow: /`.

## Test / verification

- `caddy validate` (dockerized, same gate as deploy.sh) passes for the hetzner Caddyfile with and without `XROBOTS` set, and for the parity Caddyfile.
- Booted the frontend on the host: `GET /robots.txt` → `200 text/plain` with the expected body.
- `dotnet build` zero warnings; unit suite green (277 passed).

## Ops step after merge (not in this PR)

Add `XROBOTS="noindex, nofollow"` to `/opt/lotro/.env` on the **staging** box (prod untouched), then let CD deploy — deploy.sh reloads Caddy, and the live acceptance curls from the issue can be run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuZnX7FfJd3g1RR6fzVzNY