### PR TITLE
Force every link in transactional e-mails to gold

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/Templates/EmailTemplateRenderer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/Templates/EmailTemplateRenderer.cs
@@ -1,5 +1,8 @@
 using System.Net;
 using System.Text;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Common;
+using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
 
 namespace LotroKoniecDev.AuthSystem.API.Services.Emails.Templates;
@@ -10,6 +13,13 @@ namespace LotroKoniecDev.AuthSystem.API.Services.Emails.Templates;
 /// and the palette is the frontend's OKLCH design tokens converted to hex — mail clients do not
 /// support OKLCH.
 /// </summary>
+/// <remarks>
+/// The layout is dark, so link colour cannot be left to the client: clients auto-link bare domains
+/// and addresses in body text and paint those anchors their own default blue, which is unreadable
+/// here. Two defences, because either alone has a gap — a <c>&lt;style&gt;</c> override recolours
+/// links this renderer never created, and the anchors it does create carry the colour inline for
+/// clients that drop the block.
+/// </remarks>
 internal sealed class EmailTemplateRenderer : IEmailTemplateRenderer
 {
     private const string FontStack =
@@ -24,6 +34,15 @@ internal sealed class EmailTemplateRenderer : IEmailTemplateRenderer
     private const string ColorAccent = "#d9b160";
     private const string ColorAccentInk = "#100d08";
 
+    private readonly string? _homeUrl;
+
+    public EmailTemplateRenderer(IOptions<OpenIddictSettings> openIddictSettings)
+    {
+        ArgumentNullException.ThrowIfNull(openIddictSettings);
+
+        _homeUrl = FrontendUrl.For(openIddictSettings.Value.WebClient, "/");
+    }
+
     public EmailBody Render(EmailTemplateModel model)
     {
         ArgumentNullException.ThrowIfNull(model);
@@ -31,7 +50,32 @@ internal sealed class EmailTemplateRenderer : IEmailTemplateRenderer
         return new EmailBody(RenderHtml(model), RenderPlainText(model));
     }
 
-    private static string RenderHtml(EmailTemplateModel model)
+    /// <summary>
+    /// Wins over a client's own link colour, including on anchors it generates itself. The button
+    /// keeps dark ink, or the blanket rule would paint gold text onto a gold background.
+    /// </summary>
+    private static string RenderStyleOverrides() =>
+        $$"""
+          <style>
+          a{color:{{ColorAccent}} !important;}
+          a.cta,a.cta:visited,a.cta:hover{color:{{ColorAccentInk}} !important;text-decoration:none !important;}
+          a.brand,a.brand:visited{text-decoration:none !important;}
+          a[x-apple-data-detectors]{color:{{ColorAccent}} !important;}
+          </style>
+          """;
+
+    private string RenderBrand()
+    {
+        if (_homeUrl is null)
+        {
+            return EmailBranding.Name;
+        }
+
+        string href = WebUtility.HtmlEncode(_homeUrl);
+        return $"""<a class="brand" href="{href}" style="color:{ColorAccent};text-decoration:none;">{EmailBranding.Name}</a>""";
+    }
+
+    private string RenderHtml(EmailTemplateModel model)
     {
         string heading = WebUtility.HtmlEncode(model.Heading);
         StringBuilder builder = new();
@@ -44,13 +88,14 @@ internal sealed class EmailTemplateRenderer : IEmailTemplateRenderer
              <meta charset="utf-8">
              <meta name="viewport" content="width=device-width,initial-scale=1">
              <title>{heading}</title>
+             {RenderStyleOverrides()}
              </head>
              <body style="margin:0;padding:0;background-color:{ColorBackground};">
              <div style="display:none;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;color:{ColorBackground};">{WebUtility.HtmlEncode(model.Preheader)}</div>
              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:{ColorBackground};">
              <tr><td align="center" style="padding:32px 16px;">
              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="560" style="width:100%;max-width:560px;background-color:{ColorSurface};border:1px solid {ColorBorder};border-radius:14px;">
-             <tr><td style="padding:28px 32px 0;font-family:{FontStack};font-size:15px;font-weight:700;letter-spacing:0.02em;color:{ColorAccent};">{EmailBranding.Name}</td></tr>
+             <tr><td style="padding:28px 32px 0;font-family:{FontStack};font-size:15px;font-weight:700;letter-spacing:0.02em;color:{ColorAccent};">{RenderBrand()}</td></tr>
              <tr><td style="padding:18px 32px 0;font-family:{FontStack};font-size:22px;line-height:1.3;font-weight:700;color:{ColorText};">{heading}</td></tr>
              """);
 
@@ -72,8 +117,8 @@ internal sealed class EmailTemplateRenderer : IEmailTemplateRenderer
 
                  <tr><td style="padding:26px 32px 0;">
                  <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>
-                 <td align="center" bgcolor="{ColorAccent}" style="border-radius:8px;">
-                 <a href="{href}" style="display:inline-block;padding:13px 28px;font-family:{FontStack};font-size:15px;font-weight:700;color:{ColorAccentInk};text-decoration:none;border-radius:8px;">{WebUtility.HtmlEncode(callToAction.Label)}</a>
+                 <td align="center" bgcolor="{ColorAccent}" style="background-color:{ColorAccent};border-radius:8px;">
+                 <a class="cta" href="{href}" style="display:inline-block;padding:13px 28px;font-family:{FontStack};font-size:15px;font-weight:700;color:{ColorAccentInk};text-decoration:none;border-radius:8px;">{WebUtility.HtmlEncode(callToAction.Label)}</a>
                  </td></tr></table>
                  </td></tr>
                  <tr><td style="padding:18px 32px 0;font-family:{FontStack};font-size:13px;line-height:1.6;color:{ColorTextDim};">
@@ -101,7 +146,7 @@ internal sealed class EmailTemplateRenderer : IEmailTemplateRenderer
              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="560" style="width:100%;max-width:560px;">
              <tr><td align="center" style="padding:18px 32px 0;font-family:{FontStack};font-size:12px;line-height:1.6;color:{ColorTextDim};">
              Wiadomość wysłana automatycznie — prosimy na nią nie odpowiadać.<br>
-             {EmailBranding.Name} — {EmailBranding.Tagline}
+             {RenderBrand()} — {EmailBranding.Tagline}
              </td></tr>
              </table>
              </td></tr>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/Templates/EmailTemplateRendererTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/Templates/EmailTemplateRendererTests.cs
@@ -1,10 +1,23 @@
 using LotroKoniecDev.AuthSystem.API.Services.Emails.Templates;
+using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
 
 namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Services.Emails.Templates;
 
 public sealed class EmailTemplateRendererTests
 {
+    private const string AppRoot = "https://lotro-translator.pl";
+
+    private static EmailTemplateRenderer BuildRenderer(string? appRoot = AppRoot) =>
+        new(Microsoft.Extensions.Options.Options.Create(new OpenIddictSettings
+        {
+            Issuer = "https://auth.lotro-translator.pl",
+            WebClient = new WebClientSettings
+            {
+                PostLogoutRedirectUris = appRoot is null ? [] : [appRoot]
+            }
+        }));
+
     private static EmailTemplateModel BuildModel(
         EmailCallToAction? callToAction = null,
         string? securityNote = null,
@@ -23,7 +36,7 @@ public sealed class EmailTemplateRendererTests
     public void Render_AnyModel_PutsHeadingAndParagraphsInBothBodies()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         EmailTemplateModel model = BuildModel(heading: "Potwierdź swoje konto", paragraphs: ["Dziękujemy za rejestrację."]);
 
         // Act
@@ -40,7 +53,7 @@ public sealed class EmailTemplateRendererTests
     public void Render_ModelWithCallToAction_RendersTheLabelAsAnHtmlLink()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         EmailTemplateModel model = BuildModel(
             new EmailCallToAction("Ustaw nowe hasło", "https://auth.lotro-translator.pl/Account/ResetPassword"));
 
@@ -56,7 +69,7 @@ public sealed class EmailTemplateRendererTests
     public void Render_CallToActionUrlWithQueryParameters_EscapesAmpersandsInHtmlOnly()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         const string url = "https://auth.lotro-translator.pl/Account/ResetPassword?email=a%40b.pl&token=CfDJ8A";
         EmailTemplateModel model = BuildModel(new EmailCallToAction("Ustaw nowe hasło", url));
 
@@ -73,7 +86,7 @@ public sealed class EmailTemplateRendererTests
     public void Render_CallToAction_RepeatsTheUrlAsCopyablePlainText()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         const string url = "https://auth.lotro-translator.pl/Account/ConfirmEmail?token=abc";
         EmailTemplateModel model = BuildModel(new EmailCallToAction("Potwierdź konto", url));
 
@@ -86,26 +99,87 @@ public sealed class EmailTemplateRendererTests
     }
 
     [Fact]
-    public void Render_ModelWithoutCallToAction_RendersNoLink()
+    public void Render_ModelWithoutCallToAction_RendersNoButtonOrFallbackLink()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         EmailTemplateModel model = BuildModel(callToAction: null);
 
         // Act
         EmailBody body = renderer.Render(model);
 
         // Assert
-        body.Html.ShouldNotContain("<a href=");
+        body.Html.ShouldNotContain("class=\"cta\"");
         body.Html.ShouldNotContain("Jeśli przycisk nie działa");
         body.PlainText.ShouldNotContain("http");
+    }
+
+    [Fact]
+    public void Render_Always_OverridesTheClientDefaultLinkColour()
+    {
+        // Arrange
+        EmailTemplateRenderer renderer = BuildRenderer();
+        EmailTemplateModel model = BuildModel();
+
+        // Act
+        EmailBody body = renderer.Render(model);
+
+        // Assert
+        body.Html.ShouldContain("a{color:#d9b160 !important;}");
+        body.Html.ShouldContain("a[x-apple-data-detectors]{color:#d9b160 !important;}");
+    }
+
+    [Fact]
+    public void Render_CallToAction_ExemptsTheButtonFromTheGoldOverride()
+    {
+        // Arrange
+        EmailTemplateRenderer renderer = BuildRenderer();
+        EmailTemplateModel model = BuildModel(
+            new EmailCallToAction("Ustaw nowe hasło", "https://auth.lotro-translator.pl/Account/ResetPassword"));
+
+        // Act
+        EmailBody body = renderer.Render(model);
+
+        // Assert
+        body.Html.ShouldContain("a.cta,a.cta:visited,a.cta:hover{color:#100d08 !important;");
+        body.Html.ShouldContain("<a class=\"cta\"");
+    }
+
+    [Fact]
+    public void Render_ConfiguredWebClient_TurnsTheBrandIntoAGoldLink()
+    {
+        // Arrange
+        EmailTemplateRenderer renderer = BuildRenderer(AppRoot);
+        EmailTemplateModel model = BuildModel();
+
+        // Act
+        EmailBody body = renderer.Render(model);
+
+        // Assert
+        body.Html.ShouldContain($"<a class=\"brand\" href=\"{AppRoot}/\" style=\"color:#d9b160;");
+        body.Html.ShouldContain(EmailBranding.Name);
+    }
+
+    [Fact]
+    public void Render_UnconfiguredWebClient_LeavesTheBrandAsPlainText()
+    {
+        // Arrange
+        EmailTemplateRenderer renderer = BuildRenderer(appRoot: null);
+        EmailTemplateModel model = BuildModel();
+
+        // Act
+        EmailBody body = renderer.Render(model);
+
+        // Assert
+        body.Html.ShouldNotContain("class=\"brand\"");
+        body.Html.ShouldContain(EmailBranding.Name);
     }
 
     [Fact]
     public void Render_MarkupInModelText_IsHtmlEncodedButLeftRawInPlainText()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         EmailTemplateModel model = BuildModel(
             heading: "<script>alert(1)</script>",
             paragraphs: ["Tekst z <b>znacznikiem</b>"]);
@@ -124,7 +198,7 @@ public sealed class EmailTemplateRendererTests
     public void Render_MarkupInCallToAction_IsHtmlEncoded()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         EmailTemplateModel model = BuildModel(
             new EmailCallToAction("\"><script>alert(1)</script>", "https://auth.lotro-translator.pl/\"><script>"));
 
@@ -141,7 +215,7 @@ public sealed class EmailTemplateRendererTests
     public void Render_ModelWithSecurityNote_ShowsItInBothBodies()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         const string note = "Jeśli to nie Ty prosiłeś(-aś) o reset hasła, zignoruj tę wiadomość.";
         EmailTemplateModel model = BuildModel(securityNote: note);
 
@@ -157,7 +231,7 @@ public sealed class EmailTemplateRendererTests
     public void Render_ModelWithoutSecurityNote_OmitsTheNoteSection()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         EmailTemplateModel model = BuildModel(securityNote: null);
 
         // Act
@@ -171,7 +245,7 @@ public sealed class EmailTemplateRendererTests
     public void Render_AnyModel_BrandsBothBodiesAndHidesThePreheader()
     {
         // Arrange
-        EmailTemplateRenderer renderer = new();
+        EmailTemplateRenderer renderer = BuildRenderer();
         EmailTemplateModel model = BuildModel();
 
         // Act


### PR DESCRIPTION
Follow-up to #541.

## Problem

On the dark layout the mail client's own link colour is a dark blue that is almost invisible. It appears on anchors the renderer never wrote: clients auto-link bare domains and addresses in body text, and `lotro-translator.pl` sits in the header, a paragraph and the footer, so all three render as blue links. The fallback URL under the button was the only one that looked right, because it is an anchor we styled ourselves.

## Fix

Two defences, because either alone leaves a gap:

1. **`<style>` override** — `a { color: #d9b160 !important }`. This is the only thing that reaches anchors the client generates itself; no inline style can touch those. Includes an `a[x-apple-data-detectors]` rule for Apple Mail.
2. **Own the brand links** — the brand in the header and footer becomes a real anchor carrying the colour inline, so clients that drop the `<style>` block still get gold. Its target comes from the web client's app root via the existing `FrontendUrl` helper, so a staging mail links to staging, not prod. When the web client is unconfigured it degrades to plain text, mirroring how the register page handles a missing terms-of-service URL.

The CTA button is exempted by class (`a.cta`), or the blanket rule would paint gold text onto its gold background. Its cell now also carries `background-color` in the style attribute next to the `bgcolor` attribute, so the dark button text keeps a background in clients that honour only one of the two.

## Testing

- `AuthSystem.API.Tests.Unit` — 71 passed, 4 new: the colour override is emitted, the button is exempted from it, a configured web client turns the brand into a gold link, an unconfigured one leaves it as plain text. The existing "no call to action" test now asserts on the button and fallback specifically, since the brand is legitimately a link.
- `AuthSystem.API.Tests.Integration` — 283 passed.
- `Frontend.Tests.Unit` 437, `TranslationSystem.API.Tests.Unit` 175 passed.
- Solution build clean under `TreatWarningsAsErrors`.
- Rendered and inspected the HTML with a staging-shaped configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqgaD9zAwz4vnvrNDHJQ9h