### PR TITLE
Land on the frontend when a login carries no continuation, not on the auth-api JSON root

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Common/FrontendUrl.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Common/FrontendUrl.cs
@@ -1,0 +1,24 @@
+using LotroKoniecDev.AuthSystem.API.Settings;
+
+namespace LotroKoniecDev.AuthSystem.API.Common;
+
+/// <summary>
+/// Builds absolute frontend URLs from the web client's app root — its first post-logout redirect URI —
+/// so the auth pages can link and redirect to the application without a frontend-origin setting of
+/// their own. The two contexts share no code, so the paths passed in mirror frontend routes and a
+/// rename there has to be repeated at the call site.
+/// </summary>
+/// <remarks>
+/// The scheme screen is load-bearing: on Unix a bare path such as <c>"/app"</c> parses as an absolute
+/// <c>file://</c> URI, so a misconfigured app root would otherwise yield a <c>file:///…</c> target.
+/// </remarks>
+internal static class FrontendUrl
+{
+    internal static string? For(WebClientSettings webClient, string path) =>
+        webClient.PostLogoutRedirectUris is [string appRoot, ..]
+        && Uri.TryCreate(appRoot, UriKind.Absolute, out Uri? appRootUri)
+        && (string.Equals(appRootUri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal)
+            || string.Equals(appRootUri.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal))
+            ? new Uri(appRootUri, path).ToString()
+            : null;
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
@@ -33,16 +33,28 @@ internal sealed partial class LoginModel : PageModel
     private static readonly string DummyPasswordHash =
         new PasswordHasher<ApplicationUser>().HashPassword(new ApplicationUser(), "DummyP@ssw0rd!");
 
+    /// <summary>
+    /// The frontend's own login route, which turns the freshly issued auth cookie into an application
+    /// session through a silent OIDC challenge. Mirrors the Frontend's
+    /// <c>AuthenticationDependencyInjectionExtensions.LoginPath</c>; the two contexts share no code, so
+    /// a rename there has to be repeated here (same arrangement as the register page's
+    /// <c>/regulamin</c> link).
+    /// </summary>
+    private const string FrontendLoginPath = "/auth/login";
+
     private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IOptions<OpenIddictSettings> _openIddictSettings;
     private readonly GdprSettings _gdprSettings;
     private readonly ILogger<LoginModel> _logger;
 
     public LoginModel(
         UserManager<ApplicationUser> userManager,
+        IOptions<OpenIddictSettings> openIddictSettings,
         IOptions<GdprSettings> gdprSettings,
         ILogger<LoginModel> logger)
     {
         _userManager = userManager;
+        _openIddictSettings = openIddictSettings;
         _gdprSettings = gdprSettings.Value;
         _logger = logger;
     }
@@ -63,6 +75,16 @@ internal sealed partial class LoginModel : PageModel
     /// <see cref="LocalReturnUrl.Sanitize"/>, which blocks open redirects.
     /// </summary>
     public string? ReturnUrl { get; set; }
+
+    /// <summary>
+    /// Absolute URL of the frontend's login route. Only ever the fallback for a sign-in that carries no
+    /// local continuation: this host's own root answers with the API discovery JSON, which dead-ends a
+    /// browser arriving from the reset-password or confirm-email pages. The target comes from trusted
+    /// configuration, never from the request. Null when the web client is not configured (e.g. a bare
+    /// test host) — the sign-in then falls back to the local root.
+    /// </summary>
+    public string? FrontendLoginUrl =>
+        FrontendUrl.For(_openIddictSettings.Value.WebClient, FrontendLoginPath);
 
     public string? ErrorMessage { get; set; }
 
@@ -187,7 +209,14 @@ internal sealed partial class LoginModel : PageModel
 
         LogUserLoggedIn(_logger, user.Id);
 
-        return LocalRedirect(ReturnUrl ?? "/");
+        if (ReturnUrl is not null)
+        {
+            return LocalRedirect(ReturnUrl);
+        }
+
+        return FrontendLoginUrl is { } frontendLoginUrl
+            ? Redirect(frontendLoginUrl)
+            : LocalRedirect("/");
     }
 
     [LoggerMessage(EventId = EventIds.LoginUserNotFound, Level = LogLevel.Warning, Message = "Failed login: user not found. Email: {Email}, IP: {IP}")]

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml.cs
@@ -15,6 +15,12 @@ namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
 
 internal sealed partial class RegisterModel : PageModel
 {
+    /// <summary>
+    /// The frontend's terms-of-service route; mirrors a page owned by the other context, so a rename
+    /// there has to be repeated here.
+    /// </summary>
+    private const string TermsOfServicePath = "/regulamin";
+
     private readonly ICommandHandler<RegisterUser.Command, Result<IdentityId>> _registerUserHandler;
     private readonly IOptions<OpenIddictSettings> _openIddictSettings;
     private readonly ILogger<RegisterModel> _logger;
@@ -53,16 +59,12 @@ internal sealed partial class RegisterModel : PageModel
     public bool IsRegistered { get; set; }
 
     /// <summary>
-    /// Absolute URL of the terms-of-service page on the frontend, derived from the web client's
-    /// first post-logout redirect URI (the app root) so no separate frontend-origin setting is
-    /// needed. Null when the client is not configured (e.g. a bare test host) — the register page
-    /// then renders the consent label without a link.
+    /// Absolute URL of the terms-of-service page on the frontend. Null when the web client is not
+    /// configured (e.g. a bare test host) — the register page then renders the consent label without
+    /// a link.
     /// </summary>
     public string? TermsOfServiceUrl =>
-        _openIddictSettings.Value.WebClient.PostLogoutRedirectUris is [string appRoot, ..]
-        && Uri.TryCreate(appRoot, UriKind.Absolute, out Uri? appRootUri)
-            ? new Uri(appRootUri, "/regulamin").ToString()
-            : null;
+        FrontendUrl.For(_openIddictSettings.Value.WebClient, TermsOfServicePath);
 
     public string? ErrorMessage { get; set; }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -28,6 +28,13 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
 
     public const string TestApiClientSecret = "integration-test-secret-32-chars!";
 
+    /// <summary>
+    /// Origin of the web client this host is configured with. It doubles as the frontend origin the
+    /// login page falls back to when a sign-in carries no continuation, so tests assert against it
+    /// instead of repeating the literal.
+    /// </summary>
+    public const string TestFrontendAppRoot = "https://localhost:5001";
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
@@ -43,8 +50,8 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
                 { "OpenIddict:EncryptionKey:Key", "RGV2RW5jcnlwdGlvbktleTMyQnl0ZXNMb25nMTIzNDU=" },
                 { "OpenIddict:SigningKey:Key", "RGV2U2lnbmluZ0tleTMyQnl0ZXNMb25nRW5vdWdoMTI=" },
                 { "OpenIddict:ApiClientSecret", TestApiClientSecret },
-                { "OpenIddict:WebClient:RedirectUris:0", "https://localhost:5001/callback" },
-                { "OpenIddict:WebClient:PostLogoutRedirectUris:0", "https://localhost:5001" },
+                { "OpenIddict:WebClient:RedirectUris:0", TestFrontendAppRoot + "/callback" },
+                { "OpenIddict:WebClient:PostLogoutRedirectUris:0", TestFrontendAppRoot },
                 { "AdminUser:Username", "seededadmin" },
                 { "AdminUser:Email", "admin@lotro-translator.pl" },
                 { "AdminUser:Password", "AdminTest123!" },

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
@@ -11,6 +11,12 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
 
 public sealed partial class LoginPageTests : EndpointsTestBase
 {
+    /// <summary>
+    /// Where a sign-in without a usable continuation has to land: the frontend's own login route,
+    /// derived from the web client origin this host is configured with.
+    /// </summary>
+    private const string ExpectedFrontendLoginUrl = AuthSystemApiFactory.TestFrontendAppRoot + "/auth/login";
+
     public LoginPageTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
 
     [Fact]
@@ -96,7 +102,7 @@ public sealed partial class LoginPageTests : EndpointsTestBase
     }
 
     /// <summary>
-    /// Every off-site target collapses to the home page instead of being carried into the
+    /// Every off-site target collapses to the configured frontend instead of being carried into the
     /// <c>Location</c> header. The <c>%09</c> case earns its own row: a prefix-only guard calls it
     /// local, and handing it to <c>LocalRedirect</c> fails the executor's own check — so without the
     /// control-character screen a successful login ends in an unhandled 500 rather than a redirect.
@@ -106,7 +112,7 @@ public sealed partial class LoginPageTests : EndpointsTestBase
     [InlineData("//evil.example")]
     [InlineData("/\\evil.example")]
     [InlineData("https://evil.example/harvest")]
-    public async Task LoginPage_ShouldRedirectHome_WhenReturnUrlIsNotLocal(string returnUrl)
+    public async Task LoginPage_ShouldRedirectToTheFrontend_WhenReturnUrlIsNotLocal(string returnUrl)
     {
         // Arrange — a confirmed account, so the login itself succeeds and reaches the redirect
         (RegisterRequest request, _) =
@@ -121,10 +127,36 @@ public sealed partial class LoginPageTests : EndpointsTestBase
             },
             returnUrl);
 
-        // Assert — the off-site target is dropped, never reflected into the Location header
+        // Assert — the off-site target is dropped; the fallback comes from configuration, not the query
         response.StatusCode.ShouldBe(HttpStatusCode.Found);
         response.Headers.Location.ShouldNotBeNull();
-        response.Headers.Location!.OriginalString.ShouldBe("/");
+        response.Headers.Location!.OriginalString.ShouldBe(ExpectedFrontendLoginUrl);
+    }
+
+    /// <summary>
+    /// The reset-password and confirm-email pages send the user to a bare <c>/Account/Login</c>, so a
+    /// successful sign-in has no continuation to resume. This host's root serves the discovery JSON,
+    /// which dead-ends the browser — the fallback has to leave for the frontend's login route, where
+    /// the cookie just issued completes the OIDC challenge silently.
+    /// </summary>
+    [Fact]
+    public async Task LoginPage_ShouldRedirectToTheFrontend_WhenThereIsNoReturnUrl()
+    {
+        // Arrange — a confirmed account, mirroring a user who just reset their password
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        // Act
+        HttpResponseMessage response = await PostToLoginPageAsync(new Dictionary<string, string>
+        {
+            ["Email"] = request.Email,
+            ["Password"] = request.Password
+        });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        response.Headers.Location.ShouldNotBeNull();
+        response.Headers.Location!.OriginalString.ShouldBe(ExpectedFrontendLoginUrl);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Common/FrontendUrlTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Common/FrontendUrlTests.cs
@@ -1,0 +1,59 @@
+using LotroKoniecDev.AuthSystem.API.Common;
+using LotroKoniecDev.AuthSystem.API.Settings;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Common;
+
+/// <summary>
+/// The auth pages link and redirect to the frontend using the web client's app root as the only
+/// origin source, so this is what keeps a browser from being dropped on the auth host — whose root
+/// serves the API discovery JSON — or on a bogus target when the client is unconfigured.
+/// </summary>
+public sealed class FrontendUrlTests
+{
+    [Theory]
+    [InlineData("https://lotro-translator.pl", "/auth/login", "https://lotro-translator.pl/auth/login")]
+    [InlineData("https://lotro-translator.pl/", "/regulamin", "https://lotro-translator.pl/regulamin")]
+    [InlineData("https://localhost:7017", "/auth/login", "https://localhost:7017/auth/login")]
+    [InlineData("http://localhost:7017", "/regulamin", "http://localhost:7017/regulamin")]
+    public void For_BuildsTheAbsoluteUrl_FromTheConfiguredAppRoot(string appRoot, string path, string expected)
+    {
+        WebClientSettings webClient = new() { PostLogoutRedirectUris = [appRoot] };
+
+        FrontendUrl.For(webClient, path).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void For_KeepsTheOriginOnly_WhenTheAppRootCarriesAPath()
+    {
+        // The app root doubles as the post-logout landing page, so it may carry a path — the frontend
+        // routes below are absolute and must not be appended to it.
+        WebClientSettings webClient = new() { PostLogoutRedirectUris = ["https://lotro-translator.pl/wylogowano"] };
+
+        FrontendUrl.For(webClient, "/auth/login").ShouldBe("https://lotro-translator.pl/auth/login");
+    }
+
+    [Fact]
+    public void For_IsNull_WhenTheWebClientHasNoConfiguredUri()
+    {
+        WebClientSettings webClient = new();
+
+        FrontendUrl.For(webClient, "/auth/login").ShouldBeNull();
+    }
+
+    /// <summary>
+    /// A bare path parses as an absolute <c>file://</c> URI on Unix, so the scheme screen is what keeps
+    /// a misconfigured app root from producing a <c>file:///auth/login</c> redirect target.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-an-absolute-url")]
+    [InlineData("/app")]
+    [InlineData("ftp://lotro-translator.pl")]
+    [InlineData("javascript:alert(1)")]
+    public void For_IsNull_WhenTheConfiguredAppRootIsNotAnHttpUrl(string appRoot)
+    {
+        WebClientSettings webClient = new() { PostLogoutRedirectUris = [appRoot] };
+
+        FrontendUrl.For(webClient, "/auth/login").ShouldBeNull();
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Pages/Account/LoginModelTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Pages/Account/LoginModelTests.cs
@@ -48,9 +48,36 @@ public sealed class LoginModelTests
         sut.ReturnUrl.ShouldBe(expected);
     }
 
-    private static LoginModel CreateSut() =>
+    /// <summary>
+    /// The sign-in falls back to this URL when it carries no local continuation, so it must point at
+    /// the frontend's own login route — this host's root serves the API discovery JSON and dead-ends a
+    /// browser arriving from the reset-password or confirm-email pages. The URL-building rules
+    /// themselves are pinned by <c>FrontendUrlTests</c>.
+    /// </summary>
+    [Fact]
+    public void FrontendLoginUrl_PointsAtTheFrontendLoginRoute()
+    {
+        LoginModel sut = CreateSut("https://lotro-translator.pl");
+
+        sut.FrontendLoginUrl.ShouldBe("https://lotro-translator.pl/auth/login");
+    }
+
+    [Fact]
+    public void FrontendLoginUrl_IsNull_WhenTheWebClientHasNoConfiguredUri()
+    {
+        LoginModel sut = CreateSut();
+
+        sut.FrontendLoginUrl.ShouldBeNull();
+    }
+
+    private static LoginModel CreateSut(params string[] postLogoutRedirectUris) =>
         new(
             CreateUserManager(),
+            Microsoft.Extensions.Options.Options.Create(new OpenIddictSettings
+            {
+                Issuer = "https://auth.localhost",
+                WebClient = new WebClientSettings { PostLogoutRedirectUris = postLogoutRedirectUris }
+            }),
             Microsoft.Extensions.Options.Options.Create(new GdprSettings()),
             NullLogger<LoginModel>.Instance);
 


### PR DESCRIPTION
Closes #537

## What was broken

Reset password → e-mail link → new password → **"Zaloguj się"** → login → the user landed on `https://auth.lotro-translator.pl/`, which answers with the API discovery JSON `{"name":"LotroKoniecDev.AuthSystem"}`. Signed in on the auth server, dead-ended in the browser.

Every auth page links to a bare `/Account/Login` with no `returnUrl`, so this also hit **the first login right after registration** (confirm-email), plus resend-confirmation and cancel-deletion. `Login.cshtml.cs` ended with `LocalRedirect(ReturnUrl ?? "/")`, and `/` on the auth host is the discovery endpoint — that host has no UI home page, so it is never a sensible landing spot for a browser.

## What changed

- **`LoginModel`**: with no local continuation the sign-in now redirects to the frontend's own login route (`/auth/login`). The auth cookie was just issued, so the OIDC challenge there completes silently and the user lands in the app signed in — one click, no second password prompt.
- The frontend origin comes from `OpenIddict:WebClient:PostLogoutRedirectUris[0]` — **trusted configuration, never the request** — so no new setting and no open-redirect surface. An unconfigured web client (bare test host) still falls back to `LocalRedirect("/")`.
- A valid local `returnUrl` still wins, so the OIDC flow started from the frontend is untouched.
- The app-root derivation moved into `Common/FrontendUrl`, shared with the register page's terms link. The helper also screens the scheme: on Unix a bare path parses as an absolute `file://` URI, so a misconfigured app root used to render a `file:///regulamin` link.

## How it was tested

- `AuthSystem.API.Tests.Unit` — 49 passed. New `FrontendUrlTests` (app root → absolute URL, path-carrying root keeps origin only, unconfigured/non-http roots → null) + `LoginModelTests` for the page's own fallback URL.
- `AuthSystem.API.Tests.Integration` — 283 passed (real PostgreSQL). New `LoginPage_ShouldRedirectToTheFrontend_WhenThereIsNoReturnUrl`; the existing off-site-`returnUrl` theory now asserts the same frontend fallback instead of `/`; the local-continuation test is unchanged.
- Solution build: 0 warnings, 0 errors. All other unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqgaD9zAwz4vnvrNDHJQ9h