### PR TITLE
UR-01: Windows experiments E1-E4 — DAT handle, kill-relaunch, full-corpus patch benchmark

### DIFF
--- a/docs/knowledge-base/update-49/RESULTS.md
+++ b/docs/knowledge-base/update-49/RESULTS.md
@@ -308,19 +308,43 @@ touched SubFiles" wypada z MVP.
      Sonda odpowiada więc na pytanie operacyjne („czy MY możemy patchować"), nie na pytanie
      „czy launcher ma handle write".
 
-### E1 — sonda RW na ekranie logowania: ⏳ skrypt gotowy, czeka na przebieg z userem
+### E1 — ✅ **OPEN-OK na ekranie logowania — launcher NIE trzyma DAT; gałąź A wykonalna**
 
-`scripts/experiments/e1-rw-probe.ps1` (elevated; loguje do gitignored
-`intel/update-49/e1-probe-results.log`). Protokół: `-Label baseline` (nic nie działa,
-oczekiwane OPEN-OK) → launcher odpalony NORMALNIE (nie z elevated shella — fidelity!) →
-`-Label login-screen` (**kluczowy wynik: gałąź A vs B**) → po E4-loginie `-Label in-game`
-(kontrola negatywna, oczekiwane LOCKED).
+Przebieg 2026-08-02 19:14–19:17 (`scripts/experiments/e1-rw-probe.ps1`, elevated; pełny log
+w gitignored `intel/update-49/e1-probe-results.log`):
 
-### E4 — kill launchera pre-creds → relaunch: ⏳ czeka na przebieg z userem
+| Label | Procesy | Wynik | mtime DAT w chwili sondy |
+|---|---|---|---|
+| baseline | none | OPEN-OK | 13:46:00 (bez zmian — sonda jest nieinwazyjna, nie bumpuje mtime) |
+| **login-screen** | LotroLauncher | **OPEN-OK** | 19:14:55 (launcher pisał do DAT ~16 s wcześniej, w fazie startowego checku — i już puścił) |
+| in-game | (klient 64-bit) | **LOCKED 0x80070020** sharing violation | 19:15:53 (kolejny zapis przy starcie klienta/logowaniu) |
 
-Z elevated shella: `taskkill /IM LotroLauncher.exe /F` (nazwa procesu potwierdzona na dysku)
-przy launcherze na ekranie logowania → ponowny normalny start → obserwacje usera: (a) wraca
-prosto do logowania bez re-weryfikacji/naprawy? (b) po zalogowaniu gra wstaje normalnie?
+**Gating (spec 0012): gałąź A potwierdzona jako dominująca** — na ekranie logowania DAT jest
+wolny, cichy in-place patch w oknie wpisywania hasła jest fizycznie możliwy (a z E3 wiemy, że
+nawet pełny korpus = 14.7 s). Kontrola negatywna zachowuje się poprawnie (klient trzyma DAT
+przez całą sesję). Gotcha narzędziowa: log pokazał `procs=none` przy in-game locku, bo filtr
+skryptu nie znał **`lotroclient64`** (nowoczesny klient jest 64-bitowy, `x64\lotroclient64.exe`)
+— skrypty poprawione; patcherowy `GameProcessDetector` zna `lotroclient64` od dawna (bez buga).
+
+### E4 — ✅ **kill pre-creds czysty — 3× reprodukcja; relaunch nieodróżnialny od zwykłego startu**
+
+Launcher na ekranie logowania → `taskkill /IM LotroLauncher.exe /F` → ponowny start (user,
+3 powtórzenia): **każdy start launchera wygląda identycznie** — UAC prompt → check DAT → ekran
+logowania; po killu ZERO dodatkowej weryfikacji/naprawy ponad standardowy startowy check; po
+zalogowaniu gra wstaje normalnie. **Gałąź B bezpieczna** jako fallback. Bonus rozwiązujący
+zagadkę `asInvoker`+ACL: **launcher elevuje się przez UAC przy każdym starcie** — dlatego może
+pisać do DAT mimo Users=RX (a nasz orchestrator, sam elevated, może go killnąć).
+
+### Finding E1-F1 — **mtime DAT jest wolatylny: launcher pisze do DAT przy KAŻDYM starcie**
+
+Sekwencja mtime: 13:46:00 (spoczynek; baseline-probe NIE bumpuje) → **19:14:55 przy samym
+starcie launchera** (żadnego update'u; size bez zmian) → **19:15:53 przy starcie klienta**.
+Konsekwencja projektowa: **fingerprint size+mtime z draftu Tier 0 generowałby false-positive
+co launch** (mtime rusza się w każdej sesji bez żadnej utraty tłumaczeń) → sentinel
+zdegenerowałby się do force-re-patch przy każdym starcie. Korekta w spec 0012: detekcja przez
+**content-sentinel** — odczyt próbki znanych przetłumaczonych fragmentów przez datexport READ
+(milisekundy, zero fałszywych sygnałów w obie strony); alternatywa always-repatch (~15 s/start)
+odrzucona jako bezcelowy 800k-wierszowy zapis do DAT co sesję. Finalna decyzja: #558 (Q1).
 
 ### E2 — timeline handli przy realnym update: ⏳ monitor gotowy, czeka na najbliższy update SSG
 

--- a/docs/knowledge-base/update-49/RESULTS.md
+++ b/docs/knowledge-base/update-49/RESULTS.md
@@ -265,6 +265,72 @@ exporcie to **nasz polski**, nie angielski. Spec 0001 zakłada angielski source 
 source) + jednorazowa naprawa zatrutych source'ów + docelowo eksport z czystego źródła
 (revert-file generowany z TMS przed exportem albo czysta kopia DAT).
 
+## Experiments E1–E4 — results (2026-08-02, #557)
+
+### E3 — full-corpus patch benchmark: ✅ DONE — repair-set NIE jest wymagany czasowo
+
+Setup: syntetyczny pełny korpus z export-49 (**800,865 wierszy danych**, treść = `PL ` + oryginał,
+`approved=1`, format bez zmian, CRLF zachowane) → Release CLI → patch na **KOPII** DAT 49
+z pre-utworzonym `.backup` (krok backupu = no-op „already exists" — zgodne z realnym update-day,
+gdzie backup już istnieje) → uruchomienie z osobnego cwd, żeby `SaveBaseline` nie tknął żywego
+`data/last_known_game_version.txt`.
+
+| Run | Wiersze | Wall clock (cała komenda) | Applied / Skipped / Warnings |
+|---|---|---|---|
+| Full corpus | 800,864 | **14.7 s** | 800,864 / 0 / 0 |
+| Repair-set-sized | 21,660 | **5.6 s** | 21,660 / 0 / 0 |
+
+- Wall clock obejmuje WSZYSTKO: startup CLI, preflight (w tym forum fetch przez sieć),
+  parsowanie pliku tłumaczeń (83 MB przy pełnym korpusie), patch wszystkich SubFile'ów, flush.
+  Stały narzut (startup+preflight+parse małego pliku) ≈ 3–4 s ⇒ czysty patch pełnego korpusu
+  ≈ 10–11 s.
+- Weryfikacja realności zapisu: bench DAT urósł +5,242,880 B — spójne z prefiksem `PL `
+  (~800k fragmentów × ~6.5 B UTF-16).
+- Repair-set proxy: wszystkie wiersze korpusu w 3,921 FileIds obecnych w hunkach diffa
+  48.8→49 (nadzbiór 1,277 dotkniętych istniejących SubFile'ów — zawiera też nowe SubFile'e).
+- Sprzęt: maszyna maintainera (NVMe). Nawet ×5 na wolnym dysku mieści się w oknie logowania.
+
+**Gating (spec 0012):** pełny re-patch korpusu mieści się w oknie logowania z dużym zapasem ⇒
+**repair-set = opcjonalna optymalizacja, nie wymaganie MVP**. Draft AC „repair touches only
+touched SubFiles" wypada z MVP.
+
+### Nowe fakty odkryte przy przygotowaniu E1 (anatomia locków — uściślenie)
+
+1. **`LotroLauncher.exe` ma manifest `requestedExecutionLevel=asInvoker`** — launcher sam się
+   NIE elevuje. 2. **ACL katalogu gry: `BUILTIN\Users = RX` (read+execute), zero write** —
+   zwykło-odpalony (nieelevowany) launcher **w ogóle nie może pisać do DAT**. Wnioski:
+   - Do zapisu przy update launcher musi coś elevować (UAC consent przy starcie update'u?) albo
+     user odpala go „jako administrator" — **E2 ma zidentyfikować, który proces realnie pisze**.
+   - Sonda RW **musi być elevated** (nieelevowana dostaje ACL-owy ACCESS-DENIED, który maskuje
+     stan sharing — potwierdzone self-testem skryptu).
+   - Interpretacja E1: launcher nieelevowany może na ekranie logowania trzymać handle READ
+     z restrykcyjnym sharingiem (np. `FileShare.Read`) — to też blokuje nasz otwór RW/ShareNone.
+     Sonda odpowiada więc na pytanie operacyjne („czy MY możemy patchować"), nie na pytanie
+     „czy launcher ma handle write".
+
+### E1 — sonda RW na ekranie logowania: ⏳ skrypt gotowy, czeka na przebieg z userem
+
+`scripts/experiments/e1-rw-probe.ps1` (elevated; loguje do gitignored
+`intel/update-49/e1-probe-results.log`). Protokół: `-Label baseline` (nic nie działa,
+oczekiwane OPEN-OK) → launcher odpalony NORMALNIE (nie z elevated shella — fidelity!) →
+`-Label login-screen` (**kluczowy wynik: gałąź A vs B**) → po E4-loginie `-Label in-game`
+(kontrola negatywna, oczekiwane LOCKED).
+
+### E4 — kill launchera pre-creds → relaunch: ⏳ czeka na przebieg z userem
+
+Z elevated shella: `taskkill /IM LotroLauncher.exe /F` (nazwa procesu potwierdzona na dysku)
+przy launcherze na ekranie logowania → ponowny normalny start → obserwacje usera: (a) wraca
+prosto do logowania bez re-weryfikacji/naprawy? (b) po zalogowaniu gra wstaje normalnie?
+
+### E2 — timeline handli przy realnym update: ⏳ monitor gotowy, czeka na najbliższy update SSG
+
+`scripts/experiments/e2-dat-handle-monitor.ps1` (elevated, odpalić PRZED launcherem, zostawić
+przez cały cykl update, Ctrl+C po starcie gry; loguje zmiany stanu probe/size/mtime/procesów
+co 1 s + heartbeat 30 s do gitignored `intel/update-49/e2-handle-timeline.log`). Alternatywny
+wcześniejszy przebieg: tryb repair/verify launchera, jeśli istnieje. Pytania: czy launcher
+puszcza DAT między burstami download/apply (probe-success mid-update?); który proces pisze
+(asInvoker vs elevacja); kształt okna quiesce dla gałęzi B.
+
 ## Pliki intel (gitignored `intel/update-49/`)
 
 DAT backupy 48.8 + 49 + write-test (po ~1.76 GB), pełne exporty 48.8/49 (82.6/83.1 MB), pełny

--- a/docs/knowledge-base/update-49/RESULTS.md
+++ b/docs/knowledge-base/update-49/RESULTS.md
@@ -346,14 +346,45 @@ zdegenerowałby się do force-re-patch przy każdym starcie. Korekta w spec 0012
 (milisekundy, zero fałszywych sygnałów w obie strony); alternatywa always-repatch (~15 s/start)
 odrzucona jako bezcelowy 800k-wierszowy zapis do DAT co sesję. Finalna decyzja: #558 (Q1).
 
-### E2 — timeline handli przy realnym update: ⏳ monitor gotowy, czeka na najbliższy update SSG
+### E2 — ✅ **wykonany od ręki metodą wymuszonego downgrade'u (pomysł ownera) — pełny cykl update zarejestrowany**
 
-`scripts/experiments/e2-dat-handle-monitor.ps1` (elevated, odpalić PRZED launcherem, zostawić
-przez cały cykl update, Ctrl+C po starcie gry; loguje zmiany stanu probe/size/mtime/procesów
-co 1 s + heartbeat 30 s do gitignored `intel/update-49/e2-handle-timeline.log`). Alternatywny
-wcześniejszy przebieg: tryb repair/verify launchera, jeśli istnieje. Pytania: czy launcher
-puszcza DAT między burstami download/apply (probe-success mid-update?); który proces pisze
-(asInvoker vs elevacja); kształt okna quiesce dla gałęzi B.
+**Metoda (nowa, powtarzalna):** elevated podmiana live DAT na backup 48.8 → launcher sam wykrył
+stary stan pliku i odtworzył **realny cykl update 48.8→49.1** (delta widoczna na pasku
+launchera) → `scripts/experiments/e2-dat-handle-monitor.ps1` (sonda co 1 s) przez cały cykl +
+sesję gry. Pełny log: gitignored `intel/update-49/e2-handle-timeline.log` (2 przebiegi —
+przerwa 19:40:22–19:41:53 to restart monitora przez usera przy ekranie logowania).
+
+| t (2026-08-02) | Zdarzenie |
+|---|---|
+| 19:39:32 | Monitor start: DAT=48.8 (1,893,807,856 B), probe OPEN-OK, procs=none |
+| 19:39:39 | LotroLauncher startuje (UAC) — probe **WCIĄŻ OPEN-OK przez ~11 s**: faza check+download NIE trzyma DAT |
+| 19:39:51.007 | **LOCKED** — burst apply |
+| 19:39:52.032 | **OPEN-OK**, size = 1,894,856,432 B (co do bajta rozmiar 49.1), mtime bump — **cały apply w JEDNYM ~1 s burście** |
+| 19:40–19:42 | Ekran logowania: OPEN-OK stabilnie (launcher żywy) |
+| 19:42:12 | **LOCKED, procs=lotroclient64** — klient przejmuje DAT na całą sesję; launcher znika przy spawnie klienta |
+| →koniec | LOCKED przez sesję in-game; po wyjściu z gry user zamknął monitor |
+
+**Wnioski (gating spec 0012):**
+
+1. **Download ≠ apply — faza pobierania NIE trzyma DAT.** Probe-success mid-update JEST
+   możliwy (~11 s wolnego DAT przed apply) ⇒ **convergent re-patch loop orchestratora jest
+   konieczny i wystarczający**: nasz wczesny patch może zostać nadpisany burstem apply, ostatni
+   zapis wygrywa, watch trwa do startu gry.
+2. **Apply = pojedynczy ~1 s lock-burst** (delta ~5 MB / 1,277 SubFile'ów) ⇒ quiesce 30 s dla
+   gałęzi B jest bardzo konserwatywny. Zastrzeżenie: duży major (nowy content GB-ami) może mieć
+   dłuższe/wielokrotne bursty — monitor zostaje w arsenale na następny realny major SSG.
+3. **Post-update login screen: OPEN-OK — gałąź A potwierdzona także w dniu update** (E1
+   potwierdzał ją tylko przy zwykłym starcie).
+4. Klient (`lotroclient64`) trzyma DAT od startu do końca sesji; launcher umiera przy spawnie
+   klienta — sygnały procesowe raz jeszcze potwierdzone jako strukturalnie spóźnione.
+5. **Tłumaczenia przeżyły wymuszony re-update** — user zweryfikował w UI gry („gwarantuję, że
+   je widziałem"); stan DAT zbiegł do 49.1 co do bajta rozmiaru. Zgodne z modelem per-SubFile.
+6. **Bonus metodologiczny:** forced-downgrade (podmiana DAT na starszy backup) = **powtarzalny
+   symulator pełnego cyklu update** — testy orchestratora end-to-end bez czekania na SSG; przy
+   okazji zwalidowana ścieżka „restore pristine DAT" (launcher czysto dociąga deltę).
+7. mtime NIE drgnął przy starcie klienta w tym przebiegu (w E1 drgnął przy logowaniu) —
+   wolatylność mtime jest nieprzewidywalna; finding E1-F1 (content-sentinel zamiast
+   size+mtime) stoi w mocy.
 
 ## Pliki intel (gitignored `intel/update-49/`)
 

--- a/docs/specs/0012-update-resilience.md
+++ b/docs/specs/0012-update-resilience.md
@@ -1,8 +1,10 @@
 # Spec 0012: Update-resilience — launch sentinel, update-day orchestrator, import echo-guard
 
-- **Status:** Draft — open decisions pending (owner); experiments: **E3 done** (repair-set NOT
-  required — see below), E1/E4 scripted + pending a user run, E2 monitor ready for the next SSG
-  update (`scripts/experiments/`, results: `docs/knowledge-base/update-49/RESULTS.md` §Experiments)
+- **Status:** Draft — open decisions pending (owner); experiments: **E1/E3/E4 done 2026-08-02**
+  (branch A viable — DAT free at the login screen; repair-set NOT required; pre-creds kill clean
+  3×), E2 monitor ready for the next SSG update (`scripts/experiments/`, results:
+  `docs/knowledge-base/update-49/RESULTS.md` §Experiments — incl. finding E1-F1: DAT mtime is
+  volatile, which forces the Tier-0 fingerprint revision below)
 - **Date:** 2026-08-02 (seeded from the live-test 48.8→49.1 findings + owner discussion, same day)
 - **Author:** Artur Koniec (problem framing + orchestrator/kill concept) — structured against code,
   spec 0001 and the knowledge base by Claude
@@ -41,10 +43,17 @@ corrections with stale Polish — and TMS imports stay correct at any corpus sca
 
 ### Tier 0 — launch sentinel (fundament; always on; = the Russians' proven Legacy mechanism)
 
-- `SaveBaseline` additionally stores a **DAT fingerprint** (size + LastWriteTime) in the version
-  file. On launch: fingerprint mismatch ⇒ the DAT was written by someone else since our last
-  patch ⇒ **force re-patch with a freshly synced artifact even when the translation-file hash
-  matches**. One-shot guard per fingerprint (no repair loops).
+- ~~DAT fingerprint (size + LastWriteTime)~~ **REVISED per E1-F1 (2026-08-02): the launcher
+  writes the DAT on EVERY start** (mtime bumps at launcher check and at client start, with no
+  translation loss), so a size+mtime fingerprint would false-positive every session and
+  degenerate Tier 0 into a force-re-patch-per-launch. Detection is a **content sentinel**
+  instead: on launch, read a small sample of known-translated artifact fragments via the
+  existing datexport READ path (milliseconds); any sampled fragment reverted to English ⇒
+  **force re-patch with a freshly synced artifact even when the translation-file hash
+  matches**. Sample choice: spread across distinct SubFiles (collateral reverts are
+  per-SubFile, so K sampled SubFiles detect a wipe of any of them; full certainty needs the
+  full artifact row-set — sampling breadth is an implementation knob). One-shot guard per
+  detection (no repair loops).
 - **Anti-masking handshake:** the distribution endpoint / artifact exposes the GameVersion it
   was generated for. The sentinel force-patches only when artifact-version ≥ live forum version;
   otherwise it defers (fallback-to-English semantics preserved — never re-apply pre-update
@@ -96,18 +105,19 @@ faster repair) — not a correctness or UX requirement.
 
 | # | Question | Procedure | Decides | Status |
 |---|----------|-----------|---------|--------|
-| E1 | Does the launcher hold the DAT at the login screen? | Launcher at login screen → elevated RW-open probe (`scripts/experiments/e1-rw-probe.ps1`) | A vs B as the dominant branch | ⏳ scripted, pending user run |
-| E4 | Is a pre-creds launcher kill clean? | Kill at login screen → relaunch → verify straight-to-login + game boots | Safety of branch B | ⏳ pending user run |
+| E1 | Does the launcher hold the DAT at the login screen? | Launcher at login screen → elevated RW-open probe (`scripts/experiments/e1-rw-probe.ps1`) | A vs B as the dominant branch | ✅ **OPEN-OK at login screen ⇒ branch A viable & dominant**; in-game control LOCKED (0x80070020) |
+| E4 | Is a pre-creds launcher kill clean? | Kill at login screen → relaunch → verify straight-to-login + game boots | Safety of branch B | ✅ **clean, 3× reproduced** — relaunch indistinguishable from a normal start (UAC → DAT check → login); game boots fine |
 | E3 | Full-corpus patch duration | Synthetic ~100k+-row polish.txt → patch a DAT COPY → time it | Repair-set: optional vs required | ✅ **800,864 rows = 14.7 s; 21,660 = 5.6 s ⇒ repair-set optional** |
 | E2 | Handle behavior across a real update cycle (download vs apply bursts; slow-network hour-long updates) | Next SSG update, or launcher repair/verify mode; observe probe + writes timeline (`scripts/experiments/e2-dat-handle-monitor.ps1`) | Quiesce windows; whether probe-success can occur mid-update | ⏳ monitor ready, awaits next SSG update |
 
-New lock-anatomy facts (2026-08-02, found while scripting E1): `LotroLauncher.exe` manifests
-`asInvoker` (no self-elevation) and the game dir ACL grants Users only RX — a plainly-started
-launcher cannot write the DAT at all, so SOMETHING elevates during updates (E2 identifies the
-actual writer). The probe must run elevated (a non-elevated run reports an ACL ACCESS-DENIED
-that masks the sharing state), and a LOCKED result at the login screen may mean a read handle
-with restrictive sharing rather than a write handle — either way it answers the operative
-question ("can WE patch now"), which is what branches A/B key on.
+New lock-anatomy facts (2026-08-02, E1/E4 pass): `LotroLauncher.exe` manifests `asInvoker` and
+the game dir ACL grants Users only RX, but **the launcher prompts UAC and runs elevated on every
+start** — that's how it writes the DAT despite the ACL (and why our elevated orchestrator can
+kill it). **E1-F1: the launcher writes the DAT during its startup check on EVERY launch** (and
+the client writes again at session start), so DAT mtime is NOT a "someone patched content"
+signal — this kills the size+mtime fingerprint and motivates the content-sentinel revision in
+Tier 0. Probes must run elevated (a non-elevated run reports an ACL ACCESS-DENIED that masks
+the sharing state). The 64-bit client process is `lotroclient64` (`x64\lotroclient64.exe`).
 
 Note on slow updates (owner's point): the RW probe is the **primary** signal, quiesce only a
 debounce. If E2 shows the launcher holds the DAT continuously until done, probe alone is
@@ -129,12 +139,14 @@ conservative quiesce there. An hour-long update just means the watcher idles for
 ## Acceptance criteria (draft — final after Q1–Q5)
 
 - [ ] After a simulated chunk-wipe (write-test DAT with a reverted SubFile), the next launch
-      detects the fingerprint mismatch and restores every artifact row (Tier 0).
+      detects the revert via the content sentinel and restores every artifact row (Tier 0).
 - [ ] Sentinel never patches with an artifact older than the live forum version (handshake).
 - [ ] Orchestrator branch A: patch lands between launcher-release and Play without killing
-      anything (E1-gated).
-- [ ] Orchestrator branch B: at most one launcher kill per fingerprint, only pre-client,
-      only after conservative quiesce; relaunch reaches login cleanly (E4-gated).
+      anything (E1 ✅ confirmed the window exists: DAT free at the login screen, full-corpus
+      patch 14.7 s).
+- [ ] Orchestrator branch B: at most one launcher kill per detection, only pre-client,
+      only after conservative quiesce; relaunch reaches login cleanly (E4 ✅ confirmed clean,
+      3× reproduced).
 - [ ] Echo-guard: importing a patched-DAT export against a translated corpus invalidates ONLY
       rows whose English actually changed (fixture: resident-Polish echo rows + one revert).
 - [ ] ~~Repair-set: post-update repair touches only rows in update-touched SubFiles~~ —

--- a/docs/specs/0012-update-resilience.md
+++ b/docs/specs/0012-update-resilience.md
@@ -1,10 +1,12 @@
 # Spec 0012: Update-resilience — launch sentinel, update-day orchestrator, import echo-guard
 
-- **Status:** Draft — open decisions pending (owner); experiments: **E1/E3/E4 done 2026-08-02**
-  (branch A viable — DAT free at the login screen; repair-set NOT required; pre-creds kill clean
-  3×), E2 monitor ready for the next SSG update (`scripts/experiments/`, results:
-  `docs/knowledge-base/update-49/RESULTS.md` §Experiments — incl. finding E1-F1: DAT mtime is
-  volatile, which forces the Tier-0 fingerprint revision below)
+- **Status:** Draft — open decisions pending (owner); experiments: **ALL FOUR done 2026-08-02**
+  (E1: DAT free at the login screen; E3: full corpus 14.7 s — repair-set not required; E4:
+  pre-creds kill clean 3×; E2: full forced-downgrade update cycle recorded — download leaves
+  the DAT free, apply is a ~1 s lock burst, login screen post-update free). Results:
+  `docs/knowledge-base/update-49/RESULTS.md` §Experiments — incl. findings E1-F1 (DAT mtime
+  volatile ⇒ Tier-0 content-sentinel revision below) and the forced-downgrade method (repeatable
+  update-cycle simulator; big-major burst shape still worth observing at the next real SSG major)
 - **Date:** 2026-08-02 (seeded from the live-test 48.8→49.1 findings + owner discussion, same day)
 - **Author:** Artur Koniec (problem framing + orchestrator/kill concept) — structured against code,
   spec 0001 and the knowledge base by Claude
@@ -75,7 +77,10 @@ state, not process semantics** (FileSystemWatcher + RW-open probe on the DAT):
 - **Convergent re-patch loop:** after our patch, keep watching until game start; if the launcher
   writes the DAT again (next chunk burst), re-probe and re-patch. Early patches are harmless by
   construction; the last write wins. Kill (branch B) remains gated on a conservative quiesce
-  (30+ s no writes + launcher idle) because kill is the one invasive act.
+  (30+ s no writes + launcher idle) because kill is the one invasive act. **E2-confirmed:** the
+  download phase leaves the DAT free (~11 s window in the forced 48.8→49.1 replay) so a probe
+  CAN succeed mid-update — the loop is what makes that harmless; the observed apply burst was
+  ~1 s, making the 30 s quiesce very conservative for deltas of this size.
 - Rejected detectors: process-lifecycle signals (launcher exit / game start — structurally too
   late, that was legacy's error), and screenshot+LLM login-screen detection (dominated by the
   local file-state probe on cost, latency, offline operation, privacy and determinism).
@@ -108,7 +113,7 @@ faster repair) — not a correctness or UX requirement.
 | E1 | Does the launcher hold the DAT at the login screen? | Launcher at login screen → elevated RW-open probe (`scripts/experiments/e1-rw-probe.ps1`) | A vs B as the dominant branch | ✅ **OPEN-OK at login screen ⇒ branch A viable & dominant**; in-game control LOCKED (0x80070020) |
 | E4 | Is a pre-creds launcher kill clean? | Kill at login screen → relaunch → verify straight-to-login + game boots | Safety of branch B | ✅ **clean, 3× reproduced** — relaunch indistinguishable from a normal start (UAC → DAT check → login); game boots fine |
 | E3 | Full-corpus patch duration | Synthetic ~100k+-row polish.txt → patch a DAT COPY → time it | Repair-set: optional vs required | ✅ **800,864 rows = 14.7 s; 21,660 = 5.6 s ⇒ repair-set optional** |
-| E2 | Handle behavior across a real update cycle (download vs apply bursts; slow-network hour-long updates) | Next SSG update, or launcher repair/verify mode; observe probe + writes timeline (`scripts/experiments/e2-dat-handle-monitor.ps1`) | Quiesce windows; whether probe-success can occur mid-update | ⏳ monitor ready, awaits next SSG update |
+| E2 | Handle behavior across a real update cycle (download vs apply bursts; slow-network hour-long updates) | **Forced downgrade** (swap live DAT for the 48.8 backup → launcher replays the real 48.8→49.1 cycle) + probe/writes timeline (`scripts/experiments/e2-dat-handle-monitor.ps1`) | Quiesce windows; whether probe-success can occur mid-update | ✅ **download leaves the DAT free (~11 s window, probe-success mid-update IS possible ⇒ convergent loop required & sufficient); apply = single ~1 s lock burst; post-update login screen free (branch A holds on update day); client holds the DAT for the whole session.** Caveat: ~5 MB delta — big-major burst shape TBD at the next real SSG major |
 
 New lock-anatomy facts (2026-08-02, E1/E4 pass): `LotroLauncher.exe` manifests `asInvoker` and
 the game dir ACL grants Users only RX, but **the launcher prompts UAC and runs elevated on every
@@ -120,11 +125,11 @@ Tier 0. Probes must run elevated (a non-elevated run reports an ACL ACCESS-DENIE
 the sharing state). The 64-bit client process is `lotroclient64` (`x64\lotroclient64.exe`).
 
 Note on slow updates (owner's point): the RW probe is the **primary** signal, quiesce only a
-debounce. If E2 shows the launcher holds the DAT continuously until done, probe alone is
-sufficient. If it releases between download/apply bursts, probe-success can occur mid-update —
-harmless for patching (convergent loop), decisive only for the kill branch, hence the
-conservative quiesce there. An hour-long update just means the watcher idles for an hour
-(FileSystemWatcher cost ≈ zero).
+debounce. **E2 resolved this: the launcher releases the DAT for the whole download phase and
+locks only for short apply bursts**, so probe-success mid-update is real — harmless for
+patching (convergent loop), decisive only for the kill branch, hence the conservative quiesce
+there. An hour-long slow-network update just means a long free-DAT download window and an idle
+watcher (FileSystemWatcher cost ≈ zero).
 
 ## Open decisions (owner — extracted, not invented)
 

--- a/docs/specs/0012-update-resilience.md
+++ b/docs/specs/0012-update-resilience.md
@@ -1,6 +1,8 @@
 # Spec 0012: Update-resilience — launch sentinel, update-day orchestrator, import echo-guard
 
-- **Status:** Draft — open decisions pending (owner); experiments E1–E4 pending (Windows box)
+- **Status:** Draft — open decisions pending (owner); experiments: **E3 done** (repair-set NOT
+  required — see below), E1/E4 scripted + pending a user run, E2 monitor ready for the next SSG
+  update (`scripts/experiments/`, results: `docs/knowledge-base/update-49/RESULTS.md` §Experiments)
 - **Date:** 2026-08-02 (seeded from the live-test 48.8→49.1 findings + owner discussion, same day)
 - **Author:** Artur Koniec (problem framing + orchestrator/kill concept) — structured against code,
   spec 0001 and the knowledge base by Claude
@@ -69,11 +71,15 @@ state, not process semantics** (FileSystemWatcher + RW-open probe on the DAT):
   late, that was legacy's error), and screenshot+LLM login-screen detection (dominated by the
   local file-state probe on cost, latency, offline operation, privacy and determinism).
 
-### Repair-set optimization (likely a requirement, pending E3)
+### Repair-set optimization (E3 verdict 2026-08-02: OPTIONAL, not required)
 
 TMS knows from the import diff exactly which SubFiles a version touched. Expose that set;
 the client repairs only artifact rows in touched SubFiles (~14k fragments for U49 instead of
-the full corpus). Full-corpus patch duration is unknown (8 rows ≈ 0.7–5 s) — E3 benchmarks it.
+the full corpus). **E3 measured (Release CLI, DAT copy, update-day-shaped run): full corpus
+800,864 rows = 14.7 s wall clock end-to-end (~10–11 s net patch); repair-set-sized 21,660 rows
+= 5.6 s.** A full-corpus re-patch fits the login window with a wide margin, so the repair-set
+drops out of the MVP into an optional later optimization (less I/O on the DAT, marginally
+faster repair) — not a correctness or UX requirement.
 
 ### Server side — import echo-guard + source hygiene (extends spec 0001)
 
@@ -88,12 +94,20 @@ the full corpus). Full-corpus patch duration is unknown (8 rows ≈ 0.7–5 s) �
 
 ## Experiments (inputs to final design; all local; Windows box)
 
-| # | Question | Procedure | Decides |
-|---|----------|-----------|---------|
-| E1 | Does the launcher hold the DAT at the login screen? | Launcher at login screen → elevated RW-open probe | A vs B as the dominant branch |
-| E4 | Is a pre-creds launcher kill clean? | Kill at login screen → relaunch → verify straight-to-login + game boots | Safety of branch B |
-| E3 | Full-corpus patch duration | Synthetic ~100k+-row polish.txt → patch a DAT COPY → time it | Repair-set: optional vs required |
-| E2 | Handle behavior across a real update cycle (download vs apply bursts; slow-network hour-long updates) | Next SSG update, or launcher repair/verify mode; observe probe + writes timeline | Quiesce windows; whether probe-success can occur mid-update |
+| # | Question | Procedure | Decides | Status |
+|---|----------|-----------|---------|--------|
+| E1 | Does the launcher hold the DAT at the login screen? | Launcher at login screen → elevated RW-open probe (`scripts/experiments/e1-rw-probe.ps1`) | A vs B as the dominant branch | ⏳ scripted, pending user run |
+| E4 | Is a pre-creds launcher kill clean? | Kill at login screen → relaunch → verify straight-to-login + game boots | Safety of branch B | ⏳ pending user run |
+| E3 | Full-corpus patch duration | Synthetic ~100k+-row polish.txt → patch a DAT COPY → time it | Repair-set: optional vs required | ✅ **800,864 rows = 14.7 s; 21,660 = 5.6 s ⇒ repair-set optional** |
+| E2 | Handle behavior across a real update cycle (download vs apply bursts; slow-network hour-long updates) | Next SSG update, or launcher repair/verify mode; observe probe + writes timeline (`scripts/experiments/e2-dat-handle-monitor.ps1`) | Quiesce windows; whether probe-success can occur mid-update | ⏳ monitor ready, awaits next SSG update |
+
+New lock-anatomy facts (2026-08-02, found while scripting E1): `LotroLauncher.exe` manifests
+`asInvoker` (no self-elevation) and the game dir ACL grants Users only RX — a plainly-started
+launcher cannot write the DAT at all, so SOMETHING elevates during updates (E2 identifies the
+actual writer). The probe must run elevated (a non-elevated run reports an ACL ACCESS-DENIED
+that masks the sharing state), and a LOCKED result at the login screen may mean a read handle
+with restrictive sharing rather than a write handle — either way it answers the operative
+question ("can WE patch now"), which is what branches A/B key on.
 
 Note on slow updates (owner's point): the RW probe is the **primary** signal, quiesce only a
 debounce. If E2 shows the launcher holds the DAT continuously until done, probe alone is
@@ -123,7 +137,9 @@ conservative quiesce there. An hour-long update just means the watcher idles for
       only after conservative quiesce; relaunch reaches login cleanly (E4-gated).
 - [ ] Echo-guard: importing a patched-DAT export against a translated corpus invalidates ONLY
       rows whose English actually changed (fixture: resident-Polish echo rows + one revert).
-- [ ] Repair-set: post-update repair touches only rows in update-touched SubFiles (E3-gated).
+- [ ] ~~Repair-set: post-update repair touches only rows in update-touched SubFiles~~ —
+      dropped from MVP per E3 (full-corpus re-patch = 14.7 s; repair-set is an optional
+      later optimization).
 
 ## Assumptions
 

--- a/scripts/experiments/e1-rw-probe.ps1
+++ b/scripts/experiments/e1-rw-probe.ps1
@@ -18,7 +18,7 @@ if (-not $isAdmin)
 }
 
 $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'
-$procs = (Get-Process -Name LotroLauncher, lotroclient -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }) -join '+'
+$procs = (Get-Process -Name LotroLauncher, lotroclient, lotroclient64 -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }) -join '+'
 if (-not $procs) { $procs = 'none' }
 $dat = Get-Item -LiteralPath $DatPath
 $state = "size=$($dat.Length) mtime=$($dat.LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss'))"

--- a/scripts/experiments/e1-rw-probe.ps1
+++ b/scripts/experiments/e1-rw-probe.ps1
@@ -1,0 +1,45 @@
+# E1 RW-open probe (spec 0012 / #557): can we open the LOTRO DAT ReadWrite with FileShare.None?
+# Windows-only; run from an ELEVATED PowerShell (Users have only RX on the game dir, so a
+# non-elevated run reports ACCESS-DENIED and proves nothing about sharing).
+#
+# Usage (from repo root, elevated):
+#   powershell -ExecutionPolicy Bypass -File scripts\experiments\e1-rw-probe.ps1 -Label "login-screen"
+# Labels used by the E1 protocol: baseline | login-screen | in-game
+param(
+    [string]$DatPath = 'C:\Program Files (x86)\StandingStoneGames\The Lord of the Rings Online\client_local_English.dat',
+    [string]$LogPath = (Join-Path $PSScriptRoot '..\..\intel\update-49\e1-probe-results.log'),
+    [string]$Label = 'unlabeled'
+)
+
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin)
+{
+    Write-Warning 'NOT elevated - an ACL denial would mask the sharing state. Re-run from an elevated PowerShell.'
+}
+
+$ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'
+$procs = (Get-Process -Name LotroLauncher, lotroclient -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }) -join '+'
+if (-not $procs) { $procs = 'none' }
+$dat = Get-Item -LiteralPath $DatPath
+$state = "size=$($dat.Length) mtime=$($dat.LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss'))"
+
+try
+{
+    $fs = [IO.File]::Open($DatPath, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+    $fs.Close()
+    $result = 'OPEN-OK - nobody holds the DAT; silent in-place patch is possible'
+}
+catch [System.IO.IOException]
+{
+    $hr = '0x{0:X8}' -f ($_.Exception.HResult)
+    # 0x80070020 ERROR_SHARING_VIOLATION / 0x80070021 ERROR_LOCK_VIOLATION
+    $result = "LOCKED - IOException HResult=$hr : $($_.Exception.Message.Trim())"
+}
+catch [System.UnauthorizedAccessException]
+{
+    $result = 'ACCESS-DENIED - elevation/ACL problem; result NOT conclusive, re-run elevated'
+}
+
+$line = "$ts | elevated=$isAdmin | procs=$procs | label=$Label | $state | $result"
+Write-Host $line
+Add-Content -LiteralPath $LogPath -Value $line

--- a/scripts/experiments/e2-dat-handle-monitor.ps1
+++ b/scripts/experiments/e2-dat-handle-monitor.ps1
@@ -1,0 +1,72 @@
+# E2 DAT handle/write timeline monitor (spec 0012 / #557): run across a full SSG update cycle
+# (or the launcher's repair/verify mode) to record when the DAT is written and when an RW-open
+# probe succeeds. Answers: does the launcher release the DAT between download and apply bursts,
+# and can a probe succeed mid-update (decisive for the branch-B quiesce window).
+#
+# Windows-only; run from an ELEVATED PowerShell BEFORE starting the launcher, leave it running
+# through the whole update, stop with Ctrl+C after the game boots:
+#   powershell -ExecutionPolicy Bypass -File scripts\experiments\e2-dat-handle-monitor.ps1
+# Logs one line per state change (probe result / size / mtime / process set) + a 30 s heartbeat.
+param(
+    [string]$DatPath = 'C:\Program Files (x86)\StandingStoneGames\The Lord of the Rings Online\client_local_English.dat',
+    [string]$LogPath = (Join-Path $PSScriptRoot '..\..\intel\update-49\e2-handle-timeline.log'),
+    [double]$IntervalSeconds = 1.0,
+    [int]$HeartbeatSeconds = 30
+)
+
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin)
+{
+    Write-Warning 'NOT elevated - ACL denials will mask the sharing state. Re-run from an elevated PowerShell.'
+}
+
+function Get-ProbeState
+{
+    param([string]$Path)
+    try
+    {
+        $fs = [IO.File]::Open($Path, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+        $fs.Close()
+        return 'OPEN-OK'
+    }
+    catch [System.IO.IOException] { return 'LOCKED' }
+    catch [System.UnauthorizedAccessException] { return 'ACCESS-DENIED' }
+}
+
+function Write-TimelineLine
+{
+    param([string]$Message)
+    $line = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff') | $Message"
+    Write-Host $line
+    Add-Content -LiteralPath $script:LogPath -Value $line
+}
+
+Write-TimelineLine "monitor started | elevated=$isAdmin | interval=${IntervalSeconds}s | dat=$DatPath"
+
+$previous = ''
+$lastHeartbeat = Get-Date
+while ($true)
+{
+    $dat = Get-Item -LiteralPath $DatPath -ErrorAction SilentlyContinue
+    $probe = if ($dat) { Get-ProbeState -Path $DatPath } else { 'FILE-MISSING' }
+    $procs = (Get-Process -Name LotroLauncher, lotroclient -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }) -join '+'
+    if (-not $procs) { $procs = 'none' }
+    $size = if ($dat) { $dat.Length } else { 'missing' }
+    $mtime = if ($dat) { $dat.LastWriteTime.ToString('HH:mm:ss.fff') } else { '-' }
+    $current = "probe=$probe | procs=$procs | size=$size | mtime=$mtime"
+
+    $now = Get-Date
+    if ($current -ne $previous)
+    {
+        Write-TimelineLine "CHANGE | $current"
+        $previous = $current
+        $lastHeartbeat = $now
+    }
+    elseif (($now - $lastHeartbeat).TotalSeconds -ge $HeartbeatSeconds)
+    {
+        Write-TimelineLine "heartbeat | $current"
+        $lastHeartbeat = $now
+    }
+
+    Start-Sleep -Milliseconds ([Math]::Max(100, [int]($IntervalSeconds * 1000)))
+}

--- a/scripts/experiments/e2-dat-handle-monitor.ps1
+++ b/scripts/experiments/e2-dat-handle-monitor.ps1
@@ -49,7 +49,7 @@ while ($true)
 {
     $dat = Get-Item -LiteralPath $DatPath -ErrorAction SilentlyContinue
     $probe = if ($dat) { Get-ProbeState -Path $DatPath } else { 'FILE-MISSING' }
-    $procs = (Get-Process -Name LotroLauncher, lotroclient -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }) -join '+'
+    $procs = (Get-Process -Name LotroLauncher, lotroclient, lotroclient64 -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }) -join '+'
     if (-not $procs) { $procs = 'none' }
     $size = if ($dat) { $dat.Length } else { 'missing' }
     $mtime = if ($dat) { $dat.LastWriteTime.ToString('HH:mm:ss.fff') } else { '-' }


### PR DESCRIPTION
Closes #557

## What

- **E3:** synthetic full corpus (800,865 rows, `PL ` prefix, `approved=1`) patched onto a **copy** of the 49 DAT in **14.7 s wall clock end-to-end** (800,864 applied / 0 skipped / 0 warnings; DAT +5 MiB confirms real writes). Repair-set-sized run (21,660 rows): **5.6 s**. Spec 0012 verdict: **repair-set = optional, not an MVP requirement**.
- **E1:** elevated RW-probe with the launcher at the login screen: **OPEN-OK — the launcher does not hold the DAT** → silent in-place patch (branch A) is viable and dominant. In-game negative control: LOCKED 0x80070020. Probe script: `scripts/experiments/e1-rw-probe.ps1`.
- **E4:** `taskkill` of the launcher at the login screen + relaunch is **indistinguishable from a normal start** (UAC → DAT check → login; 3× reproduced); game boots fine → branch B safe as fallback.
- **E1-F1 (new finding):** the launcher writes the DAT **on every start** (mtime volatile) → the size+mtime fingerprint from the Tier-0 draft would false-positive every session; spec 0012 revised to a **content-sentinel probe** (sample known-translated fragments via datexport READ). Also: launcher elevates via UAC each start (resolves the asInvoker+ACL puzzle); 64-bit client process is `lotroclient64`.
- **E2:** monitor script ready (`scripts/experiments/e2-dat-handle-monitor.ps1`) — runs at the next SSG update or launcher repair/verify; plan recorded per the ticket's AC.

## Why

Experiment results gate spec 0012's orchestrator branch A vs B choice and the repair-set decision (#558 / UR-00). All E1/E3/E4 verdicts are folded into `docs/knowledge-base/update-49/RESULTS.md` §Experiments and spec 0012 (experiments table, Tier-0 revision, AC).

## Test/verify

- Benchmark run from a scratch cwd so `SaveBaseline` never touched the live `data/` state; bench DAT + pre-created `.backup` live in gitignored `intel/update-49/`; no live-DAT writes anywhere (LEGAL-08 trap respected — no `launch polish`).
- No solution code touched (scripts + docs only); CLI built Release with 0 warnings for the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTsm9G5Rydyr4r1M2iivrg