### PR TITLE
Prove the prod promotion against the sha actually serving, not HEAD^1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,10 +16,12 @@ name: CD
 #   deploy-prod    → calls the SAME reusable deploy.yml under environment: production — GATED by the
 #                    required-reviewer rule AND needs: deploy-staging, so the approval IS the
 #                    staging→prod promotion of the artifact that just passed staging. The rollout
-#                    itself lives in deploy.yml: verify provenance → cut the Neon pre-migration
-#                    snapshot → ssh to the environment's box → pull + assert the attested digests →
-#                    run the migrator as a GATE → `up -d` → smoke the public origins → roll images
-#                    AND config back to the previous deploy on any failure.
+#                    itself lives in deploy.yml: N-1 promotion gate (#534 — prove the batch's
+#                    migration span against the sha ACTUALLY serving on prod, because batched
+#                    promotion makes "previous deploy" ≠ "previous merge") → verify provenance →
+#                    cut the Neon pre-migration snapshot → ssh to the environment's box → pull +
+#                    assert the attested digests → run the migrator as a GATE → `up -d` → smoke the
+#                    public origins → roll images AND config back to the previous deploy on any failure.
 #
 # The deployment unit is an immutable per-commit image (`sha-<short>`), and the environment a job
 # targets is ONE BOX (`lotro-staging` or `lotro-prod`, env-scoped var HETZNER_HOST) running
@@ -327,9 +329,13 @@ jobs:
       && vars.STAGING_ENABLED == 'true'
       && needs.gate.outputs.proceed == 'true'
       && (github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch')
+    # deployments: read — deploy.yml declares it for the prod N-1 promotion gate (#534), and a
+    # called workflow may only downgrade its caller's grant, so every caller must grant it (the
+    # staging leg never queries it — its gate steps are prod-only).
     permissions:
       contents: read
       packages: read
+      deployments: read
     uses: ./.github/workflows/deploy.yml
     with:
       environment: staging
@@ -358,6 +364,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      deployments: read # the N-1 promotion gate resolves the last successful prod deployment (#534)
     uses: ./.github/workflows/deploy.yml
     with:
       environment: production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,14 @@ jobs:
       - name: Hetzner deploy script self-test
         run: ./scripts/tests/hetzner-deploy.tests.sh
 
+      # Same two N-1 promotion gate self-tests as pr-verify (#534) — CD is triggered by THIS workflow
+      # concluding success, so both scripts the prod leg is about to run get checked here too.
+      - name: Prod-baseline resolution self-test
+        run: ./scripts/tests/resolve-prod-baseline.tests.sh
+
+      - name: N-1 promotion gate verdict self-test
+        run: ./scripts/tests/n1-promotion-gate.tests.sh
+
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,15 +12,22 @@ name: Deploy (reusable rollout)
 # was actually bought is two CX23s, so one box IS one environment).
 #
 # The rollout:
-#   1. resolve the tag to DIGESTS and verify each image's build provenance (audit 0001 H9) — an image
+#   1. (prod only — #534) prove the promotion against the release ACTUALLY serving: resolve the last
+#      successful `production` deployment's sha (cross-checked against the IMAGE_TAG the box pins,
+#      which also stands in when the API cannot answer) and, when the span since it touches
+#      Migrations/, run the ADR-0024 N-1 proof against THAT baseline. Prod promotion
+#      is batched, so the PR-time HEAD^1 proof covers the previous MERGE, not the previous DEPLOY —
+#      an expand + its contract riding one approved batch is green per step and still breaks the
+#      serving release. RED aborts here, before GHCR, Neon or the box is touched.
+#   2. resolve the tag to DIGESTS and verify each image's build provenance (audit 0001 H9) — an image
 #      this CD did not build, scan and attest never reaches a box.
-#   2. publish the pre-migration restore point + cut the Neon snapshot branch (MIGR-01/MIGR-04) — the
+#   3. publish the pre-migration restore point + cut the Neon snapshot branch (MIGR-01/MIGR-04) — the
 #      migrator is about to run, and ADR-0023's recovery story is roll-forward or restore, never Down().
-#   3. snapshot the box's live config, scp the stack files (compose + Caddyfile + deploy.sh) so the
+#   4. snapshot the box's live config, scp the stack files (compose + Caddyfile + deploy.sh) so the
 #      box's config IS the deployed commit, then run scripts/hetzner/deploy.sh over ssh: validate →
 #      pull → assert the pulled digests are the attested ones → run the migrator as a GATE → `up -d`
 #      → reload Caddy → pin the tag in .env.
-#   4. wait for the public origins to answer, smoke them (scripts/smoke.sh — the fingerprint leg,
+#   5. wait for the public origins to answer, smoke them (scripts/smoke.sh — the fingerprint leg,
 #      because `GET / -> 200` proves nothing), and roll the box back — images AND config — if anything
 #      above went red.
 #
@@ -56,6 +63,7 @@ on:
 permissions:
   contents: read # checkout (scripts/, compose.hetzner.yaml, the Caddyfile)
   packages: read # pull image manifests + provenance attestations from GHCR for the verify gate (H9)
+  deployments: read # prod N-1 promotion gate (#534): read the last successful deployment's sha
 
 env:
   REGISTRY: ghcr.io
@@ -67,7 +75,11 @@ jobs:
   deploy:
     name: Deploy to ${{ inputs.environment }} (Hetzner)
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    # Prod gets double the budget: a migration-touching promotion runs the full N-1 proof (old
+    # release build + both integration suites — n1-compat.yml gives that 30 min on its own)
+    # before the rollout even starts. Staging keeps the tight budget — a hung roll holds the
+    # per-environment mutation lock, and nothing extra runs there.
+    timeout-minutes: ${{ inputs.environment == 'production' && 60 || 30 }}
     # The environment carries the protection rules: `production` has the required-reviewer gate (this is
     # the staging→prod promotion approval); `staging` has none (auto). It also selects the env-scoped
     # vars/secrets — crucially HETZNER_HOST, which is what makes this job target one box or the other.
@@ -90,6 +102,10 @@ jobs:
       AUTH_URL: ${{ vars.AUTH_URL }}
       TMS_URL: ${{ vars.TMS_URL }}
       FRONTEND_URL: ${{ vars.FRONTEND_URL }}
+      # Is the artifact about to roll the one THIS checkout describes? Only then can the N-1
+      # promotion gate below reason about it. One definition, read by both of its steps — two
+      # copies of this expression is one edit away from a gate that neither runs nor warns.
+      PROVABLE_TAG: ${{ inputs.image_tag == '' || inputs.image_tag == format('sha-{0}', inputs.short_sha) }}
 
     steps:
       # Check out the EXACT commit the gate pinned (the commit CI tested), so the stack files and the
@@ -98,6 +114,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.deploy_sha }}
+          # Full history: the prod N-1 promotion gate (#534) resolves the serving release's sha,
+          # diffs the promotion span against it, and materializes it as a git worktree
+          # (scripts/n1-compat.sh). Shallow would blind all three.
+          fetch-depth: 0
           # No later step does authenticated git — don't leave the workflow token in .git/config.
           persist-credentials: false
 
@@ -123,6 +143,96 @@ jobs:
             exit 1
           fi
           echo "Target: ${HETZNER_USER}@${HETZNER_HOST}:${STACK_DIR}"
+
+      # Host-key pinning is the whole security of this transport: the key comes from the env var, and an
+      # unknown host key aborts the connection (StrictHostKeyChecking=yes) rather than trusting on first
+      # use. The ssh config keeps every later step down to `ssh box` / `scp … box:` with no flag soup.
+      # Runs BEFORE the N-1 promotion gate so the gate can read the pinned IMAGE_TAG — the ground
+      # truth it cross-checks the deployment record against, and its only source when the API cannot
+      # answer. Read-only: nothing here (or in the gate) mutates the box.
+      - name: Configure ssh to the box
+        env:
+          SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          printf '%s\n' "$HETZNER_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+          {
+            echo "Host box"
+            echo "  HostName ${HETZNER_HOST}"
+            echo "  User ${HETZNER_USER}"
+            echo "  IdentityFile ~/.ssh/id_deploy"
+            echo "  IdentitiesOnly yes"
+            echo "  StrictHostKeyChecking yes"
+            echo "  UserKnownHostsFile ~/.ssh/known_hosts"
+            echo "  ConnectTimeout 15"
+            echo "  ServerAliveInterval 30"
+          } > ~/.ssh/config
+          chmod 600 ~/.ssh/config
+          ssh box 'echo "ssh OK as $(id -un) on $(hostname)"; docker compose version'
+
+      # ── Prod N-1 promotion gate (#534) — after the approval, before anything touches the box ──
+      # Batched promotion breaks "previous merge == previous deploy": the PR-time proof
+      # (n1-compat.yml) covers HEAD^1, but ADR-0023's expand → backfill → contract "across ≥ 2
+      # deploys" is a property of DEPLOYS — an expand and its contract can ride ONE approved batch
+      # with every per-step check green while the release still serving breaks on the contract.
+      # Batch diffs are deliberately not inspected by hand, so this gate is mechanical and fails
+      # CLOSED, like MIGR-03 and the cd-janitor. scripts/ci/resolve-prod-baseline.sh resolves the
+      # serving sha (deployments API, cross-checked against — and when they disagree widened to —
+      # the IMAGE_TAG the box actually pins) and classifies the span; only a migration-touching span
+      # pays for the proof below. Bootstrap (nothing serving yet) is a loud skip. A manual image_tag
+      # override deploys an artifact this checkout cannot reason about — the gate steps aside with a
+      # warning (dispatch is the runbook's human-driven emergency hatch; the failure mode this gate
+      # closes is the UNATTENDED batch).
+      - name: Resolve the serving release & the promotion's migration span
+        id: n1gate
+        if: inputs.environment == 'production' && env.PROVABLE_TAG == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CANDIDATE_SHA: ${{ inputs.deploy_sha }}
+        run: ./scripts/ci/resolve-prod-baseline.sh
+
+      # The override also poisons the NEXT promotion's baseline: the deployment record this run
+      # creates names the run's sha, not the tag being rolled, so the record ends up claiming a
+      # commit the box never served. The resolver's box cross-check is what catches that — see the
+      # runbook's "Deploy a specific image tag by hand" note.
+      - name: N-1 promotion gate stepped aside (manual tag override)
+        if: inputs.environment == 'production' && env.PROVABLE_TAG != 'true'
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          echo "::warning::N-1 promotion gate skipped — manual image_tag override ('${INPUT_IMAGE_TAG}') deploys an artifact this checkout cannot prove. Runbook territory: verify schema compatibility yourself before approving."
+
+      - name: Setup .NET (N-1 proof)
+        if: steps.n1gate.outputs.mode == 'proof'
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '10.0.100'
+
+      - name: Cache NuGet packages (N-1 proof)
+        if: steps.n1gate.outputs.mode == 'proof'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj', '.config/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      # The existing ADR-0024 seam, pointed at the serving release instead of HEAD^1. RED means this
+      # batch's schema breaks the code prod is running RIGHT NOW — approving it anyway guarantees the
+      # outage the smoke window would otherwise merely risk, and rollback cannot help (schema is
+      # forward-only). The wrapper is what keeps that verdict apart from "the proof could not run":
+      # both block, but only one of them is fixed by promoting in smaller steps.
+      - name: Prove the serving release against the candidate schema (ADR-0024)
+        if: steps.n1gate.outputs.mode == 'proof'
+        env:
+          BASELINE_SHA: ${{ steps.n1gate.outputs.baseline }}
+        run: ./scripts/ci/n1-promotion-gate.sh
 
       # The gate's short_sha is trusted (hex). The dispatch image_tag input is NOT — it is free text a
       # human typed, and it ends up inside a remote shell command below, so constrain it to what a GHCR
@@ -261,34 +371,6 @@ jobs:
             echo ""
             echo "Bad migration? Runbook → \"Restore from the auto-snapshot\" (works past the 6 h window when the snapshot row above is a branch) or \"Recover from a bad migration (Neon PITR)\" (restore to the timestamp above, 6 h retention)."
           } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true
-
-      # Host-key pinning is the whole security of this transport: the key comes from the env var, and an
-      # unknown host key aborts the connection (StrictHostKeyChecking=yes) rather than trusting on first
-      # use. The ssh config keeps every later step down to `ssh box` / `scp … box:` with no flag soup.
-      - name: Configure ssh to the box
-        env:
-          SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          printf '%s\n' "$HETZNER_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
-          {
-            echo "Host box"
-            echo "  HostName ${HETZNER_HOST}"
-            echo "  User ${HETZNER_USER}"
-            echo "  IdentityFile ~/.ssh/id_deploy"
-            echo "  IdentitiesOnly yes"
-            echo "  StrictHostKeyChecking yes"
-            echo "  UserKnownHostsFile ~/.ssh/known_hosts"
-            echo "  ConnectTimeout 15"
-            echo "  ServerAliveInterval 30"
-          } > ~/.ssh/config
-          chmod 600 ~/.ssh/config
-          ssh box 'echo "ssh OK as $(id -un) on $(hostname)"; docker compose version'
 
       # The box's config must BE the deployed commit — otherwise a Caddyfile or compose change would
       # land in git and never reach the server (the failure mode the runbook's "scp again" recovery

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -129,6 +129,22 @@ jobs:
       - name: Hetzner deploy script self-test
         run: ./scripts/tests/hetzner-deploy.tests.sh
 
+      # The prod-promotion N-1 gate (#534) runs inside CD's prod leg, where its real inputs (the
+      # deployments API, the box .env, a schema) exist nowhere in CI — so both halves get a stubbed
+      # suite here. The resolver's cases pin the properties the safety story rests on: an
+      # unresolvable baseline fails CLOSED, the bootstrap skip stays reachable ONLY while nothing is
+      # serving, and a baseline the box contradicts widens to the older commit instead of trusting a
+      # deployment record that names the workflow run rather than the rolled artifact.
+      - name: Prod-baseline resolution self-test
+        run: ./scripts/tests/resolve-prod-baseline.tests.sh
+
+      # The verdict mapping is its own gate: n1-compat.sh's exit 1 (schema proven incompatible) and
+      # exit 2 (the proof never ran) both block the promotion but demand OPPOSITE fixes, and the
+      # runbook tells the approver not to retry a RED. Collapsing them would send them to split a
+      # healthy batch — or to the image_tag dispatch, which skips the gate entirely.
+      - name: N-1 promotion gate verdict self-test
+        run: ./scripts/tests/n1-promotion-gate.tests.sh
+
       # Everything below is the .NET gate: it runs only when the PR can actually affect it. A PR
       # that merely edits a script CI executes (or a Dockerfile) stops here, green, in seconds.
       - name: Setup .NET

--- a/docs/adr/0024-n1-backward-compat-ci-proof.md
+++ b/docs/adr/0024-n1-backward-compat-ci-proof.md
@@ -215,3 +215,51 @@ solely to serve this job. Decision 1 names the single line to revisit if tags ev
 - `Dockerfile.migrator`, `scripts/apply-migrations.sh` — project/startup/context pairs and the
   `-- --connection` design-time mechanism
 - EF Core docs — idempotent migration scripts; `__EFMigrationsHistory` semantics
+
+## Amendment: the deploy-time leg — prove against the sha actually serving on prod (2026-07-27, #534)
+
+Prod promotion is now **batched** (owner decision 2026-07-27, discussion on CD #180): staging
+deploys every push to `main`, prod ships every Nth candidate behind the approval gate, and batch
+diffs are deliberately **not** inspected by hand. That breaks the assumption Decision 1 was built
+on — under batching, "previous merge" (`HEAD^1`, what the PR-time job proves) and "previous
+deploy" (what the box is serving) diverge. An expand and its contract can ride one approved batch
+with every per-step proof green while the release still serving breaks on the contract step;
+ADR-0023's "across ≥ 2 deploys" is a property of *deploys*, so the gate must run at *promotion*
+time.
+
+The prod leg of `deploy.yml` therefore re-runs this proof against the serving release, after the
+approval and before GHCR, Neon or any *change* to the box (the gate itself reads the box, over the
+ssh transport configured one step earlier):
+
+- `scripts/ci/resolve-prod-baseline.sh` resolves the baseline — the newest `production`
+  deployment that ever reached a `success` status (the *history*, not the latest status: GitHub
+  re-marks old successes `inactive`, and a latest-status read would false-bootstrap every mature
+  promotion). Fail closed — an unresolvable baseline blocks the promotion.
+- The `IMAGE_TAG` pinned in the box `.env` is both the fallback when the API cannot answer **and a
+  cross-check when it can**. A deployment record carries the sha of the workflow *run*, not of the
+  artifact that was rolled, so a manual `image_tag` deploy leaves a `success` record naming a commit
+  the box never served — and the next unattended promotion would compute its span from that commit,
+  hiding every migration in between. On disagreement the resolver takes the **older** commit (the
+  wider span), and an unorderable pair (unrelated histories) fails closed. The cross-check never
+  blocks on its own: an unreadable box warns and keeps the API's answer.
+- **Bootstrap is the only fail-open verdict, so it is reserved for "nothing is serving":** no
+  deployment record at all, or no `IMAGE_TAG` on the box. A window that lists deployments *without*
+  a `success` is not that — on a mature environment every superseded candidate lands as `error`, so
+  a promotion pause longer than the API window (measured 2026-07-27: 100 records ≈ 25 days) takes
+  exactly that shape — and it resolves from the box instead of skipping.
+- A span (`<baseline>..<candidate>`) with no `Migrations/` files skips in seconds; a pre-seam
+  baseline (§ Bootstrap above) is a loud skip.
+- Otherwise `scripts/ci/n1-promotion-gate.sh` runs the existing seam, `scripts/n1-compat.sh
+  <baseline>`, and keeps its two failures apart — because they demand opposite fixes. Exit 1 (the
+  serving release cannot live on this schema) aborts with the resolution: promote in smaller steps —
+  approve a candidate containing only the expand, let it serve, then promote the contract. Exit 2
+  (the proof never ran: restore, script generation, worktree, missing seam) aborts as **unjudged**,
+  pointing at the infra failure. Collapsing the two would send the approver to split a healthy
+  batch, or to the `image_tag` dispatch that skips this gate.
+- A manual `image_tag` dispatch override deploys an artifact the checkout cannot reason about;
+  the gate steps aside with a warning (the failure mode this closes is the unattended batch).
+
+The PR-time `HEAD^1` job stays exactly as decided above — fast feedback next to the change; the
+deploy-time leg is the real guarantee. The staging leg stays ungated: staging deploys every push,
+so `HEAD^1` semantics still match it. Tests: `scripts/tests/resolve-prod-baseline.tests.sh` and
+`scripts/tests/n1-promotion-gate.tests.sh` (guards job, next to the other bash gates).

--- a/docs/adr/0024-n1-backward-compat-ci-proof.md
+++ b/docs/adr/0024-n1-backward-compat-ci-proof.md
@@ -235,18 +235,31 @@ ssh transport configured one step earlier):
   deployment that ever reached a `success` status (the *history*, not the latest status: GitHub
   re-marks old successes `inactive`, and a latest-status read would false-bootstrap every mature
   promotion). Fail closed — an unresolvable baseline blocks the promotion.
-- The `IMAGE_TAG` pinned in the box `.env` is both the fallback when the API cannot answer **and a
-  cross-check when it can**. A deployment record carries the sha of the workflow *run*, not of the
-  artifact that was rolled, so a manual `image_tag` deploy leaves a `success` record naming a commit
-  the box never served — and the next unattended promotion would compute its span from that commit,
-  hiding every migration in between. On disagreement the resolver takes the **older** commit (the
-  wider span), and an unorderable pair (unrelated histories) fails closed. The cross-check never
+- The `IMAGE_TAG` pinned in the box `.env` is both the fallback when the API cannot name a baseline
+  **and a cross-check when it can**. A deployment record carries the sha of the workflow *run*, not
+  of the artifact that was rolled, so a manual `image_tag` deploy leaves a `success` record naming a
+  commit the box never served — and the next unattended promotion would compute its span from that
+  commit, hiding every migration in between. On disagreement the resolver takes the **older** commit
+  (the wider span), and an unorderable pair (unrelated histories) fails closed. The cross-check never
   blocks on its own: an unreadable box warns and keeps the API's answer.
-- **Bootstrap is the only fail-open verdict, so it is reserved for "nothing is serving":** no
-  deployment record at all, or no `IMAGE_TAG` on the box. A window that lists deployments *without*
-  a `success` is not that — on a mature environment every superseded candidate lands as `error`, so
-  a promotion pause longer than the API window (measured 2026-07-27: 100 records ≈ 25 days) takes
-  exactly that shape — and it resolves from the box instead of skipping.
+- **Why the API is the primary source even though the box is the ground truth.** `deploy.sh` writes
+  `IMAGE_TAG` last and only on success, and a rollback re-runs it with the previous tag, so the box
+  cannot claim a *newer* commit than what serves — it is the more truthful signal, and the widening
+  cross-check above already gives it the final say whenever the two differ. What it cannot do is
+  answer reliably in every legal case: a version-tag deploy pins an image tag git cannot resolve on
+  its own (`cd.yml` publishes `{{version}}`, so `v1.2.3` → `1.2.3`; the resolver retries with the `v`
+  put back, but the class of such gaps is open), and it can go silent when a `.env` is restored or
+  reprovisioned without the line. A source that hard-fails or goes quiet on a legal deploy must not
+  be the one every promotion depends on — so it decides, but it does not lead.
+- **Bootstrap is the only fail-open verdict, so it takes TWO agreeing signals:** the API positively
+  establishing that no deployment here ever reached `success`, **and** a box pinning no `IMAGE_TAG`.
+  Neither alone is enough. A window that lists deployments *without* a `success` is what a promotion
+  pause longer than that window looks like on a mature environment (measured 2026-07-27: 100 records
+  ≈ 25 days, and every superseded candidate lands as `error`) — it resolves from the box instead. An
+  empty deployment history is not proof either: a stack rolled by hand on the box leaves no record
+  here, so the box is asked first. And a silent box whose history the API could not be read at all
+  fails closed — one unverified signal must not license the verdict that lets a batch through
+  unproven. The first-ever deploy still skips loudly: both signals genuinely agree there.
 - A span (`<baseline>..<candidate>`) with no `Migrations/` files skips in seconds; a pre-seam
   baseline (§ Bootstrap above) is a loud skip.
 - Otherwise `scripts/ci/n1-promotion-gate.sh` runs the existing seam, `scripts/n1-compat.sh

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -612,6 +612,25 @@ merge produces a fresh candidate, and any older commit can still be deployed exp
 
 ### What `deploy.yml` does
 
+**Prod leg only, first (#534 — the N-1 promotion gate):** promotion is batched, so the sha the
+approval replaces is the last *deployed* one, not the last *merged* one. The job resolves the sha
+actually serving (last successful `production` deployment via the API, cross-checked against the
+box-pinned `IMAGE_TAG`, which also stands in when the API cannot answer) and, when the span since it
+touches `Migrations/`, re-runs the ADR-0024 proof against that baseline. Two different red verdicts,
+two different fixes:
+
+- **`RED` — the batch's schema breaks the release prod is running right now. Do not retry:** approve
+  a candidate containing only the expand, let it serve, then promote the contract.
+- **`COULD NOT RUN` — the proof itself failed to build, generate or start, so the batch is
+  UNJUDGED,** not proven bad. Fix the infra failure named in the log and re-run the job. Do **not**
+  split the batch, and do not reach for the `image_tag` dispatch: it skips the gate entirely, so
+  nothing would be proven at all.
+
+Migration-free promotions skip in seconds; nothing-serving-yet skips loudly; an unresolvable baseline
+fails closed. A manual `image_tag` dispatch bypasses the gate with a warning — that path is yours to
+verify, and note that the deployment record it leaves behind names the *run's* sha rather than the
+tag you rolled, which is exactly what the box cross-check exists to catch on the promotion after it.
+
 On the runner it resolves the tag to **digests**, verifies each image's build provenance (fails
 closed), cuts the Neon pre-migration snapshot branch (MIGR-04) and publishes the restore point. Then
 it ssh'es to **that environment's box** (`vars.HETZNER_HOST` — one box IS one environment), snapshots

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -626,10 +626,15 @@ two different fixes:
   split the batch, and do not reach for the `image_tag` dispatch: it skips the gate entirely, so
   nothing would be proven at all.
 
-Migration-free promotions skip in seconds; nothing-serving-yet skips loudly; an unresolvable baseline
-fails closed. A manual `image_tag` dispatch bypasses the gate with a warning — that path is yours to
-verify, and note that the deployment record it leaves behind names the *run's* sha rather than the
-tag you rolled, which is exactly what the box cross-check exists to catch on the promotion after it.
+Migration-free promotions skip in seconds. An unresolvable baseline fails closed. The
+nothing-serving-yet skip needs **two agreeing signals** — no `production` deployment on record ever
+reached `success`, *and* the box pins no `IMAGE_TAG` — because it is the one verdict that lets a batch
+through unproven; a silent box the API cannot corroborate therefore blocks instead of skipping (check
+`/opt/lotro/.env` and `docker compose ps`; if it truly is the first deploy here, dispatch with an
+explicit `image_tag`, which bypasses the gate by design). A manual `image_tag` dispatch bypasses the
+gate with a warning — that path is yours to verify, and note that the deployment record it leaves
+behind names the *run's* sha rather than the tag you rolled, which is exactly what the box
+cross-check exists to catch on the promotion after it.
 
 On the runner it resolves the tag to **digests**, verifies each image's build provenance (fails
 closed), cuts the Neon pre-migration snapshot branch (MIGR-04) and publishes the restore point. Then

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -47,8 +47,10 @@ INERT='\.md$|^docs/|^LICENSE$|^\.gitignore$|^\.gitattributes$|\.sh$|\.ps1$|(^|/)
 # parses their COPY lists — a Dockerfile-only PR that drops a COPY ["…csproj"] line must still
 # face the guard that catches it (and the image job, which actually builds it). scripts/hetzner/
 # deploy.sh is here because it is the script CD runs on a PROD box and its self-test is the only
-# thing that checks it before it gets there (HETZ-04).
-GUARD_INPUTS='^scripts/check-ssr-purity\.(sh|ps1)$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|^scripts/claude/(issue-trust|next-ticket|work-ticket)\.sh$|^scripts/tests/claude-loop-provenance\.tests\.sh$|^scripts/hetzner/deploy\.sh$|^scripts/tests/hetzner-deploy\.tests\.sh$|(^|/)Dockerfile[^/]*$|^\.github/workflows/(pr-verify|ci)\.yml$'
+# thing that checks it before it gets there (HETZ-04); the two scripts/ci/ halves of the N-1
+# promotion gate for the same reason — CD's prod leg runs them (#534) and their self-tests are the
+# only pre-deploy check they face.
+GUARD_INPUTS='^scripts/check-ssr-purity\.(sh|ps1)$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|^scripts/claude/(issue-trust|next-ticket|work-ticket)\.sh$|^scripts/tests/claude-loop-provenance\.tests\.sh$|^scripts/hetzner/deploy\.sh$|^scripts/tests/hetzner-deploy\.tests\.sh$|^scripts/ci/(resolve-prod-baseline|n1-promotion-gate)\.sh$|^scripts/tests/(resolve-prod-baseline|n1-promotion-gate)\.tests\.sh$|(^|/)Dockerfile[^/]*$|^\.github/workflows/(pr-verify|ci)\.yml$'
 
 # Build-relevant despite matching INERT: the two workflows that DEFINE the .NET gate.
 CODE_INPUTS='^\.github/workflows/(pr-verify|ci)\.yml$'

--- a/scripts/ci/n1-promotion-gate.sh
+++ b/scripts/ci/n1-promotion-gate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Prod-promotion N-1 gate — run the ADR-0024 proof against the serving release and turn its exit
+# code into the right operator instruction (#534).
+#
+# scripts/n1-compat.sh keeps two failures apart on purpose:
+#   exit 1 — the serving release CANNOT live on this batch's schema. The batch is proven bad.
+#            Retrying changes nothing; the resolution is to promote in smaller steps (ADR-0023:
+#            approve a candidate carrying only the expand, let it serve, then promote the contract).
+#   exit 2 — the proof never ran (dotnet tool restore, schema-script generation, the worktree, a
+#            missing seam, no integration suites found). The batch is UNJUDGED, not bad; the fix is
+#            the infra failure in the log, and the promotion is blocked because an unjudged batch
+#            must not ship — not because its migrations are known to break anything.
+#
+# Collapsing the two sends the approver to split a healthy batch on an infra flake — or worse, to
+# the `image_tag` dispatch, which skips this gate entirely. So the mapping lives here, in a script
+# CI executes and the self-test pins, instead of inline in the workflow where nothing checks it.
+#
+# Env: BASELINE_SHA (required — the serving release resolved by scripts/ci/resolve-prod-baseline.sh).
+# Exit codes: 0 = the promotion may proceed, 1 = blocked, schema is incompatible,
+# 2 = blocked, the proof could not run (fail closed).
+#
+# Tests: scripts/tests/n1-promotion-gate.tests.sh (stub n1-compat.sh over a fixture tree; CI runs
+# them in the guards job). CI-only, Linux runners — no .ps1 twin, same as classify-changes.sh.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+say() {
+    echo "$1"
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        echo "$1" >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+if [ -z "${BASELINE_SHA:-}" ]; then
+    say "::error::N-1 promotion gate: BASELINE_SHA is empty — refusing to run the proof against an unknown baseline (fail closed)."
+    exit 2
+fi
+
+status=0
+"$repo_root/scripts/n1-compat.sh" "$BASELINE_SHA" || status=$?
+
+case "$status" in
+    0)
+        say "N-1 promotion gate: GREEN — the release serving on prod (${BASELINE_SHA}) survives this batch's schema."
+        ;;
+    1)
+        say "::error::N-1 promotion gate RED — this batch's migrations break the release currently serving on prod (baseline ${BASELINE_SHA}; the failing suites are in the log above). Do NOT retry: promote in smaller steps — first approve a candidate containing only the expand, let it serve, then promote the contract (ADR-0023)."
+        exit 1
+        ;;
+    *)
+        say "::error::N-1 promotion gate: the proof COULD NOT RUN (n1-compat.sh exit ${status}) against baseline ${BASELINE_SHA}, so this batch is UNJUDGED — not proven bad. Blocking the promotion (fail closed). Fix the infra failure in the log above and re-run this job; splitting the batch or dispatching a manual image_tag (which skips this gate) would only hide the fact that nothing was proven."
+        exit 2
+        ;;
+esac

--- a/scripts/ci/resolve-prod-baseline.sh
+++ b/scripts/ci/resolve-prod-baseline.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+#
+# Prod-promotion N-1 gate — baseline & span resolution (#534).
+#
+# Prod promotion is batched: staging deploys every push to main, prod ships every Nth candidate
+# behind the approval gate. That breaks the assumption the migration safety story was built on —
+# "previous merge == previous deploy". The PR-time proof (n1-compat.yml) checks HEAD^1, i.e. the
+# previous MERGE; ADR-0023's expand → backfill → contract "across ≥ 2 deploys" is a property of
+# DEPLOYS. An expand and its contract can ride one approved batch with every per-step check green
+# while the release still serving on prod breaks on the dropped column. So at promotion time the
+# executable proof (ADR-0024, scripts/n1-compat.sh — it already accepts an arbitrary baseline ref)
+# must run against the sha the box is ACTUALLY serving.
+#
+# This script resolves that baseline and classifies the promotion span; the prod leg of
+# .github/workflows/deploy.yml then runs the proof (scripts/ci/n1-promotion-gate.sh) only when the
+# span touches Migrations/ files. Resolution order:
+#
+#   1. GitHub deployments API — the newest deployment of $DEPLOY_ENVIRONMENT that ever reached a
+#      `success` status. The HISTORY matters: when a newer deployment succeeds, GitHub re-marks
+#      the previous success `inactive`, so "latest status == success" would find nothing and
+#      false-bootstrap on a mature environment. A run that failed and rolled back never reached
+#      `success` and is skipped; the in-flight run's own record is `in_progress` and is skipped
+#      too, so re-promoting a sha that already served resolves to itself (empty span, fast skip).
+#   2. The box — the IMAGE_TAG scripts/hetzner/deploy.sh pins in the box .env after every successful
+#      roll (`sha-<short>` → commit, `v*` tag → commit). Consulted when the API cannot answer, AND
+#      as a cross-check when it can (step 3).
+#   3. Cross-check. A deployment record carries the sha of the workflow RUN, not of the artifact
+#      that was rolled: a `workflow_dispatch` with an explicit image_tag rolls one commit while its
+#      record (and its `success`) names another. The box .env is the ground truth, so when the two
+#      disagree this takes the OLDER commit — the WIDER span — and an unorderable pair (unrelated
+#      histories) fails closed. Never the narrower span: that is how a migration goes unseen.
+#      The cross-check is hardening on top of a resolved baseline and never blocks on its own — an
+#      unreadable box warns and keeps the API's answer (ssh already proved itself one step earlier).
+#
+# The single fail-OPEN verdict is bootstrap, so it stays reserved for "nothing is serving": either
+# the environment has no deployment record at all, or the box pins no tag. A window that lists
+# deployments without a `success` is NOT that — on a mature environment every superseded candidate
+# lands as `error`, so a promotion pause longer than the API window (measured 2026-07-27: 100
+# records ≈ 25 days) takes exactly that shape — and it routes to the box instead of skipping.
+#
+# Verdicts (stdout `key=value` + $GITHUB_OUTPUT when set; human detail on stderr):
+#   mode=proof  baseline=<sha>   — Migrations/ files inside <baseline>..<candidate>: run the proof.
+#   mode=skip   baseline=<sha|''> — no migrations in the span, or bootstrap (nothing serving).
+#
+# Exit codes: 0 = verdict emitted, 2 = cannot resolve. Fail CLOSED: an unresolvable baseline
+# blocks the promotion — a gate that cannot compute its input must not wave a batch through.
+#
+# Env: CANDIDATE_SHA (required — the pinned deploy sha, checked out as HEAD with full history),
+# GITHUB_REPOSITORY + GH_TOKEN with `deployments: read` (the API leg), DEPLOY_ENVIRONMENT
+# (default production), STACK_DIR (default /opt/lotro — the box .env location).
+# The `ssh box` alias comes from deploy.yml's "Configure ssh to the box" step, which runs before
+# this gate exactly so the box legs have a transport.
+#
+# Tests: scripts/tests/resolve-prod-baseline.tests.sh (stub `gh` + `ssh` over a fixture repo; CI
+# runs them in the guards job). CI-only, Linux runners — no .ps1 twin, same as classify-changes.sh.
+set -euo pipefail
+
+# Same Migrations-directory shape as check-migration-safety.sh — deliberately broader than
+# n1-compat.yml's `src/**/Migrations/**` path filter: a false positive costs one redundant proof,
+# a false negative waves a schema change past the gate.
+MIGRATIONS_PATTERN='(^|/)Migrations/'
+
+log() { echo "$*" >&2; }
+
+summary() {
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        echo "$*" >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+emit() {
+    verdicts="$(printf 'mode=%s\nbaseline=%s' "$1" "$2")"
+    printf '%s\n' "$verdicts"
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        printf '%s\n' "$verdicts" >> "$GITHUB_OUTPUT"
+    fi
+}
+
+bootstrap_skip() {
+    msg="N-1 promotion gate: BOOTSTRAP — ${1} Nothing is serving that this batch's migrations could break, so the deploy-time proof is skipped (#534); the window closes at the first successful deploy."
+    log "$msg"
+    summary "$msg"
+    emit skip ""
+    exit 0
+}
+
+# rc 0 = baseline echoed; 3 = the environment has no deployment record at all (bootstrap candidate);
+# 4 = API unusable; 5 = records exist but none ever reached `success` (NOT bootstrap — see header).
+resolve_via_api() {
+    local list_json count i id sha states
+    list_json="$(gh api "repos/${GITHUB_REPOSITORY}/deployments?environment=${DEPLOY_ENVIRONMENT}&per_page=100" 2>/dev/null)" || return 4
+    count="$(printf '%s' "$list_json" | jq 'length' 2>/dev/null)" || return 4
+    # A body that is not the expected array (an object, a truncated page) yields a `length` that is
+    # either non-numeric or a key count — an unusable API, never an empty history.
+    case "$count" in
+        '' | *[!0-9]*) return 4 ;;
+    esac
+    [ "$count" -gt 0 ] || return 3
+    for i in $(seq 0 $((count - 1))); do
+        id="$(printf '%s' "$list_json" | jq -r ".[$i].id")" || return 4
+        sha="$(printf '%s' "$list_json" | jq -r ".[$i].sha")" || return 4
+        states="$(gh api "repos/${GITHUB_REPOSITORY}/deployments/${id}/statuses?per_page=100" 2>/dev/null)" || return 4
+        if printf '%s' "$states" | jq -r '.[].state' 2>/dev/null | grep -qx 'success'; then
+            printf '%s\n' "$sha"
+            return 0
+        fi
+    done
+    return 5
+}
+
+# rc 0 = baseline echoed; 3 = no IMAGE_TAG pinned yet (bootstrap candidate); 2 = hard failure.
+resolve_via_box() {
+    local tag ref sha
+    # `cat … 2>/dev/null | sed` (not `sed … file`): a box without the .env yet — the first-ever
+    # deploy — must read as "no tag pinned" (bootstrap), while a dead ssh transport stays a
+    # hard failure. The remote shell has no pipefail, so the pipeline's status is sed's.
+    # SC2029: the RUNNER must expand ${STACK_DIR} into the remote command — the box has no such
+    # variable. Intentional (same convention as deploy.yml's ssh steps).
+    # shellcheck disable=SC2029
+    tag="$(ssh box "cat ${STACK_DIR}/.env 2>/dev/null | sed -n 's/^IMAGE_TAG=//p'" </dev/null | tail -1 | tr -d '\r')" || {
+        log "ERROR: could not read IMAGE_TAG from the box over ssh."
+        return 2
+    }
+    [ -n "$tag" ] || return 3
+    case "$tag" in
+        *[!A-Za-z0-9._-]*)
+            log "ERROR: the box .env pins IMAGE_TAG '${tag}', which is not a legal image tag."
+            return 2
+            ;;
+    esac
+    case "$tag" in
+        sha-*) ref="${tag#sha-}" ;;
+        *)     ref="$tag" ;;
+    esac
+    if ! sha="$(git rev-parse --verify --quiet "${ref}^{commit}")"; then
+        log "ERROR: cannot resolve the box-pinned IMAGE_TAG '${tag}' to a commit (tried '${ref}^{commit}')."
+        log "Refusing to guess what is serving (fail closed)."
+        return 2
+    fi
+    printf '%s\n' "$sha"
+}
+
+# Sets $baseline + $baseline_source from the box, or exits (bootstrap skip / fail closed).
+# $1 = why the API leg could not answer, for the bootstrap message.
+use_box_leg() {
+    local box_rc=0
+    baseline="$(resolve_via_box)" || box_rc=$?
+    case "$box_rc" in
+        0) baseline_source="IMAGE_TAG pinned in the box .env" ;;
+        3) bootstrap_skip "${1} and the box pins no IMAGE_TAG yet (first-ever deploy)." ;;
+        *) exit 2 ;;
+    esac
+}
+
+# Widens $baseline to the box's answer when the two disagree; see header step 3.
+cross_check_with_box() {
+    local box_baseline box_rc=0
+    box_baseline="$(resolve_via_box)" || box_rc=$?
+    case "$box_rc" in
+        0) ;;
+        3)
+            log "NOTE: the box pins no IMAGE_TAG — nothing to cross-check the recorded baseline against."
+            return 0
+            ;;
+        *)
+            log "WARNING: could not read the box IMAGE_TAG to cross-check the recorded baseline — proceeding with the API's answer."
+            return 0
+            ;;
+    esac
+    if [ "$box_baseline" = "$baseline" ]; then
+        log "Cross-check: the IMAGE_TAG pinned on the box agrees with the deployments API."
+        return 0
+    fi
+    log "WARNING: the deployments API and the box disagree about what is serving — API ${baseline}, box ${box_baseline}."
+    log "A deployment record names the sha of the workflow RUN, so a manual image_tag deploy leaves it pointing at a commit the box never served. Taking the OLDER commit (the wider span)."
+    if git merge-base --is-ancestor "$box_baseline" "$baseline"; then
+        baseline="$box_baseline"
+        baseline_source="IMAGE_TAG pinned in the box .env (older than the recorded deployment — widened)"
+    elif git merge-base --is-ancestor "$baseline" "$box_baseline"; then
+        baseline_source="${baseline_source} (older than the box-pinned tag — kept)"
+    else
+        log "ERROR: neither baseline is an ancestor of the other — the two sources sit on unrelated histories, so the span cannot be computed (fail closed)."
+        log "Resolve by hand: confirm what the box is running (${STACK_DIR}/.env → IMAGE_TAG) and re-deploy that sha before promoting."
+        exit 2
+    fi
+}
+
+if [ -z "${CANDIDATE_SHA:-}" ]; then
+    log "ERROR: CANDIDATE_SHA is required (the pinned deploy sha)."
+    exit 2
+fi
+if ! git cat-file -e "${CANDIDATE_SHA}^{commit}" 2>/dev/null; then
+    log "ERROR: candidate ${CANDIDATE_SHA} is not in this checkout's history."
+    exit 2
+fi
+
+DEPLOY_ENVIRONMENT="${DEPLOY_ENVIRONMENT:-production}"
+STACK_DIR="${STACK_DIR:-/opt/lotro}"
+
+baseline=""
+baseline_source=""
+api_rc=0
+if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    baseline="$(resolve_via_api)" || api_rc=$?
+else
+    log "GITHUB_REPOSITORY is not set — the deployments API leg cannot run."
+    api_rc=4
+fi
+
+case "$api_rc" in
+    0)
+        baseline_source="last successful '${DEPLOY_ENVIRONMENT}' deployment (GitHub deployments API)"
+        ;;
+    3)
+        bootstrap_skip "no '${DEPLOY_ENVIRONMENT}' deployment is on record at all."
+        ;;
+    4)
+        log "WARNING: the deployments API is unusable — resolving from the IMAGE_TAG pinned on the box instead."
+        use_box_leg "the deployments API is unusable"
+        ;;
+    5)
+        log "WARNING: the API lists '${DEPLOY_ENVIRONMENT}' deployments but none ever reached 'success' — that is what a promotion pause longer than the API window looks like, NOT an empty history. Resolving from the IMAGE_TAG pinned on the box instead."
+        use_box_leg "no '${DEPLOY_ENVIRONMENT}' deployment on record ever reached 'success'"
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+
+if ! git cat-file -e "${baseline}^{commit}" 2>/dev/null; then
+    log "ERROR: baseline ${baseline} (${baseline_source}) is not in this checkout's history."
+    log "Refusing to guess the span (fail closed) — is the checkout fetch-depth: 0?"
+    exit 2
+fi
+
+if [ "$api_rc" -eq 0 ]; then
+    cross_check_with_box
+fi
+
+log "Serving baseline: ${baseline} — ${baseline_source}"
+
+if [ "$baseline" = "$CANDIDATE_SHA" ]; then
+    msg="N-1 promotion gate: candidate ${CANDIDATE_SHA} is the sha already serving (re-promotion) — empty span, skipping the proof."
+    log "$msg"
+    summary "$msg"
+    emit skip "$baseline"
+    exit 0
+fi
+
+if ! span_files="$(git diff --name-only "$baseline" "$CANDIDATE_SHA")"; then
+    log "ERROR: git diff ${baseline}..${CANDIDATE_SHA} failed — cannot classify the span (fail closed)."
+    exit 2
+fi
+migration_files="$(printf '%s\n' "$span_files" | grep -E "$MIGRATIONS_PATTERN" || true)"
+
+if [ -z "$migration_files" ]; then
+    msg="N-1 promotion gate: no Migrations/ files in ${baseline} → ${CANDIDATE_SHA} — schema unchanged since the serving release; skipping the proof."
+    log "$msg"
+    summary "$msg"
+    emit skip "$baseline"
+    exit 0
+fi
+
+log "Migrations inside the promotion span ${baseline} → ${CANDIDATE_SHA}:"
+printf '%s\n' "$migration_files" | sed 's/^/  /' >&2
+msg="N-1 promotion gate: the span since the serving release touches $(printf '%s\n' "$migration_files" | wc -l | tr -d ' ') Migrations/ file(s) — proving release ${baseline} against the candidate schema (ADR-0024)."
+log "$msg"
+summary "$msg"
+emit proof "$baseline"

--- a/scripts/ci/resolve-prod-baseline.sh
+++ b/scripts/ci/resolve-prod-baseline.sh
@@ -21,9 +21,16 @@
 #      false-bootstrap on a mature environment. A run that failed and rolled back never reached
 #      `success` and is skipped; the in-flight run's own record is `in_progress` and is skipped
 #      too, so re-promoting a sha that already served resolves to itself (empty span, fast skip).
-#   2. The box — the IMAGE_TAG scripts/hetzner/deploy.sh pins in the box .env after every successful
-#      roll (`sha-<short>` → commit, `v*` tag → commit). Consulted when the API cannot answer, AND
-#      as a cross-check when it can (step 3).
+#   2. The box — the IMAGE_TAG scripts/hetzner/deploy.sh pins in the box .env (`sha-<short>` →
+#      commit, a version tag → commit). Consulted when the API cannot name a baseline, AND as a
+#      cross-check when it can (step 3). deploy.sh writes that line LAST and only on success, and a
+#      rollback re-runs deploy.sh with the previous tag, so the file describes what is really
+#      running: the box cannot claim a NEWER commit than what serves. What it can do is go silent (a
+#      .env restored or reprovisioned without the line) — which is why its silence alone is not
+#      allowed to bootstrap, see below. It is the fallback rather than the primary source because a
+#      version-tag deploy pins an image tag git cannot resolve on its own (cd.yml publishes
+#      {{version}}, i.e. v1.2.3 → 1.2.3), and a source that hard-fails on a legal deploy must not be
+#      the one every promotion depends on.
 #   3. Cross-check. A deployment record carries the sha of the workflow RUN, not of the artifact
 #      that was rolled: a `workflow_dispatch` with an explicit image_tag rolls one commit while its
 #      record (and its `success`) names another. The box .env is the ground truth, so when the two
@@ -32,11 +39,12 @@
 #      The cross-check is hardening on top of a resolved baseline and never blocks on its own — an
 #      unreadable box warns and keeps the API's answer (ssh already proved itself one step earlier).
 #
-# The single fail-OPEN verdict is bootstrap, so it stays reserved for "nothing is serving": either
-# the environment has no deployment record at all, or the box pins no tag. A window that lists
-# deployments without a `success` is NOT that — on a mature environment every superseded candidate
-# lands as `error`, so a promotion pause longer than the API window (measured 2026-07-27: 100
-# records ≈ 25 days) takes exactly that shape — and it routes to the box instead of skipping.
+# Bootstrap is the single fail-OPEN verdict, so it takes TWO agreeing signals: the API must
+# positively establish that no deployment here ever reached `success`, AND the box must pin no
+# IMAGE_TAG. Neither alone is enough — an API window without a `success` is what a promotion pause
+# longer than that window looks like on a mature environment (measured 2026-07-27: 100 records ≈ 25
+# days, and every superseded candidate lands as `error`), and a silent box can be a .env that lost
+# its line while the containers keep serving. Everything else that cannot resolve fails closed.
 #
 # Verdicts (stdout `key=value` + $GITHUB_OUTPUT when set; human detail on stderr):
 #   mode=proof  baseline=<sha>   — Migrations/ files inside <baseline>..<candidate>: run the proof.
@@ -132,22 +140,40 @@ resolve_via_box() {
         sha-*) ref="${tag#sha-}" ;;
         *)     ref="$tag" ;;
     esac
-    if ! sha="$(git rev-parse --verify --quiet "${ref}^{commit}")"; then
-        log "ERROR: cannot resolve the box-pinned IMAGE_TAG '${tag}' to a commit (tried '${ref}^{commit}')."
-        log "Refusing to guess what is serving (fail closed)."
-        return 2
-    fi
-    printf '%s\n' "$sha"
+    # `v$ref` too: cd.yml publishes version images through `type=semver,pattern={{version}}`, which
+    # strips the leading v (git tag v1.2.3 → image 1.2.3), so the tag a version deploy pins is not
+    # a ref git can see until the v goes back on.
+    for candidate in "$ref" "v${ref}"; do
+        if sha="$(git rev-parse --verify --quiet "${candidate}^{commit}")"; then
+            printf '%s\n' "$sha"
+            return 0
+        fi
+    done
+    log "ERROR: cannot resolve the box-pinned IMAGE_TAG '${tag}' to a commit (tried '${ref}' and 'v${ref}')."
+    log "Refusing to guess what is serving (fail closed)."
+    return 2
 }
 
 # Sets $baseline + $baseline_source from the box, or exits (bootstrap skip / fail closed).
-# $1 = why the API leg could not answer, for the bootstrap message.
+# $1 = why the API leg could not name a baseline, for the message.
+# $2 = 'corroborated' when the API positively established that nothing ever deployed successfully
+#      here; 'unconfirmed' when it simply could not be asked. Only a corroborated silence may
+#      bootstrap: "the box pins no IMAGE_TAG" is strong evidence (deploy.sh writes that line last
+#      and only on success) but not proof — a .env that lost the line looks identical to a box that
+#      never rolled, and bootstrap is the one verdict that lets a batch through unproven.
 use_box_leg() {
     local box_rc=0
     baseline="$(resolve_via_box)" || box_rc=$?
     case "$box_rc" in
         0) baseline_source="IMAGE_TAG pinned in the box .env" ;;
-        3) bootstrap_skip "${1} and the box pins no IMAGE_TAG yet (first-ever deploy)." ;;
+        3)
+            if [ "$2" = 'corroborated' ]; then
+                bootstrap_skip "${1}, and the box pins no IMAGE_TAG either."
+            fi
+            log "ERROR: the box pins no IMAGE_TAG, but ${1} — so nothing has CONFIRMED that this environment is empty, and one unverified signal is not enough to skip the proof (fail closed)."
+            log "Check what the box is running (${STACK_DIR}/.env, docker compose ps). If this really is the first-ever deploy here, dispatch cd.yml with an explicit image_tag — that path bypasses this gate by design."
+            exit 2
+            ;;
         *) exit 2 ;;
     esac
 }
@@ -212,15 +238,16 @@ case "$api_rc" in
         baseline_source="last successful '${DEPLOY_ENVIRONMENT}' deployment (GitHub deployments API)"
         ;;
     3)
-        bootstrap_skip "no '${DEPLOY_ENVIRONMENT}' deployment is on record at all."
+        log "No '${DEPLOY_ENVIRONMENT}' deployment is on record at all — asking the box what it serves before calling this a bootstrap (a stack rolled by hand on the box leaves no record here)."
+        use_box_leg "no '${DEPLOY_ENVIRONMENT}' deployment is on record at all" corroborated
         ;;
     4)
         log "WARNING: the deployments API is unusable — resolving from the IMAGE_TAG pinned on the box instead."
-        use_box_leg "the deployments API is unusable"
+        use_box_leg "the deployments API could not be read at all" unconfirmed
         ;;
     5)
         log "WARNING: the API lists '${DEPLOY_ENVIRONMENT}' deployments but none ever reached 'success' — that is what a promotion pause longer than the API window looks like, NOT an empty history. Resolving from the IMAGE_TAG pinned on the box instead."
-        use_box_leg "no '${DEPLOY_ENVIRONMENT}' deployment on record ever reached 'success'"
+        use_box_leg "no '${DEPLOY_ENVIRONMENT}' deployment on record ever reached 'success'" corroborated
         ;;
     *)
         exit 2

--- a/scripts/tests/classify-changes.tests.sh
+++ b/scripts/tests/classify-changes.tests.sh
@@ -81,6 +81,10 @@ expect 'code=false guards=true images=false' 'the migration-safety guard'       
 expect 'code=false guards=true images=false' 'a guard self-test'                          'scripts/tests/check-migration-safety.tests.sh'
 expect 'code=false guards=true images=false' 'the script CD runs on a prod box'           'scripts/hetzner/deploy.sh'
 expect 'code=false guards=true images=false' 'the rollout self-test'                      'scripts/tests/hetzner-deploy.tests.sh'
+expect 'code=false guards=true images=false' 'the prod N-1 promotion gate resolver'       'scripts/ci/resolve-prod-baseline.sh'
+expect 'code=false guards=true images=false' 'the resolver self-test'                     'scripts/tests/resolve-prod-baseline.tests.sh'
+expect 'code=false guards=true images=false' 'the promotion gate verdict mapping'         'scripts/ci/n1-promotion-gate.sh'
+expect 'code=false guards=true images=false' 'the verdict-mapping self-test'              'scripts/tests/n1-promotion-gate.tests.sh'
 
 echo
 echo '── images ───────────────────────────────────────────────────────────────────────────────────'

--- a/scripts/tests/n1-promotion-gate.tests.sh
+++ b/scripts/tests/n1-promotion-gate.tests.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Test suite for the prod-promotion N-1 gate's verdict mapping
+# (scripts/ci/n1-promotion-gate.sh — #534).
+#
+# The one property here is the operator instruction attached to each exit code of
+# scripts/n1-compat.sh. That script separates "the serving release cannot live on this schema"
+# (exit 1) from "the proof never ran" (exit 2 — dotnet tool restore, script generation, the
+# worktree, a missing seam, no integration suites found). Both block the promotion, but they demand
+# OPPOSITE next actions: exit 1 means do NOT retry, promote in smaller steps; exit 2 means the batch
+# is UNJUDGED and the fix is the infra, not the batch. Collapsing them into one "your migrations
+# break prod" message sends the approver to split a healthy batch — or to the `image_tag` dispatch
+# that skips this gate entirely, which is the worst outcome the gate can produce.
+#
+# Each case runs the real gate script inside a fixture tree with a STUB scripts/n1-compat.sh, so the
+# mapping is exercised without Docker, .NET or a schema. The gate resolves the proof relative to its
+# own location, which is exactly what the fixture reproduces — no production test seam.
+#
+# CI runs this in the `guards` job, right next to the other bash gates.
+
+set -euo pipefail
+
+GATE_SH="$(cd "$(dirname "$0")/.." && pwd)/ci/n1-promotion-gate.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+cases=0
+CASE=""
+LAST_OUTPUT=""
+LAST_STATUS=0
+
+fail() {
+    printf '✗ [%s] %s\n' "$CASE" "$1"
+    if [ -n "${2:-}" ]; then
+        printf '%s\n' "$2" | sed 's/^/    /'
+    fi
+    printf '  --- n1-promotion-gate.sh output ---\n%s\n' "$LAST_OUTPUT" | sed 's/^/    /'
+    exit 1
+}
+
+pass() {
+    cases=$((cases + 1))
+    printf '✓ [%s] %s\n' "$CASE" "$1"
+}
+
+# --- Fixture: the gate next to a stub proof ----------------------------------------------------
+# STUB_N1_EXIT — the exit code the stubbed n1-compat.sh reports.
+# The stub records its argv so a case can prove the baseline was passed through verbatim (and that
+# it was not invoked at all when the gate refuses up front).
+FIXTURE="$TMP_ROOT/repo"
+ARGS_FILE="$TMP_ROOT/n1-compat.args"
+mkdir -p "$FIXTURE/scripts/ci"
+cp "$GATE_SH" "$FIXTURE/scripts/ci/n1-promotion-gate.sh"
+cat > "$FIXTURE/scripts/n1-compat.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$N1_ARGS_FILE"
+echo "stub n1-compat: pretending to prove ${1:-<no baseline>}"
+exit "${STUB_N1_EXIT:-0}"
+STUB
+chmod +x "$FIXTURE/scripts/n1-compat.sh"
+
+run_gate() {
+    : > "$ARGS_FILE"
+    LAST_STATUS=0
+    LAST_OUTPUT="$( (cd "$FIXTURE" && env \
+        GITHUB_STEP_SUMMARY="$TMP_ROOT/step_summary" \
+        N1_ARGS_FILE="$ARGS_FILE" \
+        "$@" ./scripts/ci/n1-promotion-gate.sh) 2>&1 )" || LAST_STATUS=$?
+}
+
+BASELINE='1f09af59d1bc0394da22452c4e6f89c6758e0ea4'
+
+CASE='proof green'
+run_gate BASELINE_SHA="$BASELINE" STUB_N1_EXIT=0
+[ "$LAST_STATUS" -eq 0 ] || fail 'a green proof must let the promotion proceed' "status $LAST_STATUS"
+grep -q 'GREEN' <<<"$LAST_OUTPUT" || fail 'the green verdict should be stated'
+grep -qx "$BASELINE" "$ARGS_FILE" || fail 'the baseline must reach n1-compat.sh verbatim, as its first argument' "$(cat "$ARGS_FILE")"
+pass 'a green proof exits 0 and passes the baseline through verbatim'
+
+CASE='proof red'
+run_gate BASELINE_SHA="$BASELINE" STUB_N1_EXIT=1
+[ "$LAST_STATUS" -eq 1 ] || fail 'an incompatible schema must block with exit 1' "status $LAST_STATUS"
+grep -q '::error::' <<<"$LAST_OUTPUT" || fail 'the block must be an annotated error'
+grep -q 'RED' <<<"$LAST_OUTPUT" || fail 'the red verdict should be stated'
+grep -q "$BASELINE" <<<"$LAST_OUTPUT" || fail 'the failure must name the baseline sha'
+grep -qi 'smaller steps' <<<"$LAST_OUTPUT" || fail 'the red verdict must carry the expand/contract resolution'
+if grep -qi 'UNJUDGED' <<<"$LAST_OUTPUT"; then fail 'a real incompatibility must NOT read as an infra failure'; fi
+pass 'exit 1 blocks with the RED verdict, the baseline and the promote-in-smaller-steps resolution'
+
+CASE='proof could not run'
+run_gate BASELINE_SHA="$BASELINE" STUB_N1_EXIT=2
+[ "$LAST_STATUS" -eq 2 ] || fail 'an unrunnable proof must block, and keep its own exit code' "status $LAST_STATUS"
+grep -q '::error::' <<<"$LAST_OUTPUT" || fail 'the block must be an annotated error'
+grep -q 'UNJUDGED' <<<"$LAST_OUTPUT" || fail 'the operator must be told the batch is unjudged, not proven bad'
+if grep -qi 'smaller steps' <<<"$LAST_OUTPUT"; then fail 'an infra failure must NOT advise splitting the batch'; fi
+if grep -qw 'RED' <<<"$LAST_OUTPUT"; then fail 'an infra failure must not be reported as a schema RED'; fi
+pass 'exit 2 blocks as UNJUDGED — no split-the-batch advice on an infra failure'
+
+CASE='proof died in an unforeseen way'
+run_gate BASELINE_SHA="$BASELINE" STUB_N1_EXIT=127
+[ "$LAST_STATUS" -eq 2 ] || fail 'any other exit code must fail closed as unrunnable' "status $LAST_STATUS"
+grep -q 'UNJUDGED' <<<"$LAST_OUTPUT" || fail 'unknown exit codes join the unjudged bucket'
+pass 'an unknown exit code fails closed as unjudged (never a silent pass)'
+
+CASE='no baseline'
+run_gate STUB_N1_EXIT=0
+[ "$LAST_STATUS" -eq 2 ] || fail 'a missing BASELINE_SHA must fail closed' "got $LAST_STATUS"
+[ ! -s "$ARGS_FILE" ] || fail 'n1-compat.sh must not run without a baseline' "$(cat "$ARGS_FILE")"
+pass 'a missing BASELINE_SHA fails closed and never invokes the proof'
+
+CASE='step summary'
+run_gate BASELINE_SHA="$BASELINE" STUB_N1_EXIT=2
+grep -q 'UNJUDGED' "$TMP_ROOT/step_summary" || fail 'the approver reads the summary — the block must land there too'
+pass 'a blocked promotion writes its verdict to the job summary'
+
+printf '\nAll %d n1-promotion-gate case(s) passed.\n' "$cases"

--- a/scripts/tests/resolve-prod-baseline.tests.sh
+++ b/scripts/tests/resolve-prod-baseline.tests.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# Test suite for the prod-promotion N-1 gate's baseline & span resolution
+# (scripts/ci/resolve-prod-baseline.sh — #534).
+#
+# The script's real inputs — the GitHub deployments API and the prod box's .env — exist nowhere in
+# CI, so each case runs it inside a throwaway fixture repo with STUB `gh` and `ssh` binaries first
+# on PATH, steered by env vars. Four properties carry the safety story and get the most cases:
+#
+#   * Fail CLOSED — an unresolvable baseline (API dead + box unreadable, a tag that is no commit,
+#     a recorded sha outside history) must block the promotion, never wave it through.
+#   * The `inactive` trap — GitHub re-marks a deployment's `success` status `inactive` once a newer
+#     deployment succeeds, so a resolver that only reads the LATEST status would find no success on
+#     a mature environment and false-bootstrap: the one skip that must stay reserved for a genuinely
+#     empty history would fire on every promotion.
+#   * The bootstrap skip is the ONLY fail-open verdict, so it must be unreachable while anything is
+#     serving. An API window that lists deployments but no `success` (the shape a promotion pause
+#     longer than the 100-record window takes on a mature environment) must resolve from the box,
+#     never skip: only "the box pins nothing either" earns the bootstrap.
+#   * The span must never be NARROWER than reality. The API records the sha of the workflow RUN, so
+#     a manual `image_tag` deploy leaves a record naming a commit the box never served; when the
+#     box disagrees, the resolver takes the OLDER of the two (the wider span) and an unorderable
+#     pair fails closed.
+#
+# CI runs this in the `guards` job, right next to the other bash gates.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RESOLVE_SH="$SCRIPTS_DIR/ci/resolve-prod-baseline.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+cases=0
+CASE=""
+LAST_OUTPUT=""
+LAST_STATUS=0
+
+fail() {
+    printf '✗ [%s] %s\n' "$CASE" "$1"
+    if [ -n "${2:-}" ]; then
+        printf '%s\n' "$2" | sed 's/^/    /'
+    fi
+    printf '  --- resolve-prod-baseline.sh output ---\n%s\n' "$LAST_OUTPUT" | sed 's/^/    /'
+    exit 1
+}
+
+pass() {
+    cases=$((cases + 1))
+    printf '✓ [%s] %s\n' "$CASE" "$1"
+}
+
+# --- Fixture repo: a linear history whose migration-free commits sit between the schema ones ---
+#   C1 adds src/App/Migrations/..._Init.cs   (expand)
+#   C2 adds src/App/Feature.cs               (no schema change)
+#   C3 adds src/App/Migrations/..._Drop.cs   (contract)
+#   C4 adds src/App/Other.cs                 (no schema change — so C3..C4 is a migration-free span
+#                                             while C2..C4 is not: the difference between trusting a
+#                                             lying API record and taking the wider span)
+FIXTURE="$TMP_ROOT/repo"
+mkdir -p "$FIXTURE"
+git -C "$FIXTURE" init --quiet --initial-branch=main
+git_commit() {
+    git -C "$FIXTURE" add -A
+    git -C "$FIXTURE" -c user.name=test -c user.email=test@test.invalid commit --quiet -m "$1"
+    git -C "$FIXTURE" rev-parse HEAD
+}
+mkdir -p "$FIXTURE/src/App/Migrations"
+echo 'readme' > "$FIXTURE/README.md"
+git_commit 'C0: init' >/dev/null
+echo 'expand' > "$FIXTURE/src/App/Migrations/20260101000000_Init.cs"
+C1="$(git_commit 'C1: expand migration')"
+echo 'feature' > "$FIXTURE/src/App/Feature.cs"
+C2="$(git_commit 'C2: feature only')"
+echo 'contract' > "$FIXTURE/src/App/Migrations/20260102000000_Drop.cs"
+C3="$(git_commit 'C3: contract migration')"
+echo 'other' > "$FIXTURE/src/App/Other.cs"
+C4="$(git_commit 'C4: feature only')"
+# A parentless commit: a baseline sharing no history with the candidate cannot be ordered against
+# it, and an unorderable pair must fail closed instead of picking a span at random.
+UNRELATED="$(git -C "$FIXTURE" -c user.name=test -c user.email=test@test.invalid \
+    commit-tree "$(git -C "$FIXTURE" rev-parse 'HEAD^{tree}')" -m 'unrelated root')"
+# What the box would pin for each of them — deploy.sh writes IMAGE_TAG=sha-<short> after a roll.
+short_c1="$(git -C "$FIXTURE" rev-parse --short=7 "$C1")"
+short_c2="$(git -C "$FIXTURE" rev-parse --short=7 "$C2")"
+short_c3="$(git -C "$FIXTURE" rev-parse --short=7 "$C3")"
+
+# --- Stubs: `gh` serves JSON fixtures, `ssh` plays the box ------------------------------------
+# STUB_GH_FAIL       — every `gh api` call dies (API unusable → box fallback)
+# STUB_DEPLOYMENTS   — JSON file served for the deployments list
+# STUB_STATUSES_DIR  — dir of <deployment-id>.json files served for each statuses call
+# STUB_SSH_FAIL      — the ssh transport dies (fallback must fail CLOSED)
+# STUB_BOX_TAG       — what the box .env pins as IMAGE_TAG ('' = nothing pinned yet)
+BIN="$TMP_ROOT/bin"
+mkdir -p "$BIN"
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+[ -z "${STUB_GH_FAIL:-}" ] || { echo 'stub: gh api failed' >&2; exit 1; }
+url=""
+for arg in "$@"; do
+    case "$arg" in
+        repos/*) url="$arg" ;;
+    esac
+done
+case "$url" in
+    */deployments/*/statuses*)
+        id="${url#*/deployments/}"
+        id="${id%%/*}"
+        cat "$STUB_STATUSES_DIR/$id.json"
+        ;;
+    */deployments\?*)
+        cat "$STUB_DEPLOYMENTS"
+        ;;
+    *)
+        echo "stub gh: unexpected url '$url'" >&2
+        exit 1
+        ;;
+esac
+STUB
+cat > "$BIN/ssh" <<'STUB'
+#!/usr/bin/env bash
+[ -z "${STUB_SSH_FAIL:-}" ] || { echo 'stub: ssh transport failed' >&2; exit 255; }
+[ -z "${STUB_BOX_TAG:-}" ] || printf '%s\n' "$STUB_BOX_TAG"
+exit 0
+STUB
+chmod +x "$BIN/gh" "$BIN/ssh"
+PATH="$BIN:$PATH"
+export PATH
+
+deployments_json() {
+    printf '%s' "$1" > "$TMP_ROOT/deployments.json"
+}
+statuses_json() {
+    mkdir -p "$TMP_ROOT/statuses"
+    printf '%s' "$2" > "$TMP_ROOT/statuses/$1.json"
+}
+
+# Neutralize the real $GITHUB_OUTPUT / $GITHUB_STEP_SUMMARY (both exist when CI runs this suite)
+# with per-case scratch files, so the script under test never pollutes the job's own outputs.
+run_resolve() {
+    GH_OUT="$TMP_ROOT/github_output"
+    : > "$GH_OUT"
+    LAST_STATUS=0
+    LAST_OUTPUT="$( (cd "$FIXTURE" && env \
+        GITHUB_REPOSITORY='koniecdev/LotroKoniecDev' \
+        GITHUB_OUTPUT="$GH_OUT" \
+        GITHUB_STEP_SUMMARY="$TMP_ROOT/step_summary" \
+        STUB_DEPLOYMENTS="$TMP_ROOT/deployments.json" \
+        STUB_STATUSES_DIR="$TMP_ROOT/statuses" \
+        "$@" "$RESOLVE_SH") 2>&1 )" || LAST_STATUS=$?
+}
+
+verdict() { grep -qx "$1" <<<"$LAST_OUTPUT"; }
+
+# --- Usage errors fail closed ------------------------------------------------------------------
+
+CASE='no CANDIDATE_SHA'
+run_resolve
+[ "$LAST_STATUS" -eq 2 ] || fail 'expected exit 2 without CANDIDATE_SHA' "got $LAST_STATUS"
+pass 'a missing CANDIDATE_SHA is a usage error (exit 2)'
+
+CASE='candidate outside history'
+run_resolve CANDIDATE_SHA=0000000000000000000000000000000000000000
+[ "$LAST_STATUS" -eq 2 ] || fail 'expected exit 2 for a candidate sha not in history' "got $LAST_STATUS"
+pass 'a candidate sha outside the checkout history is refused (exit 2)'
+
+# --- The API leg -------------------------------------------------------------------------------
+
+CASE='API happy path'
+deployments_json "[{\"id\": 11, \"sha\": \"$C3\"}, {\"id\": 10, \"sha\": \"$C2\"}]"
+statuses_json 11 '[{"state": "in_progress"}]'
+statuses_json 10 '[{"state": "success"}, {"state": "in_progress"}]'
+run_resolve CANDIDATE_SHA="$C3"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected a clean resolution' "status $LAST_STATUS"
+verdict 'mode=proof' || fail 'a span with a migration must demand the proof'
+verdict "baseline=$C2" || fail "expected baseline=$C2 (the last SUCCESSFUL deployment, not the in-flight one)"
+grep -qx 'mode=proof' "$GH_OUT" || fail 'mode was not written to GITHUB_OUTPUT'
+grep -qx "baseline=$C2" "$GH_OUT" || fail 'baseline was not written to GITHUB_OUTPUT'
+pass 'skips the in-flight record, picks the last success, demands the proof for a migration span'
+
+CASE='the inactive trap'
+# The LATEST status of the old success IS `inactive` (GitHub re-marks it when a newer deployment
+# succeeds); only the full history still contains the `success`. A latest-status-only resolver
+# would false-bootstrap here.
+deployments_json "[{\"id\": 21, \"sha\": \"$C3\"}, {\"id\": 20, \"sha\": \"$C2\"}]"
+statuses_json 21 '[{"state": "in_progress"}]'
+statuses_json 20 '[{"state": "inactive"}, {"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C3"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected a clean resolution' "status $LAST_STATUS"
+verdict "baseline=$C2" || fail 'a deployment whose success was re-marked inactive must still be the baseline'
+verdict 'mode=proof' || fail 'the migration span must still demand the proof'
+pass 'a success re-marked inactive still resolves (no false bootstrap on a mature environment)'
+
+CASE='rolled-back run skipped'
+deployments_json "[{\"id\": 31, \"sha\": \"$C2\"}, {\"id\": 30, \"sha\": \"$C1\"}]"
+statuses_json 31 '[{"state": "failure"}, {"state": "in_progress"}]'
+statuses_json 30 '[{"state": "inactive"}, {"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C3"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected a clean resolution' "status $LAST_STATUS"
+verdict "baseline=$C1" || fail 'a deployment that never reached success must be skipped (the box was rolled back)'
+pass 'a failed/rolled-back deployment is not the baseline — the one before it is'
+
+CASE='no migrations in span'
+deployments_json "[{\"id\": 40, \"sha\": \"$C1\"}]"
+statuses_json 40 '[{"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C2"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected a clean resolution' "status $LAST_STATUS"
+verdict 'mode=skip' || fail 'a migration-free span must skip the proof'
+verdict "baseline=$C1" || fail 'the skip verdict should still name the baseline'
+pass 'a migration-free promotion span skips the proof (fast path)'
+
+CASE='re-promotion of the serving sha'
+deployments_json "[{\"id\": 50, \"sha\": \"$C3\"}]"
+statuses_json 50 '[{"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C3"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected a clean resolution' "status $LAST_STATUS"
+verdict 'mode=skip' || fail 'baseline == candidate must skip (empty span)'
+pass 're-promoting the sha already serving is an empty span — skip'
+
+CASE='bootstrap: no deployments'
+deployments_json '[]'
+run_resolve CANDIDATE_SHA="$C3"
+[ "$LAST_STATUS" -eq 0 ] || fail 'the first-ever prod deploy must NOT fail' "status $LAST_STATUS"
+verdict 'mode=skip' || fail 'expected the bootstrap skip'
+grep -q 'BOOTSTRAP' <<<"$LAST_OUTPUT" || fail 'the bootstrap skip must be loud'
+pass 'an empty deployment history is a loud bootstrap skip, never a failure'
+
+CASE='bootstrap: no success yet, box pins nothing'
+deployments_json "[{\"id\": 60, \"sha\": \"$C2\"}]"
+statuses_json 60 '[{"state": "failure"}]'
+run_resolve CANDIDATE_SHA="$C3"
+[ "$LAST_STATUS" -eq 0 ] || fail 'a history with no success yet must NOT fail' "status $LAST_STATUS"
+verdict 'mode=skip' || fail 'expected the bootstrap skip'
+grep -q 'BOOTSTRAP' <<<"$LAST_OUTPUT" || fail 'the bootstrap skip must be loud'
+pass 'deployments that never succeeded AND a box pinning nothing is still a bootstrap skip'
+
+CASE='window without a success, but the box knows'
+# The fail-open trap this routing closes: on a mature environment every superseded candidate lands
+# as `error`, so a promotion pause longer than the API window (measured on this repo: 100 records ≈
+# 25 days) leaves a page with no `success` at all — indistinguishable from an empty history to a
+# resolver that reads one page. Skipping there waves through the exact batch the gate exists to
+# stop, so a non-empty history without a success must resolve from the box instead.
+deployments_json "[{\"id\": 61, \"sha\": \"$C3\"}]"
+statuses_json 61 '[{"state": "error"}]'
+run_resolve CANDIDATE_SHA="$C3" STUB_BOX_TAG="sha-$short_c1"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected the box to answer' "status $LAST_STATUS"
+verdict "baseline=$C1" || fail 'a window without a success must resolve from the box, not bootstrap'
+verdict 'mode=proof' || fail 'the migration span must demand the proof'
+if grep -q 'BOOTSTRAP' <<<"$LAST_OUTPUT"; then fail 'a box that pins a tag must never read as bootstrap'; fi
+pass 'a window listing only unsuccessful deployments resolves from the box (no false bootstrap)'
+
+CASE='window without a success and no box either'
+run_resolve CANDIDATE_SHA="$C3" STUB_SSH_FAIL=1
+[ "$LAST_STATUS" -eq 2 ] || fail 'no success on record + unreadable box must fail CLOSED' "got $LAST_STATUS"
+pass 'a window without a success and a dead box fails closed (exit 2)'
+
+CASE='malformed API body'
+# `gh api` exits 0 on a body that is not the expected array (an object, a truncated page). That is
+# an unusable API, not an empty history — it must route to the box, never to the bootstrap skip.
+deployments_json '{"message": "Not Found"}'
+run_resolve CANDIDATE_SHA="$C3" STUB_BOX_TAG="sha-$short_c1"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected the box to answer' "status $LAST_STATUS"
+verdict "baseline=$C1" || fail 'a malformed API body must fall back to the box'
+pass 'a malformed API body falls back to the box instead of bootstrapping'
+
+# --- The cross-check: the API record vs what the box actually serves ---------------------------
+# A deployment record carries the sha of the workflow RUN, not of the artifact that was rolled, so
+# it can name a commit the box never served. The box `.env` is the ground truth (deploy.sh pins it
+# after every successful roll), so when the two disagree the resolver takes the OLDER commit — the
+# wider span — and never the narrower one.
+
+CASE='cross-check: box agrees'
+deployments_json "[{\"id\": 80, \"sha\": \"$C2\"}]"
+statuses_json 80 '[{"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C3" STUB_BOX_TAG="sha-$short_c2"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected a clean resolution' "status $LAST_STATUS"
+verdict "baseline=$C2" || fail 'agreement must keep the API baseline'
+grep -q 'agrees' <<<"$LAST_OUTPUT" || fail 'a successful cross-check should say so'
+pass 'the box agreeing with the record keeps the baseline and logs the cross-check'
+
+CASE='cross-check: the box serves an OLDER release than the record claims'
+# The manual image_tag path: `sha-<older>` was rolled onto the box, but the deployment record — and
+# its `success` — names the run's sha (C3). Trusting the record computes the span C3..C4, which is
+# migration-free, and green-lights a batch whose C3 Drop migration the serving release (C2) cannot
+# survive. Taking the older commit puts that migration back inside the span.
+deployments_json "[{\"id\": 90, \"sha\": \"$C3\"}]"
+statuses_json 90 '[{"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C4" STUB_BOX_TAG="sha-$short_c2"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected a clean resolution' "status $LAST_STATUS"
+verdict "baseline=$C2" || fail 'the older (box) commit must win — the wider span'
+verdict 'mode=proof' || fail 'the widened span contains a migration and must demand the proof'
+pass 'a record newer than the served artifact is widened to what the box actually serves'
+
+CASE='cross-check: the record alone would have skipped'
+# Same inputs, box silent — pins the hole the case above closes: with nothing to cross-check
+# against, the record's narrower span is all there is, and it skips.
+run_resolve CANDIDATE_SHA="$C4"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected a clean resolution' "status $LAST_STATUS"
+verdict "baseline=$C3" || fail 'with no box answer the record stands'
+verdict 'mode=skip' || fail 'the record-only span C3..C4 is migration-free'
+pass 'the record-only span is the narrower one (documents what the cross-check buys)'
+
+CASE='cross-check: the box serves a NEWER commit than the record'
+deployments_json "[{\"id\": 100, \"sha\": \"$C2\"}]"
+statuses_json 100 '[{"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C4" STUB_BOX_TAG="sha-$short_c3"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected a clean resolution' "status $LAST_STATUS"
+verdict "baseline=$C2" || fail 'the older of the two must win regardless of which source it came from'
+pass 'a box newer than the record still resolves to the older commit (wider span)'
+
+CASE='cross-check: unorderable pair'
+deployments_json "[{\"id\": 110, \"sha\": \"$C2\"}]"
+statuses_json 110 '[{"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C4" STUB_BOX_TAG="sha-$UNRELATED"
+[ "$LAST_STATUS" -eq 2 ] || fail 'two baselines with no ancestry must fail CLOSED' "got $LAST_STATUS"
+pass 'a record and a box tag on unrelated histories fail closed (exit 2)'
+
+CASE='cross-check: an unreadable box is not a new failure mode'
+# The cross-check is hardening on top of a resolved baseline; it must never turn a working
+# promotion red on its own. ssh already proved itself in the step before this gate.
+deployments_json "[{\"id\": 120, \"sha\": \"$C2\"}]"
+statuses_json 120 '[{"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C3" STUB_SSH_FAIL=1
+[ "$LAST_STATUS" -eq 0 ] || fail 'a failed cross-check must not block a resolved baseline' "status $LAST_STATUS"
+verdict "baseline=$C2" || fail 'the API baseline must survive an unreadable box'
+pass 'an unreadable box warns and keeps the API baseline (hardening, not a new gate)'
+
+CASE='recorded sha outside history'
+deployments_json '[{"id": 70, "sha": "1111111111111111111111111111111111111111"}]'
+statuses_json 70 '[{"state": "success"}]'
+run_resolve CANDIDATE_SHA="$C3"
+[ "$LAST_STATUS" -eq 2 ] || fail 'a baseline sha outside the checkout history must fail CLOSED' "got $LAST_STATUS"
+pass 'a recorded baseline the checkout cannot see fails closed (exit 2)'
+
+# --- The box fallback (API unusable) -----------------------------------------------------------
+
+CASE='fallback: box tag resolves'
+run_resolve CANDIDATE_SHA="$C3" STUB_GH_FAIL=1 STUB_BOX_TAG="sha-$short_c2"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected the box fallback to resolve' "status $LAST_STATUS"
+verdict "baseline=$C2" || fail "expected the box-pinned sha-$short_c2 to resolve to $C2"
+verdict 'mode=proof' || fail 'the migration span must demand the proof'
+pass "a dead API falls back to the box IMAGE_TAG (sha-$short_c2 → baseline)"
+
+CASE='fallback: nothing pinned'
+run_resolve CANDIDATE_SHA="$C3" STUB_GH_FAIL=1
+[ "$LAST_STATUS" -eq 0 ] || fail 'first-ever deploy with a dead API must NOT fail' "status $LAST_STATUS"
+verdict 'mode=skip' || fail 'expected the bootstrap skip'
+grep -q 'BOOTSTRAP' <<<"$LAST_OUTPUT" || fail 'the bootstrap skip must be loud'
+pass 'a box with no IMAGE_TAG pinned is the first-ever deploy — loud bootstrap skip'
+
+CASE='fallback: unresolvable tag'
+run_resolve CANDIDATE_SHA="$C3" STUB_GH_FAIL=1 STUB_BOX_TAG='sha-deadbee'
+[ "$LAST_STATUS" -eq 2 ] || fail 'a box tag that is no commit must fail CLOSED' "got $LAST_STATUS"
+pass 'a box tag that resolves to no commit fails closed (exit 2)'
+
+CASE='fallback: hostile tag'
+run_resolve CANDIDATE_SHA="$C3" STUB_GH_FAIL=1 STUB_BOX_TAG='sha-abc; rm -rf /'
+[ "$LAST_STATUS" -eq 2 ] || fail 'a tag outside [A-Za-z0-9._-] must be rejected' "got $LAST_STATUS"
+pass 'a hostile box tag is rejected before it reaches git (exit 2)'
+
+CASE='fallback: ssh dead too'
+run_resolve CANDIDATE_SHA="$C3" STUB_GH_FAIL=1 STUB_SSH_FAIL=1
+[ "$LAST_STATUS" -eq 2 ] || fail 'API dead + box unreadable must fail CLOSED, not wave the batch through' "got $LAST_STATUS"
+pass 'both sources dead fails closed (exit 2) — the gate never guesses'
+
+printf '\nAll %d resolve-prod-baseline case(s) passed.\n' "$cases"

--- a/scripts/tests/resolve-prod-baseline.tests.sh
+++ b/scripts/tests/resolve-prod-baseline.tests.sh
@@ -12,10 +12,11 @@
 #     deployment succeeds, so a resolver that only reads the LATEST status would find no success on
 #     a mature environment and false-bootstrap: the one skip that must stay reserved for a genuinely
 #     empty history would fire on every promotion.
-#   * The bootstrap skip is the ONLY fail-open verdict, so it must be unreachable while anything is
-#     serving. An API window that lists deployments but no `success` (the shape a promotion pause
-#     longer than the 100-record window takes on a mature environment) must resolve from the box,
-#     never skip: only "the box pins nothing either" earns the bootstrap.
+#   * The bootstrap skip is the ONLY fail-open verdict, so it takes TWO agreeing signals: the API
+#     positively establishing that nothing here ever reached `success`, AND a box pinning no tag.
+#     An API window listing deployments without a `success` is what a promotion pause longer than
+#     that window looks like on a mature environment; a silent box can be a .env that lost its line
+#     while the containers keep serving. Either signal alone resolves or fails closed, never skips.
 #   * The span must never be NARROWER than reality. The API records the sha of the workflow RUN, so
 #     a manual `image_tag` deploy leaves a record naming a commit the box never served; when the
 #     box disagrees, the resolver takes the OLDER of the two (the wider span) and an unorderable
@@ -216,13 +217,33 @@ run_resolve CANDIDATE_SHA="$C3"
 verdict 'mode=skip' || fail 'baseline == candidate must skip (empty span)'
 pass 're-promoting the sha already serving is an empty span — skip'
 
-CASE='bootstrap: no deployments'
+CASE='bootstrap: no deployments, box pins nothing'
 deployments_json '[]'
 run_resolve CANDIDATE_SHA="$C3"
 [ "$LAST_STATUS" -eq 0 ] || fail 'the first-ever prod deploy must NOT fail' "status $LAST_STATUS"
 verdict 'mode=skip' || fail 'expected the bootstrap skip'
 grep -q 'BOOTSTRAP' <<<"$LAST_OUTPUT" || fail 'the bootstrap skip must be loud'
-pass 'an empty deployment history is a loud bootstrap skip, never a failure'
+pass 'an empty history plus a box pinning nothing is a loud bootstrap skip, never a failure'
+
+CASE='no deployment record, but the box is serving'
+# A stack rolled by hand on the box (runbook territory) leaves no record here. The empty history
+# alone would bootstrap-skip a box that is very much serving, so the box gets asked first.
+deployments_json '[]'
+run_resolve CANDIDATE_SHA="$C3" STUB_BOX_TAG="sha-$short_c1"
+[ "$LAST_STATUS" -eq 0 ] || fail 'expected the box to answer' "status $LAST_STATUS"
+verdict "baseline=$C1" || fail 'a box pinning a tag outranks an empty deployment history'
+if grep -q 'BOOTSTRAP' <<<"$LAST_OUTPUT"; then fail 'a serving box must never read as bootstrap'; fi
+pass 'an empty history with a serving box resolves from the box, not bootstrap'
+
+CASE='version-tag deploy'
+# cd.yml publishes version images as {{version}} — git tag v1.2.3 becomes image tag 1.2.3 — so the
+# box pins a string git cannot resolve until the v goes back on.
+git -C "$FIXTURE" tag 'v9.9.9' "$C2"
+deployments_json '[]'
+run_resolve CANDIDATE_SHA="$C3" STUB_BOX_TAG='9.9.9'
+[ "$LAST_STATUS" -eq 0 ] || fail 'a version-tag deploy must resolve, not fail closed' "status $LAST_STATUS"
+verdict "baseline=$C2" || fail 'the image tag 9.9.9 must resolve through the git tag v9.9.9'
+pass 'a box-pinned version tag resolves through its v-prefixed git tag'
 
 CASE='bootstrap: no success yet, box pins nothing'
 deployments_json "[{\"id\": 60, \"sha\": \"$C2\"}]"
@@ -340,12 +361,15 @@ verdict "baseline=$C2" || fail "expected the box-pinned sha-$short_c2 to resolve
 verdict 'mode=proof' || fail 'the migration span must demand the proof'
 pass "a dead API falls back to the box IMAGE_TAG (sha-$short_c2 → baseline)"
 
-CASE='fallback: nothing pinned'
+CASE='fallback: nothing pinned and the API cannot confirm it'
+# A silent box is strong evidence that nothing ever rolled (deploy.sh writes IMAGE_TAG last and only
+# on success) — but not proof: a .env restored without the line looks identical while the containers
+# keep serving. With the API unreadable nothing corroborates it, so this must NOT take the one
+# fail-open verdict.
 run_resolve CANDIDATE_SHA="$C3" STUB_GH_FAIL=1
-[ "$LAST_STATUS" -eq 0 ] || fail 'first-ever deploy with a dead API must NOT fail' "status $LAST_STATUS"
-verdict 'mode=skip' || fail 'expected the bootstrap skip'
-grep -q 'BOOTSTRAP' <<<"$LAST_OUTPUT" || fail 'the bootstrap skip must be loud'
-pass 'a box with no IMAGE_TAG pinned is the first-ever deploy — loud bootstrap skip'
+[ "$LAST_STATUS" -eq 2 ] || fail 'an uncorroborated silent box must fail closed, not bootstrap' "got $LAST_STATUS"
+if grep -q 'BOOTSTRAP' <<<"$LAST_OUTPUT"; then fail 'bootstrap needs the API to confirm the history is empty'; fi
+pass 'a silent box with an unreadable API fails closed — bootstrap needs two agreeing signals'
 
 CASE='fallback: unresolvable tag'
 run_resolve CANDIDATE_SHA="$C3" STUB_GH_FAIL=1 STUB_BOX_TAG='sha-deadbee'


### PR DESCRIPTION
Closes #534

## Problem

Prod promotion batches merges: staging advances on every push to `main`, prod ships every Nth candidate behind the approval gate, and batch diffs are deliberately not inspected by hand. The migration safety story assumed `deploy == merge`:

- ADR-0023 requires destructive changes to ship expand -> backfill -> contract across **>= 2 deploys**.
- The executable proof (ADR-0024, `scripts/n1-compat.sh`) checks the previous **merge** (`HEAD^1`), not the previous **deploy**.

So an expand and its contract can ride one approved batch, green at every per-step check, while the release still serving breaks on the contract. Rollback cannot help - schema is forward-only.

## What this does

The prod leg of `deploy.yml` now proves the promotion against the release **actually serving**, after the approval and before GHCR, Neon or any change to the box:

1. `scripts/ci/resolve-prod-baseline.sh` resolves the serving sha - the newest `production` deployment that ever reached a `success` status (the status **history**, not the latest status: GitHub re-marks old successes `inactive`), cross-checked against the `IMAGE_TAG` the box pins, which also stands in when the API cannot answer.
2. A span with no `Migrations/` files skips in seconds. Nothing-serving-yet skips loudly. An unresolvable baseline fails closed.
3. Otherwise `scripts/ci/n1-promotion-gate.sh` runs the existing ADR-0024 seam against that baseline and keeps its two failures apart: `RED` (schema proven incompatible - do not retry, promote in smaller steps) versus `COULD NOT RUN` (the proof never ran, so the batch is **unjudged** - fix the infra).

The PR-time `HEAD^1` job is unchanged - fast feedback next to the change; the deploy-time leg is the real guarantee. The staging leg stays ungated: staging deploys every push, so `HEAD^1` semantics already match it.

## Two traps this closes deliberately

- **The bootstrap skip is the only fail-open verdict**, so it is reserved for "nothing is serving". A window that lists deployments *without* a `success` is not that: on a mature environment every superseded candidate lands as `error`, so a promotion pause longer than the API window (measured on this repo: 100 records is about 25 days) takes exactly that shape. It resolves from the box instead of skipping.
- **A deployment record carries the sha of the workflow run, not of the rolled artifact.** A manual `image_tag` deploy therefore leaves a `success` record naming a commit the box never served, which would give the *next* unattended promotion a too-new baseline and hide every migration in between. On disagreement the resolver takes the older commit (the wider span); an unorderable pair fails closed. The cross-check never blocks on its own - an unreadable box warns and keeps the API's answer.

## Verification

- `scripts/tests/resolve-prod-baseline.tests.sh` - 24 cases (stub `gh` + `ssh` over a fixture repo): fail-closed paths, the `inactive` trap, the bootstrap boundary, the cross-check widening and its unorderable case.
- `scripts/tests/n1-promotion-gate.tests.sh` - 6 cases (stub `n1-compat.sh` over a fixture tree): each exit code maps to its own verdict and operator instruction, and a missing baseline never invokes the proof.
- Both suites run in `pr-verify` and in `ci` (CD is triggered by `ci` concluding success, so the scripts the prod leg is about to run get checked there too), and both scripts join the guard classification.
- `actionlint` + `shellcheck` clean.
- Dry-run against the live deployments API resolves `1f09af59` - the actual last successful prod deployment - and classifies today's span as migration-free.

## Acceptance criteria

- [x] A prod promotion whose migration span breaks the currently-serving release turns RED before the box is touched; the failure names the baseline sha and points at the failing suites.
- [x] A promotion with no migrations in the span adds no measurable time (one API list call plus a handful of status calls).
- [x] The first-ever prod deploy does not fail - loud skip.
- [x] The PR-time N-1 job (`n1-compat.yml`) is unchanged.