### PR TITLE
Live test 48.8->49.1: per-SubFile survival model + update-resilience spec draft

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,9 +303,12 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 
 - **Forum version** (regex `Update\s+(\d+(?:\.\d+)*)\s+Release\s+Notes` on lotro.com) is the
   reliable game-version identifier. **DAT vnum is useless as a content version** (112/3 unchanged
-  across 45.x→48.0 even while the DAT was actively patched).
-- Launcher patches the DAT **chunk-based**; **translations survive updates** — proven across
-  6 live tests incl. the 47.2→48.0 major update. `attrib +R` protection is unnecessary.
+  across 45.x→49.1 — six cycles incl. two majors — even while the DAT was actively patched).
+- Launcher patches the DAT **chunk-based**; **translations survive updates per-SubFile** — proven
+  across 9 live tests incl. the 48.0 and 49 majors. Fragments in untouched SubFiles survive
+  byte-for-byte; an update that modifies a SubFile replaces the whole chunk and **reverts our
+  fragments inside it** (first observed 48.8→49.1: 1/8; repair = normal re-patch, TMS-side =
+  the spec-0001 invalidation loop). `attrib +R` protection is unnecessary either way.
 - Simplified launch flow (translation-hash check → patch only if changed → fire-and-forget launch)
   is fully validated.
 

--- a/docs/knowledge-base/README.md
+++ b/docs/knowledge-base/README.md
@@ -29,10 +29,13 @@ Detailed analysis: [lotro-companion-data-model.md](lotro-companion-data-model.md
 - `lotro-data` GitHub repo **is** the live dataset (updated within days of each patch); labels not needed — our English comes from our own export
 - Caveats: subset coverage, join on keys never text (`${PLAYER}` vs `<--DO_NOT_TOUCH!-->`), version skew tolerated as dangling refs, no LICENSE (attribution = courtesy decision)
 
-### DAT Protection: NOT NEEDED — Translations Survive Updates (incl. MAJOR)
+### DAT Protection: NOT NEEDED — Translations Survive Updates (incl. MAJOR), per-SubFile
 Detailed analysis: [dat-protection.md](dat-protection.md)
-- **PROVEN by 8 independent tests** including updates 47.2→48.0 (2026-04-23), 48.0→48.7 (2026-06-25) and 48.7→48.8 (2026-07-11)
-- Launcher uses chunk-based patching — our fragments sit in untouched chunks → byte-for-byte intact
+- **PROVEN by 9 independent tests** including majors 47.2→48.0 (2026-04-23) and 48.8→49.1 (2026-08-02)
+- Launcher uses chunk-based patching — fragments in untouched chunks stay byte-for-byte intact
+- **Refined 2026-08-02: survival is per-SubFile, not per-fragment** — an update that modifies a
+  SubFile replaces the whole chunk and reverts our fragments inside it (first observed 48.8→49.1:
+  1/8 reverted); repair = normal re-patch / the spec-0001 invalidation loop
 - `attrib +R` protection is unnecessary; legacy `HandleUpdatePath` is actively harmful; vnum-trigger is dead
 - Simplified flow (hash-based patch + fire-and-forget) is fully validated
 
@@ -58,6 +61,14 @@ Detailed analysis: [live-test-2026-07-11.md](live-test-2026-07-11.md)
 - Live forum fetch returned 48.8 while vnum stayed 112/3 — 5th unchanged cycle
 - `launch`'s SKIP path never refreshes the stored ForumVersion — only a standalone `patch` does (code-verified); the manual export→import gap is decided in #443 + ADR-0030
 
+### Live Test — Major Update 2026-08-02 (48.8 → 49.1 "In Good Company")
+Detailed analysis: [live-test-2026-08-02.md](live-test-2026-08-02.md) · committed artifacts: [update-49/](update-49/) · raw intel: `intel/update-49/`
+- **Third live update-test; first MAJOR since 48.0 and first with the TMS deployed** — U49 released 2026-07-22, client landed on 49.1
+- **Survival 7/8 — first real casualty in 9 tests, mechanism fully understood:** SSG added 4 fragments to SubFile 620757435 → launcher replaced the whole chunk → our fragment reverted to its (unchanged) English original; counter-proof: surviving pairs' SubFiles kept identical fragment counts
+- Content-wise a full major (+7,192 fragments — more than 48.0) at a DAT growth of exactly +1 MiB (in-place chunk rewrites; second consecutive equal-1-MiB growth)
+- datexport.dll READ+WRITE confirmed on 49.1; vnum 112/3 (6th cycle); forum-fetcher returned "49.1"
+- Our `launch` deliberately skipped this cycle (LEGAL-08 made repo polish.txt synthetic — hash mismatch would have patched synthetic text into the live game); update ran through the official launcher
+
 ### Live Test — Chunk Patches 2026-03-16..22
 Detailed analysis: [live-test-2026-03-16.md](live-test-2026-03-16.md)
 - 5 chunk-patch tests, all simplified-flow branches verified
@@ -66,7 +77,7 @@ Detailed analysis: [live-test-2026-03-16.md](live-test-2026-03-16.md)
 
 ### DAT Vnum — definitively schema-version, not content-version
 Detailed analysis: [vnum-observations.md](vnum-observations.md)
-- Vnum 112/3 unchanged across 45.x → 47.x → **48.0 major** → 48.7 → 48.8 — 5 cycles, zero movement (latest: [live-test-2026-07-11.md](live-test-2026-07-11.md))
+- Vnum 112/3 unchanged across 45.x → 47.x → **48.0 major** → 48.7 → 48.8 → **49.1 major** — 6 cycles (two majors), zero movement (latest: [live-test-2026-08-02.md](live-test-2026-08-02.md))
 - Vnum = DAT binary schema version, NOT content version — any vnum-triggered logic is dead
 - Forum version ("48.0") is the reliable content identifier
 
@@ -74,10 +85,11 @@ Detailed analysis: [vnum-observations.md](vnum-observations.md)
 Detailed analysis: [dat-export-diff-2026-03-22.md](dat-export-diff-2026-03-22.md)
 - 47.1→47.2: ~5000 lines, skill rewording
 - 47.2→48.0: 587 hunks, +4,231 fragments, new region — stats in [update-48.0/RESULTS.md](update-48.0/RESULTS.md); the raw diff lives in the gitignored `intel/` (repo copy removed 2026-07, LEGAL-08 — verbatim game text)
+- 48.8→49.1: 694 hunks, +7,192 fragments — stats in [update-49/RESULTS.md](update-49/RESULTS.md); raw diff only in the gitignored `intel/update-49/` (LEGAL-08)
 
 ### LOTRO Update History
 Detailed analysis: [lotro-update-history.md](lotro-update-history.md)
-- 45.1 → 45.4.1 → 46 → 46.1 → 47 (major) → 47.1 → 47.1.1 → 47.2 → 48.0 (major, 2026-04-23) → 48.7 (2026-06-25) → 48.8 (observed 2026-07-11)
+- 45.1 → 45.4.1 → 46 → 46.1 → 47 (major) → 47.1 → 47.1.1 → 47.2 → 48.0 (major, 2026-04-23) → 48.7 (2026-06-25) → 48.8 (observed 2026-07-11) → 49 "In Good Company" (major, 2026-07-22) → 49.1 (observed 2026-08-02)
 - 48.0 content: Hatokáli Fells, Rhûn expansion, Deluxe housing, Edit UI feature
 
 ### Game Update Detection & Translation Versioning
@@ -137,6 +149,21 @@ Same shape as `update-48.0/`. The 1.76 GB DAT backups + 78 MB full exports live 
 
 No separate launch log was committed for 48.7 — the SKIP-path launch timeline is captured inside
 [`RESULTS.md`](update-48.7/RESULTS.md) ("Launch log timeline"); raw logs live in the gitignored `intel/update-48.7/`.
+
+---
+
+## `update-49/` — committed text artifacts from the 48.8 → 49.1 test (2026-08-02)
+
+Same shape as the folders above (quest text in synthetic LEGAL-08 equivalents). DAT backups
+(~1.76 GB each), full exports (82.6/83.1 MB) and the raw diff live in the gitignored
+`intel/update-49/`; committed here:
+
+| File | What it is |
+|------|-----------|
+| [`BASELINE.md`](update-49/BASELINE.md) | Pre-update 48.8 snapshot: DAT hash, export stats, the polish.txt fork after LEGAL-08 (repo file synthetic vs DAT-resident set), 8/8 survival baseline |
+| [`RESULTS.md`](update-49/RESULTS.md) | Full 48.8→49.1 results: 7/8 survival, the per-SubFile revert mechanism + counter-proof, diff stats, vnum, WRITE test |
+
+No launch log this cycle — our `launch` was deliberately skipped (see RESULTS §deviation).
 
 ---
 

--- a/docs/knowledge-base/dat-protection.md
+++ b/docs/knowledge-base/dat-protection.md
@@ -1,10 +1,20 @@
 ---
 name: DAT Protection NOT NEEDED — translations survive all updates (including major)
-description: attrib +R protection is unnecessary. Launcher uses chunk-based patching. Translations survive even major updates without any protection. Validated across 7 live tests including updates 48.0 (2026-04-23) and 48.7 (2026-06-25).
+description: attrib +R protection is unnecessary. Launcher uses chunk-based patching. Translations survive updates without any protection — with one refined limit: survival is per-SubFile (an update that modifies a SubFile reverts our fragments inside it; first observed 48.8→49.1). Validated across 9 live tests including majors 48.0 (2026-04-23) and 49 (2026-08-02).
 type: project
 originSessionId: fcf33c21-a957-445f-bc57-c8ea7814f1b6
 ---
 # DAT Protection Status: NOT NEEDED
+
+> **Addendum (2026-08-02) — the survival model is per-SubFile, not per-fragment.** 9th test
+> (major 48.8 → 49.1, "In Good Company"): **7/8 survived byte-for-byte; 1/8 REVERTED** to its
+> English original because SSG added 4 fragments to its SubFile (620757435: 1019→1023) — the
+> launcher replaced that whole chunk, wiping our fragment even though its own text was unchanged.
+> Counter-proof: the four SubFiles holding the surviving pairs kept identical fragment counts.
+> **The "protection NOT needed" conclusion stands** — `attrib +R` cannot save a chunk the update
+> legitimately replaces; the repair is a normal re-patch (and in the TMS model, exactly the
+> spec-0001 invalidation loop — its first real-world case). See
+> [live-test-2026-08-02.md](live-test-2026-08-02.md) + [update-49/RESULTS.md](update-49/RESULTS.md).
 
 > **Addendum (2026-07-11):** an 8th confirmation — resident translations survived the 48.7→48.8
 > cycle untouched (SKIP path, hash match) and a forced live `patch` (8/8, 0 warnings) confirmed
@@ -14,7 +24,7 @@ originSessionId: fcf33c21-a957-445f-bc57-c8ea7814f1b6
 
 We assumed LOTRO's official launcher overwrites DAT files on update, wiping translations. This drove the entire Legacy launch flow with attrib +R protection, process monitoring, and game client killing. **Wrong.**
 
-## Empirical evidence: 7 independent tests
+## Empirical evidence: 9 independent tests
 
 | Date | Update type | DAT modified? | Result |
 |------|-------------|---------------|--------|
@@ -25,6 +35,8 @@ We assumed LOTRO's official launcher overwrites DAT files on update, wiping tran
 | 2026-03-22 #2 | SKIP path verification | No | ✅ 255ms launch |
 | **2026-04-23** | **47.2 → 48.0 (MAJOR)** | **Yes (+14MB, +4,231 fragments)** | **✅ 8/8 survived, 4 channels verified** |
 | **2026-06-25** | **48.0 → 48.7 (point, SKIP path)** | **Yes (+1 MiB, +1,159 fragments)** | **✅ 8/8 survived, 4 channels, byte-identical** |
+| 2026-07-11 | 48.7 → 48.8 (point) | Yes (minor) | ✅ 8/8 survived + forced live WRITE-path re-patch OK |
+| **2026-08-02** | **48.8 → 49.1 (MAJOR)** | **Yes (+1 MiB, +7,192 fragments, in-place chunk rewrites)** | **⚠️ 7/8 survived byte-for-byte; 1/8 reverted — its SubFile was modified (+4 fragments) → whole chunk replaced** |
 
 ## How translations survive: chunk-based patching
 
@@ -53,14 +65,21 @@ We assumed LOTRO's official launcher overwrites DAT files on update, wiping tran
 4. Done. No protection, no monitoring, no killing processes.
 ```
 
-**Zero failures across 7 live tests including one major update.** datexport.dll READ + WRITE paths confirmed compatible with both 48.0 and 48.7 schemas (vnum 112/3 throughout).
+**Across 9 live tests (two majors) the only loss is the per-SubFile revert above — never a flow failure.** datexport.dll READ + WRITE paths confirmed compatible with 48.0, 48.7, 48.8 and 49.1 schemas (vnum 112/3 throughout).
 
 ## Russian project comparison
 
 - **Russians use:** `-disablePatch` flag (undocumented, SSG can remove anytime)
 - **We used:** `attrib +R` (OS-level block)
 - **Reality:** Neither is needed — translations survive updates anyway
-- Russians also have NinjaMark to detect overwrites — over-engineering for a non-problem
+- Russians also have NinjaMark (marker in DAT subfile 620750000) to detect launcher overwrites —
+  re-evaluated 2026-08-02 after the per-SubFile revert finding: the **problem class is real**
+  (our old "non-problem" verdict is retired), but the in-DAT marker is the wrong implementation
+  for us: it only fires when ITS OWN chunk is wiped (misses collateral wipes elsewhere), reading
+  it needs elevated DAT access on every launch (datexport opens with write intent), and our
+  lost-state edge already degrades gracefully (missing version file ⇒ hash=null ⇒ full re-patch).
+  An external DAT fingerprint (size+mtime in the version file) detects strictly more, with zero
+  DAT access on the SKIP path — see `update-49/RESULTS.md` §scenariusze (launch sentinel)
 
 ## Cross-reference
 

--- a/docs/knowledge-base/live-test-2026-08-02.md
+++ b/docs/knowledge-base/live-test-2026-08-02.md
@@ -1,0 +1,57 @@
+---
+name: Live test 2026-08-02 — Major update 48.8 → 49.1
+description: Trzeci żywy major-class update (49 "In Good Company" + patch 49.1). Survival 7/8 — pierwsza realna ofiara po 9 testach; mechanizm per-SubFile chunk replacement zlokalizowany i domknięty kontrpróbą. Intel w intel/update-49/
+type: project
+---
+# Live Test 2026-08-02 — Major Update 48.8 → 49.1 ("In Good Company")
+
+**Trzeci żywy update-test; pierwszy przez granicę MAJOR od 48.0 i pierwszy odkąd TMS jest
+wdrożony (M6).** Update 49 wydany 2026-07-22; klient po update jest na 49.1 (forum-fetcher).
+
+## Outcome
+
+⚠️✅ **Survival 7/8 — pierwsza realna ofiara update'u w 9 testach, z w pełni zrozumianym
+mechanizmem.** Kanały dowodowe:
+
+1. In-game (user) — „Stylizacje" żyją; wątpliwość co do „Ekwipunek" rozstrzygnięta exportem
+   (nasz fragment nietknięty; user patrzył na inne wystąpienie „Equipment")
+2. Export survival — pair-level 8/8, **content-level 7/8**: `620757435||225138404`
+   („Wejdź do Śródziemia") revertnięty do angielskiego oryginału
+3. Diff stability — dokładnie 1 para w 694 hunkach (ten revert); 7 par bajtowo nietkniętych
+4. Mechanizm: SubFile 620757435 urósł 1019→1023 fragmentów → launcher wymienił cały chunk;
+   kontrpróba: SubFile'e ocalałych par mają identyczne liczby fragmentów (427/5/26/15)
+
+## Nowy model survival — uściślenie po 9 testach
+
+**Survival jest per-SubFile (chunk), nie per-fragment.** Update modyfikujący SubFile revertuje
+wszystkie nasze translacje w nim — nawet gdy tekst naszego fragmentu sam się nie zmienił
+(`Enter Middle-earth` przed i po; SSG tylko dodał 4 inne fragmenty do tego SubFile'a).
+SubFile'e nietknięte = byte-for-byte survival (dotąd 100%). Naprawa = zwykły re-patch;
+w modelu TMS — dokładnie pętla invalidation ze spec 0001 (pierwszy real-world casus!).
+
+Wniosek „DAT protection NOT needed" **stoi**: `attrib +R` nie uratowałby fragmentu (chunk
+wymienia legalny update), a koszt naprawy to re-patch.
+
+## Key metrics (szczegóły: docs/knowledge-base/update-49/RESULTS.md)
+
+- DAT: +1,048,576 B (dokładnie 1 MiB — drugi raz z rzędu) · hash `4E9A8106…` → `1B94B27A…`
+- Fragmenty: +7,192 (800,864 total) — treściowo WIĘCEJ niż major 48.0, przy 14× mniejszym
+  wzroście pliku (in-place chunk rewrites)
+- Text files: +2,270 (281,253 total)
+- Diff: 694 hunks, −2,356/+9,548 linii (net = delta fragmentów ✔)
+- datexport.dll na 49.1: READ 800,864 fragments zero errors · WRITE 8/8 applied zero warnings
+- Vnum 112/3 — **6. cykl bez zmiany (drugi major)**; forum-fetcher: „49.1"
+
+## Deviation — nasz launch celowo pominięty
+
+LEGAL-08 (#481) podmienił repo `translations/polish.txt` na syntetyczny (hash `f3dd657c…` ≠
+stored `40b613a2…`) → nasz `launch` poszedłby PATCH path i wstrzyknął syntetyczny tekst do
+żywej gry. Update poszedł przez oficjalny LotroLauncher. Zestaw rezydentny w DAT odzyskany
+z gita (`d590088^` + CRLF) i hash-proven == stored hash. **Follow-up:** przywrócić spójność
+polish.txt ↔ DAT świeżym exportem z TMS zanim ktokolwiek odpali `launch polish` na tej maszynie.
+
+## TMS lifecycle — pierwszy prawdziwy przebieg (next step)
+
+`data/exported.txt` = export 49.1 (83.1 MB, SHA256 `56F6D046…32B00`). Manual ceremony
+(ADR-0030): zarejestrować GameVersion **49.1** → import → oczekiwany diff: +7,192 nowych
+fragmentów, 1 invalidation (225138404 — source change przez revert), 7 par bez zmian.

--- a/docs/knowledge-base/lotro-update-history.md
+++ b/docs/knowledge-base/lotro-update-history.md
@@ -6,6 +6,11 @@ originSessionId: fcf33c21-a957-445f-bc57-c8ea7814f1b6
 ---
 # LOTRO Update History (observed)
 
+> **Addendum (2026-08-02):** → **49 "In Good Company" (MAJOR, released 2026-07-22)** + point
+> patch **49.1** (forum fetch during our test returned "49.1"). Client updated 2026-08-02:
+> +2,270 text files / +7,192 fragments, DAT +1 MiB exactly (in-place chunk rewrites). Survival
+> 7/8 — first per-SubFile revert observed. See [live-test-2026-08-02.md](live-test-2026-08-02.md).
+
 > **Addendum (2026-07-11):** → **48.8** observed (forum fetch returned "48.8"; vnum 112/3 unchanged,
 > 5th cycle; resident translations survived 48.7 → 48.8). Tested on the first real-world AUDIT-SEC
 > run — see [live-test-2026-07-11.md](live-test-2026-07-11.md).
@@ -19,6 +24,9 @@ originSessionId: fcf33c21-a957-445f-bc57-c8ea7814f1b6
 → 47.1 → 47.1.1 → 47.2
 → 48.0 (MAJOR — 2026-04-23, Hatokáli Fells / Rhûn content)
 → 48.7 (point — 2026-06-25, +1,159 fragments / +601 text files)
+→ 48.8 (point — observed 2026-07-11)
+→ 49 "In Good Company" (MAJOR — released 2026-07-22) → 49.1 (point — observed 2026-08-02,
+  together +7,192 fragments / +2,270 text files vs 48.8)
 ```
 
 All observed with **vnum 112/3 unchanged** — see [vnum-observations.md](vnum-observations.md).
@@ -33,6 +41,8 @@ All observed with **vnum 112/3 unchanged** — see [vnum-observations.md](vnum-o
 | 2026-03-22 | 47.1 → 47.2 (chunk) | SKIP path, translations survive DAT-patching update |
 | **2026-04-23** | **47.2 → 48.0 (MAJOR)** | **First major update since simplified flow. 4-channel survival verified. datexport.dll READ + WRITE compat with 48.0 schema.** |
 | **2026-06-25** | **48.0 → 48.7 (point)** | **Second live update, first via SKIP path. 4-channel survival verified. datexport.dll READ+WRITE compat with 48.7. vnum 112/3 (4th cycle). Forum-fetcher returned "48.7".** |
+| 2026-07-11 | 48.7 → 48.8 (point) | First real-world AUDIT-SEC run; survival + forced live WRITE-path re-patch OK. Forum-fetcher returned "48.8". |
+| **2026-08-02** | **48.8 → 49.1 (MAJOR)** | **Third live update-test. Survival 7/8 — first per-SubFile revert (SubFile 620757435 modified → chunk replaced). datexport.dll READ+WRITE compat with 49.1. vnum 112/3 (6th cycle). Forum-fetcher returned "49.1". First cycle with the TMS deployed — export-49 feeds the first real spec-0001 import.** |
 
 ## Major update 48.0 content (from diff analysis)
 

--- a/docs/knowledge-base/update-49/BASELINE.md
+++ b/docs/knowledge-base/update-49/BASELINE.md
@@ -1,0 +1,101 @@
+# Baseline 48.8 — Pre-update snapshot (test: 48.8 → 49 "In Good Company")
+
+**Captured:** 2026-08-02
+**Operator:** Claude (automated)
+**Context:** Trzecia walidacja survivalu przez żywy update — pierwszy przeskok przez granicę MAJOR
+od 48.0 (Update 49 „In Good Company", wydany 2026-07-22). Pierwszy update event odkąd TMS jest
+wdrożony (M6) — post-update export napędzi pierwszy prawdziwy przebieg lifecycle'u spec 0001
+(rejestracja GameVersion 49 + import + diff/invalidation).
+**Redaction note:** quest-text content in this file uses the synthetic equivalents established by
+LEGAL-08 (2026-07); verbatim originals live only in the gitignored `intel/update-49/`.
+
+## Live DAT state (pre-update)
+
+| Attribute | Value |
+|-----------|-------|
+| Path | `C:\Program Files (x86)\StandingStoneGames\The Lord of the Rings Online\client_local_English.dat` |
+| Size | 1,893,807,856 B (1.764 GB) |
+| LastWriteTime | 2026-07-11 02:47:46 |
+| SHA256 | `4E9A8106C16159BC80C7865AE17A740D732B78AA49F96785BE144EF76E5AFD88` |
+| Backup | `intel/update-49/client_local_English.48.8.dat` (hash-verified identical) |
+
+**Prowieniencja stanu 48.8:** rozmiar identyczny z post-48.7 (1,893,807,856 B), ale hash ≠ 48.7
+(`620DA8FD…637A`). Oczekiwane — 2026-07-11 test AUDIT-SEC wykonał wymuszony live PATCH (8/8,
+size-neutral re-patch, stąd LastWrite 02:47:46), a między 48.7 a teraz doszedł drobny patch 48.8:
+export pokazuje **+5 plików / +13 fragmentów** względem post-48.7.
+
+## Export stats (z backupu)
+
+| Metric | Value | vs post-48.7 |
+|--------|-------|--------------|
+| Text files (high byte 0x25) | **278,983** | +5 |
+| Total fragments | **793,672** | +13 |
+| Export output size | 82,557,600 B | +1,244 B |
+| Output path | `intel/update-49/export-48.8.txt` | — |
+
+Export robiony z backupu (live DAT w Program Files odmawia otwarcia non-elevated — `datexport.dll`
+otwiera z write/sidecar intentem; znane ograniczenie, patrz RESULTS 48.0 §perms).
+
+## Version file (pre-update)
+
+```
+data/last_known_game_version.txt (75 B): 48.8|112|3|40b613a24dc5c1082697ddde5f542b0b607349a2613d83a88ddf225dc83ed3d6
+```
+
+- ForumVersion: `48.8` · VnumDatFile: `112` · VnumGameData: `3`
+- TranslationFileHash: `40b613a2…3ed3d6`
+- Snapshot: `intel/update-49/version-file-pre-49.txt`
+
+## Rozwidlenie polish.txt — KRYTYCZNE dla tego cyklu
+
+LEGAL-08 (#481, merged 2026-07-31) zamienił verbatim game text w **repo** na syntetyczne
+odpowiedniki. Skutek: working-copy `translations/polish.txt` ≠ zestaw rezydujący w DAT:
+
+| File | SHA256 | Size | Rola |
+|------|--------|------|------|
+| `translations/polish.txt` (repo, po LEGAL-08) | `F3DD657C…3AFE3` | 2,264 B | syntetyczny — NIE odzwierciedla DAT |
+| DAT-resident set (pre-LEGAL-08) | `40B613A2…3ED3D6` | 2,300 B (CRLF) | == stored hash w version file |
+
+Resident set odzyskany z gita (`git show d590088^:translations/polish.txt`) + restytucja CRLF —
+hash-proven == stored hash (git blob jest LF, working copy z 2026-07-11 była CRLF). Archiwum w
+gitignored `intel/update-49/` (verbatim + stan repo).
+
+**Konsekwencja protokołu:** `launch polish` / `lotro.bat` poszedłby ścieżką PATCH (hash mismatch)
+i wstrzyknął syntetyczny tekst do żywej gry → **w tym cyklu NIE używamy naszego launch**. Update
+idzie przez oficjalny LotroLauncher bezpośrednio. Obie gałęzie simplified flow są już zwalidowane
+żywymi update'ami (PATCH — kwiecień 48.0, SKIP — czerwiec 48.7); ten cykl testuje czysty
+resident-survival przez major. **Follow-up po teście:** przywrócić spójność polish.txt ↔ DAT
+(np. świeży export z TMS), żeby simplified flow znów miał prawdziwy hash-match.
+
+## Polish translations baseline — survival 8/8 (export-48.8.txt)
+
+Content-level check (para + prefiks polskiej treści obecne w exporcie):
+
+| # | FileId | GossipId | Content (synthetic where quest text) | Export line |
+|---|--------|----------|--------------------------------------|-------------|
+| 1 | 620871150 | 218649169 | `'Mamy znak, <--DO_NOT_TOUCH!-->! Szare ćmy wznoszą się rzędem…` | 255044 |
+| 2 | 620759036 | 218649169 | `'PL - We cannot let the old warden rouse…` (partial tr.) | 19821 |
+| 3 | 620757435 | 225138404 | `Wejdź do Śródziemia` | 7063 |
+| 4 | 620757027 | 9795381 | `Kliknij tutaj aby wybrać swój tytuł` | 3798 |
+| 5 | 620861331 | 228870261 | `Ekwipunek` | 227830 |
+| 6 | 620757027 | 29271026 | `Podstawowe statystyki` | 3879 |
+| 7 | 620757027 | 103943794 | `Pokaż wszystkie` | 3681 |
+| 8 | 620757027 | 85383154 | `Stylizacje` | 3765 |
+
+Pozycje linii **identyczne z post-48.7** — patch 48.8 (+5/+13) nie przesunął naszych fragmentów.
+
+## Phase 1 complete — co jest gotowe
+
+✅ Live DAT backed up (`intel/update-49/`, hash-verified `4E9A8106…5AFD88`)
+✅ Full export 48.8 (793,672 fragments)
+✅ Version file + oba warianty polish.txt zarchiwizowane (resident hash-proven)
+✅ Baseline survival: 8/8 pair-level + content-level w export-48.8.txt
+
+## Phase 2 — USER ACTION REQUIRED
+
+1. **NIE uruchamiaj `lotro.bat` / `launch polish`** (patrz sekcja rozwidlenia polish.txt).
+2. Uruchom **oficjalny LotroLauncher** bezpośrednio → pozwól mu ściągnąć Update 49.
+3. Wejdź do gry → sprawdź polskie teksty (UI: Ekwipunek / Stylizacje / Pokaż wszystkie +
+   miejsca questowe z testu kwietniowego).
+4. Wróć i napisz „done" — ruszy Phase 3 (backup 49, export-49.txt, diff, survival, WRITE test,
+   RESULTS, rejestracja GameVersion 49 w TMS + import exportu).

--- a/docs/knowledge-base/update-49/RESULTS.md
+++ b/docs/knowledge-base/update-49/RESULTS.md
@@ -1,0 +1,273 @@
+# Update 48.8 → 49.1 ("In Good Company") — Test Results
+
+**Data:** 2026-08-02
+**Operator:** Claude (automated) + user (in-game verification + update trigger)
+**Status:** ✅ **ALL TESTS PASSED — z PIERWSZĄ w historii projektu realną ofiarą update'u (1/8 fragmentów revertnięty przez wymianę SubFile'a)**
+**Redaction note:** quest-text content in this file uses the synthetic equivalents established by
+LEGAL-08 (2026-07); verbatim originals live only in the gitignored `intel/update-49/`.
+
+## Verdict
+
+**7/8 translacji przetrwało major update 48.8 → 49.1 bajtowo nietkniętych; 1/8 revertnięty do
+angielskiego oryginału — bo SSG zmodyfikował jego SubFile.** To pierwsza empiryczna obserwacja
+granicy chunk-based survival po 9 testach na żywo:
+
+1. ✅ **In-game (user):** „Stylizacje przeżyły"; wątpliwość co do „Ekwipunek" rozstrzygnięta
+   exportem — nasz fragment jest nietknięty (user patrzył na inny string „Equipment" w grze)
+2. ⚠️ **Export survival: 7/8** — pair-level 8/8 obecnych, content-level 7/8 polskich;
+   `620757435||225138404` („Wejdź do Śródziemia") revertnięty do `Enter Middle-earth`
+3. ✅ **Diff stability:** dokładnie 1 para w hunkach diffa (−polski/+angielski revert);
+   pozostałe 7 par — 0 matchów w 694 hunkach
+4. ✅ **Mechanizm revertu zlokalizowany:** SubFile 620757435 urósł 1019 → 1023 fragmentów
+   (+4 nowe) → launcher wymienił CAŁY chunk → wszystkie nasze fragmenty w nim wracają do
+   defaultu, choć tekst naszego fragmentu sam w sobie się NIE zmienił (`Enter Middle-earth`
+   przed i po). Kontrpróba: SubFile'e ocalałych par mają identyczne liczby fragmentów
+   (620757027: 427→427 · 620861331: 5→5 · 620871150: 26→26 · 620759036: 15→15)
+
+**Nowy model survival (uściślenie):** przeżycie jest **per-SubFile (chunk), nie per-fragment**.
+Update, który modyfikuje SubFile (dodaje/zmienia dowolny fragment w nim), revertuje w nim
+WSZYSTKIE nasze translacje. SubFile'e nietknięte przez update = byte-for-byte survival (jak
+dotąd w 100% przypadków). Naprawa = zwykły re-patch (hash-mismatch PATCH path), a w modelu
+TMS — dokładnie flow invalidation ze spec 0001.
+
+## Intel summary
+
+### DAT state comparison
+
+| Metric | 48.8 (baseline) | 49.1 (post-update) | Delta |
+|--------|-----------------|--------------------|-------|
+| Size (B) | 1,893,807,856 | 1,894,856,432 | **+1,048,576 (+0.055%)** — znowu równy 1 MiB |
+| SHA256 | `4E9A8106…5AFD88` | `1B94B27A…DE17A` | changed |
+| LastWriteTime | 2026-07-11 02:47:46 | 2026-08-02 13:46:00 | — |
+| TotalTextFiles | 278,983 | 281,253 | **+2,270 (+0.81%)** |
+| TotalFragments | 793,672 | 800,864 | **+7,192 (+0.906%)** |
+| Export output size | 82,557,600 B | 83,104,955 B | +547,355 B |
+
+**Obserwacja:** treściowo to pełnoprawny major (+7,192 fragmentów — więcej niż 48.0!), ale DAT
+urósł tylko o JEDEN blok 1 MiB — launcher nadpisywał istniejące chunki in-place (m.in. nasz
+620757435) i dołożył jeden blok alokacji. Drugi przypadek z rzędu równego +1 MiB (48.7 tak samo).
+
+### Diff summary (export-48.8.txt vs export-49.txt)
+
+- Diff file: 1,760,882 B, **694 change hunks** (żyje tylko w gitignored `intel/update-49/` —
+  verbatim game text, LEGAL-08; statystyki zachowane tutaj)
+- **2,356 linii usuniętych** / **9,548 dodanych** (net +7,192 = dokładnie TotalFragments delta ✔)
+- **Dokładnie 1 polish para w diffie** (revert): `-…Wejdź do Śródziemia` / `+…Enter Middle-earth`;
+  pozostałe 7 par: 0 matchów
+
+### Survival — 7/8 content-level (export-49.txt)
+
+| # | FileId | GossipId | Content (synthetic where quest text) | 48.8 line → 49 line | Survived |
+|---|--------|----------|--------------------------------------|---------------------|----------|
+| 1 | 620871150 | 218649169 | `'Mamy znak, <--DO_NOT_TOUCH!-->! Szare ćmy…` | 255044 → 255112 | ✅ |
+| 2 | 620759036 | 218649169 | `'PL - We cannot let the old warden rouse…` | 19821 → 19855 | ✅ |
+| 3 | 620757435 | 225138404 | `Wejdź do Śródziemia` → `Enter Middle-earth` | 7063 → 7092 | ❌ REVERT |
+| 4 | 620757027 | 9795381 | `Kliknij tutaj aby wybrać swój tytuł` | 3798 → 3827 | ✅ |
+| 5 | 620861331 | 228870261 | `Ekwipunek` | 227830 → 227898 | ✅ |
+| 6 | 620757027 | 29271026 | `Podstawowe statystyki` | 3879 → 3908 | ✅ |
+| 7 | 620757027 | 103943794 | `Pokaż wszystkie` | 3681 → 3710 | ✅ |
+| 8 | 620757027 | 85383154 | `Stylizacje` | 3765 → 3794 | ✅ |
+
+„Ekwipunek" (par #5): **przeżył** — in-game wątpliwość usera wynikała z patrzenia na inne
+wystąpienie „Equipment" w UI (inny FileId/GossipId), nie na nasz fragment 620861331||228870261.
+
+### Vnum — **6. cykl z rzędu bez zmiany (drugi major)**
+
+```
+Before 49:  VnumDatFile=112, VnumGameData=3
+After 49:   VnumDatFile=112, VnumGameData=3  ← UNCHANGED
+```
+
+45.x → 47.x → 48.0 → 48.7 → 48.8 → **49.1**: vnum 112/3 stałe przez 6 cykli, w tym DWA majory.
+
+### Forum version — „49.1"
+
+Preflight forum-fetcher zwrócił **ForumVersion = 49.1** podczas WRITE-path testu (SaveBaseline
+zapisał `49.1|112|3|<hash>`). Czyli SSG wydał już patch 49.1 po premierze 49 (2026-07-22) i klient
+po dzisiejszym update jest na **49.1** — tak należy zarejestrować GameVersion w TMS.
+
+### datexport.dll compatibility (49.1 schema)
+
+- ✅ **READ path (export) na 49.1 DAT:** 800,864 fragments, zero errors
+- ✅ **WRITE path (patch) na 49.1 DAT:** 8/8 applied, 0 skipped, zero warnings
+  - write-test DAT: `8EE2F022…73730`, size 1,894,856,432 (size-neutral re-patch), backup auto-created
+  - UWAGA: patch użył repo `translations/polish.txt` = syntetyczny post-LEGAL-08 (`f3dd657c…`) —
+    OK na kopii testowej; NIE aplikować na live DAT (patrz BASELINE §rozwidlenie)
+- Schema niezmieniona (vnum 112/3); pełna kompatybilność wsteczna READ+WRITE.
+
+### Deviation od poprzednich protokołów — launch pominięty (deliberate)
+
+Tym razem **nie odpalaliśmy naszego `launch`** przed update'em: repo polish.txt jest po LEGAL-08
+syntetyczny (hash mismatch → PATCH path wstrzyknąłby syntetyczny tekst do żywej gry). Update
+poszedł przez oficjalny LotroLauncher bezpośrednio. Obie gałęzie simplified flow były już
+zwalidowane żywymi update'ami (PATCH — 48.0, SKIP — 48.7); ten cykl testował czysty
+resident-survival. Version file po WRITE-teście przywrócony do `48.8|112|3|40b613a2…` (stan
+zgodny z tym, co realnie rezyduje w live DAT).
+
+## Kluczowe odkrycia / memory-worthy
+
+1. **Pierwsza realna ofiara update'u po 9 testach: survival jest per-SubFile.** SSG dodał 4
+   fragmenty do SubFile 620757435 → launcher wymienił cały chunk → nasz fragment wrócił do
+   angielskiego, mimo że jego własny tekst się nie zmienił. 7 par w nietkniętych SubFile'ach —
+   byte-for-byte survival, jak zawsze.
+2. **To jest dokładnie casus, dla którego istnieje spec 0001.** Import export-49 do TMS wykryje
+   zmianę source text dla 225138404 (diff) → invalidation → re-approve → nowy artefakt → CLI
+   sync → re-patch przywraca polski. Pierwszy real-world przebieg całej pętli invalidation.
+3. **Wniosek „protection NOT needed" stoi.** `attrib +R` i tak by nie uratował fragmentu
+   (launcher wymienia chunk w ramach legalnego update'u) — a naprawa to zwykły re-patch.
+   Model „translations survive" zyskuje uściślenie, nie zaprzeczenie.
+4. **Major może być size-cheap:** +7,192 fragmentów (więcej niż 48.0) przy wzroście DAT o
+   dokładnie +1 MiB — in-place chunk rewrites + 1 blok alokacji. Drugi kolejny przypadek
+   równego +1 MiB.
+5. **Vnum 6 cykli bez ruchu (2 majory); forum-fetcher żywy i poprawny („49.1").**
+6. **Manual-export gotcha (dla TMS):** export z patchowanego DAT niesie nasze polskie treści
+   jako „source" dla rezydentnych par. Przy imporcie 49.1: 7 par bez zmiany (polski==polski,
+   brak invalidation), 1 para z revertem → source-change → invalidation. Działa na naszą
+   korzyść, ale warto pamiętać, że „source text" tych rzędów w TMS to historycznie nasz polski.
+
+## Analiza scenariuszy diffu importu (spec 0001) wobec per-SubFile revertu — 2026-08-02
+
+Policzono z par `(FileId, GossipId)` obu exportów — przewidywany `ImportSummary` dla stanu
+DB ≈ 48.8 (prod może mieć starszy baseline → liczby większe, mechanika identyczna):
+**Added 7,836 · Source-changed 1,644 · Removed 644 (0.08% — daleko od guardu 20%) ·
+Unchanged 791,384** (net +7,192 ✔).
+
+### Scenariusz A — SSG realnie zmienił tekst przetłumaczonego wiersza (działa jak zaprojektowano)
+
+Zmiana tekstu ⇒ SubFile zmodyfikowany ⇒ chunk wymieniony ⇒ **w DAT gracza już jest świeży
+angielski** (ten test dowodzi tego mechanizmu empirycznie — spec §"fallback-to-English physics"
+pkt 1 przestał być założeniem). Import: source-changed → NeedsReview + `PreviousSourceText` →
+wiersz wypada z artefaktu → ETag/hash → re-patch bez niego → gra pokazuje angielski (poprawnie)
+→ re-translate → approve → artefakt odzyskuje wiersz → polski wraca. Pełna pętla zamknięta.
+
+### Scenariusz B — collateral revert (NASZ przypadek; NOWA klasa, luka kliencka)
+
+SSG **nie** zmienił naszego tekstu, ale zmodyfikował SubFile (tu: +4 sąsiednie fragmenty) ⇒
+chunk wymieniony ⇒ polski znika z DAT gracza. Dla TMS (przy czystym angielskim source) wiersz
+jest **Unchanged** → zostaje Approved → artefakt bajtowo identyczny → 304 + hash match → SKIP →
+**angielski w grze na czas nieokreślony; system sam tego nie wykryje**. Samoleczenie następuje
+dopiero „przy okazji" pierwszej dowolnej zmiany artefaktu (hash mismatch → pełny re-patch
+przywraca też wiersze collateral). Kluczowe: **residency jest per-gracz** (każdy patchował w
+innym momencie), więc TMS z zasady nie może wiedzieć, co komu wypadło — naprawa musi być
+**kliencka**: launch sentinel „DAT zmienił się od naszego ostatniego patcha → wymuś re-patch"
+(TP-00 #377 — teraz z twardym dowodem; kandydat do promocji).
+
+**Promień rażenia policzony (2026-08-02, z par obu exportów):** update 49 dotknął **1,277 z
+277,420** istniejących SubFile'ów tekstowych (0.46%). Siedzi w nich 14,038 fragmentów (1.75%
+korpusu 800,864): 1,644 source-changed (angielski w grze CELOWY do re-approve), 214 nowych
+(untranslated), **≈12,180 collateral (1.52% korpusu)** — przy w pełni przetłumaczonym
+rezydentnym korpusie tyle WAŻNEGO polskiego revertnąłby ten jeden major. 98.5% przeżywa
+bajtowo. Minor patche dotykają ułamka tego (48.7→48.8: ~5 SubFile'ów).
+
+**Subtelność projektowa sentinela (ujawniona tym testem):** wymuszony re-patch zaraz po update,
+ze STARYM artefaktem, nadpisałby świeży angielski stale-polskim dla wierszy z realną zmianą — a
+usunięcie wiersza z artefaktu później **nie przywraca** angielskiego w DAT (patch nie pisze
+braków) → maskowanie do następnej wymiany chunka. Sentinel musi więc: najpierw świeży artefakt
+(ETag), najlepiej dopiero gdy nowa wersja jest w TMS przetworzona; offline → nie patchować.
+
+### Corollary czasowy scenariusza B — patch-przed-update (2026-08-02, pytanie usera)
+
+Nasz flow patchuje **przed** oficjalnym launcherem (sync → hash-check → patch → fire-and-forget;
+update aplikuje się PO nas — log 48.7: my 23:05:58, update ~23:06). Skutki:
+
+- **Nawet w pełni przygotowany TMS nie chroni pierwszej sesji po update.** Gracz z kompletnie
+  re-approvowanym artefaktem: launch #1 → PATCH wgrywa wszystko na STARY DAT → update wymienia
+  chunki i wymazuje właśnie-wgrane wiersze (zmienione + collateral) → angielski w grze.
+- **Restart nie pomaga:** launch #2 → 304 + hash match → SKIP → angielski zostaje. Trigger jest
+  wyłącznie hashem pliku tłumaczeń, a ten się nie zmienił. Naprawa wyłącznie rykoszetem od
+  dowolnej następnej zmiany artefaktu (czyjeś approve).
+- **Collateral row (Enter Middle-earth) nie naprawi się NIGDY pracą adminów** — dla TMS jest
+  „Unchanged", nie ma czego re-approvować; tylko rykoszet lub sentinel.
+- **Z sentinelem (DAT-fingerprint w version file → wymuszony re-patch świeżym artefaktem)
+  koszt spada do dokładnie jednego restartu.** Zero restartów wymagałoby patchowania po
+  update = monitorowanie launchera = udowodnione szkodliwe legacy flow. Opcjonalny szlif:
+  stored ForumVersion ≠ forum ⇒ pomiń patch na launchu, na którym i tak przyjdzie update.
+
+### Przestrzeń napraw klienckich — pogłębiona 2026-08-02 (dyskusja z właścicielem)
+
+**Anatomia locków (hipoteza do zbadania):** launcher SSG: patch-faza (trzyma DAT, pisze) →
+ekran logowania (prawdopodobnie NIE trzyma DAT — do potwierdzenia!) → Play → spawnuje
+lotroclient.exe (trzyma DAT do końca sesji; nasz patch ma już branch `GameAlreadyRunning`) →
+launcher umiera. Sygnały „launcher exit / game start" (intuicja legacy flow) przychodzą **za
+późno** — DAT już zajęty przez klienta; jedyna czysta interwencja to wtedy kill+relaunch
+(= udokumentowane szkody legacy: double UAC/login, zabita sesja).
+
+**Wariant „login-window" (nowy, nieprzetestowany):** elevated proces zostaje żywy po
+odpaleniu launchera i polluje „DAT otwieralny do zapisu + mtime zmieniony od naszego baseline"
+→ patchuje W TRAKCIE gdy gracz wpisuje hasło → gra startuje już po polsku. Bez killa, bez
+podwójnego logowania, jedna elevacja. Wygrana ⇒ zero angielskich sesji przy zachowaniu
+oficjalnego launchera jako updatera. Przegrany wyścig ⇒ fallback: sentinel-next-launch
+(default) albo **opt-in kill-and-relaunch** z one-shot guardem (marker próby per
+DAT-fingerprint ⇒ brak restart-loopa). **Niewiadome empiryczne:** (1) czy launcher trzyma
+handle DAT na ekranie logowania (test: launcher na ekranie logowania + elevated próba otwarcia
+RW); (2) czas pełnego re-patcha przy dużym korpusie (8 wierszy ≈ 0.7–5 s; 100k+ nieznany —
+jeśli minuty, okno logowania nie wystarczy). Mitygacja czasu: **repair-set** — TMS zna z
+importu listę SubFile'ów dotkniętych wersją; klient naprawia tylko wiersze artefaktu w
+dotkniętych SubFile'ach (~14k fragmentów zamiast całego korpusu przy majorze).
+
+**Synteza „update-day orchestrator" (2026-08-02, iteracja z właścicielem — jego kill-launcher
+pomysł + login-window):** elevated watcher zostaje żywy po odpaleniu launchera i śledzi STAN
+PLIKÓW (nie procesów — jak rosyjski Legacy): mtime DAT + próba otwarcia RW + quiesce (brak
+zapisów przez N s). Gałęzie: (A) probe RW się udaje → **cichy patch in-place w oknie logowania,
+zero killa, zero restartu** — user nawet nie wie; (B) update skończony (quiesce), ale handle
+trzymany i klient NIE wystartował → **auto-kill LAUNCHERA pre-creds → patch → relaunch** —
+user loguje się raz, wygląda jak zwykły flow update'u (kill launchera pre-sesja ≠ kill klienta
+w trakcie sesji — szkoda legacy nie występuje); (C) klient już żyje → nic nie robimy, sentinel
+naprawi następny launch. One-shot guard per DAT-fingerprint wyklucza restart-loop. Ryzyko
+gałęzi B: fałszywy quiesce w trakcie wolnego downloadu → kill mid-update (launcher SSG jest
+wznawialny/weryfikujący, ale okno quiesce musi być konserwatywne, np. 30+ s + launcher idle).
+Detekcja przez screenshoty+LLM: ODRZUCONA — file-state probe + ew. tytuł okna (Win32) dają tę
+samą informację deterministycznie, offline i za darmo; FileSystemWatcher/polling to koszt ~zero.
+
+**Eksperymenty do wykonania (wszystkie lokalne, bez czekania na SSG poza E2):**
+E1 — launcher na ekranie logowania: elevated próba otwarcia DAT RW (czy handle trzymany) —
+2 min, rozstrzyga gałąź A vs B. E2 — realny update lub tryb repair/verify launchera jako
+symulator cyklu write→release. E3 — benchmark pełnego patcha przy dużym korpusie (syntetyczny
+polish.txt ~100k+ wierszy na KOPII DAT) — budżet czasowy okna + tak czy siak potrzebny dla M4;
+mitygacja: repair-set. E4 — kill launchera na ekranie logowania → relaunch: czy wraca czysto
+do logowania (bezpieczeństwo gałęzi B).
+
+**Rosjanie — fakty potwierdzone w `docs/RUSSIAN_PROJECT_RESEARCH.md` (2026-02-09):** ich
+detekcja jest **reaktywna, plikowa** — „Legacy śledzi zmiany w client_local_English.dat;
+zmodyfikowany przez inny program → wykrycie → propozycja re-pobrania ORYGINALNEGO DAT +
+re-patchowania"; po update gry „Legacy/patcher musi re-aplikować tłumaczenia — Legacy 3.0 robi
+to automatycznie"; gra odpalana z `-disablePatch -nosplash -skiprawdownload`. Czyli: **ich
+mechanizm = nasz sentinel** (file-state tracking, nie monitoring procesów), a „oryginalny DAT"
+= trzymają pristine source (istotne też dla naszego echo-guarda). **NIEpotwierdzone:** czy
+gracz Legacy widzi 0 czy 1 sesję z rosyjskim brakiem po update (czy Legacy orkiestruje
+oficjalny update, czy naprawia dopiero na następnym swoim launchu). Brak danych o wymuszonym
+restarcie — do ewentualnego doszczegółowienia z ich forów.
+
+### Scenariusz C/D/E — Added / Removed / Re-added
+
+Added (7,836) → wiersze untranslated, artefaktu nie dotykają. Removed (644) → soft
+`RemovedInVersion`; wypadnięcie z artefaktu tylko gdy wiersz był Approved. Re-added → reguła
+restore-status ze spec 0001. Bez niespodzianek.
+
+### Scenariusz F — echo z patchowanego DAT (systemowa pułapka ceremonii manualnej)
+
+Admin eksportuje z **własnego, spatchowanego** DAT ⇒ dla wierszy rezydentnych „source" w
+exporcie to **nasz polski**, nie angielski. Spec 0001 zakłada angielski source — dwa przebiegi:
+
+- **Czysta baza (source = prawdziwy angielski):** rezydentny wiersz importuje się jako
+  „source-changed" (angielski→polski!) → **fałszywa inwalidacja każdego
+  przetłumaczonego-i-rezydentnego wiersza** + nadpisanie source polskim. Przy 8 wierszach
+  niewidoczne; przy dużym korpusie — masowa fałszywa inwalidacja co update (guard 20% nie
+  łapie — to nie removal).
+- **Zatruta baza (source = polskie echo z wcześniejszego importu — stan dzisiejszego prod dla
+  8 wierszy):** rezydentne = „Unchanged" (polski==polski), a collateral revert wykrywa się jako
+  source-changed (polski→angielski) → inwalidacja → pętla przypadkiem działa. Paradoks: zatrute
+  source maskuje lukę B — kosztem tego, że TMS nie zna prawdziwego angielskiego tych wierszy
+  (translator bez oryginału, przyszłe diffy porównują z polskim).
+
+**Remedy (do decyzji właściciela, spec-0001 amendment + ticket):** echo-guard w imporcie
+(incoming text == aktualny polski content wiersza → traktuj jako echo/unchanged, nie ruszaj
+source) + jednorazowa naprawa zatrutych source'ów + docelowo eksport z czystego źródła
+(revert-file generowany z TMS przed exportem albo czysta kopia DAT).
+
+## Pliki intel (gitignored `intel/update-49/`)
+
+DAT backupy 48.8 + 49 + write-test (po ~1.76 GB), pełne exporty 48.8/49 (82.6/83.1 MB), pełny
+diff (1.76 MB), snapshoty polish.txt (resident pre-LEGAL-08 + repo post-LEGAL-08) i version file.
+Committed tutaj: BASELINE.md + RESULTS.md (synthetic). Kopia robocza `data/exported.txt` =
+export 49.1 (SHA256 `56F6D046…32B00`) — deliverable do importu w TMS (GameVersion **49.1**).

--- a/docs/knowledge-base/vnum-observations.md
+++ b/docs/knowledge-base/vnum-observations.md
@@ -6,6 +6,10 @@ originSessionId: fcf33c21-a957-445f-bc57-c8ea7814f1b6
 ---
 # DAT Vnum Observations
 
+> **Addendum (2026-08-02):** 6th cycle — 48.8 → **49.1 (second MAJOR)**, vnum still **112/3**
+> while the forum fetch returned "49.1". Two majors and four points without a single vnum move.
+> See [live-test-2026-08-02.md](live-test-2026-08-02.md).
+
 > **Addendum (2026-07-11):** 5th cycle confirmed — 48.7 → **48.8**, vnum still **112/3** while a
 > live forum fetch returned "48.8". See [live-test-2026-07-11.md](live-test-2026-07-11.md).
 
@@ -18,6 +22,8 @@ originSessionId: fcf33c21-a957-445f-bc57-c8ea7814f1b6
 | 2026-03-22 | 47.1 → 47.2 | 112 | 3 | Yes (chunk-patched) |
 | **2026-04-23** | **47.2 → 48.0 (MAJOR)** | **112** | **3** | **Yes (+14MB, +4,231 fragments)** |
 | **2026-06-25** | **48.0 → 48.7 (point)** | **112** | **3** | **Yes (+1 MiB, +1,159 fragments)** |
+| 2026-07-11 | 48.7 → 48.8 (point) | 112 | 3 | Yes (minor) |
+| **2026-08-02** | **48.8 → 49.1 (MAJOR)** | **112** | **3** | **Yes (+1 MiB, +7,192 fragments)** |
 
 ## Conclusions — definitively confirmed
 

--- a/docs/specs/0012-update-resilience.md
+++ b/docs/specs/0012-update-resilience.md
@@ -1,0 +1,133 @@
+# Spec 0012: Update-resilience — launch sentinel, update-day orchestrator, import echo-guard
+
+- **Status:** Draft — open decisions pending (owner); experiments E1–E4 pending (Windows box)
+- **Date:** 2026-08-02 (seeded from the live-test 48.8→49.1 findings + owner discussion, same day)
+- **Author:** Artur Koniec (problem framing + orchestrator/kill concept) — structured against code,
+  spec 0001 and the knowledge base by Claude
+- **Related:** `docs/knowledge-base/update-49/{BASELINE,RESULTS}.md` (empirics + scenario analysis),
+  `docs/knowledge-base/live-test-2026-08-02.md`, `docs/knowledge-base/dat-protection.md`
+  (per-SubFile survival model), spec 0001 (game-update lifecycle — this spec extends it),
+  ADR-0030 (manual export ceremony), `docs/RUSSIAN_PROJECT_RESEARCH.md` (Legacy = file-state
+  sentinel + `-disablePatch`), TP-00 #377 ("launch sentinel (DAT-repair gap)" — promoted here)
+
+## Business context — what the 49.1 live test proved
+
+Empirics (2026-08-02, `update-49/RESULTS.md`):
+
+1. **Survival is per-SubFile, not per-fragment.** An SSG update that modifies a SubFile replaces
+   the whole chunk; every resident translation inside reverts to English even when its own text
+   did not change ("collateral revert"). U49: 1,277/277,420 SubFiles touched → on a
+   fully-translated resident corpus **≈12,180 valid Polish fragments (1.52%) would revert per
+   major**; 98.5% survives byte-for-byte.
+2. **Our patch runs BEFORE the official launcher applies the update** (fire-and-forget), so even
+   a fully re-approved TMS cannot protect the first post-update session, and — because the
+   SKIP/PATCH trigger is translation-file-hash-only — **a restart does not repair anything**.
+   A collateral-reverted row is "Unchanged" for the TMS, so no admin work ever regenerates the
+   artifact for it; repair happens only as a side effect of unrelated approves.
+3. **The admin's export comes from a patched DAT** ("echo"): resident rows carry our Polish as
+   "source". Against a clean-English DB this mass-false-invalidates every translated resident
+   row on every import; against today's (poisoned, 8-row) DB it accidentally works but the TMS
+   loses the real English source.
+
+## Goal
+
+After any SSG update, every player's game returns to full Polish **automatically, with at most
+one visible launcher restart and exactly one login**, without ever masking SSG's text
+corrections with stale Polish — and TMS imports stay correct at any corpus scale.
+
+## Design — layered tiers (client) + import hardening (server)
+
+### Tier 0 — launch sentinel (fundament; always on; = the Russians' proven Legacy mechanism)
+
+- `SaveBaseline` additionally stores a **DAT fingerprint** (size + LastWriteTime) in the version
+  file. On launch: fingerprint mismatch ⇒ the DAT was written by someone else since our last
+  patch ⇒ **force re-patch with a freshly synced artifact even when the translation-file hash
+  matches**. One-shot guard per fingerprint (no repair loops).
+- **Anti-masking handshake:** the distribution endpoint / artifact exposes the GameVersion it
+  was generated for. The sentinel force-patches only when artifact-version ≥ live forum version;
+  otherwise it defers (fallback-to-English semantics preserved — never re-apply pre-update
+  Polish over fresh English; a dropped artifact row can NEVER un-write stale Polish, because
+  patch does not write absences).
+- Offline ⇒ never force-patch; proceed to launch (degrade to English for wiped rows).
+
+### Tier 1 — update-day orchestrator (atomic UX; branches A/B/C)
+
+The elevated launch process stays alive after spawning the official launcher and watches **file
+state, not process semantics** (FileSystemWatcher + RW-open probe on the DAT):
+
+- **A — silent in-place patch:** probe succeeds while launcher sits at the login screen (DAT
+  released after patch phase) ⇒ patch during credential typing. No kill, no restart, invisible.
+- **B — pre-creds launcher kill:** update quiesced but handle still held and lotroclient.exe not
+  started ⇒ kill the LAUNCHER (pre-session UI shell — NOT the legacy client-kill), patch,
+  relaunch launcher. One login total, reads as a normal update flow.
+- **C — player was faster (client running):** touch nothing; Tier 0 repairs next launch.
+- **Convergent re-patch loop:** after our patch, keep watching until game start; if the launcher
+  writes the DAT again (next chunk burst), re-probe and re-patch. Early patches are harmless by
+  construction; the last write wins. Kill (branch B) remains gated on a conservative quiesce
+  (30+ s no writes + launcher idle) because kill is the one invasive act.
+- Rejected detectors: process-lifecycle signals (launcher exit / game start — structurally too
+  late, that was legacy's error), and screenshot+LLM login-screen detection (dominated by the
+  local file-state probe on cost, latency, offline operation, privacy and determinism).
+
+### Repair-set optimization (likely a requirement, pending E3)
+
+TMS knows from the import diff exactly which SubFiles a version touched. Expose that set;
+the client repairs only artifact rows in touched SubFiles (~14k fragments for U49 instead of
+the full corpus). Full-corpus patch duration is unknown (8 rows ≈ 0.7–5 s) — E3 benchmarks it.
+
+### Server side — import echo-guard + source hygiene (extends spec 0001)
+
+- **Echo-guard:** on import, an incoming row whose text equals the row's current Polish content
+  is an echo of our own patch ⇒ treat as Unchanged (do not touch SourceText, do not invalidate).
+- **One-time source repair** for already-poisoned rows (today: 8).
+- **Pristine-source direction (optional, Q-gated):** generate a revert file from TMS SourceText
+  before export, or keep a pristine DAT copy (the Russians re-download the original DAT for the
+  same reason).
+- **Artifact metadata:** GameVersion of generation (needed by the Tier-0 handshake) + the
+  touched-SubFiles set per version (repair-set).
+
+## Experiments (inputs to final design; all local; Windows box)
+
+| # | Question | Procedure | Decides |
+|---|----------|-----------|---------|
+| E1 | Does the launcher hold the DAT at the login screen? | Launcher at login screen → elevated RW-open probe | A vs B as the dominant branch |
+| E4 | Is a pre-creds launcher kill clean? | Kill at login screen → relaunch → verify straight-to-login + game boots | Safety of branch B |
+| E3 | Full-corpus patch duration | Synthetic ~100k+-row polish.txt → patch a DAT COPY → time it | Repair-set: optional vs required |
+| E2 | Handle behavior across a real update cycle (download vs apply bursts; slow-network hour-long updates) | Next SSG update, or launcher repair/verify mode; observe probe + writes timeline | Quiesce windows; whether probe-success can occur mid-update |
+
+Note on slow updates (owner's point): the RW probe is the **primary** signal, quiesce only a
+debounce. If E2 shows the launcher holds the DAT continuously until done, probe alone is
+sufficient. If it releases between download/apply bursts, probe-success can occur mid-update —
+harmless for patching (convergent loop), decisive only for the kill branch, hence the
+conservative quiesce there. An hour-long update just means the watcher idles for an hour
+(FileSystemWatcher cost ≈ zero).
+
+## Open decisions (owner — extracted, not invented)
+
+- **Q1 — MVP scope:** Tier 0 only, or Tier 0 + handshake (recommended), or Tier 0+1 together?
+- **Q2 — One spec or two:** keep client sentinel/orchestrator and server echo-guard in this one
+  spec (recommended — two sides of the same coin) or split?
+- **Q3 — `-disablePatch` takeover:** park with an M4 revisit trigger (recommended) or analyze now?
+- **Q4 — Kill branch (B):** default-on with one-shot guard, or opt-in setting?
+- **Q5 — Placement/priority:** promote from TP-00 #377 into dedicated tickets gated before public
+  launch — confirm milestone/labels.
+
+## Acceptance criteria (draft — final after Q1–Q5)
+
+- [ ] After a simulated chunk-wipe (write-test DAT with a reverted SubFile), the next launch
+      detects the fingerprint mismatch and restores every artifact row (Tier 0).
+- [ ] Sentinel never patches with an artifact older than the live forum version (handshake).
+- [ ] Orchestrator branch A: patch lands between launcher-release and Play without killing
+      anything (E1-gated).
+- [ ] Orchestrator branch B: at most one launcher kill per fingerprint, only pre-client,
+      only after conservative quiesce; relaunch reaches login cleanly (E4-gated).
+- [ ] Echo-guard: importing a patched-DAT export against a translated corpus invalidates ONLY
+      rows whose English actually changed (fixture: resident-Polish echo rows + one revert).
+- [ ] Repair-set: post-update repair touches only rows in update-touched SubFiles (E3-gated).
+
+## Assumptions
+
+- Chunk/SubFile replacement model per `dat-protection.md` (9 live tests).
+- The official launcher's patcher is resumable/verifying (industry standard; E4/E2 sanity-check).
+- Patcher/TMS remain separate bounded contexts — repair-set and artifact-version travel through
+  the HTTP contract, never shared code.


### PR DESCRIPTION
## Summary
- Full live-test documentation of update 48.8 -> 49.1 ("In Good Company"): 7/8 survival with the **first-ever real casualty** — a collateral revert via whole-SubFile chunk replacement (`docs/knowledge-base/update-49/`).
- Blast radius measured: 1,277/277,420 SubFiles touched; **~12,180 collateral fragments (1.52%)** would revert per major on a fully-translated resident corpus; vnum 112/3 unchanged (6th cycle).
- Scenario analysis vs spec 0001: two systemic gaps documented — **collateral-revert repair gap** (hash-only trigger; patch runs before the launcher applies the update; restart repairs nothing) and **import echo-poisoning** (patched-DAT exports carry Polish as "source").
- **Spec 0012 draft** (`docs/specs/0012-update-resilience.md`): launch sentinel (Tier 0) + update-day orchestrator (Tier 1, branches A/B/C) + import echo-guard + repair-set; experiments E1–E4 and owner decisions Q1–Q5 extracted.
- Knowledge-base index + dat-protection/vnum/update-history addenda + CLAUDE.md digest updated; NinjaMark re-evaluated with current-model rationale.

Docs-only change. Raw intel (DAT backups, full exports, diff) stays in gitignored `intel/update-49/`; committed docs use LEGAL-08 synthetic equivalents for quest text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTsm9G5Rydyr4r1M2iivrg