### PR TITLE
Harden every returnUrl guard against the control-character bypass

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Common/LocalReturnUrl.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Common/LocalReturnUrl.cs
@@ -1,0 +1,27 @@
+namespace LotroKoniecDev.AuthSystem.API.Common;
+
+/// <summary>
+/// The single guard for every caller-supplied <c>returnUrl</c> the auth pages reflect into HTML or
+/// redirect to: yields the value only when it is a same-site path, otherwise <see langword="null"/>
+/// so the caller falls back to a safe default.
+/// </summary>
+/// <remarks>
+/// Control characters are rejected because the WHATWG URL parser strips ASCII tab and newline, so
+/// <c>"/\t/evil.example"</c> reads as the protocol-relative <c>"//evil.example"</c> once a browser
+/// parses it — a prefix-only check would call that value local. Screening here keeps the value safe
+/// for the page to reflect and spares <c>LocalRedirect</c>'s executor, which rejects such a target
+/// and would turn a successful login into an unhandled 500. The <c>"~/"</c> form is dropped too; no
+/// auth page emits one. Twin of the frontend's <c>Infrastructure/Security/LocalReturnUrl</c> —
+/// change both together.
+/// </remarks>
+internal static class LocalReturnUrl
+{
+    internal static string? Sanitize(string? returnUrl) =>
+        returnUrl is not null
+        && returnUrl.StartsWith('/')
+        && !returnUrl.StartsWith("//", StringComparison.Ordinal)
+        && !returnUrl.StartsWith("/\\", StringComparison.Ordinal)
+        && !returnUrl.Any(char.IsControl)
+            ? returnUrl
+            : null;
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Common;
 using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
@@ -55,18 +56,24 @@ internal sealed partial class LoginModel : PageModel
     [BindProperty]
     public bool RememberMe { get; set; }
 
+    /// <summary>
+    /// The local continuation captured from the OIDC flow (e.g. the <c>/connect/authorize</c> URL the
+    /// user was bounced from), carried through the form so a successful login resumes it. Reflected
+    /// into the page and used as the redirect target only after passing
+    /// <see cref="LocalReturnUrl.Sanitize"/>, which blocks open redirects.
+    /// </summary>
     public string? ReturnUrl { get; set; }
 
     public string? ErrorMessage { get; set; }
 
     public void OnGet(string? returnUrl = null)
     {
-        ReturnUrl = returnUrl;
+        ReturnUrl = LocalReturnUrl.Sanitize(returnUrl);
     }
 
     public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
     {
-        ReturnUrl = returnUrl;
+        ReturnUrl = LocalReturnUrl.Sanitize(returnUrl);
 
         if (string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Password))
         {
@@ -180,12 +187,7 @@ internal sealed partial class LoginModel : PageModel
 
         LogUserLoggedIn(_logger, user.Id);
 
-        if (!string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))
-        {
-            return LocalRedirect(returnUrl);
-        }
-
-        return LocalRedirect("/");
+        return LocalRedirect(ReturnUrl ?? "/");
     }
 
     [LoggerMessage(EventId = EventIds.LoginUserNotFound, Level = LogLevel.Warning, Message = "Failed login: user not found. Email: {Email}, IP: {IP}")]

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Common;
 using LotroKoniecDev.AuthSystem.API.Features.Auth;
 using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
@@ -69,19 +70,19 @@ internal sealed partial class RegisterModel : PageModel
     /// The local OIDC continuation captured from the login flow (e.g. the <c>/connect/authorize</c>
     /// URL the user was bounced from). Carried verbatim into the post-registration login link so a
     /// registration detour resumes the interrupted authorization once the account is confirmed and
-    /// signed in. Reflected into the page only after passing <see cref="SanitizeReturnUrl"/> to block
-    /// open redirects.
+    /// signed in. Reflected into the page only after passing <see cref="LocalReturnUrl.Sanitize"/> to
+    /// block open redirects.
     /// </summary>
     public string? ReturnUrl { get; set; }
 
     public void OnGet(string? returnUrl = null)
     {
-        ReturnUrl = SanitizeReturnUrl(returnUrl);
+        ReturnUrl = LocalReturnUrl.Sanitize(returnUrl);
     }
 
     public async Task<IActionResult> OnPostAsync(string? returnUrl, CancellationToken cancellationToken)
     {
-        ReturnUrl = SanitizeReturnUrl(returnUrl);
+        ReturnUrl = LocalReturnUrl.Sanitize(returnUrl);
 
         if (string.IsNullOrWhiteSpace(Username) || string.IsNullOrWhiteSpace(Email) ||
             string.IsNullOrWhiteSpace(Password))
@@ -143,14 +144,6 @@ internal sealed partial class RegisterModel : PageModel
         IsRegistered = true;
         return Page();
     }
-
-    /// <summary>
-    /// Keeps only a safe, same-site <paramref name="returnUrl"/>: a non-local value (an absolute or
-    /// protocol-relative URL) is dropped so it can never be reflected into a link and turned into an
-    /// open redirect. Mirrors the login page's <see cref="IUrlHelper.IsLocalUrl"/> guard.
-    /// </summary>
-    private string? SanitizeReturnUrl(string? returnUrl) =>
-        !string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl) ? returnUrl : null;
 
     /// <summary>
     /// Maps the authoritative handler error onto a friendly Polish message. The required-field,

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Auth/AuthEndpointsExtensions.cs
@@ -1,3 +1,4 @@
+using LotroKoniecDev.Frontend.Infrastructure.Security;
 using LotroKoniecDev.Frontend.Settings;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -58,7 +59,7 @@ internal static class AuthEndpointsExtensions
         IOptionsMonitor<OpenIdConnectOptions> openIdConnectOptionsMonitor,
         ILoggerFactory loggerFactory)
     {
-        string redirectUri = IsLocalUrl(returnUrl) ? returnUrl! : "/";
+        string redirectUri = LocalReturnUrl.Sanitize(returnUrl) ?? "/";
 
         IConfigurationManager<OpenIdConnectConfiguration>? configurationManager = openIdConnectOptionsMonitor
             .Get(OpenIdConnectDefaults.AuthenticationScheme)
@@ -94,7 +95,7 @@ internal static class AuthEndpointsExtensions
     {
         await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
 
-        string redirect = IsLocalUrl(returnUrl) ? returnUrl! : "/";
+        string redirect = LocalReturnUrl.Sanitize(returnUrl) ?? "/";
         return Results.Redirect(redirect);
     }
 
@@ -118,13 +119,5 @@ internal static class AuthEndpointsExtensions
         }
 
         return Results.Redirect(endSessionUrl);
-    }
-
-    private static bool IsLocalUrl(string? url)
-    {
-        return !string.IsNullOrWhiteSpace(url)
-               && url.StartsWith('/')
-               && !url.StartsWith("//", StringComparison.Ordinal)
-               && !url.StartsWith("/\\", StringComparison.Ordinal);
     }
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/CookieConsent/CookieConsentEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/CookieConsent/CookieConsentEndpointsExtensions.cs
@@ -1,3 +1,5 @@
+using LotroKoniecDev.Frontend.Infrastructure.Security;
+
 namespace LotroKoniecDev.Frontend.Infrastructure.CookieConsent;
 
 /// <summary>
@@ -32,16 +34,7 @@ internal static class CookieConsentEndpointsExtensions
             "true",
             CookieConsentCookie.BuildOptions(context.Request.IsHttps));
 
-        string safeReturn = IsLocalPath(returnPath) ? returnPath : "/";
+        string safeReturn = LocalReturnUrl.Sanitize(returnPath) ?? "/";
         return Results.Redirect(safeReturn);
     }
-
-    // Control characters are rejected because the WHATWG URL parser strips ASCII tab/newline —
-    // "/\t/evil.example" would reach the browser as the protocol-relative "//evil.example"
-    // (mirrors ASP.NET Core's UrlHelper.IsLocalUrl hardening).
-    private static bool IsLocalPath(string path) =>
-        path.StartsWith('/')
-        && !path.StartsWith("//", StringComparison.Ordinal)
-        && !path.StartsWith("/\\", StringComparison.Ordinal)
-        && !path.Any(char.IsControl);
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Security/LocalReturnUrl.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Security/LocalReturnUrl.cs
@@ -1,0 +1,24 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.Security;
+
+/// <summary>
+/// The single guard for every caller-supplied return target the app redirects to — the login
+/// challenge, the local sign-out and the cookie-consent bounce-back: yields the value only when it
+/// is a same-site path, otherwise <see langword="null"/> so the caller falls back to a safe default.
+/// </summary>
+/// <remarks>
+/// Control characters are rejected because the WHATWG URL parser strips ASCII tab and newline, so
+/// <c>"/\t/evil.example"</c> would reach the browser as the protocol-relative
+/// <c>"//evil.example"</c> — an open redirect a plain prefix check lets through.
+/// Twin of the auth server's <c>Common/LocalReturnUrl</c> — change both together.
+/// </remarks>
+internal static class LocalReturnUrl
+{
+    internal static string? Sanitize(string? returnUrl) =>
+        returnUrl is not null
+        && returnUrl.StartsWith('/')
+        && !returnUrl.StartsWith("//", StringComparison.Ordinal)
+        && !returnUrl.StartsWith("/\\", StringComparison.Ordinal)
+        && !returnUrl.Any(char.IsControl)
+            ? returnUrl
+            : null;
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
@@ -94,6 +95,61 @@ public sealed partial class LoginPageTests : EndpointsTestBase
         lockedOutMessage.ShouldBe(nonExistentMessage);
     }
 
+    /// <summary>
+    /// Every off-site target collapses to the home page instead of being carried into the
+    /// <c>Location</c> header. The <c>%09</c> case earns its own row: a prefix-only guard calls it
+    /// local, and handing it to <c>LocalRedirect</c> fails the executor's own check — so without the
+    /// control-character screen a successful login ends in an unhandled 500 rather than a redirect.
+    /// </summary>
+    [Theory]
+    [InlineData("/\t/evil.example")]
+    [InlineData("//evil.example")]
+    [InlineData("/\\evil.example")]
+    [InlineData("https://evil.example/harvest")]
+    public async Task LoginPage_ShouldRedirectHome_WhenReturnUrlIsNotLocal(string returnUrl)
+    {
+        // Arrange — a confirmed account, so the login itself succeeds and reaches the redirect
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        // Act
+        HttpResponseMessage response = await PostToLoginPageAsync(
+            new Dictionary<string, string>
+            {
+                ["Email"] = request.Email,
+                ["Password"] = request.Password
+            },
+            returnUrl);
+
+        // Assert — the off-site target is dropped, never reflected into the Location header
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        response.Headers.Location.ShouldNotBeNull();
+        response.Headers.Location!.OriginalString.ShouldBe("/");
+    }
+
+    [Fact]
+    public async Task LoginPage_ShouldResumeTheContinuation_WhenReturnUrlIsLocal()
+    {
+        // Arrange — the interrupted authorization the login flow is expected to resume
+        const string continuation = "/connect/authorize?client_id=lotrokoniecdev-test&response_type=code";
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        // Act
+        HttpResponseMessage response = await PostToLoginPageAsync(
+            new Dictionary<string, string>
+            {
+                ["Email"] = request.Email,
+                ["Password"] = request.Password
+            },
+            continuation);
+
+        // Assert — hardening must not break the flow it protects
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        response.Headers.Location.ShouldNotBeNull();
+        response.Headers.Location!.OriginalString.ShouldBe(continuation);
+    }
+
     private async Task LockOutAsync(string username)
     {
         await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
@@ -118,9 +174,21 @@ public sealed partial class LoginPageTests : EndpointsTestBase
         return match.Groups[1].Value.Trim();
     }
 
-    private async Task<HttpResponseMessage> PostToLoginPageAsync(Dictionary<string, string> formFields)
+    /// <summary>
+    /// Posts credentials to the login page, optionally carrying an OIDC continuation in the query
+    /// string. Both legs run on one non-redirecting client — it must be the same client so its cookie
+    /// container carries the antiforgery cookie from the GET into the POST, and non-redirecting so
+    /// the sign-in redirect target stays observable as a <c>Location</c> header instead of being
+    /// followed away.
+    /// </summary>
+    private async Task<HttpResponseMessage> PostToLoginPageAsync(
+        Dictionary<string, string> formFields,
+        string? returnUrl = null)
     {
-        HttpResponseMessage pageResponse = await ApiClient.Http.GetAsync(
+        using HttpClient browser = Factory.CreateClient(
+            new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        HttpResponseMessage pageResponse = await browser.GetAsync(
             new Uri("/Account/Login", UriKind.Relative));
         pageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
 
@@ -131,19 +199,15 @@ public sealed partial class LoginPageTests : EndpointsTestBase
             formFields["__RequestVerificationToken"] = antiForgeryToken;
         }
 
+        string postUrl = returnUrl is null
+            ? "/Account/Login"
+            : $"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}";
+
         using FormUrlEncodedContent content = new(formFields);
-        using HttpRequestMessage request = new(HttpMethod.Post, "/Account/Login");
+        using HttpRequestMessage request = new(HttpMethod.Post, postUrl);
         request.Content = content;
 
-        if (pageResponse.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
-        {
-            foreach (string cookie in cookies)
-            {
-                request.Headers.Add("Cookie", cookie.Split(';')[0]);
-            }
-        }
-
-        return await ApiClient.Http.SendAsync(request);
+        return await browser.SendAsync(request);
     }
 
     private static string? ExtractAntiForgeryToken(string html)

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Common/LocalReturnUrlTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Common/LocalReturnUrlTests.cs
@@ -1,0 +1,53 @@
+using LotroKoniecDev.AuthSystem.API.Common;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Common;
+
+/// <summary>
+/// The auth pages reflect <c>returnUrl</c> into their own links and redirect to it after a
+/// successful sign-in, so anything this guard lets through becomes an open redirect on the auth
+/// origin — the highest-value phishing target in the stack.
+/// </summary>
+public sealed class LocalReturnUrlTests
+{
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/dashboard")]
+    [InlineData("/translations?status=NeedsReview")]
+    [InlineData("/connect/authorize?client_id=web&redirect_uri=https%3A%2F%2Fapp.example%2Fcallback")]
+    public void Sanitize_WhenTargetIsALocalPath_KeepsItVerbatim(string returnUrl)
+    {
+        LocalReturnUrl.Sanitize(returnUrl).ShouldBe(returnUrl);
+    }
+
+    [Theory]
+    [InlineData("https://evil.example/harvest")]
+    [InlineData("http://evil.example")]
+    [InlineData("//evil.example")]
+    [InlineData("/\\evil.example")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("dashboard")]
+    [InlineData(" /dashboard")]
+    [InlineData("~/dashboard")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Sanitize_WhenTargetIsNotALocalPath_DropsIt(string? returnUrl)
+    {
+        LocalReturnUrl.Sanitize(returnUrl).ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Browsers strip ASCII tab and newline before parsing, so <c>/&lt;tab&gt;/evil.example</c> reads
+    /// as the protocol-relative <c>//evil.example</c> — it must never be reflected into a link on the
+    /// page. Arriving as <c>%09</c> in the query string, the value is already decoded by model
+    /// binding when it reaches the guard.
+    /// </summary>
+    [Theory]
+    [InlineData("/\t/evil.example")]
+    [InlineData("/\n/evil.example")]
+    [InlineData("/\r\n/evil.example")]
+    [InlineData("/\t\\evil.example")]
+    public void Sanitize_WhenTargetHidesBehindControlCharacters_DropsIt(string returnUrl)
+    {
+        LocalReturnUrl.Sanitize(returnUrl).ShouldBeNull();
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Pages/Account/LoginModelTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Pages/Account/LoginModelTests.cs
@@ -1,0 +1,68 @@
+using LotroKoniecDev.AuthSystem.API.Pages.Account;
+using LotroKoniecDev.AuthSystem.API.Settings;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Pages.Account;
+
+/// <summary>
+/// The login page both reflects <c>returnUrl</c> into its own form action and uses it as the
+/// post-sign-in redirect target, so the value has to be sanitized on the way in — a raw query value
+/// must never reach the property. Pins the wiring the register page already had.
+/// </summary>
+public sealed class LoginModelTests
+{
+    [Theory]
+    [InlineData("/connect/authorize?client_id=web", "/connect/authorize?client_id=web")]
+    [InlineData("/", "/")]
+    [InlineData("https://evil.example/harvest", null)]
+    [InlineData("//evil.example", null)]
+    [InlineData("/\\evil.example", null)]
+    [InlineData("/\t/evil.example", null)]
+    [InlineData(null, null)]
+    public void OnGet_KeepsOnlyALocalReturnUrl(string? returnUrl, string? expected)
+    {
+        LoginModel sut = CreateSut();
+
+        sut.OnGet(returnUrl);
+
+        sut.ReturnUrl.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("/connect/authorize?client_id=web", "/connect/authorize?client_id=web")]
+    [InlineData("https://evil.example/harvest", null)]
+    [InlineData("/\t/evil.example", null)]
+    public async Task OnPostAsync_KeepsOnlyALocalReturnUrl_EvenWhenTheCredentialsAreRejected(
+        string returnUrl, string? expected)
+    {
+        // The empty-credentials branch returns before any store call, so the re-rendered page is
+        // observable without a user — and that page carries ReturnUrl back into the form action.
+        LoginModel sut = CreateSut();
+
+        await sut.OnPostAsync(returnUrl);
+
+        sut.ReturnUrl.ShouldBe(expected);
+    }
+
+    private static LoginModel CreateSut() =>
+        new(
+            CreateUserManager(),
+            Microsoft.Extensions.Options.Options.Create(new GdprSettings()),
+            NullLogger<LoginModel>.Instance);
+
+    private static UserManager<ApplicationUser> CreateUserManager() =>
+        new(
+            Substitute.For<IUserStore<ApplicationUser>>(),
+            Microsoft.Extensions.Options.Options.Create(new IdentityOptions()),
+            new PasswordHasher<ApplicationUser>(),
+            [],
+            [],
+            new UpperInvariantLookupNormalizer(),
+            new IdentityErrorDescriber(),
+            services: null!,
+            NullLogger<UserManager<ApplicationUser>>.Instance);
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/AuthEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Auth/AuthEndpointsExtensionsTests.cs
@@ -68,6 +68,10 @@ public sealed class AuthEndpointsExtensionsTests
     [InlineData("https://evil.example.com/harvest", "/")]
     [InlineData("//evil.example.com", "/")]
     [InlineData("/\\evil.example.com", "/")]
+    // Browsers strip ASCII tab/newline, so this would resolve to the protocol-relative
+    // "//evil.example.com" once the challenge's RedirectUri reaches the address bar.
+    [InlineData("/\t/evil.example.com", "/")]
+    [InlineData("/\r\n/evil.example.com", "/")]
     [InlineData("", "/")]
     [InlineData(null, "/")]
     public async Task LoginAsync_WhenAuthorityReachable_SanitizesReturnUrlToALocalRedirect(
@@ -121,6 +125,8 @@ public sealed class AuthEndpointsExtensionsTests
     [InlineData("https://evil.example.com/harvest")]
     [InlineData("//evil.example.com")]
     [InlineData("/\\evil.example.com")]
+    [InlineData("/\t/evil.example.com")]
+    [InlineData("/\r\n/evil.example.com")]
     [InlineData("")]
     [InlineData(null)]
     public async Task LocalSignOutAsync_WhenReturnUrlIsNotLocal_RedirectsHome(string? returnUrl)

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Security/LocalReturnUrlTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Security/LocalReturnUrlTests.cs
@@ -1,0 +1,52 @@
+using LotroKoniecDev.Frontend.Infrastructure.Security;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Security;
+
+/// <summary>
+/// Guards the login challenge, the local sign-out and the cookie-consent bounce-back — every route
+/// that redirects to a caller-supplied target. Twin of the auth server's <c>LocalReturnUrlTests</c>:
+/// the two guards must stay behaviourally identical.
+/// </summary>
+public sealed class LocalReturnUrlTests
+{
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/dashboard")]
+    [InlineData("/translations?status=NeedsReview")]
+    [InlineData("/account/deletion-scheduled?until=2026-07-25T10%3A00%3A00Z")]
+    public void Sanitize_WhenTargetIsALocalPath_KeepsItVerbatim(string returnUrl)
+    {
+        LocalReturnUrl.Sanitize(returnUrl).ShouldBe(returnUrl);
+    }
+
+    [Theory]
+    [InlineData("https://evil.example/harvest")]
+    [InlineData("http://evil.example")]
+    [InlineData("//evil.example")]
+    [InlineData("/\\evil.example")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("dashboard")]
+    [InlineData(" /dashboard")]
+    [InlineData("~/dashboard")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Sanitize_WhenTargetIsNotALocalPath_DropsIt(string? returnUrl)
+    {
+        LocalReturnUrl.Sanitize(returnUrl).ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Browsers strip ASCII tab and newline before parsing a URL, so
+    /// <c>Location: /&lt;tab&gt;/evil.example</c> is followed as the protocol-relative
+    /// <c>//evil.example</c> — a prefix-only check would call that value local.
+    /// </summary>
+    [Theory]
+    [InlineData("/\t/evil.example")]
+    [InlineData("/\n/evil.example")]
+    [InlineData("/\r\n/evil.example")]
+    [InlineData("/\t\\evil.example")]
+    public void Sanitize_WhenTargetHidesBehindControlCharacters_DropsIt(string returnUrl)
+    {
+        LocalReturnUrl.Sanitize(returnUrl).ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## What this fixes

The repo had **three** separate local-URL guards and only one of them rejected control characters. Browsers strip ASCII tab and newline before parsing a URL, so `/%09/evil.example` (a tab after the slash) reads as the protocol-relative `//evil.example`. A prefix-only guard calls that value local and hands it straight to a redirect.

### The real gap — frontend

`AuthEndpointsExtensions.IsLocalUrl` guarded the login challenge (`RedirectUri`) and the local sign-out (`Results.Redirect`). Neither sink validates its target, so a tab-hidden host survived into the `Location` header. The cookie-consent guard sitting right next to it already had this exact fix (#468) — this call site was missed when that landed.

### The smaller one — auth server

The login page stored the **raw** query value in `ReturnUrl` and reflected it into its own form action, while the register page sanitized the same value. The redirect itself was already safe: `LocalRedirect`'s executor rejects such a target on .NET 10. But it rejects by *throwing*, so the tab case would turn a successful login into an unhandled 500 rather than a clean bounce home. This inconsistency is also what CodeQL flags as `cs/web/xss` on `Login.cshtml:546` and `Register.cshtml:487`.

## The change

One guard per assembly, replacing all three copies:

| File | Used by |
|---|---|
| `src/AuthSystem/.../Common/LocalReturnUrl.cs` | login page, register page |
| `src/Frontend/.../Infrastructure/Security/LocalReturnUrl.cs` | login challenge, local sign-out, cookie-consent bounce-back |

Both reject anything that is not a same-site path, plus control characters and the `~/` form no page emits. They are deliberate twins — the doc comment on each says to change both together, the same rule the repo already applies to its `.sh`/`.ps1` script twins. They live in separate assemblies because the frontend does not reference SharedKernel, and a new shared project for one predicate is not worth the Dockerfile restore-graph churn.

The login page now sanitizes on the way in, exactly like register already did, and redirects to the sanitized property instead of re-checking the raw parameter.

## Tests

- A shared hostile-input matrix in both assemblies: absolute, protocol-relative, backslash, `javascript:`, tilde, leading-space, tab, LF, CRLF — plus the local paths that must survive verbatim, including a real `/connect/authorize?...` continuation.
- A login page-model test pinning the sanitizing wiring on both `OnGet` and `OnPost`.
- An integration test that drives a real login against PostgreSQL and asserts the `Location` header, both for hostile targets (must collapse to `/`) and for a local continuation (must be resumed).

Verified the tests actually bite: removing the control-character screen fails **16** unit tests and the integration case. Full local run — solution build 0 warnings / 0 errors, AuthSystem unit 36/36, Frontend unit 437/437, AuthSystem integration 282/282, plus the SSR-purity and Dockerfile restore-graph guards.

## Notes

- No ticket — found while investigating the two open CodeQL alerts.
- No schema change, no config change, nothing to deploy beyond the images.