### PR TITLE
RabbitMQ introduction: transactional outbox, broker consumer, dead-lettering, inbox dedup + production deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ POSTGRES_PASSWORD=changeme
 # Local dev password for the bundled broker (any non-empty value). Placeholder — pick your own;
 # it never leaves your machine (.env is git-ignored). The username is `rabbitmq`, hard-coded in
 # compose.yaml: log into the management UI at http://localhost:15672 with rabbitmq/<this value>.
+# The host auth-api reads its side from appsettings.Development.json (baked as `changeme`) — if
+# you change it here, update that file to match, then `docker compose down -v` (the broker only
+# applies the password on first boot of an empty volume).
 # The built-in `guest` account is deliberately unused — it may only connect from the broker's own
 # host, so the host dev Kestrels would get ACCESS_REFUSED against it.
 RABBITMQ_PASSWORD=changeme

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,14 @@
 # (baked as `changeme`) — if you change it here, update those two connection strings to match.
 POSTGRES_PASSWORD=changeme
 
+# --- RabbitMQ ---
+# Local dev password for the bundled broker (any non-empty value). Placeholder — pick your own;
+# it never leaves your machine (.env is git-ignored). The username is `rabbitmq`, hard-coded in
+# compose.yaml: log into the management UI at http://localhost:15672 with rabbitmq/<this value>.
+# The built-in `guest` account is deliberately unused — it may only connect from the broker's own
+# host, so the host dev Kestrels would get ACCESS_REFUSED against it.
+RABBITMQ_PASSWORD=changeme
+
 # The host dev Kestrels serve HTTPS with the native ASP.NET Core dev cert (run once:
 # `dotnet dev-certs https --trust`) — no PFX, no mount. This infra-only dev compose (ADR-0006,
 # amended by #190/M6-14) runs no app containers, so there is no dev-cert password key here.

--- a/.env.hetzner.example
+++ b/.env.hetzner.example
@@ -34,6 +34,13 @@ OpenIddict__EncryptionKey__Key=
 OpenIddict__ApiClientSecret=
 OpenIddict__SigningKey__RsaPrivateKeyXml=
 
+# --- RabbitMQ (the in-stack broker container; auth-api outbox relay + e-mail consumer) ---
+# Box-local secret — generate one per environment: openssl rand -base64 24
+# Compose FAILS LOUDLY when this is missing (${VAR:?} in compose.hetzner.yaml), so add it to the
+# box .env BEFORE deploying a tag that carries the broker. Applied to the broker on FIRST boot
+# only — rotating later goes through rabbitmqctl (docs/deployment/runbook.md → "Secrets").
+RABBITMQ_PASSWORD=
+
 # --- Email (Brevo SMTP; Username is the SMTP login from the Brevo dashboard, not the account email) ---
 #
 # Email__SenderEmail MUST be an address Brevo is authorised to send as — either the verified

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -24,6 +24,11 @@ POSTGRES_PASSWORD=changeme-prod-password
 ConnectionStrings__TranslationDatabase=Host=postgres;Port=5432;Database=lotro_translation;Username=postgres;Password=changeme-prod-password;Ssl Mode=Require;Trust Server Certificate=true
 ConnectionStrings__AuthDatabase=Host=postgres;Port=5432;Database=lotro_auth;Username=postgres;Password=changeme-prod-password;Ssl Mode=Require;Trust Server Certificate=true
 
+# --- RabbitMQ (in-stack broker; auth-api outbox relay + e-mail consumer) ---
+# Applied to the broker on FIRST boot only (empty data volume); pick your own — .env.prod is
+# git-ignored. Management UI (loopback): http://localhost:15673 with rabbitmq/<this value>.
+RABBITMQ_PASSWORD=changeme-prod-password
+
 # --- OpenIddict production keys (auth-api; fail-fast at startup if missing/invalid) ---
 # Generate all three at once with: scripts/gen-openiddict-keys.sh >> .env.prod
 #   OpenIddict__EncryptionKey__Key            base64 of a >= 32-byte symmetric key

--- a/.github/workflows/health-ping.yml
+++ b/.github/workflows/health-ping.yml
@@ -49,8 +49,9 @@ jobs:
           # scale-to-zero Neon compute awake — that ruling outlives Azure, because Neon still
           # suspends — and names the full /health as the on-demand deep check. Once a day is exactly
           # that occasion — this is the only probe that proves the database is reachable.
-          # auth's /health also covers SMTP, so a red run here can legitimately mean "Brevo is down",
-          # not "the site is down"; the response body below says which check failed.
+          # auth's /health also covers SMTP and the in-stack RabbitMQ broker, so a red run here can
+          # legitimately mean "Brevo is down" or "the broker container is down" — not "the site is
+          # down"; the response body below says which check failed.
           #
           # The Static-SSR frontend exposes /health/live but nothing deep, so '/' is its liveness.
           probe() {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,6 +82,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageVersion Include="Testcontainers" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.13.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,6 +46,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <!-- Email -->
     <PackageVersion Include="MailKit" Version="4.17.0" />
+    <!-- Messaging -->
+    <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
     <!-- DI -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />

--- a/LotroKoniecDev.sln.DotSettings
+++ b/LotroKoniecDev.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EntityFramework_002EModelValidation_002EUnlimitedStringLength/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Koniec/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lotro/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/compose.hetzner.yaml
+++ b/compose.hetzner.yaml
@@ -55,6 +55,37 @@ services:
       ConnectionStrings__AuthDatabase: ${ConnectionStrings__AuthDatabase}
     restart: "no"
 
+  rabbitmq:
+    # Version pinned in lockstep with the dev compose.yaml and the integration suite's
+    # RabbitMqBrokerFixture (same image minus the management UI) — bump all three together, or the
+    # suite keeps proving the dead-letter topology against a different broker generation than the
+    # one this stack runs.
+    image: rabbitmq:4.3.4-management-alpine
+    restart: unless-stopped
+    # RabbitMQ keys its on-disk state (users, quorum-queue membership, parked dead letters) by node
+    # name, which defaults to rabbit@<hostname> — and compose hostnames are random per container.
+    # Without this pin every recreation would boot a FRESH node next to the old data and silently
+    # orphan the quorum queues, dead-letter parking lot included.
+    hostname: lotro-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: rabbitmq
+      # Applied on FIRST boot only (empty data volume) — editing the box .env later does NOT rotate
+      # the live credential; rotation goes through rabbitmqctl (runbook → Secrets).
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:?generate one and add RABBITMQ_PASSWORD to the box .env (runbook → Secrets)}
+    ports:
+      # Management UI on the box loopback ONLY — reach it via `ssh -L 15672:localhost:15672 <box>`,
+      # never from the internet. It is the dead-letter parking-lot inspection/replay surface
+      # (runbook → Message broker).
+      - "127.0.0.1:15672:15672"
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
   auth-api:
     image: ghcr.io/${IMAGE_NAMESPACE:-koniecdev}/lotrokoniecdev-auth-api:${IMAGE_TAG:-latest}
     restart: unless-stopped
@@ -83,6 +114,12 @@ services:
       Email__Sender: ${Email__Sender}
       Email__Username: ${Email__Username:-}
       Email__Password: ${Email__Password:-}
+      # The broker is the in-stack `rabbitmq` service above. Deliberately NO depends_on edge to it:
+      # auth-api boots while the broker is down — the publisher connects lazily and the consumer
+      # retries with backoff — and a broker outage must never block an app deploy.
+      RabbitMq__Host: rabbitmq
+      RabbitMq__Username: rabbitmq
+      RabbitMq__Password: ${RABBITMQ_PASSWORD:?generate one and add RABBITMQ_PASSWORD to the box .env (runbook → Secrets)}
       # AUTH_ADMIN_USERNAME must match ^[a-zA-Z0-9]+$ or auth-api fails at startup (ADR-0022).
       AdminUser__Username: ${AUTH_ADMIN_USERNAME:-}
       AdminUser__Email: ${AUTH_ADMIN_EMAIL:-}
@@ -211,6 +248,7 @@ services:
 volumes:
   auth-keys:
   frontend-keys:
+  rabbitmq-data:
   caddy-data:
   caddy-config:
 

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -76,6 +76,37 @@ services:
         condition: service_healthy
     restart: "no"
 
+  rabbitmq:
+    # Version pinned in lockstep with the dev compose.yaml, compose.hetzner.yaml and the
+    # integration suite's RabbitMqBrokerFixture (same image minus the management UI) — bump them
+    # together, or the suite keeps proving the dead-letter topology against a different broker
+    # generation than the one the stacks run.
+    image: rabbitmq:4.3.4-management-alpine
+    # RabbitMQ keys its on-disk state (users, quorum-queue membership, parked dead letters) by node
+    # name, which defaults to rabbit@<hostname> — and compose hostnames are random per container.
+    # Without this pin every recreation would boot a FRESH node next to the old data and silently
+    # orphan the quorum queues, dead-letter parking lot included.
+    hostname: lotro-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: rabbitmq
+      # Applied on FIRST boot only (empty data volume); a later change needs rabbitmqctl or a
+      # volume drop (-v).
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:?add RABBITMQ_PASSWORD to .env.prod (see .env.prod.example)}
+    ports:
+      # Alternate host port (dev compose publishes the UI on 15672) so the prod-parity stack can
+      # run alongside dev. Loopback-only, mirroring the deployed stack. AMQP itself is deliberately
+      # NOT published — only the in-stack auth-api talks to it (dev needs 5672 on the host because
+      # its apps are host Kestrels; here they are containers).
+      - "127.0.0.1:15673:15672"
+    volumes:
+      - lotrokoniecdev-prod-rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
   auth-api:
     build:
       context: .
@@ -110,6 +141,12 @@ services:
       Email__Sender: ${Email__Sender}
       Email__Username: ${Email__Username:-}
       Email__Password: ${Email__Password:-}
+      # The broker is the in-stack `rabbitmq` service above. Deliberately NO depends_on edge to it:
+      # auth-api boots while the broker is down — the publisher connects lazily and the consumer
+      # retries with backoff (same wiring as compose.hetzner.yaml).
+      RabbitMq__Host: rabbitmq
+      RabbitMq__Username: rabbitmq
+      RabbitMq__Password: ${RABBITMQ_PASSWORD:?add RABBITMQ_PASSWORD to .env.prod (see .env.prod.example)}
       # AUTH_ADMIN_USERNAME must match ^[a-zA-Z0-9]+$ or auth-api fails at startup (ADR-0022).
       AdminUser__Username: ${AUTH_ADMIN_USERNAME:-}
       AdminUser__Email: ${AUTH_ADMIN_EMAIL:-}
@@ -252,6 +289,7 @@ volumes:
   lotrokoniecdev-prod-postgres-data:
   lotrokoniecdev-prod-auth-keys:
   lotrokoniecdev-prod-frontend-keys:
+  lotrokoniecdev-prod-rabbitmq-data:
   lotrokoniecdev-prod-caddy-data:
 
 networks:

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,11 @@ services:
     # minus the management UI) — bump both together, or the suite keeps proving the dead-letter
     # topology against the old broker generation.
     image: rabbitmq:4.3.4-management-alpine
+    # RabbitMQ keys its on-disk state by node name (rabbit@<hostname>), and compose hostnames are
+    # random per container — without this pin a recreation boots a fresh node and orphans the
+    # volume's quorum queues. Harmless in dev (down -v resets anyway), but kept identical to the
+    # deployed stacks so the durability behavior never differs.
+    hostname: lotro-rabbitmq
     environment:
       RABBITMQ_DEFAULT_USER: rabbitmq
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,7 +33,9 @@ services:
     hostname: lotro-rabbitmq
     environment:
       RABBITMQ_DEFAULT_USER: rabbitmq
-      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+      # The default matches appsettings.Development.json, so a dev .env predating this key still
+      # boots a broker the host Kestrels can log into (an empty password would ACCESS_REFUSED them).
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-changeme}
     ports:
       - "5672:5672"
       - "15672:15672"

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,9 @@ services:
       start_period: 10s
 
   rabbitmq:
+    # Version pinned in lockstep with the integration suite's RabbitMqBrokerFixture (same image
+    # minus the management UI) — bump both together, or the suite keeps proving the dead-letter
+    # topology against the old broker generation.
     image: rabbitmq:4.3.4-management-alpine
     environment:
       RABBITMQ_DEFAULT_USER: rabbitmq

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,23 @@ services:
       retries: 30
       start_period: 10s
 
+  rabbitmq:
+    image: rabbitmq:4.3.4-management-alpine
+    environment:
+      RABBITMQ_DEFAULT_USER: rabbitmq
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - lotrokoniecdev-rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
   aspire-dashboard:
     image: mcr.microsoft.com/dotnet/aspire-dashboard:latest
     environment:
@@ -62,3 +79,4 @@ services:
 
 volumes:
   lotrokoniecdev-postgres-data:
+  lotrokoniecdev-rabbitmq-data:

--- a/docs/adr/0035-signal-driven-outbox-relay-instead-of-interval-polling.md
+++ b/docs/adr/0035-signal-driven-outbox-relay-instead-of-interval-polling.md
@@ -1,0 +1,174 @@
+# ADR-0035: Signal-driven outbox relay instead of interval polling
+
+**Status:** Accepted
+**Date:** 2026-08-02
+**Decision-makers:** Solo maintainer
+**Related:** AuthSystem messaging (rabbitmq-introduction branch), `OutboxRelay`, `RegisterUser`, ADR-0025 (Neon probe burn), ADR-0034 (Hetzner hosting), `docs/knowledge-base` Neon PITR topology notes
+
+## Context
+
+The auth outbox (`OutboxMessages`, written by `RegisterUser.cs` inside its registration
+transaction) needs a relay that publishes committed rows to RabbitMQ. The textbook relay is a
+`BackgroundService` polling every few seconds — and on this stack that design is not a style
+choice but a budget decision:
+
+- Production databases are **Neon Free tier, scale-to-zero**: 100 CU-h/month per project,
+  compute suspends after ~5 min without queries and bills a 0.25 CU minimum while awake.
+- Any poll interval **below** the suspend threshold keeps compute awake 24/7:
+  0.25 CU × 730 h ≈ **180 CU-h/month** — the cap blows mid-month with zero users. Intervals
+  **above** the threshold pay ~0.02 CU-h per wake-up (one query resurrects compute for the
+  ~5-min suspend window): a 10-min poll ≈ 90 CU-h/month, 30-min ≈ 30 CU-h/month. Polling only
+  becomes affordable at multi-hour cadence, which defeats "the confirmation e-mail arrives now".
+- ADR-0025 already documented this failure class (a health probe silently burning compute);
+  #407 proved such leaks stay invisible for days.
+- The decisive topology fact: **the outbox writer and the relay live in the same process**
+  (auth-api, single replica per ADR-0034's one-box compose deploy — no Kubernetes, no scale-out
+  planned). The process that commits an outbox row can wake the relay in memory, for free, at
+  the exact moment the database is provably awake (it just served that write).
+- The delayed-delivery tail is tolerable specifically for today's only message type:
+  `EmailConfirmationRequested`'s user-facing recovery path, `ResendEmailConfirmation.cs`,
+  bypasses the outbox entirely (direct SMTP), so a stuck row never strands a user.
+- One live trap: `RegisterUser` commits via an **explicit transaction**
+  (`SaveChangesAsync` → `transaction.CommitAsync`). Any wake-up hooked to `SaveChanges` (e.g. a
+  naive `SaveChangesInterceptor`) fires before the commit, the relay reads nothing, and the row
+  orphans until the next sweep.
+
+## Decision
+
+### 1. The relay is woken by an in-process signal, not a timer
+
+`OutboxSignal` (singleton, a 1-slot `SemaphoreSlim`) is the wake-up line. The relay
+(`OutboxRelay`) blocks on `WaitAsync` and drains the whole backlog per wake-up. No
+`PeriodicTimer`, no fixed poll interval exists to tune. Repeated notifies coalesce into one
+pending wake-up because a drain pass reads everything anyway.
+
+### 2. Writers notify after the commit — this is a binding convention
+
+Every outbox writer calls `OutboxSignal.Notify()` **after its transaction commits**, never
+inside it (see Context: the `RegisterUser` explicit-transaction trap). With one writer today the
+call is explicit in the handler. If writers multiply (≥3), promote the convention to a
+`SaveChangesInterceptor`+`IDbTransactionInterceptor` pair via a follow-up ADR; until then the
+explicit call is the YAGNI-correct form. A forgotten notify is a soft failure: the row waits for
+a sweep instead of being lost.
+
+### 3. Two sweeps bound the orphan window
+
+- **Startup sweep:** the relay's first pass runs before any wait, catching rows whose nudge died
+  with the previous process (crash between commit and publish, deploy restart).
+- **Safety sweep:** the signal wait times out every **6 hours** and sweeps anyway. Cost ceiling
+  ≈ 120 wake-ups/month × 0.02 CU-h ≈ 2.5 % of the Neon budget; latency ceiling for a fully
+  orphaned row: 6 h. Tighter bounds buy latency no current message type needs.
+
+### 4. Failure backoff escalates and caps at the sweep cadence
+
+A pass with any failed row (broker down, unroutable type, DB fault) waits
+30 s → 1 m → 5 m → 30 m → 6 h instead of the full sweep interval; a fresh notify overrides the
+wait at any time. The ceiling deliberately equals the safety-sweep interval so a poison message
+degenerates into the already-priced sweep cadence, not an around-the-clock retry poll.
+
+### 5. Outbox `Type` maps to routing keys explicitly
+
+`OutboxMessageRouting` translates the payload contract name (`Type`, e.g.
+`nameof(EmailConfirmationRequested)`) to its `RabbitMqTopology` routing key
+(`email.confirmation`). An unmapped type is marked failed with a diagnostic `LastError` and
+retried on sweep cadence — it never reaches the broker as an unroutable mandatory publish.
+
+### 6. Delivery semantics stay at-least-once, per-row commit
+
+The relay marks each row (`MarkAsProcessed`/`MarkFailed`) and saves **per message**, narrowing
+the crash window in which an already-published message is re-published after restart. Consumers
+must deduplicate on the AMQP `message-id` (= outbox row id) and tolerate reordering after
+retries; nothing in this design promises ordering across failures.
+
+## Consequences
+
+### Positive
+
+- Idle cost is **zero**: no background DB traffic exists, Neon suspends normally. Every relay
+  query lands milliseconds after a write, while compute is already awake.
+- Publish latency in the happy path is milliseconds (commit → notify → drain), better than any
+  affordable poll interval.
+- The orphan tail is bounded (6 h) and, for the only current message type, user-recoverable via
+  the outbox-independent resend path.
+- No new infrastructure: one semaphore, one hosted service, both already in-process.
+
+### Negative / Accepted Trade-offs
+
+- **Hard single-replica assumption.** A second auth-api replica (or an extracted relay) breaks
+  this silently: duplicate publishes from concurrent sweeps (no `FOR UPDATE SKIP LOCKED`), and
+  rows written by a dead replica wait for another replica's sweep. Scaling out requires
+  revisiting this ADR (LISTEN/NOTIFY + row locking is the upgrade path). Accepted: replicas are
+  explicitly out of scope for this deployment.
+- **Unbounded-ish latency tail vs. polling's 5 s worst case.** "Usually instant, worst case 6 h"
+  is the price of the budget; acceptable while every message type has a user-driven fallback or
+  no urgency.
+- **Convention, not mechanism.** Writers must remember the after-commit `Notify()`; raw-SQL or
+  out-of-band inserts (psql debugging) wait for a sweep. Mitigated by the sweeps and by rule 2's
+  escalation trigger.
+- **Broker outages re-awaken the database** on the retry backoff for their duration — a long
+  RabbitMQ outage costs both undelivered mail and some CU-h. Capped by the 6 h ceiling.
+- The design's reason lives in Neon economics; on a paid tier or self-hosted Postgres it looks
+  like over-engineering and someone will be tempted to "simplify" it back to polling. This ADR
+  is the guard.
+
+## Alternatives Considered
+
+### A. Interval polling (`PeriodicTimer`, 5 s–2 min)
+
+The textbook relay. Any interval below Neon's ~5-min suspend threshold keeps compute awake
+24/7 (~180 CU-h/month vs. the 100 CU-h cap); intervals above it still pay ~0.02 CU-h per empty
+wake-up and push e-mail latency to the same order as the safety sweep anyway. There is no
+interval that is both responsive and affordable. Rejected.
+
+### B. Quartz.NET scheduling the poll
+
+Adds a scheduler library to run the same poll, and with a persistent (`QRTZ_*`) job store Quartz
+itself polls the database for due jobs and cluster locks — a second compute-burner managing the
+first. With an in-memory store it offers nothing a semaphore lacks and still dies with the
+process. Rejected.
+
+### C. Postgres `LISTEN/NOTIFY`
+
+Correct cross-process wake-up — but it requires a standing connection, Neon drops connections on
+suspend (subscription lost, reconnect loop required), and it only pays off once writer and relay
+live in different processes, which contradicts the current topology. Noted as the upgrade path
+if replicas ever arrive. Rejected for now.
+
+### D. CDC via Debezium (WAL / logical replication)
+
+The enterprise outbox answer (Debezium even ships an outbox event router). Disqualified three
+times over: Neon disables scale-to-zero entirely while logical replication is active (the full
+~180 CU-h/month bill back); an idle replication slot retains WAL against the 0.5 GB Free storage
+cap (currently ~0.37 GB used — days to overflow); and a JVM connector container on 4 GB Hetzner
+boxes is infrastructure disproportionate to a near-zero message volume. Rejected.
+
+### E. Pay: Neon Launch tier, or self-host Postgres on the VPS
+
+$19/month (300 CU-h) or a Postgres container beside the apps would make plain polling fine.
+Viable, deliberately deferred: pre-launch there is no revenue to justify the spend, and
+self-hosting forfeits Neon PITR/branching that MIGR-04 and the N-1 gates lean on. If either
+happens later, revisit this ADR before "simplifying" the relay. Rejected for now.
+
+## Implementation Notes
+
+- `src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxSignal.cs` — the 1-slot semaphore
+  wake-up line (singleton).
+- `src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxMessageRouting.cs` — `Type` →
+  routing-key map over `RabbitMqTopology`.
+- `src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/OutboxRelay.cs` — startup
+  sweep, signal wait with 6 h timeout, batched drain (100/fetch over
+  `IX_OutboxMessages_Unprocessed`), escalating backoff, per-row mark+save.
+- `src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs` — after-commit
+  `Notify()` (the binding convention of decision 2).
+- `src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs` — singleton signal +
+  hosted relay registration.
+- Tests: `OutboxSignalTests`, `OutboxMessageRoutingTests` (unit);
+  `OutboxRelayTests` + `SpyMessagePublisher` (integration, real PostgreSQL, no broker).
+
+## References
+
+- ADR-0025 — the prior Neon compute-burn incident class ("never tag a DB check ready").
+- ADR-0034 — Hetzner single-box compose topology (the single-replica premise).
+- ADR-0023 / ADR-0024 — migration gates that lean on Neon PITR (why self-hosting isn't free).
+- `docs/deployment/runbook.md` — Neon project/branch topology and CU-h counters.
+- Neon docs: scale-to-zero suspend behavior; logical replication disabling scale-to-zero.

--- a/docs/adr/0036-broker-enforced-dead-lettering-with-a-delivery-limit.md
+++ b/docs/adr/0036-broker-enforced-dead-lettering-with-a-delivery-limit.md
@@ -1,0 +1,162 @@
+# ADR-0036: Broker-enforced dead-lettering with a quorum-queue delivery limit
+
+**Status:** Accepted
+**Date:** 2026-08-03
+**Decision-makers:** Solo maintainer
+**Related:** ADR-0035 (signal-driven outbox relay), ADR-0034 (Hetzner one-box compose deploy),
+`RabbitMqTopology`, `EmailConfirmationConsumer`, `docs/adr/0035` §6 (at-least-once semantics)
+
+## Context
+
+The rabbitmq-introduction branch gave the confirmation e-mail an outbox → broker → consumer
+pipeline, but both consumer failure paths ended badly:
+
+- **Poison** (unreadable payload): `basic.nack` with `requeue: false` — and without a dead-letter
+  exchange the broker **deletes the message permanently**. The log line said "dropped loudly";
+  the data was still gone.
+- **Transient** (SMTP down): a 30 s in-process pause, then `basic.nack` with `requeue: true` —
+  an **unbounded** retry loop. A permanently failing send (broken template, upstream rejecting
+  the sender) would grind the same message forever.
+
+Constraints that shape the fix:
+
+- **At-least-once end to end (ADR-0035 §6):** the relay may re-publish after a crash, so the
+  safety net must never turn "retry later" into "lost".
+- **Solo-maintainer ops on a one-box compose deploy (ADR-0034):** the failure parking lot must
+  be inspectable with what already runs (management UI, logs) — no new services, no extra
+  consumers.
+- **Queue arguments are immutable.** Redeclaring an existing queue with different arguments
+  fails the channel with `PRECONDITION_FAILED` — every argument chosen here is a small
+  commitment; changing one later means delete + redeclare (dev: `docker compose down -v`).
+- **The broker's consumer ack timeout (30 min default)** caps any in-process pause taken while
+  a delivery is unacked; exceeding it kills the channel.
+- **RabbitMQ ≥ 4.3 counts specifically.** The delivery limit is measured against
+  `x-delivery-count`, which increments **only** on `basic.reject` and on connection loss.
+  `basic.nack` is an "explicit return" (increments only `acquired-count`) and `basic.get`
+  redelivery counts nothing — both redeliver forever without ever tripping the limit. Proven
+  empirically by the integration suite: a nack-requeue loop passed 17 000 deliveries with
+  `x-delivery-limit: 5` before the assertion gave up.
+
+## Decision
+
+### 1. `emails.send` becomes a quorum queue with a delivery limit
+
+`x-queue-type: quorum`, `x-delivery-limit: 5`, `x-dead-letter-exchange: lotro.emails.dlx`.
+The **broker** enforces "1 initial delivery + 5 redeliveries, then park" — the cap holds across
+consumer restarts and even for a crash loop, because connection loss increments the same
+counter. Classic queues track no redelivery count at all, which would push retry bookkeeping
+into every consumer (and a consumer-side count resets on restart).
+
+### 2. Dead letters flow through a fanout DLX into one terminal parking lot
+
+`lotro.emails.dlx` (fanout) → `emails.send.dlq` (quorum). Fanout, because "everything that dies
+goes to the one parking lot" needs no routing decisions — and dead-lettering preserves the
+original routing key on the message, so replay knows where it belongs. Nothing consumes the
+DLQ; it carries no delivery limit and no DLX of its own — it is terminal by design.
+
+### 3. The dead-letter hop itself is at-least-once
+
+`x-dead-letter-strategy: at-least-once` (+ its prerequisite `x-overflow: reject-publish`,
+inert while no `x-max-length` is set). The default `at-most-once` may drop a dead letter under
+pressure — a safety net that can silently lose the very message it exists to keep is not one.
+
+### 4. The consumer rejects; it never nacks
+
+All failure paths use `basic.reject` (see Context: only rejects count). Poison is rejected
+without requeue on first sight — no redelivery fixes an unreadable payload — and parks
+immediately with `x-death` reason `rejected`. Transient failures are rejected with requeue
+behind an **escalating in-process pause** (30 s → 2 m → 5 m → 10 m → 15 m, one entry per
+allowed redelivery, each far under the ack timeout): the ladder in total outlasts a realistic
+SMTP outage (~33 min) before the message parks with reason `delivery_limit`. Pausing in-process
+blocks the (prefetch-1) consumer deliberately — every message in this queue needs the same SMTP
+relay, so none of the waiting ones could succeed either. The final allowed attempt is announced
+at `Error` level before the parking reject.
+
+### 5. Replay is manual
+
+Ops story: inspect `emails.send.dlq` in the management UI, fix the cause, re-publish to
+`lotro.emails` under the message's preserved routing key (shovel or UI). No replay endpoint, no
+automated re-drive — YAGNI at the current volume; the user-facing recovery for the only current
+message type is the outbox-independent resend endpoint (ADR-0035).
+
+## Consequences
+
+### Positive
+
+- **No silent loss anywhere:** poison parks instead of vanishing; exhausted retries park
+  instead of looping; the park hop itself is at-least-once.
+- **Every failure loop is bounded** — including consumer crash loops — by one broker-enforced
+  counter shared with the backoff ladder (`RabbitMqTopology.EmailDeliveryLimit`).
+- ~33 min of SMTP outage rides out on backoff alone, no human needed; beyond that the message
+  waits intact in the DLQ.
+- The whole mechanism is topology + one consumer — no new infrastructure (fits ADR-0034 ops).
+
+### Negative / Accepted Trade-offs
+
+- **The in-process pause blocks the single consumer.** Accepted: shared SMTP dependency (see
+  Decision 4). If a second message type with a *different* downstream ever shares this queue,
+  give it its own queue instead of revisiting the pause.
+- **Nobody watches the DLQ yet.** Parking emits an `Error` log (2332/2339), but there is no
+  alert on DLQ depth; that belongs to the prod broker config (monitoring/alerting) planned next.
+- **Version-sensitive semantics.** The reject-vs-nack counting rule is RabbitMQ ≥ 4.3 behavior;
+  the integration suite pins it against the same image generation compose runs, so a broker bump
+  that changes the rules fails loudly in CI, not in prod.
+- **Argument immutability makes this a one-shot declare.** Existing dev brokers must
+  `docker compose down -v` (or delete the queues) once; documented here and in the declaration's
+  remarks. No prod broker exists yet, so the cost is zero today.
+- `at-least-once` dead-lettering holds unconfirmed dead letters in memory until the DLQ accepts
+  them; harmless at this volume, revisit if a high-throughput queue ever adopts this recipe.
+
+## Alternatives Considered
+
+### A. TTL retry-queue ladder (retry queue with per-message TTL, DLX back to the work queue)
+
+The textbook non-blocking backoff: rejected messages wait in a side queue whose TTL returns
+them. Rejected: two more queues + an exchange whose TTLs are frozen into immutable queue
+arguments (every cadence tweak = delete + redeclare), to buy non-blocking behavior that buys
+nothing here — the consumer it would unblock has nothing else it could usefully do (Decision 4).
+
+### B. Delayed-message exchange plugin
+
+A community plugin adding a broker capability for scheduled delivery. Rejected: new operational
+surface (plugin lifecycle on every environment) for the same non-benefit as A.
+
+### C. Consumer-side retry counting (parse `x-death`, or republish with an attempts header)
+
+Rejected: the broker already keeps the authoritative counter (`x-delivery-count`); a republish
+mints a new message identity, which breaks `message-id`-based deduplication (ADR-0035 §6) and
+moves the loss window into application code — the exact class of bug this ADR removes.
+
+### D. Rely on the 4.x default delivery limit (20) instead of an explicit argument
+
+Rejected: implicit, version-dependent, and disconnected from the backoff ladder; an explicit
+shared constant keeps "allowed redeliveries" and "pauses between them" provably in step.
+
+### E. Status quo (no DLX, unbounded nack-requeue)
+
+Rejected outright: deletes poison messages and loops transient failures forever — both
+disproven by the guarantees above.
+
+## Implementation Notes
+
+- `RabbitMqTopology` — names + `EmailDeliveryLimit` (single source of truth, shared by the
+  declaration, the consumer and the tests).
+- `RabbitMqTopologyDeclaration` — DLX/DLQ declared **before** the work queue (no window where
+  dead letters reach an unbound exchange); argument sets documented in-file.
+- `EmailConfirmationConsumer` — reject-only acknowledgement, `RedeliveryBackoffs` ladder,
+  final-attempt `Error` log (EventId 2339).
+- `RedeliveryCount` — tolerant `x-delivery-count` reader (absent/foreign types → 0; erring
+  toward extra patience, never early parking).
+- Tests: `DeadLetterTopologyTests` (real broker via Testcontainers — rejected→DLQ with reason
+  `rejected` and preserved routing key; exhaustion→DLQ with reason `delivery_limit` after
+  exactly limit+1 deliveries; declaration idempotence; ack leaves DLQ empty) +
+  `RedeliveryCountTests` (unit). The broker image pins the compose generation
+  (`rabbitmq:4.3.4-alpine`).
+
+## References
+
+- RabbitMQ docs: Quorum Queues — delivery limit, `x-delivery-count`/`acquired-count` increment
+  table (the ≥ 4.3 reject-vs-nack rule); Dead Lettering — `at-least-once` strategy and its
+  `reject-publish` prerequisite.
+- ADR-0035 — outbox relay; at-least-once + `message-id` deduplication contract.
+- ADR-0034 — one-box compose topology (the ops-surface constraint).

--- a/docs/adr/0036-broker-enforced-dead-lettering-with-a-delivery-limit.md
+++ b/docs/adr/0036-broker-enforced-dead-lettering-with-a-delivery-limit.md
@@ -52,7 +52,9 @@ into every consumer (and a consumer-side count resets on restart).
 `lotro.emails.dlx` (fanout) → `emails.send.dlq` (quorum). Fanout, because "everything that dies
 goes to the one parking lot" needs no routing decisions — and dead-lettering preserves the
 original routing key on the message, so replay knows where it belongs. Nothing consumes the
-DLQ; it carries no delivery limit and no DLX of its own — it is terminal by design.
+DLQ; it sets no explicit delivery limit and no DLX of its own — it is terminal by design. It
+still inherits the quorum **default** delivery limit (20), which constrains how replay may ever
+consume it (Decision 5).
 
 ### 3. The dead-letter hop itself is at-least-once
 
@@ -77,7 +79,10 @@ at `Error` level before the parking reject.
 Ops story: inspect `emails.send.dlq` in the management UI, fix the cause, re-publish to
 `lotro.emails` under the message's preserved routing key (shovel or UI). No replay endpoint, no
 automated re-drive — YAGNI at the current volume; the user-facing recovery for the only current
-message type is the outbox-independent resend endpoint (ADR-0035).
+message type is the outbox-independent resend endpoint (ADR-0035). One hard rule binds any
+future re-drive tooling: **ack-and-republish, never reject-requeue** — the DLQ inherits the
+quorum default delivery limit (20) and has no DLX of its own, so a reject-requeue loop against
+it would silently drop the parked message after 20 attempts.
 
 ## Consequences
 

--- a/docs/adr/0037-consumer-side-inbox-deduplication-on-the-message-id.md
+++ b/docs/adr/0037-consumer-side-inbox-deduplication-on-the-message-id.md
@@ -1,0 +1,197 @@
+# ADR-0037: Consumer-side inbox deduplication on the broker message id
+
+**Status:** Accepted
+**Date:** 2026-08-03
+**Decision-makers:** Solo maintainer
+**Related:** ADR-0035 §6 (at-least-once + the message-id deduplication promise), ADR-0036
+(broker-enforced dead-lettering), `OutboxRelay`, `RabbitMqMessagePublisher`,
+`EmailConfirmationConsumer`, `EmailConfirmationRequestProcessor`
+
+## Context
+
+The confirmation-e-mail pipeline is at-least-once on **both** hops, by design (ADR-0035 §6):
+
+- The **relay** may re-publish: a crash between `PublishAsync` and `MarkAsProcessed` leaves the
+  outbox row unprocessed, and the next pass publishes the same message again.
+- The **broker** may redeliver: a crash between processing and the ack returns the delivery to
+  the queue, and the consumer sees it again.
+
+ADR-0035 already committed to the standard answer — "consumers deduplicate on the message id"
+(`OutboxRelay.PublishOneAsync` remarks) — and the publisher stamps `MessageId` with the outbox
+row's Guid, a stable identity across re-publishes. But nothing on the consumer side keeps that
+promise yet. The only guard is the processor's *natural* idempotency (redelivery finds
+`EmailConfirmed` already set, or at worst re-sends the e-mail), and its own remarks admit the
+weakness: every new message type must re-earn that property by business-logic luck.
+
+Constraints that shape the fix:
+
+- **The side effect is an SMTP send.** It cannot join a database transaction, and the SMTP
+  protocol carries no idempotency key — so no design can make the send itself exactly-once;
+  a design can only shrink the duplicate window and bound the damage.
+- **ADR-0036 just made retry, backoff and the parking lot broker-owned** (quorum queue,
+  `x-delivery-limit: 5`, DLX → DLQ), proven against a real broker. The inbox must compose with
+  that machinery, not rebuild it.
+- **Neon scale-to-zero (ADR-0035):** every database touch costs compute, and a cold resume
+  takes ~31 s — measured on this very stack. Extra background pollers are the anti-goal;
+  touching the database only when a message actually arrived is fine, because the delivery
+  itself proves the system is awake.
+
+## Decision
+
+### 1. An `InboxMessages` table records every fully processed message id
+
+`InboxMessages(MessageId uuid PK, ProcessedOn timestamptz)` in the auth database, next to the
+outbox. A row means "this message id has been processed to completion; never process it again."
+Deliberately no `Type`, no `Payload`, no attempt counters: `MessageId` equals
+`OutboxMessages.Id`, so the full context of any inbox row is one join away, and retry
+bookkeeping already lives on the broker (ADR-0036) — duplicating either would be dead weight.
+
+### 2. The consumer checks before processing and records after success
+
+`EmailConfirmationConsumer.OnDeliveredAsync` becomes: deserialize → **look up the message id in
+the inbox** → on a hit, ack immediately (a duplicate never touches business logic) → on a miss,
+run the processor → on success, **insert the inbox row, save, then ack**. Failure paths are
+untouched: the reject/backoff/DLQ ladder of ADR-0036 stays the sole owner of retries.
+
+The marker lands **after** the send, not before. Marker-first (a claim) would trade
+duplicate-e-mail risk for lost-e-mail risk: a crash between claim and send acks a message whose
+e-mail never went out, and a confirmation that never arrives is strictly worse than one that
+arrives twice — the user's only recovery is noticing silence and requesting a resend. The
+pipeline therefore stays honestly at-least-once, same as both hops before it.
+
+### 3. A delivery without a message id is poison
+
+The publisher always stamps `MessageId`; a message without one (or with a non-Guid value) did
+not come from this pipeline and cannot be deduplicated. Processing it "blind" would reopen the
+unbounded-duplicate hole this ADR closes, so it is rejected without requeue on first sight and
+parks in the DLQ for a human — the same treatment as an unreadable payload.
+
+### 4. Database faults ride the existing transient path
+
+The inbox lookup and insert are database reads/writes and can fail (Neon cold start, outage).
+Such failures follow the same route as any transient processor failure: reject with requeue,
+counted by the broker's `x-delivery-count`, bounded by the delivery limit. No new failure
+handling exists for the inbox — one ladder, one counter, one parking lot.
+
+### 5. One table, one consumer — the discriminator is a documented constraint, not a column
+
+Today exactly one queue and one consumer exist. **A second consumer of the same message (a
+fanout binding) must not share this table without adding a consumer discriminator** — two
+consumers deduplicating against each other's rows would each silently skip work the other did.
+The constraint is recorded here and in the entity's remarks instead of shipping a speculative
+`Consumer` column nobody queries (YAGNI, and the migration to add it later is additive).
+
+### 6. No retention sweep
+
+One row per confirmation e-mail, ~40 bytes; the outbox keeps its processed rows too. A
+retention sweep would be the first scheduled database work this system runs purely for hygiene
+— against ADR-0035's whole point — to reclaim megabytes per decade. Deliberately skipped;
+if volume ever materializes, one shared outbox+inbox sweep ships as its own ticket. A pleasant
+side effect of keeping rows forever: replaying an already-processed message from the DLQ
+(ADR-0036 Decision 5) hits the inbox and acks without a duplicate e-mail, no matter how much
+later the replay happens.
+
+## Failure-ordering analysis: why "the database died on vacation" sends zero e-mails
+
+The nightmare scenario — Postgres down for hours, nobody watching, the user's mailbox filling
+with retries — is prevented by *ordering*, not just by limits. Before any SMTP traffic, the
+consumer performs two database reads: the inbox lookup (Decision 2) and the processor's
+`FindByIdAsync` user load. A dead database therefore fails every attempt **before** a single
+e-mail leaves:
+
+| Scenario | E-mails sent | Bound |
+|---|---|---|
+| Database down for the whole episode | **0** — every attempt dies at a pre-send read | ≤ 6 deliveries over ~33 min (ladder), then DLQ |
+| Database dies exactly between the SMTP send and the inbox insert, every attempt | 1 per delivery, realistically 2 | hard cap **6** (`x-delivery-limit: 5` + initial) |
+| Replay of an already-processed message from the DLQ | **0** — inbox hit, ack | — |
+
+After the retries exhaust, the message waits intact in `emails.send.dlq` until a human returns
+and replays it (ack-and-republish, never reject-requeue — ADR-0036 Decision 5). Nothing loops,
+nothing is lost, and the reputation-burning flood is structurally impossible: the broker's
+delivery limit caps *total* deliveries per message id forever, across restarts and crash loops.
+
+## Consequences
+
+### Positive
+
+- **Deduplication is mechanical, not per-type business luck.** The relay's promise
+  ("consumers deduplicate on the message id") is finally kept, and the next message type
+  inherits the recipe instead of re-earning idempotency in its handler.
+- **The DLQ replay story gets safer:** replaying a processed message becomes a no-op.
+- **Zero new infrastructure** — one table, a few consumer lines; retry/backoff/parking stay
+  broker-owned (ADR-0036 untouched). Fits the solo-maintainer ops surface (ADR-0034).
+- **The database is touched only when a message actually arrives** — no poller, no sweep,
+  matching ADR-0035's compute posture.
+
+### Negative / Accepted Trade-offs
+
+- **The send itself stays at-least-once.** A crash in the millisecond window between the SMTP
+  send and the inbox insert still duplicates one e-mail (bounded at 6 by the delivery limit).
+  Closing that window requires an idempotency key at the provider, which SMTP cannot express.
+  If e-mail delivery ever moves to an HTTP API that accepts one, passing `MessageId` closes it
+  — recorded here as the designated future move, not built now.
+- **One extra read and one extra write per processed message.** Negligible at this volume, and
+  incurred only while the database is provably awake.
+- **Unbounded table growth**, accepted knowingly (Decision 6).
+- **The no-discriminator constraint (Decision 5) is prose, not schema.** A future fanout
+  consumer must read this ADR (or the entity's remarks) before reusing the table.
+
+## Alternatives Considered
+
+### A. Full inbox — store-then-ack with a database-side processor
+
+The consumer writes the raw message to the table, acks immediately, and a signal-driven
+background processor (a mirror of `OutboxRelay`) does the work with database-side retry state.
+Rejected: it re-implements exactly the machinery ADR-0036 just made broker-owned — retry
+counting, backoff, a parking lot — as a second state machine, plus a second poller on a
+scale-to-zero database. The variant earns its keep when a consumer does transactional database
+work per message or the broker cannot retry properly; neither is true here.
+
+### B. Status quo — natural idempotency only
+
+Rejected: no durable trace of processing, so the duplicate-e-mail window spans the entire gap
+between "sent" and "acked" (including whole crash-restart cycles), and every future message
+type must re-earn idempotency from its business rules. ADR-0035 §6's promise would stay
+unkept.
+
+### C. Claim-before-send (insert the marker first)
+
+Rejected for the asymmetry in Decision 2: it converts duplicate-e-mail risk into lost-e-mail
+risk, and a silent nothing is the worse failure for a confirmation e-mail.
+
+### D. Circuit breaker in the consumer (Polly)
+
+Rejected as redundant: with prefetch 1 and the in-process backoff pause (ADR-0036 Decision 4),
+a failing dependency already halts *all* consumption — the "open circuit" exists structurally,
+with zero additional configuration to tune or get wrong.
+
+### E. Idempotency key at the e-mail provider
+
+The only mechanism that could make the send itself exactly-once — and inapplicable over SMTP.
+Not an alternative to the inbox but its complement; recorded in Consequences as the designated
+follow-up if the transport ever becomes an HTTP API.
+
+## Implementation Notes
+
+- `InboxMessage` (Persistence, `Inbox/` beside `Outbox/`) — `Create` factory + guards,
+  private EF constructor, mirroring `OutboxMessage`; configuration via Fluent API with
+  `nameof()` column names; purely additive migration (trivially N-1 safe under ADR-0023).
+- `EmailConfirmationConsumer.OnDeliveredAsync` — the only consumer change: id parse (poison on
+  absence), inbox lookup, post-success insert; `AuthDbContext` resolved from the existing
+  per-delivery scope like the relay does — no new abstraction. A primary-key violation on the
+  insert is treated as "already processed" (ack): a concurrent duplicate lost the race, which
+  means the work is done.
+- Tests, matching the branch's discipline: unit (`InboxMessage` factory guards) + integration
+  against the real broker (duplicate publish of one message id → exactly one e-mail via the
+  spy sender, one inbox row, empty queue; processor failure → no inbox row, redelivery really
+  retries; missing message id → parks in the DLQ, zero e-mails).
+
+## References
+
+- ADR-0035 — outbox relay; §6 at-least-once semantics and the message-id deduplication
+  contract this ADR fulfils.
+- ADR-0036 — broker-enforced dead-lettering; delivery limit, backoff ladder, replay rules.
+- RabbitMQ docs: Quorum Queues (`x-delivery-limit`, `x-delivery-count`).
+- The idempotent-consumer / inbox pattern as described for NServiceBus ("Outbox") and
+  MassTransit ("transactional inbox") — this is the dedup-guard flavor, chosen over the
+  store-and-forward flavor per Alternative A.

--- a/docs/adr/0037-consumer-side-inbox-deduplication-on-the-message-id.md
+++ b/docs/adr/0037-consumer-side-inbox-deduplication-on-the-message-id.md
@@ -176,15 +176,22 @@ follow-up if the transport ever becomes an HTTP API.
 - `InboxMessage` (Persistence, `Inbox/` beside `Outbox/`) — `Create` factory + guards,
   private EF constructor, mirroring `OutboxMessage`; configuration via Fluent API with
   `nameof()` column names; purely additive migration (trivially N-1 safe under ADR-0023).
-- `EmailConfirmationConsumer.OnDeliveredAsync` — the only consumer change: id parse (poison on
-  absence), inbox lookup, post-success insert; `AuthDbContext` resolved from the existing
-  per-delivery scope like the relay does — no new abstraction. A primary-key violation on the
-  insert is treated as "already processed" (ack): a concurrent duplicate lost the race, which
-  means the work is done.
-- Tests, matching the branch's discipline: unit (`InboxMessage` factory guards) + integration
-  against the real broker (duplicate publish of one message id → exactly one e-mail via the
-  spy sender, one inbox row, empty queue; processor failure → no inbox row, redelivery really
-  retries; missing message id → parks in the DLQ, zero e-mails).
+- `EmailConfirmationDeliveryProcessor` (scoped, `Services/Emails/`) — the inbox lookup, the
+  delegation to `EmailConfirmationRequestProcessor` and the post-success insert live in this one
+  component because two delivery paths must run them identically: the broker consumer and the
+  integration suite's broker-less bridge (`AuthSystemApiFactory`), which would otherwise carry a
+  drifting copy of the dedup logic. `AuthDbContext` comes from the existing per-delivery scope
+  like the relay's does. A primary-key violation on the insert is treated as "already processed"
+  (ack): a concurrent duplicate lost the race, which means the work is done.
+- `EmailConfirmationConsumer.OnDeliveredAsync` — id parse (poison on an unusable id, pinned by
+  unit tests) and the swap to the delivery processor; every failure path stays as ADR-0036 left
+  it.
+- Tests, matching the branch's discipline: unit (`InboxMessage` factory guards; message-id
+  parsing incl. absent/non-Guid/empty) + integration against real PostgreSQL through the shared
+  delivery component (duplicate delivery of one message id → exactly one e-mail via the spy
+  sender and one inbox row; failed processing → no row, the healed redelivery really retries).
+  The broker's side of the poison path — reject parks in the DLQ — is already pinned by
+  `DeadLetterTopologyTests` against a real broker.
 
 ## References
 

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -24,6 +24,7 @@
 - [Bringing the stack up](#bringing-the-stack-up) — dev, prod-parity, (re)provisioning a box, and the one-time network cutover
 - [Continuous deployment (CD over ssh)](#continuous-deployment-cd-over-ssh) — build-once → auto staging → gated prod promotion
 - [Database migrations](#database-migrations) — strategy, running them, and recovering from a bad migration (Neon PITR + the MIGR-04 auto-snapshot)
+- [Message broker (RabbitMQ)](#message-broker-rabbitmq) — the in-stack broker, the dead-letter parking lot, replay & rotation traps
 - [Post-deploy smoke test](#post-deploy-smoke-test) — one command verifies a deployed environment end-to-end
 - [Observability & monitoring](#observability--monitoring) — what exists today, and the gap the migration left
 - [Disaster recovery](#disaster-recovery)
@@ -70,16 +71,19 @@ TLS-terminating ingress:
 
 | Service | Image (`ghcr.io/koniecdev/…`) | Listens | Health | Persists |
 |---|---|---|---|---|
-| **auth-api** | `lotrokoniecdev-auth-api` | `:8080` (HTTP) | `/health` (deep: DB + SMTP), `/health/live`, `/health/ready` (probe — runs no checks, ADR-0025) | Data Protection keyring → `/keys` |
+| **auth-api** | `lotrokoniecdev-auth-api` | `:8080` (HTTP) | `/health` (deep: DB + SMTP + broker), `/health/live`, `/health/ready` (probe — runs no checks, ADR-0025) | Data Protection keyring → `/keys` |
 | **tms-api** | `lotrokoniecdev-tms-api` | `:8080` (HTTP) | `/health` (deep: DB), `/health/live`, `/health/ready` (probe — runs no checks, ADR-0025) | translation artifacts (read-only mount) |
 | **frontend** | `lotrokoniecdev-frontend` | `:8080` (HTTP) | — | Data Protection keyring → `/keys` |
 | **migrator** | `lotrokoniecdev-migrator` | one-shot (exits 0) | exit code | — |
 | _ingress_ | **Caddy** (`caddy:2-alpine`) | `:80`, `:443` | — | ACME certs + config volumes |
+| _broker_ | **RabbitMQ** (`rabbitmq:4.3.4-management-alpine` — pinned, see the compose comment) | `:5672` in-stack (AMQP; auth-api only) | `rabbitmq-diagnostics ping` (container healthcheck) + the `rabbitmq` leg of auth's deep `/health` | broker state (users, quorum queues, parked dead letters) → `rabbitmq-data` volume |
 
 Container contract (ADR-0008 §2): each app serves **plain HTTP on `:8080`** and expects a
 TLS-terminating ingress in front; runs **non-root**; logs **structured JSON to stdout**; takes **all
-runtime configuration from environment variables**. Only Caddy publishes ports; the apps use
-`expose:` and are reachable **only** through the proxy. The migrator runs to completion *before* the
+runtime configuration from environment variables**. Only Caddy publishes internet-facing ports; the
+apps use `expose:` and are reachable **only** through the proxy (the broker's management UI is the
+one loopback exception — `127.0.0.1:15672`, reachable exclusively over an ssh tunnel, see
+[Message broker](#message-broker-rabbitmq)). The migrator runs to completion *before* the
 APIs serve traffic, so there is never half-migrated serving.
 
 ## Environment variable matrix
@@ -112,7 +116,8 @@ variable that does not appear there does nothing, whatever this table says.
 
 Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:AccessTokenLifetimeMinutes`
 = 60, `OpenIddict:RefreshTokenLifetimeDays` = 14, `Import:*`, `TranslationFileRebuild:DebounceWindow`
-= 2 s (ADR-0021), `Email:TimeoutSeconds`/`MaxSendAttempts`, `AllowedHosts` = `*`).
+= 2 s (ADR-0021), `Email:TimeoutSeconds`/`MaxSendAttempts`, `RabbitMq:Port` = 5672,
+`RabbitMq:VirtualHost` = `/`, `AllowedHosts` = `*`).
 
 > ⚠️ **Live prod domain is `lotro-translator.pl`** — auth → `https://auth.lotro-translator.pl`,
 > tms → `https://tms.lotro-translator.pl`, frontend → `https://lotro-translator.pl`. The three
@@ -141,6 +146,9 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 | `Email__SenderEmail` | `noreply@lotro-translator.pl` | a Brevo-**authorised** sender (today `koniecdev@gmail.com`) | ✅ all | plain | ⚠️ Not a free-text label — an unauthorised sender is accepted by the relay and **silently dropped** by the receiver. See [E-mail deliverability](#e-mail-deliverability--the-sender-must-be-one-brevo-is-authorised-to-send-as). |
 | `Email__Sender` | `lotro-translator.pl` | `LOTRO PL` | ✅ all | plain | Display name. |
 | `Email__Username` / `Email__Password` | — | Brevo SMTP login + key | optional¹ | **secret** (Password) | ¹If `Username` is set, `Password` is required. The login is shaped `<id>@smtp-brevo.com` — **not** the Brevo account e-mail (that fails with `535`). |
+| `RabbitMq__Host` | `localhost` (the compose broker, published on `:5672`) | `rabbitmq` (the in-stack broker service) | ✅ all | plain | Validated on start (every environment) — but auth-api **boots and serves with the broker down**: outbox rows wait, the consumer retries. See [Message broker](#message-broker-rabbitmq). |
+| `RabbitMq__Username` | `rabbitmq` | `rabbitmq` | ✅ all | plain | Matches the `RABBITMQ_DEFAULT_USER` literal in every compose file. |
+| `RabbitMq__Password` | `changeme` (appsettings.Development + the dev compose `RABBITMQ_PASSWORD`) | from `RABBITMQ_PASSWORD` | ✅ all | **secret** | ⚠️ The broker applies `RABBITMQ_DEFAULT_PASS` on **first boot only** — rotation is a lockstep dance, see the [secrets table](#secret-material--source-of-truth-and-how-to-rotate). |
 | `AdminUser__Username` / `AdminUser__Email` / `AdminUser__Password` | from `AUTH_ADMIN_*` | from `AUTH_ADMIN_*` | optional | **secret** (Password) | Seeds one admin **only when missing**; leave blank to skip. Username must match `^[a-zA-Z0-9]+$` (ADR-0022) or auth-api fails at startup; the admin logs in **by e-mail**. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` (launchSettings → the compose aspire-dashboard) | — (empty: no sink today, ADR-0034) | optional | plain | Empty = telemetry export disabled. See [Observability](#observability--monitoring). |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | `grpc` / `http/protobuf` | optional | plain | Defaults to `grpc`. |
@@ -229,6 +237,7 @@ which is why they are named volumes and not bind mounts.
 | `Email__Username` | auth-api | **Brevo** dashboard → SMTP & API → SMTP keys | The SMTP **login**, shaped `<id>@smtp-brevo.com` — **not** the Brevo account e-mail, which fails the handshake with `535`. |
 | `Email__Password` | auth-api | **Brevo** (owner pastes) | Generate a new SMTP key in Brevo. Shown **once** and never readable back — the copies in the box `.env` and in GitHub secrets are both write-only, so a lost key is re-generated, never recovered. |
 | `AUTH_ADMIN_PASSWORD` (+ `AUTH_ADMIN_USERNAME`, `AUTH_ADMIN_EMAIL`) | auth-api → `AdminUser__*` seeder | **owner-chosen** | Seeded **only when missing**, so editing `.env` never rotates a live admin — see the reseed traps. `AUTH_ADMIN_USERNAME` must match `^[a-zA-Z0-9]+$` (ADR-0022) or auth-api fails at startup. |
+| `RABBITMQ_PASSWORD` (→ auth-api `RabbitMq__Password` **and** the broker's `RABBITMQ_DEFAULT_PASS`) | rabbitmq, auth-api | **box-local** — generate: `openssl rand -base64 24` | ⚠️ Same create-if-missing shape as the admin seed: the broker applies `RABBITMQ_DEFAULT_PASS` on **first boot only** (empty data volume), so editing `.env` later rotates what auth-api presents but **not** what the broker expects. Rotate in lockstep: `docker compose -f compose.hetzner.yaml exec rabbitmq rabbitmqctl change_password rabbitmq '<new>'` → update `.env` → `docker compose -f compose.hetzner.yaml up -d auth-api`. |
 | `SMOKE_CLIENT_SECRET` *(GitHub secret, per environment — **not** a box var)* | `scripts/smoke.sh`, CD | == `OpenIddict__ApiClientSecret` of that env | `gh secret set SMOKE_CLIENT_SECRET --env <staging\|production> --body "$VALUE"` — **never `--body -`**: gh takes `-` literally and the smoke leg then 401s. |
 | GHCR pull token *(not an env var — `docker login` state in `/home/deploy/.docker/config.json`)* | `docker compose pull` | **GitHub PAT**, scope `read:packages` **only** | Re-run `scripts/hetzner/bootstrap.sh` (its login leg prompts for user + PAT on a TTY). |
 | `HETZNER_SSH_KEY` *(GitHub secret, per environment — **not** a box var)* | CD over ssh (`deploy.yml`) | generated for CD — one key per box | The `deploy` user's key, never `root`'s. Mint + install + pin the host key: [One-time setup per environment](#one-time-setup-per-environment). |
@@ -989,6 +998,73 @@ Steps 2–4 can be rehearsed on staging at any time, without a deploy: restore t
 five minutes ago (a data no-op while staging is idle), check the [Verifying](#verifying) output is
 unchanged, then delete the preserved branch. Do **not** run it while manual QA is in progress — the
 restore drops connections and rewinds anything written after the restore point.
+
+## Message broker (RabbitMQ)
+
+Since the outbox/broker work (ADRs 0035–0037) each box runs a **single-node RabbitMQ container** in
+the stack (`rabbitmq` in `compose.hetzner.yaml` — pinned image, pinned `hostname`, named
+`rabbitmq-data` volume). Only **auth-api** talks to it: the outbox relay publishes committed rows to
+the `lotro.emails` exchange and the e-mail consumer consumes `emails.send`. Everything either side
+needs — exchanges, quorum queues, bindings, the dead-letter wiring — is **declared idempotently by
+the app on channel open**, so a fresh broker needs zero manual provisioning.
+
+The broker is deliberately a **soft dependency**:
+
+- **auth-api boots and serves with the broker down** — there is no `depends_on` edge on purpose. The
+  publisher connects lazily, the consumer retries with escalating backoff, committed outbox rows
+  wait (ADR-0035's safety sweep is the ceiling). An outage delays confirmation e-mails; it never
+  blocks login or token issuance.
+- It surfaces as the **`rabbitmq` check on auth's deep `/health`** (deliberately not on
+  `/health/ready`, same reasoning as SMTP) — the daily health ping is what tells you the container
+  died between deploys.
+
+### Management UI — over an ssh tunnel only
+
+The UI is published on the **box loopback** only, never the internet:
+
+```bash
+ssh -L 15672:localhost:15672 deploy@<box-ip>
+# then http://localhost:15672 — user `rabbitmq`, password = RABBITMQ_PASSWORD from the box .env
+```
+
+### The dead-letter parking lot (`emails.send.dlq`)
+
+Messages land there in exactly two ways (ADR-0036): **poison** (unreadable payload or unusable
+message id — rejected on first sight) and **exhausted** (`x-delivery-limit` = 5 redeliveries spent,
+e.g. an SMTP outage the backoff ladder could not outlast). Nothing consumes the queue; it waits for
+a human — a parked message usually means a user never got a confirmation e-mail, so diagnose from
+the payload's `IdentityUserId` plus the matching outbox row's error.
+
+**Replay = ack-and-republish, NEVER reject-requeue** (ADR-0036 §5). The parking lot is a quorum
+queue with the *default* delivery limit (20) and no DLX of its own, so a reject-requeue loop
+**silently drops** the parked message. In the management UI:
+
+1. **Inspect** without consuming: `emails.send.dlq` → *Get messages* with ack mode *Nack message
+   requeue true* (a nack is an "explicit return" — it does not tick the delivery count; a reject
+   does).
+2. **Replay**: *Publish message* on the **`lotro.emails`** exchange with the message's preserved
+   routing key (e.g. `email.confirmation`), its original **`message_id` property** and body. The
+   inbox deduplicates on the message id (ADR-0037), so replaying an already-processed id is a safe
+   no-op.
+3. Only after the replay demonstrably processed (e-mail sent / inbox row present): remove the parked
+   copy — *Get messages* with ack mode *Automatic ack*.
+
+### Traps
+
+- **The broker-carrying release needs the box `.env` updated FIRST**: append `RABBITMQ_PASSWORD`
+  (`openssl rand -base64 24`) to `/opt/lotro/.env` on **both** boxes before merging it. Missing it
+  is loud, not silent: compose interpolation fails (`${RABBITMQ_PASSWORD:?…}`) inside `deploy.sh`'s
+  config-validation step, which aborts the deploy while the old release keeps serving.
+- **`RABBITMQ_DEFAULT_PASS` applies on first boot only** (empty data volume). Editing the box `.env`
+  later rotates what auth-api presents but **not** what the broker expects — rotate in lockstep via
+  `rabbitmqctl change_password` (exact commands: the
+  [secrets table](#secret-material--source-of-truth-and-how-to-rotate)).
+- **Queue arguments are immutable.** Redeclaring `emails.send` with different `x-*` arguments fails
+  the channel with `PRECONDITION_FAILED` (ADR-0036). Changing them on a live box means draining and
+  deleting the queue first — treat it as a small migration, not a config tweak.
+- **Never remove the `hostname:` pin** on the service. RabbitMQ keys its on-disk state by node name
+  (`rabbit@<hostname>`); an unpinned recreation boots a fresh node beside the old data and orphans
+  the volume's quorum queues — parked dead letters included.
 
 ## Post-deploy smoke test
 

--- a/docs/superpowers/plans/2026-08-03-inbox-deduplication.md
+++ b/docs/superpowers/plans/2026-08-03-inbox-deduplication.md
@@ -1,0 +1,754 @@
+# Inbox Deduplication (ADR-0037) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the e-mail consumer a durable inbox (dedup on the broker message id) so a redelivered or re-published message never sends a second confirmation e-mail — per ADR-0037 (`docs/adr/0037-consumer-side-inbox-deduplication-on-the-message-id.md`).
+
+**Architecture:** One new table (`InboxMessages`: MessageId PK + ProcessedOn) in the auth database. The dedup orchestration (check inbox → run `EmailConfirmationRequestProcessor` → record on success) lives in one new scoped component, `EmailConfirmationDeliveryProcessor`, resolved by BOTH real delivery paths: `EmailConfirmationConsumer.OnDeliveredAsync` (production, real broker) and the integration suite's broker-less bridge in `AuthSystemApiFactory` (which today calls the processor directly and would otherwise need a drifting copy of the dedup logic). Retry/backoff/DLQ stay broker-owned (ADR-0036) — this plan never touches them.
+
+**Tech Stack:** .NET 10 / C# 14, EF Core 10 + Npgsql (PostgreSQL), RabbitMQ.Client v7, xUnit + Shouldly, Testcontainers (integration suite).
+
+## Global Constraints
+
+- **Zero warnings**: `TreatWarningsAsErrors` is repo-wide — any warning IS a failing build. Verify with `dotnet build LotroKoniecDev.slnx`.
+- **Branch**: work on the existing `rabbitmq-introduction` branch. Never commit to main.
+- **Commit trailer** (every commit):
+
+  ```
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01RkmEvoRyYvnHSCiNGLfMzK
+  ```
+
+- **C# style**: `sealed` everything without explicit inheritance; explicit constructors (no primary constructors in classes); `var` only for anonymous types; file-scoped namespaces; Allman braces; no `#region`; `/// <summary>` XML docs (never plain `//` to document a member); LINQ methods, never query syntax; code and identifiers in English.
+- **Errors are values**: business failures → `Result` (`LotroKoniecDev.SharedKernel.Monads`; `IsSuccess`/`IsFailure`/`Error` all exist); `Ensure.*`/`Argument*Exception.Throw*` guards are for programmer errors only.
+- **EF Core**: Fluent API only, no attributes; no needless `IsRequired()` (value types are already required); migrations are forward-only and this one must be purely additive (`CREATE TABLE` only — trivially N-1 safe, no `MIGRATION-SAFETY` comment needed).
+- **Tests**: xUnit + Shouldly (never raw `Assert.*`); naming `MethodName_Scenario_ExpectedResult`; AAA with assertions inline in the test method; `[Theory]`+`[InlineData]` for unhappy-path matrices. Xunit/Shouldly are global usings in both auth test projects — don't add `using Xunit;`/`using Shouldly;`.
+- **Never add** `Mediator`/`MediatR` packages (ADR-0001).
+- **Docker required** for the integration suite (`tests/LotroKoniecDev.AuthSystem.API.Tests.Integration` boots a PostgreSQL Testcontainer). If Docker is unavailable, say so loudly instead of skipping silently.
+
+---
+
+### Task 1: `InboxMessage` entity + unit tests
+
+**Files:**
+- Create: `src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Inbox/InboxMessage.cs`
+- Test: `tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Inbox/InboxMessageTests.cs`
+
+**Interfaces:**
+- Consumes: `LotroKoniecDev.SharedKernel.Guards.Ensure.NotEmpty(Guid)` and `Ensure.NotEmpty(DateTimeOffset)` — both throw `ArgumentException`.
+- Produces: `public sealed class InboxMessage` with `Guid MessageId { get; }`, `DateTimeOffset ProcessedOn { get; }`, `static InboxMessage Create(Guid messageId, DateTimeOffset processedOn)`. Tasks 2 and 3 rely on exactly these names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Inbox/InboxMessageTests.cs`:
+
+```csharp
+using LotroKoniecDev.AuthSystem.Persistence.Inbox;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Inbox;
+
+public sealed class InboxMessageTests
+{
+    [Fact]
+    public void Create_WithValidArguments_SetsMessageIdAndProcessedOn()
+    {
+        // Arrange
+        Guid messageId = Guid.CreateVersion7();
+        DateTimeOffset processedOn = new(2026, 8, 3, 12, 0, 0, TimeSpan.Zero);
+
+        // Act
+        InboxMessage message = InboxMessage.Create(messageId, processedOn);
+
+        // Assert
+        message.MessageId.ShouldBe(messageId);
+        message.ProcessedOn.ShouldBe(processedOn);
+    }
+
+    [Fact]
+    public void Create_WithEmptyMessageId_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            InboxMessage.Create(Guid.Empty, DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void Create_WithDefaultProcessedOn_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            InboxMessage.Create(Guid.CreateVersion7(), default));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Unit --filter "FullyQualifiedName~InboxMessageTests"`
+Expected: build FAILURE — `InboxMessage` and namespace `...Persistence.Inbox` do not exist yet.
+
+- [ ] **Step 3: Write the entity**
+
+Create `src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Inbox/InboxMessage.cs`. Member order per house rules (properties → factory → private ctors); the parameterless ctor is for EF:
+
+```csharp
+using LotroKoniecDev.SharedKernel.Guards;
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Inbox;
+
+/// <summary>
+/// One row per fully processed broker delivery, keyed by the broker message id — which equals the
+/// publishing <see cref="Outbox.OutboxMessage"/>'s Id, so the full context of any inbox row is one
+/// join away. The consumer checks this table before doing any work and records into it after
+/// success, so a redelivered or re-published message is acknowledged without a second side effect
+/// (ADR-0037).
+/// </summary>
+/// <remarks>
+/// Deliberately carries no Type, no Payload and no attempt counters: the outbox row with the same
+/// id holds the former two, and retry bookkeeping is broker-owned (ADR-0036). One hard constraint
+/// from ADR-0037: this table serves the single e-mail consumer — a second consumer of the same
+/// message (a fanout binding) must NOT share it without adding a consumer discriminator, or the
+/// two would silently skip each other's work.
+/// </remarks>
+public sealed class InboxMessage
+{
+    public Guid MessageId { get; }
+    public DateTimeOffset ProcessedOn { get; }
+
+    public static InboxMessage Create(Guid messageId, DateTimeOffset processedOn)
+    {
+        Ensure.NotEmpty(messageId);
+        Ensure.NotEmpty(processedOn);
+        InboxMessage instance = new(messageId: messageId, processedOn: processedOn);
+        return instance;
+    }
+
+    private InboxMessage(Guid messageId, DateTimeOffset processedOn)
+    {
+        MessageId = messageId;
+        ProcessedOn = processedOn;
+    }
+
+    private InboxMessage()
+    {
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Unit --filter "FullyQualifiedName~InboxMessageTests"`
+Expected: 3 PASS. (The unit test project reaches `Persistence` transitively through its `API` project reference — no csproj edit needed.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Inbox/InboxMessage.cs \
+        tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Inbox/InboxMessageTests.cs
+git commit -m "Add the inbox message that records a processed delivery id"
+```
+
+(Include the Global Constraints trailer in this and every commit message.)
+
+---
+
+### Task 2: EF configuration + `DbSet` + migration
+
+**Files:**
+- Create: `src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/InboxMessageConfiguration.cs`
+- Modify: `src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/DbContexts/AuthDbContext.cs`
+- Generated: `src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/<timestamp>_AddInboxMessages.cs` (+ `.Designer.cs`, + snapshot update)
+
+**Interfaces:**
+- Consumes: `InboxMessage` from Task 1.
+- Produces: `AuthDbContext.InboxMessages` (`DbSet<InboxMessage>`) — Task 3 queries and inserts through it. Table `authsystem."InboxMessages"`.
+
+- [ ] **Step 1: Write the configuration**
+
+Create `src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/InboxMessageConfiguration.cs`:
+
+```csharp
+using LotroKoniecDev.AuthSystem.Persistence.Inbox;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Configurations;
+
+internal sealed class InboxMessageConfiguration : IEntityTypeConfiguration<InboxMessage>
+{
+    public void Configure(EntityTypeBuilder<InboxMessage> builder)
+    {
+        builder.ToTable("InboxMessages");
+
+        builder.HasKey(message => message.MessageId);
+
+        // Both properties are get-only, and EF Core's convention only discovers properties that
+        // have BOTH a getter and a setter — each needs an explicit Property() call to exist in
+        // the model at all (same gotcha as OutboxMessageConfiguration).
+        builder.Property(message => message.MessageId)
+            .ValueGeneratedNever();
+
+        builder.Property(message => message.ProcessedOn);
+    }
+}
+```
+
+(No index beyond the PK: the only query is a PK lookup. The configuration is picked up automatically — `AuthDbContext.OnModelCreating` calls `ApplyConfigurationsFromAssembly`.)
+
+- [ ] **Step 2: Add the DbSet**
+
+In `src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/DbContexts/AuthDbContext.cs`, add the using and the property (directly under the `OutboxMessages` DbSet):
+
+```csharp
+using LotroKoniecDev.AuthSystem.Persistence.Inbox;
+```
+
+```csharp
+    public DbSet<InboxMessage> InboxMessages => Set<InboxMessage>();
+```
+
+- [ ] **Step 3: Generate the migration**
+
+From the repo root (`dotnet-ef` is a pinned local tool; Auth resolves through its API project — only it carries EF Core Design — while the migration files land in Persistence; the design-time factory accepts `--connection`, so no live database is needed):
+
+```bash
+dotnet tool restore
+dotnet ef migrations add AddInboxMessages \
+  --project src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence \
+  --startup-project src/AuthSystem/LotroKoniecDev.AuthSystem.API \
+  --context AuthDbContext \
+  -- --connection "Host=localhost;Database=lotro_auth;Username=postgres;Password=changeme"
+```
+
+- [ ] **Step 4: Verify the migration is purely additive**
+
+Open the generated `<timestamp>_AddInboxMessages.cs` and check `Up()` contains EXACTLY one operation: `CreateTable` for `InboxMessages` in schema `authsystem` with columns `MessageId` (uuid, PK) and `ProcessedOn` (timestamp with time zone), and nothing else. Any extra operation (a `DropColumn`, an `AlterColumn`) means the model drifted — most likely a get-only property missing its explicit `Property()` call — fix the configuration and regenerate (`dotnet ef migrations remove` with the same arguments, then re-add).
+
+- [ ] **Step 5: Build and run the auth unit suite**
+
+Run: `dotnet build LotroKoniecDev.slnx` then `dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Unit`
+Expected: zero warnings, all PASS. (The integration suite applies migrations automatically per-container; local compose users rebuild via `docker compose up --build migrator` — nothing to do in this plan.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence
+git commit -m "Add the inbox table to the auth database"
+```
+
+---
+
+### Task 3: `EmailConfirmationDeliveryProcessor` + EventIds + DI + integration tests
+
+**Files:**
+- Create: `src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationDeliveryProcessor.cs`
+- Modify: `src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs` (new ids)
+- Modify: `src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs` (one registration)
+- Test: `tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/InboxDeduplicationTests.cs`
+
+**Interfaces:**
+- Consumes: `AuthDbContext.InboxMessages` + `InboxMessage.Create` (Tasks 1–2); existing `EmailConfirmationRequestProcessor.ProcessAsync(EmailConfirmationRequested, CancellationToken)` returning `Result`; `TimeProvider` (registered singleton); `EmailConfirmationRequested(Guid IdentityUserId)` record from `LotroKoniecDev.AuthSystem.API.Outbox`.
+- Produces: `internal sealed partial class EmailConfirmationDeliveryProcessor` (scoped) with `Task<Result> ProcessOnceAsync(EmailConfirmationRequested message, Guid messageId, CancellationToken cancellationToken)`. Task 4 resolves it in the consumer and the factory bridge.
+
+- [ ] **Step 1: Add the EventIds**
+
+In `src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs`, after the `// Email Confirmation Consumer (2330–2339)` block (which is full), add:
+
+```csharp
+    // Inbox deduplication (2340–2349)
+    public const int EmailConsumerDuplicateSkipped = 2340;
+    public const int EmailConsumerInboxRaceLost = 2341;
+    public const int EmailConsumerMessageIdUnusable = 2342;
+```
+
+(`EmailConsumerMessageIdUnusable` is used by Task 4's consumer change — adding it now keeps the block in one commit. An unused const raises no warning.)
+
+- [ ] **Step 2: Write the failing integration tests**
+
+Create `tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/InboxDeduplicationTests.cs`. It mirrors `OutboxRelayTests` (same base class, same wait-on-state idiom — never wait on time). The API assembly's internals are already visible to this test project (the factory resolves the internal `EmailConfirmationRequestProcessor` today):
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Inbox;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+/// <summary>
+/// Proves the inbox deduplication of ADR-0037 against real PostgreSQL, through
+/// <see cref="EmailConfirmationDeliveryProcessor"/> — the one component both real delivery paths
+/// (the broker consumer and this suite's broker-less bridge) resolve: a processed message id is
+/// recorded, a duplicate of it is acknowledged without a second e-mail, and a failed processing
+/// leaves no record so redelivery genuinely retries.
+/// </summary>
+public sealed class InboxDeduplicationTests : EndpointsTestBase
+{
+    public InboxDeduplicationTests(AuthSystemApiFactory appFactory) : base(appFactory)
+    {
+    }
+
+    [Fact]
+    public async Task ProcessOnce_ShouldRecordTheMessageId_WhenProcessingSucceeds()
+    {
+        // Arrange
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy);
+        await AccountConfirmationEmailSpy.WaitForCaptureAsync();
+        Guid messageId = Guid.CreateVersion7();
+        int sendsBefore = AccountConfirmationEmailSpy.CallCount;
+
+        // Act
+        Result ackDecision = await ProcessOnceAsync(identityId.Value, messageId);
+
+        // Assert
+        ackDecision.IsSuccess.ShouldBeTrue();
+        AccountConfirmationEmailSpy.CallCount.ShouldBe(sendsBefore + 1);
+        (await CountInboxRowsAsync(messageId)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ProcessOnce_ShouldAckWithoutSecondEmail_WhenMessageIdAlreadyRecorded()
+    {
+        // Arrange
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy);
+        await AccountConfirmationEmailSpy.WaitForCaptureAsync();
+        Guid messageId = Guid.CreateVersion7();
+        await ProcessOnceAsync(identityId.Value, messageId);
+        int sendsAfterFirstDelivery = AccountConfirmationEmailSpy.CallCount;
+
+        // Act — the same message id delivered again (redelivery or relay re-publish)
+        Result duplicateAckDecision = await ProcessOnceAsync(identityId.Value, messageId);
+
+        // Assert — acked, no second e-mail, still exactly one row
+        duplicateAckDecision.IsSuccess.ShouldBeTrue();
+        AccountConfirmationEmailSpy.CallCount.ShouldBe(sendsAfterFirstDelivery);
+        (await CountInboxRowsAsync(messageId)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ProcessOnce_ShouldLeaveNoRecord_WhenProcessingFails()
+    {
+        // Arrange
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy);
+        await AccountConfirmationEmailSpy.WaitForCaptureAsync();
+        Guid messageId = Guid.CreateVersion7();
+        AccountConfirmationEmailSpy.ShouldFail = true;
+
+        // Act — the failed send must not be remembered as processed
+        Result failedAckDecision = await ProcessOnceAsync(identityId.Value, messageId);
+
+        // Assert
+        failedAckDecision.IsFailure.ShouldBeTrue();
+        (await CountInboxRowsAsync(messageId)).ShouldBe(0);
+
+        // Act again — after the dependency heals, the redelivery really retries and records
+        AccountConfirmationEmailSpy.ShouldFail = false;
+        Result redeliveryAckDecision = await ProcessOnceAsync(identityId.Value, messageId);
+
+        // Assert
+        redeliveryAckDecision.IsSuccess.ShouldBeTrue();
+        (await CountInboxRowsAsync(messageId)).ShouldBe(1);
+    }
+
+    private async Task<Result> ProcessOnceAsync(Guid identityUserId, Guid messageId)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        EmailConfirmationDeliveryProcessor deliveryProcessor =
+            scope.ServiceProvider.GetRequiredService<EmailConfirmationDeliveryProcessor>();
+        return await deliveryProcessor.ProcessOnceAsync(
+            new EmailConfirmationRequested(identityUserId), messageId, CancellationToken.None);
+    }
+
+    private async Task<int> CountInboxRowsAsync(Guid messageId)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        return await db.InboxMessages.AsNoTracking().CountAsync(row => row.MessageId == messageId);
+    }
+}
+```
+
+Note on the deliberate test gap: the primary-key-violation branch (`EmailConsumerInboxRaceLost`, two racing inserts of the same id) is NOT integration-tested — hitting it black-box requires interleaving a competing insert between the component's check and its save, which no seam allows. The branch is three lines of defensive code reviewed in Task 5; do not add a seam just to reach it.
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Integration --filter "FullyQualifiedName~InboxDeduplicationTests"`
+Expected: build FAILURE — `EmailConfirmationDeliveryProcessor` does not exist yet.
+
+- [ ] **Step 4: Write the component**
+
+Create `src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationDeliveryProcessor.cs` (`PostgresException`/`PostgresErrorCodes` come from Npgsql, available transitively through the Persistence reference):
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Inbox;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// The delivery-level wrapper around <see cref="EmailConfirmationRequestProcessor"/>: consults the
+/// inbox before doing any work and records the message id after success (ADR-0037). Both real
+/// delivery paths — <see cref="BackgroundServices.EmailConfirmationConsumer"/> and the integration
+/// suite's broker-less bridge — resolve this one component, so the dedup logic cannot drift
+/// between them.
+/// </summary>
+/// <remarks>
+/// Returns the same ack-decision contract as the processor: success means "ack, drop it from the
+/// queue" (processed now, or already processed before), failure means "worth redelivering". The
+/// inbox row lands AFTER the send on purpose — recording first would trade duplicate-e-mail risk
+/// for lost-e-mail risk (ADR-0037 Decision 2). Database faults deliberately escape as exceptions:
+/// the consumer's existing transient path rejects the delivery and the broker's delivery limit
+/// bounds the loop (ADR-0037 Decision 4).
+/// </remarks>
+internal sealed partial class EmailConfirmationDeliveryProcessor
+{
+    private readonly AuthDbContext _db;
+    private readonly EmailConfirmationRequestProcessor _processor;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<EmailConfirmationDeliveryProcessor> _logger;
+
+    public EmailConfirmationDeliveryProcessor(
+        AuthDbContext db,
+        EmailConfirmationRequestProcessor processor,
+        TimeProvider timeProvider,
+        ILogger<EmailConfirmationDeliveryProcessor> logger)
+    {
+        _db = db;
+        _processor = processor;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result> ProcessOnceAsync(
+        EmailConfirmationRequested message,
+        Guid messageId,
+        CancellationToken cancellationToken)
+    {
+        bool alreadyProcessed = await _db.InboxMessages
+            .AsNoTracking()
+            .AnyAsync(inboxMessage => inboxMessage.MessageId == messageId, cancellationToken);
+        if (alreadyProcessed)
+        {
+            LogDuplicateSkipped(_logger, messageId);
+            return Result.Success();
+        }
+
+        Result ackDecision = await _processor.ProcessAsync(message, cancellationToken);
+        if (ackDecision.IsFailure)
+        {
+            return ackDecision;
+        }
+
+        _db.InboxMessages.Add(InboxMessage.Create(messageId, _timeProvider.GetUtcNow()));
+
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsPrimaryKeyViolation(ex))
+        {
+            // A concurrent duplicate won the insert race, which means the work is done — same
+            // ack decision as a pre-check hit.
+            LogInboxRaceLost(_logger, messageId);
+        }
+
+        return Result.Success();
+    }
+
+    private static bool IsPrimaryKeyViolation(DbUpdateException exception)
+    {
+        return exception.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation };
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerDuplicateSkipped,
+        Level = LogLevel.Information,
+        Message = "Skipping message {MessageId}: the inbox already recorded it as processed")]
+    private static partial void LogDuplicateSkipped(ILogger logger, Guid messageId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerInboxRaceLost,
+        Level = LogLevel.Information,
+        Message = "Recording message {MessageId} lost an insert race to a concurrent duplicate; acknowledging as processed")]
+    private static partial void LogInboxRaceLost(ILogger logger, Guid messageId);
+}
+```
+
+- [ ] **Step 5: Register it in DI**
+
+In `src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs`, directly under the existing `services.AddScoped<EmailConfirmationRequestProcessor>();` line, add:
+
+```csharp
+            services.AddScoped<EmailConfirmationDeliveryProcessor>();
+```
+
+- [ ] **Step 6: Run the new tests to verify they pass**
+
+Run: `dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Integration --filter "FullyQualifiedName~InboxDeduplicationTests"`
+Expected: 3 PASS (Docker must be running).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/AuthSystem/LotroKoniecDev.AuthSystem.API \
+        tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/InboxDeduplicationTests.cs
+git commit -m "Skip deliveries the inbox already recorded"
+```
+
+---
+
+### Task 4: Wire the consumer and the suite's bridge through the shared component
+
+**Files:**
+- Modify: `src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs`
+- Modify: `tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs` (bridge method `DeliverLikeTheConsumerWouldAsync`)
+- Test: `tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/EmailConfirmationConsumerTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: `EmailConfirmationDeliveryProcessor.ProcessOnceAsync(EmailConfirmationRequested, Guid, CancellationToken)` from Task 3; `EventIds.EmailConsumerMessageIdUnusable` from Task 3 Step 1.
+- Produces: `internal static bool EmailConfirmationConsumer.TryReadMessageId(IReadOnlyBasicProperties properties, out Guid messageId)` — unit-tested here, used nowhere else.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+In `tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/EmailConfirmationConsumerTests.cs`, add `using RabbitMQ.Client;` to the usings and append inside the class:
+
+```csharp
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-guid")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    public void TryReadMessageId_WithUnusableValue_ReturnsFalse(string? rawMessageId)
+    {
+        // Arrange — BasicProperties implements IReadOnlyBasicProperties
+        BasicProperties properties = new() { MessageId = rawMessageId };
+
+        // Act
+        bool usable = EmailConfirmationConsumer.TryReadMessageId(properties, out Guid _);
+
+        // Assert
+        usable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryReadMessageId_WithGuidValue_ReturnsTheParsedId()
+    {
+        // Arrange
+        Guid messageId = Guid.CreateVersion7();
+        BasicProperties properties = new() { MessageId = messageId.ToString() };
+
+        // Act
+        bool usable = EmailConfirmationConsumer.TryReadMessageId(properties, out Guid parsed);
+
+        // Assert
+        usable.ShouldBeTrue();
+        parsed.ShouldBe(messageId);
+    }
+```
+
+Also update the class's `<summary>` first sentence to cover the new concern, e.g. append: `Also pins the poison decision for unusable message ids (ADR-0037): a delivery the inbox cannot deduplicate must be rejected, not processed blind.`
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Unit --filter "FullyQualifiedName~EmailConfirmationConsumerTests"`
+Expected: build FAILURE — `TryReadMessageId` does not exist.
+
+- [ ] **Step 3: Change the consumer**
+
+In `src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs`:
+
+**(a)** In `OnDeliveredAsync`, insert the message-id gate at the very top of the `try` block, BEFORE the existing `TryDeserialize` call:
+
+```csharp
+            if (!TryReadMessageId(delivery.BasicProperties, out Guid messageId))
+            {
+                // Poison: without a usable message id the delivery cannot be deduplicated, and
+                // processing it blind would reopen the unbounded-duplicate hole the inbox closes
+                // (ADR-0037) — so it parks in the dead-letter queue for a human instead.
+                LogMessageIdUnusable(_logger, delivery.BasicProperties.MessageId);
+                await channel.BasicRejectAsync(
+                    delivery.DeliveryTag,
+                    requeue: false,
+                    cancellationToken: stoppingToken);
+                return;
+            }
+```
+
+**(b)** Replace the processor resolution block
+
+```csharp
+            Result ackDecision;
+            await using (AsyncServiceScope scope = _scopeFactory.CreateAsyncScope())
+            {
+                EmailConfirmationRequestProcessor processor =
+                    scope.ServiceProvider.GetRequiredService<EmailConfirmationRequestProcessor>();
+                ackDecision = await processor.ProcessAsync(message, stoppingToken);
+            }
+```
+
+with:
+
+```csharp
+            Result ackDecision;
+            await using (AsyncServiceScope scope = _scopeFactory.CreateAsyncScope())
+            {
+                EmailConfirmationDeliveryProcessor deliveryProcessor =
+                    scope.ServiceProvider.GetRequiredService<EmailConfirmationDeliveryProcessor>();
+                ackDecision = await deliveryProcessor.ProcessOnceAsync(message, messageId, stoppingToken);
+            }
+```
+
+**(c)** Add the helper (place it directly above `TryDeserialize`):
+
+```csharp
+    /// <summary>
+    /// Reads the broker message id the inbox deduplicates on (ADR-0037). Internal so the unit
+    /// suite can pin the poison decision: absent, non-Guid and empty-Guid ids must all fail.
+    /// </summary>
+    internal static bool TryReadMessageId(IReadOnlyBasicProperties properties, out Guid messageId)
+    {
+        return Guid.TryParse(properties.MessageId, out messageId) && messageId != Guid.Empty;
+    }
+```
+
+**(d)** Add the log method next to the other `LoggerMessage`s:
+
+```csharp
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerMessageIdUnusable,
+        Level = LogLevel.Error,
+        Message = "Rejecting message with unusable message id {MessageId} into the dead-letter queue: the inbox cannot deduplicate a delivery without an id")]
+    private static partial void LogMessageIdUnusable(ILogger logger, string? messageId);
+```
+
+**(e)** In the class-level `<remarks>`, after the sentence ending `— at-least-once, matching the outbox's own semantics (the processor stays idempotent, see its remarks).`, insert one sentence:
+
+```
+On top of that, deliveries are deduplicated on the broker message id through the inbox
+(ADR-0037), so a redelivery of an already-processed message acks without a second e-mail.
+```
+
+- [ ] **Step 4: Rewire the suite's bridge**
+
+In `tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs`, in `DeliverLikeTheConsumerWouldAsync`, replace the scope block
+
+```csharp
+        await using AsyncServiceScope scope = services.CreateAsyncScope();
+        EmailConfirmationRequestProcessor processor =
+            scope.ServiceProvider.GetRequiredService<EmailConfirmationRequestProcessor>();
+        await processor.ProcessAsync(payload, CancellationToken.None);
+```
+
+with:
+
+```csharp
+        await using AsyncServiceScope scope = services.CreateAsyncScope();
+        EmailConfirmationDeliveryProcessor deliveryProcessor =
+            scope.ServiceProvider.GetRequiredService<EmailConfirmationDeliveryProcessor>();
+        await deliveryProcessor.ProcessOnceAsync(payload, message.MessageId, CancellationToken.None);
+```
+
+and extend the method's `<summary>` to say the bridge now includes the inbox dedup, e.g.: `... in a fresh scope per message, exactly like EmailConfirmationConsumer.OnDeliveredAsync — including the inbox deduplication of ADR-0037, which therefore runs under this suite's real PostgreSQL.`
+
+- [ ] **Step 5: Run both auth suites**
+
+Run: `dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Unit && dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Integration`
+Expected: all PASS — the new unit theories, the Task 3 tests still green through the rewired bridge, and every pre-existing registration/relay test unaffected (each relay publish carries a fresh outbox-row id, so the dedup never suppresses a legitimate first delivery).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs \
+        tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/EmailConfirmationConsumerTests.cs \
+        tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+git commit -m "Deduplicate broker deliveries through the inbox"
+```
+
+---
+
+### Task 5: Align ADR-0037's implementation notes + full verification
+
+**Files:**
+- Modify: `docs/adr/0037-consumer-side-inbox-deduplication-on-the-message-id.md` (Implementation Notes only — the Decisions stand)
+
+**Interfaces:** none — documentation + verification.
+
+- [ ] **Step 1: Update the ADR's Implementation Notes**
+
+The ADR was written before the test-architecture constraint surfaced (the broker-less integration suite bridges deliveries around the consumer, so consumer-inlined dedup would be untestable there without a drifting copy). Replace the second bullet of `## Implementation Notes`:
+
+```
+- `EmailConfirmationConsumer.OnDeliveredAsync` — the only consumer change: id parse (poison on
+  absence), inbox lookup, post-success insert; `AuthDbContext` resolved from the existing
+  per-delivery scope like the relay does — no new abstraction. A primary-key violation on the
+  insert is treated as "already processed" (ack): a concurrent duplicate lost the race, which
+  means the work is done.
+```
+
+with:
+
+```
+- `EmailConfirmationDeliveryProcessor` (scoped, `Services/Emails/`) — the inbox lookup, the
+  delegation to `EmailConfirmationRequestProcessor` and the post-success insert live in this one
+  component because two delivery paths must run them identically: the broker consumer and the
+  integration suite's broker-less bridge (`AuthSystemApiFactory`), which would otherwise carry a
+  drifting copy of the dedup logic. `AuthDbContext` comes from the existing per-delivery scope
+  like the relay's does. A primary-key violation on the insert is treated as "already processed"
+  (ack): a concurrent duplicate lost the race, which means the work is done.
+- `EmailConfirmationConsumer.OnDeliveredAsync` — id parse (poison on an unusable id, pinned by
+  unit tests) and the swap to the delivery processor; every failure path stays as ADR-0036 left
+  it.
+```
+
+and replace the tests bullet:
+
+```
+- Tests, matching the branch's discipline: unit (`InboxMessage` factory guards) + integration
+  against the real broker (duplicate publish of one message id → exactly one e-mail via the
+  spy sender, one inbox row, empty queue; processor failure → no inbox row, redelivery really
+  retries; missing message id → parks in the DLQ, zero e-mails).
+```
+
+with:
+
+```
+- Tests, matching the branch's discipline: unit (`InboxMessage` factory guards; message-id
+  parsing incl. absent/non-Guid/empty) + integration against real PostgreSQL through the shared
+  delivery component (duplicate delivery of one message id → exactly one e-mail via the spy
+  sender and one inbox row; failed processing → no row, the healed redelivery really retries).
+  The broker's side of the poison path — reject parks in the DLQ — is already pinned by
+  `DeadLetterTopologyTests` against a real broker.
+```
+
+- [ ] **Step 2: Full build + full runnable test sweep**
+
+Run: `dotnet build LotroKoniecDev.slnx` (zero warnings) and `dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Unit && dotnet test tests/LotroKoniecDev.AuthSystem.API.Tests.Integration`
+Expected: zero warnings, all PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/adr/0037-consumer-side-inbox-deduplication-on-the-message-id.md
+git commit -m "Align ADR-0037 implementation notes with the delivery seam"
+```
+
+---
+
+## Plan Self-Review (done at authoring time)
+
+- **Spec coverage:** ADR Decisions 1–6 map to Tasks 1–4 (table → T1/T2; check/process/record → T3; poison on unusable id → T4; DB faults escape to the existing transient path → T3 remarks + unchanged consumer catch-all; no discriminator / no retention → entity remarks, nothing to build). The failure-ordering analysis required no code — the ordering falls out of T3's check-before-process.
+- **Placeholders:** none; every code step carries the full code.
+- **Type consistency:** `InboxMessage.Create(Guid, DateTimeOffset)` (T1) = usage in T3; `ProcessOnceAsync(EmailConfirmationRequested, Guid, CancellationToken)` (T3) = usage in T4 consumer and bridge; `EventIds.EmailConsumerMessageIdUnusable` added in T3 Step 1, consumed in T4 Step 3d.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -100,6 +100,7 @@ internal static class ApiDependencyInjection
             // The processor is scoped because the consumer resolves it per message, mirroring how
             // a request would; the pump itself is a singleton hosted service.
             services.AddScoped<EmailConfirmationRequestProcessor>();
+            services.AddScoped<EmailConfirmationDeliveryProcessor>();
             services.AddHostedService<EmailConfirmationConsumer>();
 
             // PERF-02: reference refresh tokens accumulate one row per refresh and are never

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -96,6 +96,12 @@ internal static class ApiDependencyInjection
             services.AddSingleton<OutboxSignal>();
             services.AddHostedService<OutboxRelay>();
 
+            // The consuming side of the same pipeline: broker deliveries -> confirmation e-mails.
+            // The processor is scoped because the consumer resolves it per message, mirroring how
+            // a request would; the pump itself is a singleton hosted service.
+            services.AddScoped<EmailConfirmationRequestProcessor>();
+            services.AddHostedService<EmailConfirmationConsumer>();
+
             // PERF-02: reference refresh tokens accumulate one row per refresh and are never
             // deleted otherwise; prune expired/invalid tokens and authorizations daily.
             services.AddHostedService<OpenIddictPruneService>();

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -11,6 +11,7 @@ using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.API.Features.Auth;
 using LotroKoniecDev.AuthSystem.API.Hateoas.AccountAggregateFactories;
 using LotroKoniecDev.AuthSystem.API.Hateoas.DiscoveryFactories;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Services.Emails;
 using LotroKoniecDev.AuthSystem.API.Services.Emails.Templates;
 using LotroKoniecDev.AuthSystem.API.Services.Gdpr;
@@ -89,6 +90,11 @@ internal static class ApiDependencyInjection
             services.AddHostedService<AccountDeletionFinalizerHostedService>();
 
             services.AddScoped<IUserSessionRevoker, UserSessionRevoker>();
+
+            // Signal-driven outbox relay (ADR-0035): outbox writers nudge the singleton signal
+            // after their commit instead of the relay polling the database on an interval.
+            services.AddSingleton<OutboxSignal>();
+            services.AddHostedService<OutboxRelay>();
 
             // PERF-02: reference refresh tokens accumulate one row per refresh and are never
             // deleted otherwise; prune expired/invalid tokens and authorizations daily.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
@@ -147,25 +147,29 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
                 // Poison: no amount of redelivery fixes an unreadable payload, so it is dropped
                 // loudly instead of requeued into an infinite loop.
                 LogPoisonMessage(_logger, delivery.BasicProperties.MessageId);
-                await channel.BasicNackAsync(delivery.DeliveryTag, multiple: false, requeue: false, cancellationToken: stoppingToken);
+                await channel.BasicNackAsync(
+                    delivery.DeliveryTag,
+                    multiple: false,
+                    requeue: false,
+                    cancellationToken: stoppingToken);
                 return;
             }
 
-            Result outcome;
+            Result ackDecision;
             await using (AsyncServiceScope scope = _scopeFactory.CreateAsyncScope())
             {
                 EmailConfirmationRequestProcessor processor =
                     scope.ServiceProvider.GetRequiredService<EmailConfirmationRequestProcessor>();
-                outcome = await processor.ProcessAsync(message, stoppingToken);
+                ackDecision = await processor.ProcessAsync(message, stoppingToken);
             }
 
-            if (outcome.IsSuccess)
+            if (ackDecision.IsSuccess)
             {
                 await channel.BasicAckAsync(delivery.DeliveryTag, multiple: false, cancellationToken: stoppingToken);
                 return;
             }
 
-            LogTransientFailure(_logger, delivery.BasicProperties.MessageId, outcome.Error.ToString());
+            LogTransientFailure(_logger, delivery.BasicProperties.MessageId, ackDecision.Error.ToString());
             await Task.Delay(TransientFailureDelay, stoppingToken);
             await channel.BasicNackAsync(delivery.DeliveryTag, multiple: false, requeue: true, cancellationToken: stoppingToken);
         }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
@@ -94,16 +94,7 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
     {
         try
         {
-            IChannel channel = await ConnectWithRetryAsync(stoppingToken);
-
-            AsyncEventingBasicConsumer consumer = new(channel);
-            consumer.ReceivedAsync += (_, delivery) => OnDeliveredAsync(channel, delivery, stoppingToken);
-
-            await channel.BasicConsumeAsync(
-                queue: RabbitMqTopology.EmailQueue,
-                autoAck: false,
-                consumer: consumer,
-                cancellationToken: stoppingToken);
+            await AttachConsumerWithRetryAsync(stoppingToken);
 
             LogStarted(_logger, RabbitMqTopology.EmailQueue);
 
@@ -121,7 +112,17 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
         }
     }
 
-    private async Task<IChannel> ConnectWithRetryAsync(CancellationToken stoppingToken)
+    /// <summary>
+    /// Connects, declares the topology and registers the consumer as one all-or-nothing attempt.
+    /// The whole attach sits inside the retry loop on purpose: any non-cancellation exception
+    /// escaping <see cref="ExecuteAsync"/> would stop the entire host
+    /// (<see cref="BackgroundServiceExceptionBehavior.StopHost"/>), and a failure between the
+    /// connect and the consume registration — a topology mismatch, a channel torn down in the gap
+    /// — must degrade e-mail delivery, never take login down with it. A failed attempt disposes
+    /// whatever it managed to open before backing off, so retrying cannot accumulate half-attached
+    /// connections (each of which automatic recovery would otherwise keep alive forever).
+    /// </summary>
+    private async Task AttachConsumerWithRetryAsync(CancellationToken stoppingToken)
     {
         int failedAttempts = 0;
 
@@ -134,6 +135,7 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
 
                 _connection = await connectionFactory.CreateConnectionAsync(stoppingToken);
                 IChannel channel = await _connection.CreateChannelAsync(cancellationToken: stoppingToken);
+                _channel = channel;
                 await RabbitMqTopologyDeclaration.DeclareAsync(channel, stoppingToken);
 
                 // Prefetch 1: the broker hands over the next message only after the previous one
@@ -144,11 +146,20 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
                     global: false,
                     cancellationToken: stoppingToken);
 
-                _channel = channel;
-                return channel;
+                AsyncEventingBasicConsumer consumer = new(channel);
+                consumer.ReceivedAsync += (_, delivery) => OnDeliveredAsync(channel, delivery, stoppingToken);
+
+                await channel.BasicConsumeAsync(
+                    queue: RabbitMqTopology.EmailQueue,
+                    autoAck: false,
+                    consumer: consumer,
+                    cancellationToken: stoppingToken);
+
+                return;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                await CloseAsync();
                 failedAttempts++;
                 TimeSpan wait = ConnectBackoffs[Math.Min(failedAttempts - 1, ConnectBackoffs.Length - 1)];
                 LogConnectFailed(_logger, ex, wait.TotalSeconds);
@@ -296,11 +307,14 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
 
     private async Task CloseAsync()
     {
-        if (_channel is not null)
+        IChannel? channel = _channel;
+        _channel = null;
+
+        if (channel is not null)
         {
             try
             {
-                await _channel.DisposeAsync();
+                await channel.DisposeAsync();
             }
             catch (Exception ex)
             {
@@ -308,11 +322,14 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
             }
         }
 
-        if (_connection is not null)
+        IConnection? connection = _connection;
+        _connection = null;
+
+        if (connection is not null)
         {
             try
             {
-                await _connection.DisposeAsync();
+                await connection.DisposeAsync();
             }
             catch (Exception ex)
             {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
@@ -58,9 +58,11 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
     /// consumer, which is harmless — every message in the queue needs the same SMTP relay, so
     /// none of the waiting ones could succeed either. Hard ceiling: the pause holds the delivery
     /// unacked, and the broker kills the channel when an ack takes longer than its consumer
-    /// timeout (30 min default) — every entry must stay well under that.
+    /// timeout (30 min default) — every entry must stay well under that. Internal so the unit
+    /// suite can pin both invariants (one entry per allowed redelivery, ceiling under the
+    /// timeout) instead of trusting this prose.
     /// </summary>
-    private static readonly TimeSpan[] RedeliveryBackoffs =
+    internal static readonly TimeSpan[] RedeliveryBackoffs =
     [
         TimeSpan.FromSeconds(30),
         TimeSpan.FromMinutes(2),
@@ -234,7 +236,10 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
     /// Best-effort reject for the unexpected-exception path: when even the reject fails (typically
     /// a dead channel), the delivery is unacked anyway and the broker requeues it on channel close
     /// — and that connection loss increments the delivery count too, so even a crash loop is
-    /// bounded by the delivery limit.
+    /// bounded by the delivery limit. The pause is deliberately flat (always the ladder's first
+    /// rung, not indexed by redelivery count): an unexpected exception says nothing about SMTP
+    /// health, so this path only takes the edge off a hot loop — a persistently throwing
+    /// processor burns the delivery limit in minutes and parks, which is exactly the bound wanted.
     /// </summary>
     private async Task TryRequeueAsync(IChannel channel, ulong deliveryTag, CancellationToken stoppingToken)
     {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
@@ -142,7 +142,7 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
         try
         {
             EmailConfirmationRequested? message = TryDeserialize(delivery.Body.Span);
-            if (message is null || message.UserId == Guid.Empty)
+            if (message is null || message.IdentityUserId == Guid.Empty)
             {
                 // Poison: no amount of redelivery fixes an unreadable payload, so it is dropped
                 // loudly instead of requeued into an infinite loop.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
@@ -1,0 +1,279 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace LotroKoniecDev.AuthSystem.API.BackgroundServices;
+
+/// <summary>
+/// Consumes <see cref="RabbitMqTopology.EmailQueue"/> and turns each delivery into a confirmation
+/// e-mail via <see cref="EmailConfirmationRequestProcessor"/>. Push-based, not polled: after
+/// <c>BasicConsumeAsync</c> registers the subscription, the broker pushes deliveries over the open
+/// connection and the client library invokes <see cref="OnDeliveredAsync"/> per message —
+/// <see cref="ExecuteAsync"/> only sets this up and then parks until shutdown.
+/// </summary>
+/// <remarks>
+/// Acknowledgement is manual (<c>autoAck: false</c>) and happens only after the processor
+/// finished: a crash mid-send leaves the delivery unacked, the broker returns it to the queue,
+/// and the next start redelivers — at-least-once, matching the outbox's own semantics
+/// (the processor stays idempotent, see its remarks). The broker being down must never block
+/// application startup, so connecting happens here with escalating backoff, and the client's
+/// automatic recovery re-attaches the consumer if the connection drops later.
+/// </remarks>
+internal sealed partial class EmailConfirmationConsumer : BackgroundService
+{
+    /// <summary>
+    /// Escalating wait between initial connection attempts. The ceiling stays low (the broker is
+    /// a container on the same box, outages are deploy-length), and unlike the outbox relay this
+    /// retry costs no database compute — it only re-tries a local TCP connect.
+    /// </summary>
+    private static readonly TimeSpan[] ConnectBackoffs =
+    [
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(15),
+        TimeSpan.FromMinutes(1)
+    ];
+
+    /// <summary>
+    /// Pause before a transient failure is nacked back to the queue. With a prefetch of one the
+    /// broker redelivers immediately after the nack, so without this pause a down SMTP relay
+    /// would spin the redeliver-fail loop hot; 30 s turns that into a calm retry cadence.
+    /// </summary>
+    private static readonly TimeSpan TransientFailureDelay = TimeSpan.FromSeconds(30);
+
+    private readonly RabbitMqOptions _settings;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<EmailConfirmationConsumer> _logger;
+
+    private IConnection? _connection;
+    private IChannel? _channel;
+
+    public EmailConfirmationConsumer(
+        IOptions<RabbitMqOptions> options,
+        IServiceScopeFactory scopeFactory,
+        ILogger<EmailConfirmationConsumer> logger)
+    {
+        _settings = options.Value;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            IChannel channel = await ConnectWithRetryAsync(stoppingToken);
+
+            AsyncEventingBasicConsumer consumer = new(channel);
+            consumer.ReceivedAsync += (_, delivery) => OnDeliveredAsync(channel, delivery, stoppingToken);
+
+            await channel.BasicConsumeAsync(
+                queue: RabbitMqTopology.EmailQueue,
+                autoAck: false,
+                consumer: consumer,
+                cancellationToken: stoppingToken);
+
+            LogStarted(_logger, RabbitMqTopology.EmailQueue);
+
+            // All work happens in OnDeliveredAsync on the library's dispatch loop; this task only
+            // keeps the service (and with it the channel) alive until shutdown.
+            await Task.Delay(Timeout.Infinite, stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Graceful shutdown.
+        }
+        finally
+        {
+            await CloseAsync();
+        }
+    }
+
+    private async Task<IChannel> ConnectWithRetryAsync(CancellationToken stoppingToken)
+    {
+        int failedAttempts = 0;
+
+        while (true)
+        {
+            try
+            {
+                ConnectionFactory connectionFactory =
+                    RabbitMqConnectionFactoryBuilder.Build(_settings, "lotro-auth-api-email-consumer");
+
+                _connection = await connectionFactory.CreateConnectionAsync(stoppingToken);
+                IChannel channel = await _connection.CreateChannelAsync(cancellationToken: stoppingToken);
+                await RabbitMqTopologyDeclaration.DeclareAsync(channel, stoppingToken);
+
+                // Prefetch 1: the broker hands over the next message only after the previous one
+                // was acked, so a backlog never floods this process and e-mails go out one by one.
+                await channel.BasicQosAsync(
+                    prefetchSize: 0,
+                    prefetchCount: 1,
+                    global: false,
+                    cancellationToken: stoppingToken);
+
+                _channel = channel;
+                return channel;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                failedAttempts++;
+                TimeSpan wait = ConnectBackoffs[Math.Min(failedAttempts - 1, ConnectBackoffs.Length - 1)];
+                LogConnectFailed(_logger, ex, wait.TotalSeconds);
+                await Task.Delay(wait, stoppingToken);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Handles one delivery end-to-end. Every path must end in exactly one ack or nack — an
+    /// exception escaping this handler would be swallowed by the client library and leave the
+    /// delivery unacked (stuck) until the channel dies.
+    /// </summary>
+    private async Task OnDeliveredAsync(
+        IChannel channel,
+        BasicDeliverEventArgs delivery,
+        CancellationToken stoppingToken)
+    {
+        try
+        {
+            EmailConfirmationRequested? message = TryDeserialize(delivery.Body.Span);
+            if (message is null || message.UserId == Guid.Empty)
+            {
+                // Poison: no amount of redelivery fixes an unreadable payload, so it is dropped
+                // loudly instead of requeued into an infinite loop.
+                LogPoisonMessage(_logger, delivery.BasicProperties.MessageId);
+                await channel.BasicNackAsync(delivery.DeliveryTag, multiple: false, requeue: false, cancellationToken: stoppingToken);
+                return;
+            }
+
+            Result outcome;
+            await using (AsyncServiceScope scope = _scopeFactory.CreateAsyncScope())
+            {
+                EmailConfirmationRequestProcessor processor =
+                    scope.ServiceProvider.GetRequiredService<EmailConfirmationRequestProcessor>();
+                outcome = await processor.ProcessAsync(message, stoppingToken);
+            }
+
+            if (outcome.IsSuccess)
+            {
+                await channel.BasicAckAsync(delivery.DeliveryTag, multiple: false, cancellationToken: stoppingToken);
+                return;
+            }
+
+            LogTransientFailure(_logger, delivery.BasicProperties.MessageId, outcome.Error.ToString());
+            await Task.Delay(TransientFailureDelay, stoppingToken);
+            await channel.BasicNackAsync(delivery.DeliveryTag, multiple: false, requeue: true, cancellationToken: stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Shutdown mid-message: deliberately neither ack nor nack — closing the channel
+            // returns the unacked delivery to the queue and the next start picks it up.
+        }
+        catch (Exception ex)
+        {
+            LogUnexpectedError(_logger, ex, delivery.BasicProperties.MessageId);
+            await TryRequeueAsync(channel, delivery.DeliveryTag, stoppingToken);
+        }
+    }
+
+    /// <summary>
+    /// Best-effort nack for the unexpected-exception path: when even the nack fails (typically a
+    /// dead channel), the delivery is unacked anyway and the broker requeues it on channel close.
+    /// </summary>
+    private async Task TryRequeueAsync(IChannel channel, ulong deliveryTag, CancellationToken stoppingToken)
+    {
+        try
+        {
+            await Task.Delay(TransientFailureDelay, stoppingToken);
+            await channel.BasicNackAsync(deliveryTag, multiple: false, requeue: true, cancellationToken: stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown while backing off; the unacked delivery requeues on channel close.
+        }
+        catch (Exception ex)
+        {
+            LogUnexpectedError(_logger, ex, messageId: null);
+        }
+    }
+
+    private static EmailConfirmationRequested? TryDeserialize(ReadOnlySpan<byte> body)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<EmailConfirmationRequested>(body);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private async Task CloseAsync()
+    {
+        if (_channel is not null)
+        {
+            try
+            {
+                await _channel.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                LogTeardownWarning(_logger, ex);
+            }
+        }
+
+        if (_connection is not null)
+        {
+            try
+            {
+                await _connection.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                LogTeardownWarning(_logger, ex);
+            }
+        }
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerStarted,
+        Level = LogLevel.Information,
+        Message = "Consuming e-mail messages from queue {Queue}")]
+    private static partial void LogStarted(ILogger logger, string queue);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerConnectFailed,
+        Level = LogLevel.Warning,
+        Message = "Connecting the e-mail consumer to the broker failed; retrying in {DelaySeconds}s")]
+    private static partial void LogConnectFailed(ILogger logger, Exception exception, double delaySeconds);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerPoisonMessage,
+        Level = LogLevel.Error,
+        Message = "Dropping poison message {MessageId}: the payload could not be read as a known contract")]
+    private static partial void LogPoisonMessage(ILogger logger, string? messageId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerTransientFailure,
+        Level = LogLevel.Warning,
+        Message = "Processing message {MessageId} failed with {Error}; requeueing for another attempt")]
+    private static partial void LogTransientFailure(ILogger logger, string? messageId, string error);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerUnexpectedError,
+        Level = LogLevel.Error,
+        Message = "Unexpected error while handling message {MessageId}")]
+    private static partial void LogUnexpectedError(ILogger logger, Exception exception, string? messageId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerTeardownWarning,
+        Level = LogLevel.Debug,
+        Message = "Failed to cleanly close the consumer connection or channel")]
+    private static partial void LogTeardownWarning(ILogger logger, Exception exception);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Services.Emails;
 using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
 using LotroKoniecDev.SharedKernel.Monads;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -20,9 +21,17 @@ namespace LotroKoniecDev.AuthSystem.API.BackgroundServices;
 /// Acknowledgement is manual (<c>autoAck: false</c>) and happens only after the processor
 /// finished: a crash mid-send leaves the delivery unacked, the broker returns it to the queue,
 /// and the next start redelivers — at-least-once, matching the outbox's own semantics
-/// (the processor stays idempotent, see its remarks). The broker being down must never block
-/// application startup, so connecting happens here with escalating backoff, and the client's
-/// automatic recovery re-attaches the consumer if the connection drops later.
+/// (the processor stays idempotent, see its remarks). Failures split three ways (ADR-0036):
+/// poison payloads are rejected into the dead-letter queue immediately, transient failures are
+/// requeued behind an escalating pause, and the broker itself parks a message that exhausts
+/// <see cref="RabbitMqTopology.EmailDeliveryLimit"/> — so no failure loops forever and none is
+/// silently lost. Failed deliveries use <c>basic.reject</c>, never <c>basic.nack</c>: since
+/// RabbitMQ 4.3 only rejects (and connection losses) increment the <c>x-delivery-count</c> the
+/// delivery limit is measured against — a nack-requeue is an "explicit return" the broker
+/// redelivers forever without counting. The broker being down must never block application
+/// startup, so connecting
+/// happens here with escalating backoff, and the client's automatic recovery re-attaches the
+/// consumer if the connection drops later.
 /// </remarks>
 internal sealed partial class EmailConfirmationConsumer : BackgroundService
 {
@@ -39,11 +48,26 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
     ];
 
     /// <summary>
-    /// Pause before a transient failure is nacked back to the queue. With a prefetch of one the
-    /// broker redelivers immediately after the nack, so without this pause a down SMTP relay
-    /// would spin the redeliver-fail loop hot; 30 s turns that into a calm retry cadence.
+    /// Pause before a transient failure is rejected back to the queue, indexed by the broker's
+    /// redelivery count — one entry per redelivery that
+    /// <see cref="RabbitMqTopology.EmailDeliveryLimit"/> allows, so the two move together. With a
+    /// prefetch of one the broker redelivers immediately after the reject; without a pause a down
+    /// SMTP relay would spin the redeliver-fail loop hot and burn through the delivery limit in
+    /// seconds. Escalating instead of flat, because the ladder must in total outlast a realistic
+    /// SMTP outage (~30 min) before the message parks in the DLQ. Pausing in-process blocks this
+    /// consumer, which is harmless — every message in the queue needs the same SMTP relay, so
+    /// none of the waiting ones could succeed either. Hard ceiling: the pause holds the delivery
+    /// unacked, and the broker kills the channel when an ack takes longer than its consumer
+    /// timeout (30 min default) — every entry must stay well under that.
     /// </summary>
-    private static readonly TimeSpan TransientFailureDelay = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan[] RedeliveryBackoffs =
+    [
+        TimeSpan.FromSeconds(30),
+        TimeSpan.FromMinutes(2),
+        TimeSpan.FromMinutes(5),
+        TimeSpan.FromMinutes(10),
+        TimeSpan.FromMinutes(15)
+    ];
 
     private readonly RabbitMqOptions _settings;
     private readonly IServiceScopeFactory _scopeFactory;
@@ -130,7 +154,7 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
     }
 
     /// <summary>
-    /// Handles one delivery end-to-end. Every path must end in exactly one ack or nack — an
+    /// Handles one delivery end-to-end. Every path must end in exactly one ack or reject — an
     /// exception escaping this handler would be swallowed by the client library and leave the
     /// delivery unacked (stuck) until the channel dies.
     /// </summary>
@@ -144,12 +168,11 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
             EmailConfirmationRequested? message = TryDeserialize(delivery.Body.Span);
             if (message is null || message.IdentityUserId == Guid.Empty)
             {
-                // Poison: no amount of redelivery fixes an unreadable payload, so it is dropped
-                // loudly instead of requeued into an infinite loop.
+                // Poison: no amount of redelivery fixes an unreadable payload, so it is rejected
+                // on first sight — the broker dead-letters it into the parking lot for a human.
                 LogPoisonMessage(_logger, delivery.BasicProperties.MessageId);
-                await channel.BasicNackAsync(
+                await channel.BasicRejectAsync(
                     delivery.DeliveryTag,
-                    multiple: false,
                     requeue: false,
                     cancellationToken: stoppingToken);
                 return;
@@ -169,13 +192,35 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
                 return;
             }
 
-            LogTransientFailure(_logger, delivery.BasicProperties.MessageId, ackDecision.Error.ToString());
-            await Task.Delay(TransientFailureDelay, stoppingToken);
-            await channel.BasicNackAsync(delivery.DeliveryTag, multiple: false, requeue: true, cancellationToken: stoppingToken);
+            int redeliveries = RedeliveryCount.Read(delivery.BasicProperties.Headers);
+            if (redeliveries >= RabbitMqTopology.EmailDeliveryLimit)
+            {
+                // Final attempt: this reject pushes the count past the delivery limit, so the
+                // broker parks the message in the DLQ instead of redelivering — no pause needed.
+                LogRetriesExhausted(
+                    _logger,
+                    delivery.BasicProperties.MessageId,
+                    ackDecision.Error,
+                    RabbitMqTopology.EmailDeliveryLimit);
+                await channel.BasicRejectAsync(
+                    delivery.DeliveryTag,
+                    requeue: true,
+                    cancellationToken: stoppingToken);
+                return;
+            }
+
+            LogTransientFailure(
+                _logger,
+                delivery.BasicProperties.MessageId,
+                ackDecision.Error,
+                redeliveries + 1,
+                RabbitMqTopology.EmailDeliveryLimit);
+            await Task.Delay(RedeliveryBackoffs[Math.Min(redeliveries, RedeliveryBackoffs.Length - 1)], stoppingToken);
+            await channel.BasicRejectAsync(delivery.DeliveryTag, requeue: true, cancellationToken: stoppingToken);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
-            // Shutdown mid-message: deliberately neither ack nor nack — closing the channel
+            // Shutdown mid-message: deliberately neither ack nor reject — closing the channel
             // returns the unacked delivery to the queue and the next start picks it up.
         }
         catch (Exception ex)
@@ -186,15 +231,17 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
     }
 
     /// <summary>
-    /// Best-effort nack for the unexpected-exception path: when even the nack fails (typically a
-    /// dead channel), the delivery is unacked anyway and the broker requeues it on channel close.
+    /// Best-effort reject for the unexpected-exception path: when even the reject fails (typically
+    /// a dead channel), the delivery is unacked anyway and the broker requeues it on channel close
+    /// — and that connection loss increments the delivery count too, so even a crash loop is
+    /// bounded by the delivery limit.
     /// </summary>
     private async Task TryRequeueAsync(IChannel channel, ulong deliveryTag, CancellationToken stoppingToken)
     {
         try
         {
-            await Task.Delay(TransientFailureDelay, stoppingToken);
-            await channel.BasicNackAsync(deliveryTag, multiple: false, requeue: true, cancellationToken: stoppingToken);
+            await Task.Delay(RedeliveryBackoffs[0], stoppingToken);
+            await channel.BasicRejectAsync(deliveryTag, requeue: true, cancellationToken: stoppingToken);
         }
         catch (OperationCanceledException)
         {
@@ -260,14 +307,20 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
     [LoggerMessage(
         EventId = EventIds.EmailConsumerPoisonMessage,
         Level = LogLevel.Error,
-        Message = "Dropping poison message {MessageId}: the payload could not be read as a known contract")]
+        Message = "Rejecting poison message {MessageId} into the dead-letter queue: the payload could not be read as a known contract")]
     private static partial void LogPoisonMessage(ILogger logger, string? messageId);
 
     [LoggerMessage(
         EventId = EventIds.EmailConsumerTransientFailure,
         Level = LogLevel.Warning,
-        Message = "Processing message {MessageId} failed with {Error}; requeueing for another attempt")]
-    private static partial void LogTransientFailure(ILogger logger, string? messageId, string error);
+        Message = "Processing message {MessageId} failed with {Error}; requeueing for redelivery {Redelivery} of {DeliveryLimit}")]
+    private static partial void LogTransientFailure(ILogger logger, string? messageId, Error error, int redelivery, int deliveryLimit);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerRetriesExhausted,
+        Level = LogLevel.Error,
+        Message = "Processing message {MessageId} still failed with {Error} after {DeliveryLimit} redeliveries; the broker moves it to the dead-letter queue")]
+    private static partial void LogRetriesExhausted(ILogger logger, string? messageId, Error error, int deliveryLimit);
 
     [LoggerMessage(
         EventId = EventIds.EmailConsumerUnexpectedError,

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailConfirmationConsumer.cs
@@ -21,7 +21,9 @@ namespace LotroKoniecDev.AuthSystem.API.BackgroundServices;
 /// Acknowledgement is manual (<c>autoAck: false</c>) and happens only after the processor
 /// finished: a crash mid-send leaves the delivery unacked, the broker returns it to the queue,
 /// and the next start redelivers — at-least-once, matching the outbox's own semantics
-/// (the processor stays idempotent, see its remarks). Failures split three ways (ADR-0036):
+/// (the processor stays idempotent, see its remarks). On top of that, deliveries are
+/// deduplicated on the broker message id through the inbox (ADR-0037), so a redelivery of an
+/// already-processed message acks without a second e-mail. Failures split three ways (ADR-0036):
 /// poison payloads are rejected into the dead-letter queue immediately, transient failures are
 /// requeued behind an escalating pause, and the broker itself parks a message that exhausts
 /// <see cref="RabbitMqTopology.EmailDeliveryLimit"/> — so no failure loops forever and none is
@@ -167,6 +169,19 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
     {
         try
         {
+            if (!TryReadMessageId(delivery.BasicProperties, out Guid messageId))
+            {
+                // Poison: without a usable message id the delivery cannot be deduplicated, and
+                // processing it blind would reopen the unbounded-duplicate hole the inbox closes
+                // (ADR-0037) — so it parks in the dead-letter queue for a human instead.
+                LogMessageIdUnusable(_logger, delivery.BasicProperties.MessageId);
+                await channel.BasicRejectAsync(
+                    delivery.DeliveryTag,
+                    requeue: false,
+                    cancellationToken: stoppingToken);
+                return;
+            }
+
             EmailConfirmationRequested? message = TryDeserialize(delivery.Body.Span);
             if (message is null || message.IdentityUserId == Guid.Empty)
             {
@@ -183,9 +198,9 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
             Result ackDecision;
             await using (AsyncServiceScope scope = _scopeFactory.CreateAsyncScope())
             {
-                EmailConfirmationRequestProcessor processor =
-                    scope.ServiceProvider.GetRequiredService<EmailConfirmationRequestProcessor>();
-                ackDecision = await processor.ProcessAsync(message, stoppingToken);
+                EmailConfirmationDeliveryProcessor deliveryProcessor =
+                    scope.ServiceProvider.GetRequiredService<EmailConfirmationDeliveryProcessor>();
+                ackDecision = await deliveryProcessor.ProcessOnceAsync(message, messageId, stoppingToken);
             }
 
             if (ackDecision.IsSuccess)
@@ -258,6 +273,15 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
         }
     }
 
+    /// <summary>
+    /// Reads the broker message id the inbox deduplicates on (ADR-0037). Internal so the unit
+    /// suite can pin the poison decision: absent, non-Guid and empty-Guid ids must all fail.
+    /// </summary>
+    internal static bool TryReadMessageId(IReadOnlyBasicProperties properties, out Guid messageId)
+    {
+        return Guid.TryParse(properties.MessageId, out messageId) && messageId != Guid.Empty;
+    }
+
     private static EmailConfirmationRequested? TryDeserialize(ReadOnlySpan<byte> body)
     {
         try
@@ -314,6 +338,12 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
         Level = LogLevel.Error,
         Message = "Rejecting poison message {MessageId} into the dead-letter queue: the payload could not be read as a known contract")]
     private static partial void LogPoisonMessage(ILogger logger, string? messageId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerMessageIdUnusable,
+        Level = LogLevel.Error,
+        Message = "Rejecting message with unusable message id {MessageId} into the dead-letter queue: the inbox cannot deduplicate a delivery without an id")]
+    private static partial void LogMessageIdUnusable(ILogger logger, string? messageId);
 
     [LoggerMessage(
         EventId = EventIds.EmailConsumerTransientFailure,

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/OutboxRelay.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/OutboxRelay.cs
@@ -171,7 +171,10 @@ internal sealed partial class OutboxRelay : BackgroundService
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                message.MarkFailed(ex.Message);
+                // MarkFailed guards against blank input, and Exception.Message is external data —
+                // an exception type with an empty message must not blow up the whole pass.
+                string error = string.IsNullOrWhiteSpace(ex.Message) ? ex.GetType().Name : ex.Message;
+                message.MarkFailed(error);
                 LogMessagePublishFailed(_logger, ex, message.Id, message.Type, message.Attempts);
                 published = false;
             }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/OutboxRelay.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/OutboxRelay.cs
@@ -1,0 +1,206 @@
+using Microsoft.EntityFrameworkCore;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+
+namespace LotroKoniecDev.AuthSystem.API.BackgroundServices;
+
+/// <summary>
+/// Publishes committed outbox rows to the broker. Signal-driven rather than interval-polled
+/// (ADR-0035): writers nudge <see cref="OutboxSignal"/> right after their commit, so the database
+/// is only queried moments after work was created — while its compute is already awake — plus one
+/// catch-up sweep at startup and a slow safety sweep. A fixed-interval poller would keep the
+/// scale-to-zero database awake around the clock for a queue that is almost always empty.
+/// </summary>
+internal sealed partial class OutboxRelay : BackgroundService
+{
+    /// <summary>
+    /// Upper bound per fetch so a post-outage backlog is drained in slices instead of one list;
+    /// the query walks the partial index (<c>IX_OutboxMessages_Unprocessed</c>) top-down.
+    /// </summary>
+    private const int BatchSize = 100;
+
+    /// <summary>
+    /// Ceiling on how long an orphaned row can wait: a commit that raced a crash left no nudge
+    /// behind, so a slow sweep re-checks. Six hours of cadence costs ~2.5% of the Neon Free
+    /// monthly compute budget (ADR-0035) — tighter bounds buy latency nobody needs.
+    /// </summary>
+    private static readonly TimeSpan SafetySweepInterval = TimeSpan.FromHours(6);
+
+    /// <summary>
+    /// Escalating wait after a failed pass. The ceiling deliberately equals
+    /// <see cref="SafetySweepInterval"/>, so a permanently failing row degenerates into the
+    /// safety-sweep cadence instead of an around-the-clock retry poll.
+    /// </summary>
+    private static readonly TimeSpan[] RetryBackoffs =
+    [
+        TimeSpan.FromSeconds(30),
+        TimeSpan.FromMinutes(1),
+        TimeSpan.FromMinutes(5),
+        TimeSpan.FromMinutes(30),
+        TimeSpan.FromHours(6)
+    ];
+
+    private readonly IMessagePublisher _messagePublisher;
+    private readonly OutboxSignal _outboxSignal;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<OutboxRelay> _logger;
+
+    public OutboxRelay(
+        IMessagePublisher messagePublisher,
+        OutboxSignal outboxSignal,
+        IServiceScopeFactory scopeFactory,
+        TimeProvider timeProvider,
+        ILogger<OutboxRelay> logger)
+    {
+        _messagePublisher = messagePublisher;
+        _outboxSignal = outboxSignal;
+        _scopeFactory = scopeFactory;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            int failedPasses = 0;
+
+            // The first pass runs before any wait: the startup catch-up sweep that publishes rows
+            // whose nudge died with the previous process.
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                bool passWasClean = await ProcessPendingAsync(stoppingToken);
+                failedPasses = passWasClean ? 0 : failedPasses + 1;
+
+                TimeSpan maxWait = passWasClean
+                    ? SafetySweepInterval
+                    : RetryBackoffs[Math.Min(failedPasses - 1, RetryBackoffs.Length - 1)];
+
+                await _outboxSignal.WaitAsync(maxWait, stoppingToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Graceful shutdown.
+        }
+    }
+
+    /// <summary>
+    /// Drains every pending row in <see cref="BatchSize"/> slices. Returns <c>false</c> when any
+    /// row failed (broker refusal, unroutable type, database fault), so the caller backs off
+    /// instead of re-fetching the same failing rows in a tight loop.
+    /// </summary>
+    private async Task<bool> ProcessPendingAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            while (true)
+            {
+                await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
+                AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+                List<OutboxMessage> batch = await db.OutboxMessages
+                    .Where(message => message.ProcessedOn == null)
+                    .OrderBy(message => message.OccurredOn)
+                    .Take(BatchSize)
+                    .ToListAsync(stoppingToken);
+
+                if (batch.Count == 0)
+                {
+                    return true;
+                }
+
+                bool anyFailed = false;
+
+                foreach (OutboxMessage message in batch)
+                {
+                    anyFailed |= !await PublishOneAsync(db, message, stoppingToken);
+                }
+
+                if (anyFailed)
+                {
+                    return false;
+                }
+
+                if (batch.Count < BatchSize)
+                {
+                    return true;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogRelayPassFailed(_logger, ex);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Publishes one row and saves its outcome immediately: marking per message rather than per
+    /// batch narrows the crash window in which an already-published message gets re-published
+    /// after a restart (the outbox is at-least-once either way; consumers deduplicate on the
+    /// message id).
+    /// </summary>
+    private async Task<bool> PublishOneAsync(
+        AuthDbContext db,
+        OutboxMessage message,
+        CancellationToken stoppingToken)
+    {
+        bool published;
+
+        if (!OutboxMessageRouting.TryGetRoutingKey(message.Type, out string? routingKey))
+        {
+            message.MarkFailed($"No routing key is mapped for outbox message type '{message.Type}'.");
+            LogMessageUnroutable(_logger, message.Id, message.Type);
+            published = false;
+        }
+        else
+        {
+            try
+            {
+                await _messagePublisher.PublishAsync(routingKey, message.Payload, message.Id, stoppingToken);
+                message.MarkAsProcessed(_timeProvider.GetUtcNow());
+                published = true;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                message.MarkFailed(ex.Message);
+                LogMessagePublishFailed(_logger, ex, message.Id, message.Type, message.Attempts);
+                published = false;
+            }
+        }
+
+        await db.SaveChangesAsync(stoppingToken);
+        return published;
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.OutboxRelayPassFailed,
+        Level = LogLevel.Error,
+        Message = "Outbox relay pass failed before reaching individual messages. Will retry with backoff.")]
+    private static partial void LogRelayPassFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        EventId = EventIds.OutboxMessagePublishFailed,
+        Level = LogLevel.Warning,
+        Message = "Publishing outbox message {MessageId} of type {MessageType} failed (attempt {Attempts}). Will retry with backoff.")]
+    private static partial void LogMessagePublishFailed(
+        ILogger logger,
+        Exception exception,
+        Guid messageId,
+        string messageType,
+        int attempts);
+
+    [LoggerMessage(
+        EventId = EventIds.OutboxMessageUnroutable,
+        Level = LogLevel.Error,
+        Message = "Outbox message {MessageId} carries type {MessageType} with no mapped routing key; it stays unprocessed until a mapping ships.")]
+    private static partial void LogMessageUnroutable(ILogger logger, Guid messageId, string messageType);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -87,6 +87,11 @@ internal static class EventIds
     public const int EmailConsumerTeardownWarning = 2338;
     public const int EmailConsumerRetriesExhausted = 2339;
 
+    // Inbox deduplication (2340–2349)
+    public const int EmailConsumerDuplicateSkipped = 2340;
+    public const int EmailConsumerInboxRaceLost = 2341;
+    public const int EmailConsumerMessageIdUnusable = 2342;
+
     // Startup (2350–2359)
     public const int StartupTransientDatabaseFailure = 2350;
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -75,6 +75,17 @@ internal static class EventIds
     public const int OutboxMessagePublishFailed = 2321;
     public const int OutboxMessageUnroutable = 2322;
 
+    // Email Confirmation Consumer (2330–2339)
+    public const int EmailConsumerConnectFailed = 2330;
+    public const int EmailConsumerStarted = 2331;
+    public const int EmailConsumerPoisonMessage = 2332;
+    public const int EmailConsumerTransientFailure = 2333;
+    public const int EmailConsumerUnexpectedError = 2334;
+    public const int EmailConfirmationUserGone = 2335;
+    public const int EmailConfirmationAlreadyConfirmed = 2336;
+    public const int EmailConfirmationAddressMissing = 2337;
+    public const int EmailConsumerTeardownWarning = 2338;
+
     // Startup (2350–2359)
     public const int StartupTransientDatabaseFailure = 2350;
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -70,6 +70,11 @@ internal static class EventIds
     public const int OpenIddictPruneCompleted = 2310;
     public const int OpenIddictPruneFailed = 2311;
 
+    // Outbox Relay (2320–2329)
+    public const int OutboxRelayPassFailed = 2320;
+    public const int OutboxMessagePublishFailed = 2321;
+    public const int OutboxMessageUnroutable = 2322;
+
     // Startup (2350–2359)
     public const int StartupTransientDatabaseFailure = 2350;
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -85,6 +85,7 @@ internal static class EventIds
     public const int EmailConfirmationAlreadyConfirmed = 2336;
     public const int EmailConfirmationAddressMissing = 2337;
     public const int EmailConsumerTeardownWarning = 2338;
+    public const int EmailConsumerRetriesExhausted = 2339;
 
     // Startup (2350–2359)
     public const int StartupTransientDatabaseFailure = 2350;

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Identity;
@@ -5,14 +6,17 @@ using Microsoft.EntityFrameworkCore;
 using LotroKoniecDev.AuthSystem.API.ApiErrors;
 using LotroKoniecDev.AuthSystem.API.Common;
 using LotroKoniecDev.AuthSystem.API.Extensions;
-using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
 using LotroKoniecDev.SharedKernel.Authorization;
 using LotroKoniecDev.SharedKernel.Constants;
 using LotroKoniecDev.SharedKernel.Messaging;
 using LotroKoniecDev.SharedKernel.Monads;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace LotroKoniecDev.AuthSystem.API.Features.Auth;
 
@@ -60,23 +64,23 @@ internal sealed partial class RegisterUser : IApiEndpoint
     internal sealed partial class Handler : ICommandHandler<Command, Result<IdentityId>>
     {
         private readonly UserManager<ApplicationUser> _userManager;
-        private readonly IAccountConfirmationEmailSender _accountConfirmationEmailSender;
         private readonly TimeProvider _timeProvider;
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
+        private readonly AuthDbContext _db;
 
         public Handler(
             UserManager<ApplicationUser> userManager,
-            IAccountConfirmationEmailSender accountConfirmationEmailSender,
             TimeProvider timeProvider,
             IValidator<Command> validator,
-            ILogger<Handler> logger)
+            ILogger<Handler> logger,
+            AuthDbContext db)
         {
             _userManager = userManager;
-            _accountConfirmationEmailSender = accountConfirmationEmailSender;
             _timeProvider = timeProvider;
             _validator = validator;
             _logger = logger;
+            _db = db;
         }
 
         public async ValueTask<Result<IdentityId>> Handle(
@@ -89,7 +93,24 @@ internal sealed partial class RegisterUser : IApiEndpoint
                 return Result.Failure<IdentityId>(validationResult.ToValidationError(nameof(RegisterUser)));
             }
 
-            ApplicationUser user;
+            // The context enables EnableRetryOnFailure, so EF refuses a user-initiated transaction
+            // unless the whole unit of work runs inside an execution strategy — a retry has to be
+            // able to replay begin-to-commit, not a single statement inside it.
+            IExecutionStrategy executionStrategy = _db.Database.CreateExecutionStrategy();
+
+            return await executionStrategy.ExecuteAsync(async () => await RegisterAsync(command, cancellationToken));
+        }
+
+        private async Task<Result<IdentityId>> RegisterAsync(
+            Command command,
+            CancellationToken cancellationToken)
+        {
+            // A retried attempt starts from a rolled-back transaction while the tracker still holds
+            // the previous attempt's entities as Added — replaying without a reset would insert twice.
+            _db.ChangeTracker.Clear();
+
+            await using IDbContextTransaction transaction =
+                await _db.Database.BeginTransactionAsync(cancellationToken);
 
             try
             {
@@ -105,7 +126,7 @@ internal sealed partial class RegisterUser : IApiEndpoint
                     return Result.Failure<IdentityId>(AuthErrors.UserAlreadyExistsByUsername);
                 }
 
-                user = new()
+                ApplicationUser user = new()
                 {
                     UserName = command.Username,
                     Email = command.Email,
@@ -143,35 +164,32 @@ internal sealed partial class RegisterUser : IApiEndpoint
                         string.Join(", ", roleIdentityResult.Errors.Select(e => e.Description))));
                 }
 
-                string emailToken = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-                Result emailResult = await _accountConfirmationEmailSender.SendEmailConfirmationAsync(
-                    user.Id, command.Email, emailToken, cancellationToken);
-                if (emailResult.IsFailure)
-                {
-                    LogConfirmationEmailFailed(_logger, user.Id, emailResult.Error.Message);
+                EmailConfirmationRequested emailConfirmationRequested = new(user.Id);
+                OutboxMessage outboxMessage = OutboxMessage.Create(
+                    type: nameof(EmailConfirmationRequested),
+                    payload: JsonSerializer.Serialize(emailConfirmationRequested),
+                    occurredOn: _timeProvider.GetUtcNow());
 
-                    await _userManager.ConfirmEmailAsync(user, emailToken);
-                }
+                _db.OutboxMessages.Add(outboxMessage);
+                await _db.SaveChangesAsync(cancellationToken);
+
+                await transaction.CommitAsync(cancellationToken);
+
+                // No cross-context profile creation here (the KittySaver RegisterUser->CreatePerson
+                // saga is deliberately not lifted): the translator profile is provisioned lazily and
+                // idempotently on the first authenticated TranslationSystem request (ADR-0002 §7).
+                return IdentityId.Create(user.Id);
             }
             catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
             {
                 // DbUpdateException: unique constraint race condition on CreateAsync.
                 // InvalidOperationException: "Sequence contains more than one element" from
-                //   FindByEmailAsync when duplicate users exist concurrently — can happen in
-                //   pre-checks or ConfirmEmailAsync's internal validation.
+                //   FindByEmailAsync when duplicate users exist concurrently.
                 string maskedEmail = command.Email.MaskEmail();
                 LogConcurrentRegistration(_logger, ex, maskedEmail);
                 return Result.Failure<IdentityId>(AuthErrors.UserAlreadyExistsByEmail);
             }
-
-            // No cross-context profile creation here (the KittySaver RegisterUser->CreatePerson
-            // saga is deliberately not lifted): the translator profile is provisioned lazily and
-            // idempotently on the first authenticated TranslationSystem request (ADR-0002 §7).
-            return IdentityId.Create(user.Id);
         }
-
-        [LoggerMessage(EventId = EventIds.RegisterEmailFallback, Level = LogLevel.Warning, Message = "Failed to send confirmation email for user {UserId}: {Error}. Auto-confirming account as fallback")]
-        private static partial void LogConfirmationEmailFailed(ILogger logger, Guid userId, string error);
 
         [LoggerMessage(EventId = EventIds.RegisterConcurrentRace, Level = LogLevel.Warning, Message = "Concurrent registration race condition for email {Email}")]
         private static partial void LogConcurrentRegistration(ILogger logger, Exception exception, string email);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
@@ -68,19 +68,22 @@ internal sealed partial class RegisterUser : IApiEndpoint
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
         private readonly AuthDbContext _db;
+        private readonly OutboxSignal _outboxSignal;
 
         public Handler(
             UserManager<ApplicationUser> userManager,
             TimeProvider timeProvider,
             IValidator<Command> validator,
             ILogger<Handler> logger,
-            AuthDbContext db)
+            AuthDbContext db,
+            OutboxSignal outboxSignal)
         {
             _userManager = userManager;
             _timeProvider = timeProvider;
             _validator = validator;
             _logger = logger;
             _db = db;
+            _outboxSignal = outboxSignal;
         }
 
         public async ValueTask<Result<IdentityId>> Handle(
@@ -174,6 +177,10 @@ internal sealed partial class RegisterUser : IApiEndpoint
                 await _db.SaveChangesAsync(cancellationToken);
 
                 await transaction.CommitAsync(cancellationToken);
+
+                // Only after the commit: the relay reads committed rows, so a nudge sent inside
+                // the transaction would race it into seeing nothing (ADR-0035).
+                _outboxSignal.Notify();
 
                 // No cross-context profile creation here (the KittySaver RegisterUser->CreatePerson
                 // saga is deliberately not lifted): the translator profile is provisioned lazily and

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
@@ -192,6 +192,12 @@ internal sealed partial class RegisterUser : IApiEndpoint
                 // DbUpdateException: unique constraint race condition on CreateAsync.
                 // InvalidOperationException: "Sequence contains more than one element" from
                 //   FindByEmailAsync when duplicate users exist concurrently.
+                // Known edge: if CommitAsync's acknowledgement is lost after the server actually
+                // committed, the execution strategy replays and lands here via the email pre-check,
+                // returning UserAlreadyExistsByEmail for a registration that in fact succeeded.
+                // Accepted: the committed outbox row still delivers the confirmation e-mail, so the
+                // user can complete the flow; the airtight fix (ExecuteInTransaction + verification
+                // query) buys little for this endpoint's stakes.
                 string maskedEmail = command.Email.MaskEmail();
                 LogConcurrentRegistration(_logger, ex, maskedEmail);
                 return Result.Failure<IdentityId>(AuthErrors.UserAlreadyExistsByEmail);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Health/RabbitMqHealthCheck.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Health/RabbitMqHealthCheck.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using RabbitMQ.Client;
+
+namespace LotroKoniecDev.AuthSystem.API.Health;
+
+/// <summary>
+/// Proves the broker accepts an AMQP connection with the configured credentials — a full handshake
+/// rather than a bare TCP connect, so a wrong password or virtual host surfaces here instead of
+/// only in the relay's retry logs. Deliberately NOT tagged "ready" (same reasoning as
+/// <see cref="SmtpHealthCheck"/>): a broker outage degrades e-mail delivery gracefully — outbox
+/// rows wait, the consumer reconnects with backoff — while login and token issuance keep working,
+/// so it must not pull the service out of the ingress rotation. A down broker surfaces on the full
+/// /health, which the daily health ping probes.
+/// </summary>
+internal sealed class RabbitMqHealthCheck : IHealthCheck
+{
+    private readonly RabbitMqOptions _settings;
+
+    public RabbitMqHealthCheck(IOptions<RabbitMqOptions> options)
+    {
+        _settings = options.Value;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            ConnectionFactory connectionFactory =
+                RabbitMqConnectionFactoryBuilder.Build(_settings, "lotro-auth-api-health-check");
+
+            using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+            await using IConnection connection = await connectionFactory.CreateConnectionAsync(cts.Token);
+
+            return HealthCheckResult.Healthy($"Broker reachable at {_settings.Host}:{_settings.Port}");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"Broker unreachable at {_settings.Host}:{_settings.Port}",
+                exception: ex);
+        }
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/LotroKoniecDev.AuthSystem.API.csproj
@@ -51,6 +51,8 @@
     <ItemGroup>
         <InternalsVisibleTo Include="LotroKoniecDev.AuthSystem.API.Tests.Integration" />
         <InternalsVisibleTo Include="LotroKoniecDev.AuthSystem.API.Tests.Unit" />
+        <!-- NSubstitute proxies of the internal e-mail interfaces (Castle DynamicProxy). -->
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/EmailConfirmationRequested.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/EmailConfirmationRequested.cs
@@ -11,4 +11,4 @@ namespace LotroKoniecDev.AuthSystem.API.Outbox;
 /// message that waits in the queue, gets retried, or sits in a dead-letter queue. The consumer
 /// mints the token and reads the address off the user at the moment it sends.
 /// </remarks>
-public sealed record EmailConfirmationRequested(Guid UserId);
+public sealed record EmailConfirmationRequested(Guid IdentityUserId);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/EmailConfirmationRequested.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/EmailConfirmationRequested.cs
@@ -1,0 +1,14 @@
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// Outbox payload contract for "send this user their confirmation e-mail", serialised by the
+/// producer and deserialised by the relay and the consumer.
+/// </summary>
+/// <remarks>
+/// Carries the user id alone, on purpose. The confirmation token is a delivery detail rather than
+/// part of the intent, and it expires — minting it here would start its lifetime at registration
+/// while the e-mail promises the countdown starts at delivery, making that sentence false for every
+/// message that waits in the queue, gets retried, or sits in a dead-letter queue. The consumer
+/// mints the token and reads the address off the user at the moment it sends.
+/// </remarks>
+public sealed record EmailConfirmationRequested(Guid UserId);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxMessageRouting.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxMessageRouting.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// Maps an outbox row's <c>Type</c> — the payload contract name the consumer deserializes by —
+/// to the broker routing key it travels under. The two stay separate concepts on purpose: the
+/// type says what the payload is, the routing key says which bindings receive it, and conflating
+/// them would let a contract rename silently unroute messages from a live queue.
+/// </summary>
+internal static class OutboxMessageRouting
+{
+    private static readonly Dictionary<string, string> RoutingKeysByType = new(StringComparer.Ordinal)
+    {
+        [nameof(EmailConfirmationRequested)] = RabbitMqTopology.EmailConfirmationRoutingKey
+    };
+
+    public static bool TryGetRoutingKey(string type, [NotNullWhen(true)] out string? routingKey)
+    {
+        return RoutingKeysByType.TryGetValue(type, out routingKey);
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxSignal.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxSignal.cs
@@ -1,0 +1,44 @@
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// In-process wake-up line between outbox writers and the relay: a writer calls
+/// <see cref="Notify"/> right after its transaction commits, and the relay's pending
+/// <see cref="WaitAsync"/> returns instead of sleeping out its safety-sweep timeout.
+/// This nudge — not a fixed poll interval — is what drives the relay, so the database is
+/// only queried moments after a write, while its compute is already awake (ADR-0035).
+/// </summary>
+/// <remarks>
+/// The semaphore is capped at one pending wake-up on purpose: the relay drains the whole
+/// backlog on every pass, so ten commits before it wakes still need only one pass.
+/// </remarks>
+internal sealed class OutboxSignal : IDisposable
+{
+    private readonly SemaphoreSlim _pendingWakeUp = new(initialCount: 0, maxCount: 1);
+
+    public void Notify()
+    {
+        try
+        {
+            _pendingWakeUp.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+            // A wake-up is already pending; it covers this commit too.
+        }
+    }
+
+    /// <returns>
+    /// <c>true</c> when woken by <see cref="Notify"/>; <c>false</c> when <paramref name="timeout"/>
+    /// elapsed first — the relay treats both the same and sweeps, the timeout merely bounds how
+    /// long an orphaned row (committed, but crashed before its nudge) can wait.
+    /// </returns>
+    public Task<bool> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        return _pendingWakeUp.WaitAsync(timeout, cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        _pendingWakeUp.Dispose();
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -226,7 +226,14 @@ try
         // surface in logs, via "resend confirmation", and on the full /health.
         .AddCheck<SmtpHealthCheck>(
             "smtp",
-            tags: ["smtp"]);
+            tags: ["smtp"])
+        // The broker is likewise NOT tagged "ready": e-mail messaging degrades gracefully while it
+        // is down (outbox rows wait, the consumer reconnects with backoff), and login/token
+        // issuance don't need it. A down broker container surfaces on the full /health the daily
+        // health ping probes.
+        .AddCheck<RabbitMqHealthCheck>(
+            "rabbitmq",
+            tags: ["broker"]);
 
     const string rateLimitPolicy = "fixed-by-ip";
     const string authEndpointRateLimitPolicy = "auth-endpoint-limit";

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountConfirmationEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountConfirmationEmailSender.cs
@@ -29,7 +29,11 @@ internal sealed class AccountConfirmationEmailSender : IAccountConfirmationEmail
         _logger = logger;
     }
 
-    public async Task<Result> SendEmailConfirmationAsync(Guid userId, string email, string confirmationToken, CancellationToken cancellationToken)
+    public async Task<Result> SendEmailConfirmationAsync(
+        Guid userId,
+        string email,
+        string confirmationToken,
+        CancellationToken cancellationToken)
     {
         string link = _emailVerificationLinkFactory.Create(email, confirmationToken);
 
@@ -53,11 +57,13 @@ internal sealed class AccountConfirmationEmailSender : IAccountConfirmationEmail
             ["RecipientUserId"] = userId
         });
 
-        return await _emailService
+        Result sendResult = await _emailService
             .SendAsync(
                 receiverEmail: email,
                 subject: $"Potwierdź konto — {EmailBranding.Name}",
                 body: _templateRenderer.Render(template),
                 cancellationToken: cancellationToken);
+
+        return sendResult;
     }
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationDeliveryProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationDeliveryProcessor.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Inbox;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// The delivery-level wrapper around <see cref="EmailConfirmationRequestProcessor"/>: consults the
+/// inbox before doing any work and records the message id after success (ADR-0037). Both real
+/// delivery paths — <see cref="BackgroundServices.EmailConfirmationConsumer"/> and the integration
+/// suite's broker-less bridge — resolve this one component, so the dedup logic cannot drift
+/// between them.
+/// </summary>
+/// <remarks>
+/// Returns the same ack-decision contract as the processor: success means "ack, drop it from the
+/// queue" (processed now, or already processed before), failure means "worth redelivering". The
+/// inbox row lands AFTER the send on purpose — recording first would trade duplicate-e-mail risk
+/// for lost-e-mail risk (ADR-0037 Decision 2). Database faults deliberately escape as exceptions:
+/// the consumer's existing transient path rejects the delivery and the broker's delivery limit
+/// bounds the loop (ADR-0037 Decision 4).
+/// </remarks>
+internal sealed partial class EmailConfirmationDeliveryProcessor
+{
+    private readonly AuthDbContext _db;
+    private readonly EmailConfirmationRequestProcessor _processor;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<EmailConfirmationDeliveryProcessor> _logger;
+
+    public EmailConfirmationDeliveryProcessor(
+        AuthDbContext db,
+        EmailConfirmationRequestProcessor processor,
+        TimeProvider timeProvider,
+        ILogger<EmailConfirmationDeliveryProcessor> logger)
+    {
+        _db = db;
+        _processor = processor;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result> ProcessOnceAsync(
+        EmailConfirmationRequested message,
+        Guid messageId,
+        CancellationToken cancellationToken)
+    {
+        bool alreadyProcessed = await _db.InboxMessages
+            .AsNoTracking()
+            .AnyAsync(inboxMessage => inboxMessage.MessageId == messageId, cancellationToken);
+        if (alreadyProcessed)
+        {
+            LogDuplicateSkipped(_logger, messageId);
+            return Result.Success();
+        }
+
+        Result ackDecision = await _processor.ProcessAsync(message, cancellationToken);
+        if (ackDecision.IsFailure)
+        {
+            return ackDecision;
+        }
+
+        _db.InboxMessages.Add(InboxMessage.Create(messageId, _timeProvider.GetUtcNow()));
+
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsPrimaryKeyViolation(ex))
+        {
+            // A concurrent duplicate won the insert race, which means the work is done — same
+            // ack decision as a pre-check hit.
+            LogInboxRaceLost(_logger, messageId);
+        }
+
+        return Result.Success();
+    }
+
+    private static bool IsPrimaryKeyViolation(DbUpdateException exception)
+    {
+        return exception.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation };
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerDuplicateSkipped,
+        Level = LogLevel.Information,
+        Message = "Skipping message {MessageId}: the inbox already recorded it as processed")]
+    private static partial void LogDuplicateSkipped(ILogger logger, Guid messageId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerInboxRaceLost,
+        Level = LogLevel.Information,
+        Message = "Recording message {MessageId} lost an insert race to a concurrent duplicate; acknowledging as processed")]
+    private static partial void LogInboxRaceLost(ILogger logger, Guid messageId);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationDeliveryProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationDeliveryProcessor.cs
@@ -47,7 +47,6 @@ internal sealed partial class EmailConfirmationDeliveryProcessor
         CancellationToken cancellationToken)
     {
         bool alreadyProcessed = await _db.InboxMessages
-            .AsNoTracking()
             .AnyAsync(inboxMessage => inboxMessage.MessageId == messageId, cancellationToken);
         if (alreadyProcessed)
         {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationRequestProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationRequestProcessor.cs
@@ -38,22 +38,22 @@ internal sealed partial class EmailConfirmationRequestProcessor
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        ApplicationUser? user = await _userManager.FindByIdAsync(message.UserId.ToString());
+        ApplicationUser? user = await _userManager.FindByIdAsync(message.IdentityUserId.ToString());
         if (user is null)
         {
-            LogUserGone(_logger, message.UserId);
+            LogUserGone(_logger, message.IdentityUserId);
             return Result.Success();
         }
 
         if (user.EmailConfirmed)
         {
-            LogAlreadyConfirmed(_logger, message.UserId);
+            LogAlreadyConfirmed(_logger, message.IdentityUserId);
             return Result.Success();
         }
 
         if (string.IsNullOrWhiteSpace(user.Email))
         {
-            LogAddressMissing(_logger, message.UserId);
+            LogAddressMissing(_logger, message.IdentityUserId);
             return Result.Success();
         }
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationRequestProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationRequestProcessor.cs
@@ -8,9 +8,7 @@ namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 /// <summary>
 /// The business reaction to a consumed <see cref="EmailConfirmationRequested"/> message: load the
 /// user, mint the confirmation token at send time (see the payload's remarks on token lifetime),
-/// and dispatch the e-mail. Success means "this message needs no redelivery" — a vanished or
-/// already-confirmed user is a success, because retrying can never change the outcome. Failure
-/// means "worth retrying" and drives the consumer's nack.
+/// and dispatch the e-mail.
 /// </summary>
 /// <remarks>
 /// Delivery is at-least-once (ADR-0035), so this must stay idempotent. Today that comes free:
@@ -34,6 +32,16 @@ internal sealed partial class EmailConfirmationRequestProcessor
         _logger = logger;
     }
 
+    /// <summary>
+    /// Handles one consumed message end-to-end and returns the acknowledgement decision.
+    /// </summary>
+    /// <returns>
+    /// NOT a business outcome — the answer to "does this message need redelivery?". Success means
+    /// "ack, drop it from the queue": either the e-mail went out, or redelivery can never change
+    /// the outcome (user vanished, address already confirmed, no address on the account) — nacking
+    /// those would loop the same message forever. Failure means "worth retrying" (e.g. the SMTP
+    /// relay is down) and drives the consumer's nack + requeue.
+    /// </returns>
     public async Task<Result> ProcessAsync(EmailConfirmationRequested message, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -53,17 +61,18 @@ internal sealed partial class EmailConfirmationRequestProcessor
 
         if (string.IsNullOrWhiteSpace(user.Email))
         {
-            LogAddressMissing(_logger, message.IdentityUserId);
+            LogEmailMissing(_logger, message.IdentityUserId);
             return Result.Success();
         }
 
         string confirmationToken = await _userManager.GenerateEmailConfirmationTokenAsync(user);
 
-        return await _accountConfirmationEmailSender.SendEmailConfirmationAsync(
+        Result sendEmailConfirmationResult = await _accountConfirmationEmailSender.SendEmailConfirmationAsync(
             user.Id,
             user.Email,
             confirmationToken,
             cancellationToken);
+        return sendEmailConfirmationResult;
     }
 
     [LoggerMessage(
@@ -82,5 +91,5 @@ internal sealed partial class EmailConfirmationRequestProcessor
         EventId = EventIds.EmailConfirmationAddressMissing,
         Level = LogLevel.Warning,
         Message = "Skipping confirmation e-mail for user {UserId}: the account carries no e-mail address")]
-    private static partial void LogAddressMissing(ILogger logger, Guid userId);
+    private static partial void LogEmailMissing(ILogger logger, Guid userId);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationRequestProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationRequestProcessor.cs
@@ -1,0 +1,86 @@
+using Microsoft.AspNetCore.Identity;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// The business reaction to a consumed <see cref="EmailConfirmationRequested"/> message: load the
+/// user, mint the confirmation token at send time (see the payload's remarks on token lifetime),
+/// and dispatch the e-mail. Success means "this message needs no redelivery" — a vanished or
+/// already-confirmed user is a success, because retrying can never change the outcome. Failure
+/// means "worth retrying" and drives the consumer's nack.
+/// </summary>
+/// <remarks>
+/// Delivery is at-least-once (ADR-0035), so this must stay idempotent. Today that comes free:
+/// a redelivered message finds <see cref="ApplicationUser.EmailConfirmed"/> already set, or at
+/// worst re-sends a confirmation e-mail — annoying, never harmful. A new message type must
+/// re-earn this property before it may reuse the pattern.
+/// </remarks>
+internal sealed partial class EmailConfirmationRequestProcessor
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IAccountConfirmationEmailSender _accountConfirmationEmailSender;
+    private readonly ILogger<EmailConfirmationRequestProcessor> _logger;
+
+    public EmailConfirmationRequestProcessor(
+        UserManager<ApplicationUser> userManager,
+        IAccountConfirmationEmailSender accountConfirmationEmailSender,
+        ILogger<EmailConfirmationRequestProcessor> logger)
+    {
+        _userManager = userManager;
+        _accountConfirmationEmailSender = accountConfirmationEmailSender;
+        _logger = logger;
+    }
+
+    public async Task<Result> ProcessAsync(EmailConfirmationRequested message, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationUser? user = await _userManager.FindByIdAsync(message.UserId.ToString());
+        if (user is null)
+        {
+            LogUserGone(_logger, message.UserId);
+            return Result.Success();
+        }
+
+        if (user.EmailConfirmed)
+        {
+            LogAlreadyConfirmed(_logger, message.UserId);
+            return Result.Success();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            LogAddressMissing(_logger, message.UserId);
+            return Result.Success();
+        }
+
+        string confirmationToken = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+
+        return await _accountConfirmationEmailSender.SendEmailConfirmationAsync(
+            user.Id,
+            user.Email,
+            confirmationToken,
+            cancellationToken);
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConfirmationUserGone,
+        Level = LogLevel.Information,
+        Message = "Skipping confirmation e-mail for user {UserId}: the account no longer exists")]
+    private static partial void LogUserGone(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConfirmationAlreadyConfirmed,
+        Level = LogLevel.Debug,
+        Message = "Skipping confirmation e-mail for user {UserId}: the address is already confirmed")]
+    private static partial void LogAlreadyConfirmed(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConfirmationAddressMissing,
+        Level = LogLevel.Warning,
+        Message = "Skipping confirmation e-mail for user {UserId}: the account carries no e-mail address")]
+    private static partial void LogAddressMissing(ILogger logger, Guid userId);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.Development.json
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.Development.json
@@ -72,5 +72,12 @@
     "Mode": "None",
     "TimeoutSeconds": 10,
     "MaxSendAttempts": 3
+  },
+  "RabbitMq": {
+    "Host": "localhost",
+    "Port": 5672,
+    "Username": "rabbitmq",
+    "Password": "changeme",
+    "VirtualHost": "/"
   }
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/EventIds.cs
@@ -10,4 +10,9 @@ internal static class EventIds
     public const int EmailUnexpectedError = 3101;
     public const int EmailAuthenticationError = 3102;
     public const int EmailDisconnectWarning = 3103;
+
+    // Messaging (3200–3299)
+    public const int BrokerConnected = 3200;
+    public const int BrokerMessagePublished = 3201;
+    public const int BrokerTeardownWarning = 3202;
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/InfrastructureDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/InfrastructureDependencyInjection.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
 using LotroKoniecDev.AuthSystem.Infrastructure.Options;
 
 namespace LotroKoniecDev.AuthSystem.Infrastructure;
@@ -15,6 +16,7 @@ public static class InfrastructureDependencyInjection
             services.AddValidatorsFromAssembly(typeof(IInfrastructureMarker).Assembly);
             services.AddInfrastructureOptions();
             services.AddEmails();
+            services.AddMessaging();
 
             return services;
         }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/LotroKoniecDev.AuthSystem.Infrastructure.csproj
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/LotroKoniecDev.AuthSystem.Infrastructure.csproj
@@ -14,6 +14,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+      <PackageReference Include="RabbitMQ.Client" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/LotroKoniecDev.AuthSystem.Infrastructure.csproj
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/LotroKoniecDev.AuthSystem.Infrastructure.csproj
@@ -23,4 +23,8 @@
       <ProjectReference Include="..\..\Utilities\LotroKoniecDev.Options\LotroKoniecDev.Options.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="LotroKoniecDev.AuthSystem.API.Tests.Integration" />
+    </ItemGroup>
+
 </Project>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/IMessagePublisher.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/IMessagePublisher.cs
@@ -1,0 +1,26 @@
+namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+/// <summary>
+/// Hands one already-serialized message to the broker.
+/// </summary>
+/// <remarks>
+/// Failures surface as exceptions rather than a <c>Result</c>: a refused publish is an
+/// infrastructure fault (broker down, unroutable key, nack), not a business outcome, and the
+/// caller — the outbox relay — needs the transport detail to decide between retrying and
+/// recording the failure on the outbox row.
+/// </remarks>
+public interface IMessagePublisher
+{
+    /// <param name="routingKey">A key from <see cref="RabbitMqTopology"/>.</param>
+    /// <param name="payload">The serialized message body; UTF-8 JSON.</param>
+    /// <param name="messageId">
+    /// The outbox row's identifier, carried on the wire as the AMQP <c>message-id</c> so the
+    /// consumer can deduplicate redeliveries against it.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    Task PublishAsync(
+        string routingKey,
+        string payload,
+        Guid messageId,
+        CancellationToken cancellationToken);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/MessagingDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/MessagingDependencyInjection.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+internal static class MessagingDependencyInjection
+{
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        /// The publisher is a singleton because it owns a TCP connection and a channel; a scoped
+        /// registration would open and tear one down per request, which is the classic way to
+        /// exhaust a broker's connection limit.
+        /// </summary>
+        public IServiceCollection AddMessaging()
+        {
+            services.AddSingleton<IMessagePublisher, RabbitMqMessagePublisher>();
+            return services;
+        }
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqConnectionFactoryBuilder.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqConnectionFactoryBuilder.cs
@@ -1,0 +1,26 @@
+using RabbitMQ.Client;
+
+namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+/// <summary>
+/// Builds the one <see cref="ConnectionFactory"/> shape every broker client in this process uses,
+/// so recovery behavior cannot drift between the publisher and the consumer. Publisher and
+/// consumer deliberately hold separate connections (distinguished by
+/// <paramref name="clientProvidedName"/>): AMQP applies TCP back-pressure to a publishing
+/// connection under load, which would stall consuming if both directions shared one socket.
+/// </summary>
+public static class RabbitMqConnectionFactoryBuilder
+{
+    public static ConnectionFactory Build(RabbitMqOptions settings, string clientProvidedName) =>
+        new()
+        {
+            HostName = settings.Host,
+            Port = settings.Port,
+            UserName = settings.Username,
+            Password = settings.Password,
+            VirtualHost = settings.VirtualHost,
+            ClientProvidedName = clientProvidedName,
+            AutomaticRecoveryEnabled = true,
+            TopologyRecoveryEnabled = true
+        };
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
@@ -1,0 +1,241 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.SharedKernel.Guards;
+using RabbitMQ.Client;
+
+namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+/// <summary>
+/// Publishes over one long-lived connection and one long-lived channel, both opened on the first
+/// publish instead of in the constructor: a web application must boot even while the broker is
+/// still starting, and nothing in the request pipeline needs the broker to be reachable.
+/// </summary>
+internal sealed partial class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposable
+{
+    private const string JsonContentType = "application/json";
+
+    /// <summary>
+    /// Confirmations turn <see cref="IChannel.BasicPublishAsync{TProperties}(string,string,bool,TProperties,ReadOnlyMemory{byte},CancellationToken)"/>
+    /// from "written to the socket" into "the broker took responsibility for the message": without
+    /// them the call returns before the broker has seen anything, the relay marks the outbox row
+    /// processed, and a message lost in flight is lost for good. Tracking correlates the broker's
+    /// nack or return back to the exact publish, so both arrive as an exception on this very call.
+    /// </summary>
+    private static readonly CreateChannelOptions ChannelOptions = new(
+        publisherConfirmationsEnabled: true,
+        publisherConfirmationTrackingEnabled: true);
+
+    private readonly ConnectionFactory _connectionFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<RabbitMqMessagePublisher> _logger;
+    private readonly SemaphoreSlim _connectionGate = new(1, 1);
+
+    private IConnection? _connection;
+    private IChannel? _channel;
+    private bool _disposed;
+
+    public RabbitMqMessagePublisher(
+        IOptions<RabbitMqOptions> options,
+        TimeProvider timeProvider,
+        ILogger<RabbitMqMessagePublisher> logger)
+    {
+        RabbitMqOptions settings = options.Value;
+
+        _connectionFactory = new ConnectionFactory
+        {
+            HostName = settings.Host,
+            Port = settings.Port,
+            UserName = settings.Username,
+            Password = settings.Password,
+            VirtualHost = settings.VirtualHost,
+            ClientProvidedName = "lotro-auth-api",
+            AutomaticRecoveryEnabled = true,
+            TopologyRecoveryEnabled = true
+        };
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task PublishAsync(
+        string routingKey,
+        string payload,
+        Guid messageId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(routingKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+        Ensure.NotEmpty(messageId);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        IChannel channel = await GetChannelAsync(cancellationToken);
+
+        BasicProperties properties = new()
+        {
+            MessageId = messageId.ToString(),
+            ContentType = JsonContentType,
+            ContentEncoding = Encoding.UTF8.WebName,
+            DeliveryMode = DeliveryModes.Persistent,
+            Timestamp = new AmqpTimestamp(_timeProvider.GetUtcNow().ToUnixTimeSeconds())
+        };
+
+        byte[] body = Encoding.UTF8.GetBytes(payload);
+
+        await channel.BasicPublishAsync(
+            exchange: RabbitMqTopology.EmailsExchange,
+            routingKey: routingKey,
+            mandatory: true,
+            basicProperties: properties,
+            body: body,
+            cancellationToken: cancellationToken);
+
+        LogMessagePublished(_logger, messageId, routingKey);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        await CloseChannelAsync();
+        await CloseConnectionAsync();
+        _connectionGate.Dispose();
+    }
+
+    /// <summary>
+    /// Returns the shared channel, opening the connection, the channel and the topology on first
+    /// use and rebuilding whichever of them the broker has since torn down.
+    /// </summary>
+    private async Task<IChannel> GetChannelAsync(CancellationToken cancellationToken)
+    {
+        IChannel? current = _channel;
+        if (current is { IsOpen: true })
+        {
+            return current;
+        }
+
+        await _connectionGate.WaitAsync(cancellationToken);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (_channel is { IsOpen: true })
+            {
+                return _channel;
+            }
+
+            await CloseChannelAsync(); //if channel is not null
+
+            if (_connection is not { IsOpen: true })
+            {
+                await CloseConnectionAsync();
+                _connection = await _connectionFactory.CreateConnectionAsync(cancellationToken);
+                LogBrokerConnected(_logger, _connectionFactory.HostName, _connectionFactory.VirtualHost);
+            }
+
+            IChannel channel = await _connection.CreateChannelAsync(ChannelOptions, cancellationToken);
+            await DeclareTopologyAsync(channel, cancellationToken);
+            _channel = channel;
+
+            return channel;
+        }
+        finally
+        {
+            _connectionGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Declares the exchange, the queue and the binding of <see cref="RabbitMqTopology"/>. AMQP
+    /// declarations are idempotent, so both sides may declare the same topology; the publisher
+    /// does it too because a topic exchange silently drops messages that reach no bound queue —
+    /// publishing before the consumer has ever started would otherwise lose them.
+    /// </summary>
+    private static async Task DeclareTopologyAsync(IChannel channel, CancellationToken cancellationToken)
+    {
+        await channel.ExchangeDeclareAsync(
+            exchange: RabbitMqTopology.EmailsExchange,
+            type: ExchangeType.Topic,
+            durable: true,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: cancellationToken);
+
+        await channel.QueueDeclareAsync(
+            queue: RabbitMqTopology.EmailQueue,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: cancellationToken);
+
+        await channel.QueueBindAsync(
+            queue: RabbitMqTopology.EmailQueue,
+            exchange: RabbitMqTopology.EmailsExchange,
+            routingKey: RabbitMqTopology.EmailBindingPattern,
+            arguments: null,
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task CloseChannelAsync()
+    {
+        IChannel? channel = _channel;
+        _channel = null;
+
+        if (channel is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await channel.DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            LogBrokerTeardownWarning(_logger, ex);
+        }
+    }
+
+    private async Task CloseConnectionAsync()
+    {
+        IConnection? connection = _connection;
+        _connection = null;
+
+        if (connection is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await connection.DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            LogBrokerTeardownWarning(_logger, ex);
+        }
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.BrokerConnected,
+        Level = LogLevel.Information,
+        Message = "Opened a broker connection to {Host} on virtual host {VirtualHost}")]
+    private static partial void LogBrokerConnected(ILogger logger, string host, string virtualHost);
+
+    [LoggerMessage(
+        EventId = EventIds.BrokerMessagePublished,
+        Level = LogLevel.Debug,
+        Message = "Published message {MessageId} with routing key {RoutingKey}")]
+    private static partial void LogMessagePublished(ILogger logger, Guid messageId, string routingKey);
+
+    [LoggerMessage(
+        EventId = EventIds.BrokerTeardownWarning,
+        Level = LogLevel.Debug,
+        Message = "Failed to cleanly close a broker connection or channel")]
+    private static partial void LogBrokerTeardownWarning(ILogger logger, Exception exception);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
@@ -40,19 +40,7 @@ internal sealed partial class RabbitMqMessagePublisher : IMessagePublisher, IAsy
         TimeProvider timeProvider,
         ILogger<RabbitMqMessagePublisher> logger)
     {
-        RabbitMqOptions settings = options.Value;
-
-        _connectionFactory = new ConnectionFactory
-        {
-            HostName = settings.Host,
-            Port = settings.Port,
-            UserName = settings.Username,
-            Password = settings.Password,
-            VirtualHost = settings.VirtualHost,
-            ClientProvidedName = "lotro-auth-api",
-            AutomaticRecoveryEnabled = true,
-            TopologyRecoveryEnabled = true
-        };
+        _connectionFactory = RabbitMqConnectionFactoryBuilder.Build(options.Value, "lotro-auth-api-publisher");
         _timeProvider = timeProvider;
         _logger = logger;
     }
@@ -138,7 +126,7 @@ internal sealed partial class RabbitMqMessagePublisher : IMessagePublisher, IAsy
             }
 
             IChannel channel = await _connection.CreateChannelAsync(ChannelOptions, cancellationToken);
-            await DeclareTopologyAsync(channel, cancellationToken);
+            await RabbitMqTopologyDeclaration.DeclareAsync(channel, cancellationToken);
             _channel = channel;
 
             return channel;
@@ -147,38 +135,6 @@ internal sealed partial class RabbitMqMessagePublisher : IMessagePublisher, IAsy
         {
             _connectionGate.Release();
         }
-    }
-
-    /// <summary>
-    /// Declares the exchange, the queue and the binding of <see cref="RabbitMqTopology"/>. AMQP
-    /// declarations are idempotent, so both sides may declare the same topology; the publisher
-    /// does it too because a topic exchange silently drops messages that reach no bound queue —
-    /// publishing before the consumer has ever started would otherwise lose them.
-    /// </summary>
-    private static async Task DeclareTopologyAsync(IChannel channel, CancellationToken cancellationToken)
-    {
-        await channel.ExchangeDeclareAsync(
-            exchange: RabbitMqTopology.EmailsExchange,
-            type: ExchangeType.Topic,
-            durable: true,
-            autoDelete: false,
-            arguments: null,
-            cancellationToken: cancellationToken);
-
-        await channel.QueueDeclareAsync(
-            queue: RabbitMqTopology.EmailQueue,
-            durable: true,
-            exclusive: false,
-            autoDelete: false,
-            arguments: null,
-            cancellationToken: cancellationToken);
-
-        await channel.QueueBindAsync(
-            queue: RabbitMqTopology.EmailQueue,
-            exchange: RabbitMqTopology.EmailsExchange,
-            routingKey: RabbitMqTopology.EmailBindingPattern,
-            arguments: null,
-            cancellationToken: cancellationToken);
     }
 
     private async Task CloseChannelAsync()

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
@@ -126,8 +126,20 @@ internal sealed partial class RabbitMqMessagePublisher : IMessagePublisher, IAsy
             }
 
             IChannel channel = await _connection.CreateChannelAsync(ChannelOptions, cancellationToken);
-            await RabbitMqTopologyDeclaration.DeclareAsync(channel, cancellationToken);
             _channel = channel;
+
+            try
+            {
+                await RabbitMqTopologyDeclaration.DeclareAsync(channel, cancellationToken);
+            }
+            catch
+            {
+                // A failed declaration (typically PRECONDITION_FAILED on drifted queue arguments)
+                // leaves a channel the broker already closed; dispose the client half instead of
+                // handing it back for the next publish to trip over.
+                await CloseChannelAsync();
+                throw;
+            }
 
             return channel;
         }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
@@ -128,7 +128,7 @@ internal sealed partial class RabbitMqMessagePublisher : IMessagePublisher, IAsy
                 return _channel;
             }
 
-            await CloseChannelAsync(); //if channel is not null
+            await CloseChannelAsync();
 
             if (_connection is not { IsOpen: true })
             {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqOptions.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqOptions.cs
@@ -1,0 +1,11 @@
+namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+public sealed class RabbitMqOptions
+{
+    internal const string ConfigurationSection = "RabbitMq";
+    public required string Host { get; init; }
+    public int Port { get; init; } = 5672;
+    public required string Username { get; init; }
+    public required string Password { get; init; }
+    public string VirtualHost { get; init; } = "/";
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqOptionsValidator.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqOptionsValidator.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+
+namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+public sealed class RabbitMqOptionsValidator : AbstractValidator<RabbitMqOptions>
+{
+    public RabbitMqOptionsValidator()
+    {
+        RuleFor(x => x.Host)
+            .NotEmpty()
+            .WithMessage(
+                $"{RabbitMqOptions.ConfigurationSection}:{nameof(RabbitMqOptions.Host)} (the broker host) is required. "
+                + $"Inject it via the {RabbitMqOptions.ConfigurationSection}__{nameof(RabbitMqOptions.Host)} environment variable.");
+
+        RuleFor(x => x.Port)
+            .InclusiveBetween(1, 65535)
+            .WithMessage($"{nameof(RabbitMqOptions.Port)} must be between 1 and 65535");
+
+        RuleFor(x => x.Username)
+            .NotEmpty()
+            .WithMessage($"{nameof(RabbitMqOptions.Username)} is required");
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .WithMessage($"{nameof(RabbitMqOptions.Password)} is required");
+
+        RuleFor(x => x.VirtualHost)
+            .NotEmpty()
+            .WithMessage($"{nameof(RabbitMqOptions.VirtualHost)} is required (use \"/\" for the default virtual host)");
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
@@ -1,0 +1,35 @@
+namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+/// <summary>
+/// The single source of truth for the broker topology: the publisher sends to
+/// <see cref="EmailsExchange"/> with one of the routing keys below, and the consumer declares
+/// <see cref="EmailQueue"/> bound to the very same exchange with <see cref="EmailBindingPattern"/>.
+/// Both sides share these symbols, so a routing key can no longer drift from a binding by a typo.
+/// </summary>
+public static class RabbitMqTopology
+{
+    /// <summary>
+    /// Topic exchange carrying every outgoing e-mail message.
+    /// Topic rather than direct even though a single queue consumes it today: a second consumer
+    /// (metrics, a digest, a different transport) can bind its own subset of the keys later
+    /// without touching the publisher.
+    /// </summary>
+    public const string EmailsExchange = "lotro.emails";
+
+    /// <summary>
+    /// The queue the e-mail sender consumes.
+    /// </summary>
+    public const string EmailQueue = "emails.send";
+
+    /// <summary>
+    /// Binding pattern for <see cref="EmailQueue"/>.
+    /// <c>#</c> (any number of words) rather than <c>*</c> (exactly one), so keys that grow a
+    /// segment — <c>email.password-reset.retry</c> — keep routing without a binding change.
+    /// </summary>
+    public const string EmailBindingPattern = "email.#";
+
+    /// <summary>
+    /// Routing key of the account confirmation e-mail.
+    /// </summary>
+    public const string EmailConfirmationRoutingKey = "email.confirmation";
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
@@ -32,4 +32,29 @@ public static class RabbitMqTopology
     /// Routing key of the account confirmation e-mail.
     /// </summary>
     public const string EmailConfirmationRoutingKey = "email.confirmation";
+
+    /// <summary>
+    /// Dead-letter exchange: the broker republishes here every message that
+    /// <see cref="EmailQueue"/> gives up on — rejected as poison by the consumer, or past
+    /// <see cref="EmailDeliveryLimit"/>. Fanout, because "everything that dies goes to the one
+    /// parking lot" needs no routing decisions, and the original routing key survives on the
+    /// message itself for replay.
+    /// </summary>
+    public const string EmailsDeadLetterExchange = "lotro.emails.dlx";
+
+    /// <summary>
+    /// The parking lot bound to <see cref="EmailsDeadLetterExchange"/>. Nothing consumes it:
+    /// messages wait for a human (management UI) to diagnose and replay them back to
+    /// <see cref="EmailsExchange"/> under their original routing key.
+    /// </summary>
+    public const string EmailDeadLetterQueue = "emails.send.dlq";
+
+    /// <summary>
+    /// How many times the broker redelivers a message of <see cref="EmailQueue"/> before
+    /// dead-lettering it (<c>x-delivery-limit</c>): 1 initial delivery + this many redeliveries,
+    /// then the parking lot. Broker-enforced, so the cap holds even across consumer restarts —
+    /// a crash-requeue loop counts like any other redelivery. Moves together with the consumer's
+    /// redelivery backoff ladder (one ladder entry per allowed redelivery).
+    /// </summary>
+    public const int EmailDeliveryLimit = 5;
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopologyDeclaration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopologyDeclaration.cs
@@ -3,16 +3,76 @@ using RabbitMQ.Client;
 namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
 
 /// <summary>
-/// Declares the exchange, the queue and the binding of <see cref="RabbitMqTopology"/>. AMQP
+/// Declares the exchanges, the queues and the bindings of <see cref="RabbitMqTopology"/>. AMQP
 /// declarations are idempotent, so both the publisher and the consumer run the same declaration
 /// on channel open: whichever side starts first creates the topology, the other becomes a no-op.
 /// The publisher needs it because a topic exchange silently drops messages that reach no bound
 /// queue; the consumer needs it because consuming from a queue that nobody declared yet fails.
 /// </summary>
+/// <remarks>
+/// Idempotent only while the arguments stay identical — redeclaring an existing queue with
+/// different arguments fails the channel with <c>PRECONDITION_FAILED</c>. Changing anything in
+/// <see cref="EmailQueueArguments"/> therefore requires deleting the queue first (dev:
+/// <c>docker compose down -v</c>); see ADR-0036.
+/// </remarks>
 public static class RabbitMqTopologyDeclaration
 {
+    /// <summary>
+    /// <see cref="RabbitMqTopology.EmailQueue"/> is a quorum queue so the broker itself tracks
+    /// redeliveries (<c>x-delivery-count</c>) and enforces
+    /// <see cref="RabbitMqTopology.EmailDeliveryLimit"/> — classic queues count neither, which
+    /// would push retry bookkeeping into every consumer. Exhausted and rejected messages
+    /// dead-letter to <see cref="RabbitMqTopology.EmailsDeadLetterExchange"/>; the
+    /// <c>at-least-once</c> strategy makes that hop as loss-proof as the publish that delivered
+    /// the message (the default <c>at-most-once</c> may drop dead letters under pressure), and it
+    /// requires <c>x-overflow: reject-publish</c> — inert here because no <c>x-max-length</c> is
+    /// set, so nothing ever overflows.
+    /// </summary>
+    private static readonly Dictionary<string, object?> EmailQueueArguments = new()
+    {
+        ["x-queue-type"] = "quorum",
+        ["x-dead-letter-exchange"] = RabbitMqTopology.EmailsDeadLetterExchange,
+        ["x-delivery-limit"] = RabbitMqTopology.EmailDeliveryLimit,
+        ["x-dead-letter-strategy"] = "at-least-once",
+        ["x-overflow"] = "reject-publish"
+    };
+
+    /// <summary>
+    /// The parking lot is a quorum queue for the same durability as the queue it backstops; it
+    /// carries no delivery limit and no dead-letter exchange of its own — it is terminal.
+    /// </summary>
+    private static readonly Dictionary<string, object?> DeadLetterQueueArguments = new()
+    {
+        ["x-queue-type"] = "quorum"
+    };
+
     public static async Task DeclareAsync(IChannel channel, CancellationToken cancellationToken)
     {
+        // Dead-letter side first: the parking lot must exist before anything can be routed to
+        // it, or dead letters published in the gap would reach an exchange with no bound queue.
+        await channel.ExchangeDeclareAsync(
+            exchange: RabbitMqTopology.EmailsDeadLetterExchange,
+            type: ExchangeType.Fanout,
+            durable: true,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: cancellationToken);
+
+        await channel.QueueDeclareAsync(
+            queue: RabbitMqTopology.EmailDeadLetterQueue,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: DeadLetterQueueArguments,
+            cancellationToken: cancellationToken);
+
+        await channel.QueueBindAsync(
+            queue: RabbitMqTopology.EmailDeadLetterQueue,
+            exchange: RabbitMqTopology.EmailsDeadLetterExchange,
+            routingKey: string.Empty,
+            arguments: null,
+            cancellationToken: cancellationToken);
+
         await channel.ExchangeDeclareAsync(
             exchange: RabbitMqTopology.EmailsExchange,
             type: ExchangeType.Topic,
@@ -26,7 +86,7 @@ public static class RabbitMqTopologyDeclaration
             durable: true,
             exclusive: false,
             autoDelete: false,
-            arguments: null,
+            arguments: EmailQueueArguments,
             cancellationToken: cancellationToken);
 
         await channel.QueueBindAsync(

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopologyDeclaration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopologyDeclaration.cs
@@ -38,8 +38,11 @@ public static class RabbitMqTopologyDeclaration
     };
 
     /// <summary>
-    /// The parking lot is a quorum queue for the same durability as the queue it backstops; it
-    /// carries no delivery limit and no dead-letter exchange of its own — it is terminal.
+    /// The parking lot is a quorum queue for the same durability as the queue it backstops; no
+    /// dead-letter exchange of its own and no explicit delivery limit — it is terminal. The
+    /// quorum <em>default</em> delivery limit (20) still applies though, so any replay must
+    /// ack-and-republish, never reject-requeue — a reject-requeue loop would silently drop the
+    /// parked message (ADR-0036).
     /// </summary>
     private static readonly Dictionary<string, object?> DeadLetterQueueArguments = new()
     {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopologyDeclaration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopologyDeclaration.cs
@@ -1,0 +1,39 @@
+using RabbitMQ.Client;
+
+namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+/// <summary>
+/// Declares the exchange, the queue and the binding of <see cref="RabbitMqTopology"/>. AMQP
+/// declarations are idempotent, so both the publisher and the consumer run the same declaration
+/// on channel open: whichever side starts first creates the topology, the other becomes a no-op.
+/// The publisher needs it because a topic exchange silently drops messages that reach no bound
+/// queue; the consumer needs it because consuming from a queue that nobody declared yet fails.
+/// </summary>
+public static class RabbitMqTopologyDeclaration
+{
+    public static async Task DeclareAsync(IChannel channel, CancellationToken cancellationToken)
+    {
+        await channel.ExchangeDeclareAsync(
+            exchange: RabbitMqTopology.EmailsExchange,
+            type: ExchangeType.Topic,
+            durable: true,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: cancellationToken);
+
+        await channel.QueueDeclareAsync(
+            queue: RabbitMqTopology.EmailQueue,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: cancellationToken);
+
+        await channel.QueueBindAsync(
+            queue: RabbitMqTopology.EmailQueue,
+            exchange: RabbitMqTopology.EmailsExchange,
+            routingKey: RabbitMqTopology.EmailBindingPattern,
+            arguments: null,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RedeliveryCount.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RedeliveryCount.cs
@@ -1,0 +1,34 @@
+namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+/// <summary>
+/// Reads the <c>x-delivery-count</c> header a quorum queue stamps on every redelivery: absent on
+/// the first delivery, then 1, 2, … — the very counter the broker compares against
+/// <c>x-delivery-limit</c> when it decides to dead-letter. Reading it lets the consumer scale its
+/// backoff per attempt and announce the final attempt, instead of keeping a count of its own that
+/// a restart would reset.
+/// </summary>
+public static class RedeliveryCount
+{
+    private const string DeliveryCountHeader = "x-delivery-count";
+
+    /// <summary>
+    /// Returns the broker's redelivery count, or 0 when the header is absent or unreadable —
+    /// under-counting is the safe direction, because it can only grant a message extra patience,
+    /// never park it early.
+    /// </summary>
+    public static int Read(IDictionary<string, object?>? headers)
+    {
+        if (headers is null || !headers.TryGetValue(DeliveryCountHeader, out object? value))
+        {
+            return 0;
+        }
+
+        return value switch
+        {
+            long count => (int)long.Clamp(count, 0L, int.MaxValue),
+            int count => int.Max(count, 0),
+            byte count => count,
+            _ => 0
+        };
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Options/OptionsDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Options/OptionsDependencyInjection.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
 using LotroKoniecDev.Options;
 
 namespace LotroKoniecDev.AuthSystem.Infrastructure.Options;
@@ -11,6 +12,7 @@ internal static class OptionsDependencyInjection
         public IServiceCollection AddInfrastructureOptions()
         {
             services.AddOptionsWithFluentValidation<EmailOptions>(EmailOptions.ConfigurationSection);
+            services.AddOptionsWithFluentValidation<RabbitMqOptions>(RabbitMqOptions.ConfigurationSection);
 
             return services;
         }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/InboxMessageConfiguration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/InboxMessageConfiguration.cs
@@ -1,0 +1,23 @@
+using LotroKoniecDev.AuthSystem.Persistence.Inbox;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Configurations;
+
+internal sealed class InboxMessageConfiguration : IEntityTypeConfiguration<InboxMessage>
+{
+    public void Configure(EntityTypeBuilder<InboxMessage> builder)
+    {
+        builder.ToTable("InboxMessages");
+
+        builder.HasKey(message => message.MessageId);
+
+        // Both properties are get-only, and EF Core's convention only discovers properties that
+        // have BOTH a getter and a setter — each needs an explicit Property() call to exist in
+        // the model at all (same gotcha as OutboxMessageConfiguration).
+        builder.Property(message => message.MessageId)
+            .ValueGeneratedNever();
+
+        builder.Property(message => message.ProcessedOn);
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/OutboxMessageConfiguration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/OutboxMessageConfiguration.cs
@@ -12,19 +12,31 @@ internal sealed class OutboxMessageConfiguration : IEntityTypeConfiguration<Outb
 
         builder.HasKey(message => message.Id);
 
+        // Id, Type, Payload and OccurredOn are get-only, and EF Core's convention only discovers
+        // properties that have BOTH a getter and a setter. Every one of them therefore needs an
+        // explicit Property() call to exist in the model at all — delete a seemingly empty call
+        // below and the column silently vanishes, which the next migration renders as DropColumn.
+        // (ProcessedOn and Attempts carry a private setter, so convention does map them.)
         builder.Property(message => message.Id)
             .ValueGeneratedNever();
 
         builder.Property(message => message.Type)
             .HasMaxLength(OutboxMessage.TypeMaxLength);
 
+        // Deliberately text, not jsonb: an outbox row must be a byte-faithful record of what was
+        // put on the wire, and jsonb stores a parsed document — it reorders keys, drops duplicates
+        // and whitespace, and normalises numbers, so a read-back would no longer equal the write.
+        // That fidelity is what any future payload hash or signature would rest on. The validation
+        // jsonb would add guards a class of failure System.Text.Json cannot produce anyway, and it
+        // would move that failure inside the registration transaction.
         builder.Property(message => message.Payload);
 
         builder.Property(message => message.OccurredOn);
 
         builder.Property(message => message.LastError)
             .HasMaxLength(OutboxMessage.LastErrorMaxLength);
-        
+
+
         builder.HasIndex(message => message.OccurredOn)
             .HasDatabaseName("IX_OutboxMessages_Unprocessed")
             .HasFilter($"\"{nameof(OutboxMessage.ProcessedOn)}\" IS NULL");

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/OutboxMessageConfiguration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/OutboxMessageConfiguration.cs
@@ -1,0 +1,32 @@
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Configurations;
+
+internal sealed class OutboxMessageConfiguration : IEntityTypeConfiguration<OutboxMessage>
+{
+    public void Configure(EntityTypeBuilder<OutboxMessage> builder)
+    {
+        builder.ToTable("OutboxMessages");
+
+        builder.HasKey(message => message.Id);
+
+        builder.Property(message => message.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(message => message.Type)
+            .HasMaxLength(OutboxMessage.TypeMaxLength);
+
+        builder.Property(message => message.Payload);
+
+        builder.Property(message => message.OccurredOn);
+
+        builder.Property(message => message.LastError)
+            .HasMaxLength(OutboxMessage.LastErrorMaxLength);
+        
+        builder.HasIndex(message => message.OccurredOn)
+            .HasDatabaseName("IX_OutboxMessages_Unprocessed")
+            .HasFilter($"\"{nameof(OutboxMessage.ProcessedOn)}\" IS NULL");
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/DbContexts/AuthDbContext.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/DbContexts/AuthDbContext.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationRoles.Entities;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
 
 namespace LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 
@@ -12,6 +13,8 @@ public sealed class AuthDbContext : IdentityDbContext<ApplicationUser, Applicati
     public AuthDbContext(DbContextOptions<AuthDbContext> options) : base(options)
     {
     }
+
+    public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/DbContexts/AuthDbContext.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/DbContexts/AuthDbContext.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationRoles.Entities;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Inbox;
 using LotroKoniecDev.AuthSystem.Persistence.Outbox;
 
 namespace LotroKoniecDev.AuthSystem.Persistence.DbContexts;
@@ -15,6 +16,8 @@ public sealed class AuthDbContext : IdentityDbContext<ApplicationUser, Applicati
     }
 
     public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
+
+    public DbSet<InboxMessage> InboxMessages => Set<InboxMessage>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Inbox/InboxMessage.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Inbox/InboxMessage.cs
@@ -1,0 +1,41 @@
+using LotroKoniecDev.SharedKernel.Guards;
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Inbox;
+
+/// <summary>
+/// One row per fully processed broker delivery, keyed by the broker message id — which equals the
+/// publishing <see cref="Outbox.OutboxMessage"/>'s Id, so the full context of any inbox row is one
+/// join away. The consumer checks this table before doing any work and records into it after
+/// success, so a redelivered or re-published message is acknowledged without a second side effect
+/// (ADR-0037).
+/// </summary>
+/// <remarks>
+/// Deliberately carries no Type, no Payload and no attempt counters: the outbox row with the same
+/// id holds the former two, and retry bookkeeping is broker-owned (ADR-0036). One hard constraint
+/// from ADR-0037: this table serves the single e-mail consumer — a second consumer of the same
+/// message (a fanout binding) must NOT share it without adding a consumer discriminator, or the
+/// two would silently skip each other's work.
+/// </remarks>
+public sealed class InboxMessage
+{
+    public Guid MessageId { get; }
+    public DateTimeOffset ProcessedOn { get; }
+
+    public static InboxMessage Create(Guid messageId, DateTimeOffset processedOn)
+    {
+        Ensure.NotEmpty(messageId);
+        Ensure.NotEmpty(processedOn);
+        InboxMessage instance = new(messageId: messageId, processedOn: processedOn);
+        return instance;
+    }
+
+    private InboxMessage(Guid messageId, DateTimeOffset processedOn)
+    {
+        MessageId = messageId;
+        ProcessedOn = processedOn;
+    }
+
+    private InboxMessage()
+    {
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260728192042_AddOutboxMessages.Designer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260728192042_AddOutboxMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728192042_AddOutboxMessages")]
+    partial class AddOutboxMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260728192042_AddOutboxMessages.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260728192042_AddOutboxMessages.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOutboxMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OutboxMessages",
+                schema: "authsystem",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Type = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Payload = table.Column<string>(type: "text", nullable: false),
+                    OccurredOn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ProcessedOn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Attempts = table.Column<int>(type: "integer", nullable: false),
+                    LastError = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxMessages", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_Unprocessed",
+                schema: "authsystem",
+                table: "OutboxMessages",
+                column: "OccurredOn",
+                filter: "\"ProcessedOn\" IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OutboxMessages",
+                schema: "authsystem");
+        }
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260803180321_AddInboxMessages.Designer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260803180321_AddInboxMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260803180321_AddInboxMessages")]
+    partial class AddInboxMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260803180321_AddInboxMessages.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260803180321_AddInboxMessages.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInboxMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InboxMessages",
+                schema: "authsystem",
+                columns: table => new
+                {
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProcessedOn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InboxMessages", x => x.MessageId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "InboxMessages",
+                schema: "authsystem");
+        }
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Outbox/OutboxMessage.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Outbox/OutboxMessage.cs
@@ -1,0 +1,79 @@
+using LotroKoniecDev.SharedKernel.Guards;
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Outbox;
+
+public sealed class OutboxMessage
+{
+    public const int TypeMaxLength = 500;
+    public const int LastErrorMaxLength = 2000;
+
+    public Guid Id { get; }
+    public string Type { get; }
+    public string Payload { get; }
+    public DateTimeOffset OccurredOn { get; }
+    public DateTimeOffset? ProcessedOn { get; private set; }
+    public int Attempts { get; private set; }
+    public string? LastError { get; private set; }
+
+    public bool IsProcessed()
+    {
+        bool isProcessed = ProcessedOn is not null;
+        return isProcessed;
+    }
+    
+    public void MarkAsProcessed(DateTimeOffset processedOn)
+    {
+        if (IsProcessed())
+        {
+            return;
+        }
+
+        ProcessedOn = processedOn;
+    }
+
+    public void MarkFailed(string error)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(error);
+
+        error = error.Trim();
+        if (error.Length > LastErrorMaxLength)
+        {
+            error = error[..LastErrorMaxLength];
+        }
+
+        Attempts++;
+        LastError = error;
+    }
+
+    public static OutboxMessage Create(
+        string type,
+        string payload,
+        DateTimeOffset occurredOn)
+    {
+        Ensure.NotEmpty(occurredOn);
+        ArgumentException.ThrowIfNullOrWhiteSpace(type);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(type.Length, TypeMaxLength);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+        Guid id = Guid.CreateVersion7();
+        OutboxMessage instance = new(id: id, type: type, payload: payload, occurredOn: occurredOn);
+        return instance;
+    }
+
+    private OutboxMessage(
+        Guid id,
+        string type,
+        string payload,
+        DateTimeOffset occurredOn)
+    {
+        Id = id;
+        Type = type;
+        Payload = payload;
+        OccurredOn = occurredOn;
+    }
+
+    private OutboxMessage()
+    {
+        Type = null!;
+        Payload = "";
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -64,6 +64,11 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
                 { "Email:Sender", "lotro-translator.pl" },
                 { "Email:Host", "localhost" },
                 { "Email:Port", "59999" },
+                // No broker in this suite; the values only have to satisfy the unconditional
+                // RabbitMqOptionsValidator at startup — nothing connects to them.
+                { "RabbitMq:Host", "localhost" },
+                { "RabbitMq:Username", "rabbitmq" },
+                { "RabbitMq:Password", "changeme" },
             });
         });
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -4,9 +4,12 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Testcontainers.PostgreSql;
+using LotroKoniecDev.AuthSystem.API.BackgroundServices;
 using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Services.Emails;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
@@ -114,8 +117,21 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
             services.AddSingleton<IAccountDeletionEmailSender>(sp =>
                 sp.GetRequiredService<SpyAccountDeletionEmailSender>());
 
+            // The suite runs without a broker: the consumer would loop on connection retries and
+            // spam warnings, so it is removed outright (its business logic has its own unit
+            // tests via EmailConfirmationRequestProcessor).
+            ServiceDescriptor? emailConsumer = services.FirstOrDefault(d =>
+                d.ServiceType == typeof(IHostedService)
+                && d.ImplementationType == typeof(EmailConfirmationConsumer));
+            if (emailConsumer is not null)
+            {
+                services.Remove(emailConsumer);
+            }
+
             // Replace the RabbitMQ publisher with a spy: the suite runs without a broker, and the
-            // outbox relay tests assert against what reached the (fake) wire.
+            // outbox relay tests assert against what reached the (fake) wire. The spy's delivery
+            // bridge plays the removed consumer's part, so registration still ends in a captured
+            // confirmation e-mail: outbox -> relay -> spy publish -> processor -> spy sender.
             ServiceDescriptor? existingMessagePublisher = services
                 .FirstOrDefault(d => d.ServiceType == typeof(IMessagePublisher));
             if (existingMessagePublisher is not null)
@@ -123,7 +139,8 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
                 services.Remove(existingMessagePublisher);
             }
 
-            services.AddSingleton<SpyMessagePublisher>();
+            services.AddSingleton<SpyMessagePublisher>(sp =>
+                new SpyMessagePublisher(message => DeliverLikeTheConsumerWouldAsync(sp, message)));
             services.AddSingleton<IMessagePublisher>(sp =>
                 sp.GetRequiredService<SpyMessagePublisher>());
 
@@ -154,6 +171,33 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
         {
             logging.SetMinimumLevel(LogLevel.Warning);
         });
+    }
+
+    /// <summary>
+    /// The suite's stand-in for the broker-to-consumer hop: what the relay publishes is pushed
+    /// through the same <see cref="EmailConfirmationRequestProcessor"/> the real consumer runs,
+    /// in a fresh scope per message, exactly like <c>EmailConfirmationConsumer.OnDeliveredAsync</c>.
+    /// </summary>
+    private static async Task DeliverLikeTheConsumerWouldAsync(
+        IServiceProvider services,
+        SpyMessagePublisher.PublishedMessage message)
+    {
+        if (message.RoutingKey != RabbitMqTopology.EmailConfirmationRoutingKey)
+        {
+            return;
+        }
+
+        EmailConfirmationRequested? payload =
+            System.Text.Json.JsonSerializer.Deserialize<EmailConfirmationRequested>(message.Payload);
+        if (payload is null)
+        {
+            return;
+        }
+
+        await using AsyncServiceScope scope = services.CreateAsyncScope();
+        EmailConfirmationRequestProcessor processor =
+            scope.ServiceProvider.GetRequiredService<EmailConfirmationRequestProcessor>();
+        await processor.ProcessAsync(payload, CancellationToken.None);
     }
 
     public async Task InitializeAsync()

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -69,8 +69,11 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
                 { "Email:Host", "localhost" },
                 { "Email:Port", "59999" },
                 // No broker in this suite; the values only have to satisfy the unconditional
-                // RabbitMqOptionsValidator at startup — nothing connects to them.
+                // RabbitMqOptionsValidator at startup. The port is a deliberately dead one (same
+                // trick as Email:Port above) so RabbitMqHealthCheck is deterministically Unhealthy
+                // — the full /health test must not flip when the dev compose broker (:5672) runs.
                 { "RabbitMq:Host", "localhost" },
+                { "RabbitMq:Port", "59998" },
                 { "RabbitMq:Username", "rabbitmq" },
                 { "RabbitMq:Password", "changeme" },
             });

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -9,6 +9,7 @@ using Testcontainers.PostgreSql;
 using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.API.Services.Emails;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
 using LotroKoniecDev.AuthSystem.Persistence;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 
@@ -112,6 +113,19 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
             services.AddSingleton<SpyAccountDeletionEmailSender>();
             services.AddSingleton<IAccountDeletionEmailSender>(sp =>
                 sp.GetRequiredService<SpyAccountDeletionEmailSender>());
+
+            // Replace the RabbitMQ publisher with a spy: the suite runs without a broker, and the
+            // outbox relay tests assert against what reached the (fake) wire.
+            ServiceDescriptor? existingMessagePublisher = services
+                .FirstOrDefault(d => d.ServiceType == typeof(IMessagePublisher));
+            if (existingMessagePublisher is not null)
+            {
+                services.Remove(existingMessagePublisher);
+            }
+
+            services.AddSingleton<SpyMessagePublisher>();
+            services.AddSingleton<IMessagePublisher>(sp =>
+                sp.GetRequiredService<SpyMessagePublisher>());
 
             // Replace AuthDbContext to use the test connection string directly
             ServiceDescriptor? dbContextDescriptor = services

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -175,8 +175,10 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
 
     /// <summary>
     /// The suite's stand-in for the broker-to-consumer hop: what the relay publishes is pushed
-    /// through the same <see cref="EmailConfirmationRequestProcessor"/> the real consumer runs,
-    /// in a fresh scope per message, exactly like <c>EmailConfirmationConsumer.OnDeliveredAsync</c>.
+    /// through the same <see cref="EmailConfirmationDeliveryProcessor"/> the real consumer runs,
+    /// in a fresh scope per message, exactly like <c>EmailConfirmationConsumer.OnDeliveredAsync</c>
+    /// — including the inbox deduplication of ADR-0037, which therefore runs under this suite's
+    /// real PostgreSQL.
     /// </summary>
     private static async Task DeliverLikeTheConsumerWouldAsync(
         IServiceProvider services,
@@ -195,9 +197,9 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
         }
 
         await using AsyncServiceScope scope = services.CreateAsyncScope();
-        EmailConfirmationRequestProcessor processor =
-            scope.ServiceProvider.GetRequiredService<EmailConfirmationRequestProcessor>();
-        await processor.ProcessAsync(payload, CancellationToken.None);
+        EmailConfirmationDeliveryProcessor deliveryProcessor =
+            scope.ServiceProvider.GetRequiredService<EmailConfirmationDeliveryProcessor>();
+        await deliveryProcessor.ProcessOnceAsync(payload, message.MessageId, CancellationToken.None);
     }
 
     public async Task InitializeAsync()

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/LotroKoniecDev.AuthSystem.API.Tests.Integration.csproj
@@ -22,6 +22,7 @@
         <PackageReference Include="System.Security.Cryptography.Xml" />
         <PackageReference Include="Testcontainers" />
         <PackageReference Include="Testcontainers.PostgreSql"/>
+        <PackageReference Include="Testcontainers.RabbitMq"/>
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
     </ItemGroup>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Factories/UserFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Factories/UserFactory.cs
@@ -75,6 +75,10 @@ internal static class UserFactory
         IdentityId identityId = JsonSerializer.Deserialize<IdentityId>(stringResponse, apiClient.JsonOptions);
         identityId.Value.ShouldNotBe(Guid.Empty);
 
+        // The confirmation e-mail travels the outbox pipeline now (commit -> relay -> delivery),
+        // so wait for the capture instead of assuming the register response implies it.
+        await accountConfirmationEmailSpy.WaitForCaptureAsync();
+
         return (request, identityId);
     }
 
@@ -82,6 +86,8 @@ internal static class UserFactory
         TestApiClient apiClient,
         SpyAccountConfirmationEmailSender accountConfirmationEmailSpy)
     {
+        await accountConfirmationEmailSpy.WaitForCaptureAsync();
+
         accountConfirmationEmailSpy.LastEmail.ShouldNotBeNullOrEmpty("Expected email confirmation spy to have captured an email.");
         accountConfirmationEmailSpy.LastConfirmationToken.ShouldNotBeNullOrEmpty("Expected email confirmation spy to have captured a token.");
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/RabbitMqBrokerFixture.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/RabbitMqBrokerFixture.cs
@@ -12,8 +12,9 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 public sealed class RabbitMqBrokerFixture : IAsyncLifetime
 {
     /// <summary>
-    /// Same major.minor as compose.yaml, so the suite proves the topology against the broker
-    /// generation the stack actually runs; management UI is dead weight in a test.
+    /// Pinned to the exact compose.yaml version (management UI stripped — dead weight in a
+    /// test), so the suite proves the topology against the broker generation the stack actually
+    /// runs. compose.yaml points back here: a bump must touch both.
     /// </summary>
     private readonly RabbitMqContainer _container = new RabbitMqBuilder("rabbitmq:4.3.4-alpine")
         .Build();

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/RabbitMqBrokerFixture.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/RabbitMqBrokerFixture.cs
@@ -1,3 +1,5 @@
+using DotNet.Testcontainers.Containers;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
 using RabbitMQ.Client;
 using Testcontainers.RabbitMq;
 
@@ -37,5 +39,42 @@ public sealed class RabbitMqBrokerFixture : IAsyncLifetime
         };
 
         return await connectionFactory.CreateConnectionAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// The container's coordinates as the very settings shape production binds from
+    /// configuration, so a test can construct the real publisher against this broker.
+    /// </summary>
+    public RabbitMqOptions BuildOptions()
+    {
+        Uri amqpUri = new(_container.GetConnectionString());
+        string[] userInfo = amqpUri.UserInfo.Split(':');
+
+        return new RabbitMqOptions
+        {
+            Host = amqpUri.Host,
+            Port = amqpUri.Port,
+            Username = Uri.UnescapeDataString(userInfo[0]),
+            Password = Uri.UnescapeDataString(userInfo[1]),
+            VirtualHost = amqpUri.AbsolutePath.Length > 1
+                ? Uri.UnescapeDataString(amqpUri.AbsolutePath.TrimStart('/'))
+                : "/"
+        };
+    }
+
+    /// <summary>
+    /// Server-side kill of every client connection — the broker-restart scenario a long-lived
+    /// publisher must survive by rebuilding its channel on the next publish.
+    /// </summary>
+    public async Task CloseAllConnectionsAsync()
+    {
+        ExecResult result = await _container.ExecAsync(
+            ["rabbitmqctl", "close_all_connections", "integration-test induced failure"]);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"rabbitmqctl close_all_connections failed (exit code {result.ExitCode}).\nStdout:\n{result.Stdout}\nStderr:\n{result.Stderr}");
+        }
     }
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/RabbitMqBrokerFixture.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/RabbitMqBrokerFixture.cs
@@ -1,0 +1,40 @@
+using RabbitMQ.Client;
+using Testcontainers.RabbitMq;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+
+/// <summary>
+/// One real RabbitMQ container per test class — the rest of the suite deliberately runs
+/// broker-less behind <see cref="SpyMessagePublisher"/>, but dead-letter routing, quorum-queue
+/// redelivery counting and the delivery limit are broker behavior: only the broker itself can
+/// prove our declared topology actually has them.
+/// </summary>
+public sealed class RabbitMqBrokerFixture : IAsyncLifetime
+{
+    /// <summary>
+    /// Same major.minor as compose.yaml, so the suite proves the topology against the broker
+    /// generation the stack actually runs; management UI is dead weight in a test.
+    /// </summary>
+    private readonly RabbitMqContainer _container = new RabbitMqBuilder("rabbitmq:4.3.4-alpine")
+        .Build();
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _container.DisposeAsync();
+    }
+
+    public async Task<IConnection> ConnectAsync(CancellationToken cancellationToken)
+    {
+        ConnectionFactory connectionFactory = new()
+        {
+            Uri = new Uri(_container.GetConnectionString())
+        };
+
+        return await connectionFactory.CreateConnectionAsync(cancellationToken);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountConfirmationEmailSender.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountConfirmationEmailSender.cs
@@ -26,6 +26,22 @@ public sealed class SpyAccountConfirmationEmailSender : IAccountConfirmationEmai
             : Task.FromResult(Result.Success());
     }
 
+    /// <summary>
+    /// Blocks until a confirmation e-mail lands or the timeout passes. Registration stopped being
+    /// synchronous when it went through the outbox (commit -> relay -> delivery -> this spy), so
+    /// tests reading <see cref="LastEmail"/> right after a register call must wait on state, not
+    /// assume immediacy. Returns silently either way — the assertions stay at the call site.
+    /// </summary>
+    public async Task WaitForCaptureAsync(TimeSpan? timeout = null)
+    {
+        using CancellationTokenSource waitWindow = new(timeout ?? TimeSpan.FromSeconds(15));
+
+        while (LastEmail is null && !waitWindow.IsCancellationRequested)
+        {
+            await Task.Delay(50);
+        }
+    }
+
     public void Reset()
     {
         LastEmail = null;

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyMessagePublisher.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyMessagePublisher.cs
@@ -1,0 +1,42 @@
+using System.Collections.Concurrent;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+
+/// <summary>
+/// Replaces the RabbitMQ publisher so the suite needs no broker: captures what the relay
+/// publishes and, when <see cref="FailWith"/> is set, refuses every publish the way a dead
+/// broker would.
+/// </summary>
+internal sealed class SpyMessagePublisher : IMessagePublisher
+{
+    internal sealed record PublishedMessage(string RoutingKey, string Payload, Guid MessageId);
+
+    private readonly ConcurrentQueue<PublishedMessage> _published = new();
+
+    public IReadOnlyCollection<PublishedMessage> Published => _published;
+
+    public Exception? FailWith { get; set; }
+
+    public Task PublishAsync(
+        string routingKey,
+        string payload,
+        Guid messageId,
+        CancellationToken cancellationToken)
+    {
+        Exception? failure = FailWith;
+        if (failure is not null)
+        {
+            throw failure;
+        }
+
+        _published.Enqueue(new PublishedMessage(routingKey, payload, messageId));
+        return Task.CompletedTask;
+    }
+
+    public void Reset()
+    {
+        FailWith = null;
+        _published.Clear();
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyMessagePublisher.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyMessagePublisher.cs
@@ -6,19 +6,27 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 /// <summary>
 /// Replaces the RabbitMQ publisher so the suite needs no broker: captures what the relay
 /// publishes and, when <see cref="FailWith"/> is set, refuses every publish the way a dead
-/// broker would.
+/// broker would. The optional delivery bridge stands in for the broker-to-consumer hop:
+/// each accepted publish is handed straight to it, the way the real queue would push the
+/// message at <c>EmailConfirmationConsumer</c> (which the suite removes, having no broker).
 /// </summary>
 internal sealed class SpyMessagePublisher : IMessagePublisher
 {
     internal sealed record PublishedMessage(string RoutingKey, string Payload, Guid MessageId);
 
     private readonly ConcurrentQueue<PublishedMessage> _published = new();
+    private readonly Func<PublishedMessage, Task>? _deliverAsync;
+
+    public SpyMessagePublisher(Func<PublishedMessage, Task>? deliverAsync = null)
+    {
+        _deliverAsync = deliverAsync;
+    }
 
     public IReadOnlyCollection<PublishedMessage> Published => _published;
 
     public Exception? FailWith { get; set; }
 
-    public Task PublishAsync(
+    public async Task PublishAsync(
         string routingKey,
         string payload,
         Guid messageId,
@@ -30,8 +38,13 @@ internal sealed class SpyMessagePublisher : IMessagePublisher
             throw failure;
         }
 
-        _published.Enqueue(new PublishedMessage(routingKey, payload, messageId));
-        return Task.CompletedTask;
+        PublishedMessage message = new(routingKey, payload, messageId);
+        _published.Enqueue(message);
+
+        if (_deliverAsync is not null)
+        {
+            await _deliverAsync(message);
+        }
     }
 
     public void Reset()

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConfirmEmailEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ConfirmEmailEndpointTests.cs
@@ -215,6 +215,7 @@ public sealed class ConfirmEmailEndpointTests : EndpointsTestBase
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
+        await AccountConfirmationEmailSpy.WaitForCaptureAsync();
         AccountConfirmationEmailSpy.CallCount.ShouldBe(1);
         AccountConfirmationEmailSpy.LastEmail.ShouldBe(request.Email);
         AccountConfirmationEmailSpy.LastConfirmationToken.ShouldNotBeNullOrEmpty();

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/InboxDeduplicationTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/InboxDeduplicationTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+/// <summary>
+/// Proves the inbox deduplication of ADR-0037 against real PostgreSQL, through
+/// <see cref="EmailConfirmationDeliveryProcessor"/> — the one component both real delivery paths
+/// (the broker consumer and this suite's broker-less bridge) resolve: a processed message id is
+/// recorded, a duplicate of it is acknowledged without a second e-mail, and a failed processing
+/// leaves no record so redelivery genuinely retries.
+/// </summary>
+public sealed class InboxDeduplicationTests : EndpointsTestBase
+{
+    public InboxDeduplicationTests(AuthSystemApiFactory appFactory) : base(appFactory)
+    {
+    }
+
+    [Fact]
+    public async Task ProcessOnce_ShouldRecordTheMessageId_WhenProcessingSucceeds()
+    {
+        // Arrange
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy);
+        await AccountConfirmationEmailSpy.WaitForCaptureAsync();
+        Guid messageId = Guid.CreateVersion7();
+        int sendsBefore = AccountConfirmationEmailSpy.CallCount;
+
+        // Act
+        Result ackDecision = await ProcessOnceAsync(identityId.Value, messageId);
+
+        // Assert
+        ackDecision.IsSuccess.ShouldBeTrue();
+        AccountConfirmationEmailSpy.CallCount.ShouldBe(sendsBefore + 1);
+        (await CountInboxRowsAsync(messageId)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ProcessOnce_ShouldAckWithoutSecondEmail_WhenMessageIdAlreadyRecorded()
+    {
+        // Arrange
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy);
+        await AccountConfirmationEmailSpy.WaitForCaptureAsync();
+        Guid messageId = Guid.CreateVersion7();
+        await ProcessOnceAsync(identityId.Value, messageId);
+        int sendsAfterFirstDelivery = AccountConfirmationEmailSpy.CallCount;
+
+        // Act — the same message id delivered again (redelivery or relay re-publish)
+        Result duplicateAckDecision = await ProcessOnceAsync(identityId.Value, messageId);
+
+        // Assert — acked, no second e-mail, still exactly one row
+        duplicateAckDecision.IsSuccess.ShouldBeTrue();
+        AccountConfirmationEmailSpy.CallCount.ShouldBe(sendsAfterFirstDelivery);
+        (await CountInboxRowsAsync(messageId)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ProcessOnce_ShouldLeaveNoRecord_WhenProcessingFails()
+    {
+        // Arrange
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy);
+        await AccountConfirmationEmailSpy.WaitForCaptureAsync();
+        Guid messageId = Guid.CreateVersion7();
+        AccountConfirmationEmailSpy.ShouldFail = true;
+
+        // Act — the failed send must not be remembered as processed
+        Result failedAckDecision = await ProcessOnceAsync(identityId.Value, messageId);
+
+        // Assert
+        failedAckDecision.IsFailure.ShouldBeTrue();
+        (await CountInboxRowsAsync(messageId)).ShouldBe(0);
+
+        // Act again — after the dependency heals, the redelivery really retries and records
+        AccountConfirmationEmailSpy.ShouldFail = false;
+        Result redeliveryAckDecision = await ProcessOnceAsync(identityId.Value, messageId);
+
+        // Assert
+        redeliveryAckDecision.IsSuccess.ShouldBeTrue();
+        (await CountInboxRowsAsync(messageId)).ShouldBe(1);
+    }
+
+    private async Task<Result> ProcessOnceAsync(Guid identityUserId, Guid messageId)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        EmailConfirmationDeliveryProcessor deliveryProcessor =
+            scope.ServiceProvider.GetRequiredService<EmailConfirmationDeliveryProcessor>();
+        return await deliveryProcessor.ProcessOnceAsync(
+            new EmailConfirmationRequested(identityUserId), messageId, CancellationToken.None);
+    }
+
+    private async Task<int> CountInboxRowsAsync(Guid messageId)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        return await db.InboxMessages.AsNoTracking().CountAsync(row => row.MessageId == messageId);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/OutboxRelayTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/OutboxRelayTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+/// <summary>
+/// Exercises the signal-driven relay end-to-end against the real host: registration commits an
+/// outbox row and nudges the signal, the hosted relay publishes to the (spy) broker and marks the
+/// row processed. No fixed poll interval exists to lean on (ADR-0035), so every test waits on the
+/// observable database state, never on time.
+/// </summary>
+public sealed class OutboxRelayTests : EndpointsTestBase
+{
+    private static readonly TimeSpan RelayReactionTimeout = TimeSpan.FromSeconds(15);
+
+    private readonly SpyMessagePublisher _messagePublisherSpy;
+
+    public OutboxRelayTests(AuthSystemApiFactory appFactory) : base(appFactory)
+    {
+        _messagePublisherSpy = appFactory.Services.GetRequiredService<SpyMessagePublisher>();
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _messagePublisherSpy.Reset();
+    }
+
+    [Fact]
+    public async Task Relay_ShouldPublishAndMarkProcessed_WhenRegistrationCommits()
+    {
+        // Arrange & Act — registration is the outbox writer under test
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        // Assert
+        OutboxMessage? message = await WaitForOutboxRowAsync(
+            row => row.Payload.Contains(identityId.Value.ToString(), StringComparison.OrdinalIgnoreCase)
+                   && row.ProcessedOn != null);
+
+        message.ShouldNotBeNull();
+        message.IsProcessed().ShouldBeTrue();
+        message.Attempts.ShouldBe(0);
+        message.LastError.ShouldBeNull();
+
+        SpyMessagePublisher.PublishedMessage published = _messagePublisherSpy.Published
+            .ShouldHaveSingleItem();
+        published.MessageId.ShouldBe(message.Id);
+        published.RoutingKey.ShouldBe(RabbitMqTopology.EmailConfirmationRoutingKey);
+        published.Payload.ShouldBe(message.Payload);
+    }
+
+    [Fact]
+    public async Task Relay_ShouldMarkFailedAndRetainRow_WhenBrokerRefusesPublish()
+    {
+        // Arrange
+        _messagePublisherSpy.FailWith = new InvalidOperationException("broker down");
+        Guid messageId = await InsertOutboxRowAsync(nameof(EmailConfirmationRequested));
+
+        // Act
+        NotifyRelay();
+
+        // Assert — the row survives the refusal, carrying the failure diagnostics
+        OutboxMessage? failed = await WaitForOutboxRowAsync(
+            row => row.Id == messageId && row.Attempts > 0);
+
+        failed.ShouldNotBeNull();
+        failed.IsProcessed().ShouldBeFalse();
+        failed.LastError.ShouldBe("broker down");
+
+        // Act again — the broker heals and a fresh nudge retries the same row
+        _messagePublisherSpy.FailWith = null;
+        NotifyRelay();
+
+        OutboxMessage? recovered = await WaitForOutboxRowAsync(
+            row => row.Id == messageId && row.ProcessedOn != null);
+
+        recovered.ShouldNotBeNull();
+        recovered.IsProcessed().ShouldBeTrue();
+        _messagePublisherSpy.Published.ShouldContain(published => published.MessageId == messageId);
+    }
+
+    [Fact]
+    public async Task Relay_ShouldMarkFailedWithoutPublishing_WhenTypeHasNoRoutingKey()
+    {
+        // Arrange
+        Guid messageId = await InsertOutboxRowAsync("TypeNobodyMapped");
+
+        // Act
+        NotifyRelay();
+
+        // Assert
+        OutboxMessage? unroutable = await WaitForOutboxRowAsync(
+            row => row.Id == messageId && row.Attempts > 0);
+
+        unroutable.ShouldNotBeNull();
+        unroutable.IsProcessed().ShouldBeFalse();
+        unroutable.LastError.ShouldNotBeNull();
+        unroutable.LastError.ShouldContain("No routing key");
+        _messagePublisherSpy.Published.ShouldBeEmpty();
+    }
+
+    private void NotifyRelay()
+    {
+        Factory.Services.GetRequiredService<OutboxSignal>().Notify();
+    }
+
+    private async Task<Guid> InsertOutboxRowAsync(string type)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        OutboxMessage message = OutboxMessage.Create(
+            type: type,
+            payload: $$"""{"UserId":"{{Guid.CreateVersion7()}}"}""",
+            occurredOn: DateTimeOffset.UtcNow);
+
+        db.OutboxMessages.Add(message);
+        await db.SaveChangesAsync();
+
+        return message.Id;
+    }
+
+    /// <summary>
+    /// Polls the database until a row matches or <see cref="RelayReactionTimeout"/> elapses, then
+    /// returns the latest snapshot (or null) — the assertions on it stay in the test body.
+    /// </summary>
+    private async Task<OutboxMessage?> WaitForOutboxRowAsync(Func<OutboxMessage, bool> predicate)
+    {
+        using CancellationTokenSource timeout = new(RelayReactionTimeout);
+
+        while (true)
+        {
+            await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+            AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+            List<OutboxMessage> rows = await db.OutboxMessages.AsNoTracking().ToListAsync();
+            OutboxMessage? match = rows.FirstOrDefault(predicate);
+
+            if (match is not null || timeout.IsCancellationRequested)
+            {
+                return match;
+            }
+
+            await Task.Delay(100);
+        }
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterEndpointTests.cs
@@ -242,37 +242,8 @@ public sealed class RegisterEndpointTests : EndpointsTestBase
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
     }
 
-    [Fact]
-    public async Task Register_ShouldAutoConfirmEmail_WhenEmailSendingFails()
-    {
-        // Arrange
-        AccountConfirmationEmailSpy.Reset();
-        AccountConfirmationEmailSpy.ShouldFail = true;
-        RegisterRequest request = UserFactory.GenerateRandomRegisterRequest(Faker);
-
-        // Act
-        HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
-            new Uri("auth/register", UriKind.Relative), request);
-
-        // Assert - registration should still succeed
-        await response.EnsureSuccessWithDetailsAsync();
-        response.StatusCode.ShouldBe(HttpStatusCode.Created);
-
-        // Assert - user should be able to login without email confirmation
-        // (because auto-confirm fallback should have activated)
-        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
-        {
-            ["grant_type"] = "password",
-            ["username"] = request.Email,
-            ["password"] = request.Password,
-            ["client_id"] = "lotrokoniecdev-test",
-            ["scope"] = "email profile roles api offline_access"
-        });
-
-        HttpResponseMessage tokenResponse = await ApiClient.Http.PostAsync(
-            new Uri("connect/token", UriKind.Relative), tokenRequest);
-
-        await tokenResponse.EnsureSuccessWithDetailsAsync();
-        tokenResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
-    }
+    // The former Register_ShouldAutoConfirmEmail_WhenEmailSendingFails test died with the
+    // synchronous send: registration no longer touches SMTP, so there is no in-request failure
+    // to fall back from. A failed delivery now stays queued for redelivery, and the user-facing
+    // recovery is the resend-confirmation endpoint.
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
@@ -40,6 +40,7 @@ public sealed partial class RegisterPageTests : EndpointsTestBase
 
         string html = await response.Content.ReadAsStringAsync();
         html.ShouldContain("Konto zostało utworzone");
+        await AccountConfirmationEmailSpy.WaitForCaptureAsync();
         AccountConfirmationEmailSpy.LastEmail.ShouldBe(request.Email);
     }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Health/HealthEndpointsTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Health/HealthEndpointsTests.cs
@@ -11,7 +11,7 @@ public sealed class HealthEndpointsTests
     }
 
     [Fact]
-    public async Task GetHealth_WithoutToken_ShouldSurfaceDbAndSmtpChecks()
+    public async Task GetHealth_WithoutToken_ShouldSurfaceDbSmtpAndBrokerChecks()
     {
         // Arrange
         using HttpClient client = _factory.CreateClient();
@@ -20,11 +20,13 @@ public sealed class HealthEndpointsTests
         HttpResponseMessage response = await client.GetAsync("/health");
         string body = await response.Content.ReadAsStringAsync();
 
-        // Assert — Testing points SMTP at a dead port, so the full report is Unhealthy (503) by
-        // design; what this test pins is that the db + smtp checks stay reachable on demand here.
+        // Assert — Testing points SMTP and the broker at dead ports, so the full report is
+        // Unhealthy (503) by design; what this test pins is that the db + smtp + broker checks
+        // stay reachable on demand here.
         response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
         body.ShouldContain("authdb");
         body.ShouldContain("smtp");
+        body.ShouldContain("rabbitmq");
     }
 
     [Fact]
@@ -50,9 +52,11 @@ public sealed class HealthEndpointsTests
         HttpResponseMessage response = await client.GetAsync("/health/ready");
         string body = await response.Content.ReadAsStringAsync();
 
-        // Assert — ACA probes this path every few seconds; it must never touch Postgres (ADR-0025).
+        // Assert — ACA probes this path every few seconds; it must never touch Postgres (ADR-0025)
+        // nor the broker (a broker outage must not pull auth out of the ingress rotation).
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         body.ShouldContain("\"status\": \"Healthy\"");
         body.ShouldNotContain("authdb");
+        body.ShouldNotContain("rabbitmq");
     }
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/DeadLetterTopologyTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/DeadLetterTopologyTests.cs
@@ -95,12 +95,16 @@ public sealed class DeadLetterTopologyTests : IClassFixture<RabbitMqBrokerFixtur
         // basic.reject and a push consumer, mirroring production: only rejects (and connection
         // losses) increment the x-delivery-count the limit is measured against — a nack-requeue
         // or a BasicGet loop would spin forever without ever tripping it (RabbitMQ ≥ 4.3).
-        int deliveries = 0;
+        List<int> redeliveryCounts = [];
         await using IChannel consumerChannel = await _connection!.CreateChannelAsync();
         AsyncEventingBasicConsumer consumer = new(consumerChannel);
         consumer.ReceivedAsync += async (_, delivery) =>
         {
-            Interlocked.Increment(ref deliveries);
+            lock (redeliveryCounts)
+            {
+                redeliveryCounts.Add(RedeliveryCount.Read(delivery.BasicProperties.Headers));
+            }
+
             await consumerChannel.BasicRejectAsync(delivery.DeliveryTag, requeue: true);
         };
 
@@ -114,8 +118,17 @@ public sealed class DeadLetterTopologyTests : IClassFixture<RabbitMqBrokerFixtur
         BasicGetResult? dead = await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, DeliveryTimeout);
         await consumerChannel.BasicCancelAsync(consumerTag);
 
-        dead.ShouldNotBeNull($"after {Volatile.Read(ref deliveries)} deliveries nothing was dead-lettered");
-        Volatile.Read(ref deliveries).ShouldBe(RabbitMqTopology.EmailDeliveryLimit + 1);
+        int[] observed;
+        lock (redeliveryCounts)
+        {
+            observed = redeliveryCounts.ToArray();
+        }
+
+        dead.ShouldNotBeNull($"after {observed.Length} deliveries nothing was dead-lettered");
+        // The exact 0..limit sequence also pins RedeliveryCount.Read against the CLR type the
+        // real client hands over for x-delivery-count — if that bridge broke, every entry would
+        // read 0 and the consumer's exhaustion branch would never fire in production.
+        observed.ShouldBe(Enumerable.Range(0, RabbitMqTopology.EmailDeliveryLimit + 1).ToArray());
         dead.Body.ToArray().ShouldBe(body);
         FirstDeathReason(dead.BasicProperties).ShouldBe("delivery_limit");
     }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/DeadLetterTopologyTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/DeadLetterTopologyTests.cs
@@ -1,0 +1,196 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Text;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Messaging;
+
+/// <summary>
+/// Proves the safety-net semantics of <see cref="RabbitMqTopologyDeclaration"/> against a real
+/// broker: a rejected message parks in the DLQ instead of vanishing, a message that exhausts
+/// <see cref="RabbitMqTopology.EmailDeliveryLimit"/> parks instead of looping forever, and the
+/// declaration stays idempotent so publisher and consumer can keep racing to run it. These are
+/// broker guarantees, not application code — the assertions pin the queue arguments that buy
+/// them (ADR-0036).
+/// </summary>
+public sealed class DeadLetterTopologyTests : IClassFixture<RabbitMqBrokerFixture>, IAsyncLifetime
+{
+    private static readonly TimeSpan DeliveryTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan EmptyQueueGrace = TimeSpan.FromSeconds(2);
+
+    private readonly RabbitMqBrokerFixture _broker;
+    private IConnection? _connection;
+    private IChannel? _channel;
+
+    public DeadLetterTopologyTests(RabbitMqBrokerFixture broker)
+    {
+        _broker = broker;
+    }
+
+    private IChannel Channel => _channel ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public async Task InitializeAsync()
+    {
+        _connection = await _broker.ConnectAsync(CancellationToken.None);
+        _channel = await _connection.CreateChannelAsync();
+        await RabbitMqTopologyDeclaration.DeclareAsync(_channel, CancellationToken.None);
+        await _channel.QueuePurgeAsync(RabbitMqTopology.EmailQueue);
+        await _channel.QueuePurgeAsync(RabbitMqTopology.EmailDeadLetterQueue);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_channel is not null)
+        {
+            await _channel.DisposeAsync();
+        }
+
+        if (_connection is not null)
+        {
+            await _connection.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Declaration_ShouldStayIdempotent_WhenDeclaredAgainOnAnotherChannel()
+    {
+        // Act — the publisher and the consumer both declare on channel open; a drifted argument
+        // set would fail here with PRECONDITION_FAILED instead of being a no-op
+        await using IChannel secondChannel = await _connection!.CreateChannelAsync();
+        Task declareAgain = RabbitMqTopologyDeclaration.DeclareAsync(secondChannel, CancellationToken.None);
+
+        // Assert
+        await Should.NotThrowAsync(declareAgain);
+    }
+
+    [Fact]
+    public async Task Broker_ShouldParkMessageInDeadLetterQueue_WhenConsumerRejectsIt()
+    {
+        // Arrange
+        byte[] body = Encoding.UTF8.GetBytes("""{"poison":true}""");
+        await PublishAsync(body);
+        BasicGetResult delivery = (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, DeliveryTimeout)).ShouldNotBeNull();
+
+        // Act — the consumer's poison path: reject without requeue
+        await Channel.BasicRejectAsync(delivery.DeliveryTag, requeue: false);
+
+        // Assert — the message parked instead of vanishing, keeping its routing key for replay
+        BasicGetResult dead = (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, DeliveryTimeout)).ShouldNotBeNull();
+        dead.Body.ToArray().ShouldBe(body);
+        dead.RoutingKey.ShouldBe(RabbitMqTopology.EmailConfirmationRoutingKey);
+        FirstDeathReason(dead.BasicProperties).ShouldBe("rejected");
+    }
+
+    [Fact]
+    public async Task Broker_ShouldParkMessageInDeadLetterQueue_WhenDeliveryLimitIsExhausted()
+    {
+        // Arrange
+        byte[] body = Encoding.UTF8.GetBytes("""{"transient":true}""");
+        await PublishAsync(body);
+
+        // Act — the consumer's transient path taken to exhaustion: reject-requeue every delivery.
+        // basic.reject and a push consumer, mirroring production: only rejects (and connection
+        // losses) increment the x-delivery-count the limit is measured against — a nack-requeue
+        // or a BasicGet loop would spin forever without ever tripping it (RabbitMQ ≥ 4.3).
+        int deliveries = 0;
+        await using IChannel consumerChannel = await _connection!.CreateChannelAsync();
+        AsyncEventingBasicConsumer consumer = new(consumerChannel);
+        consumer.ReceivedAsync += async (_, delivery) =>
+        {
+            Interlocked.Increment(ref deliveries);
+            await consumerChannel.BasicRejectAsync(delivery.DeliveryTag, requeue: true);
+        };
+
+        await consumerChannel.BasicQosAsync(prefetchSize: 0, prefetchCount: 1, global: false);
+        string consumerTag = await consumerChannel.BasicConsumeAsync(
+            queue: RabbitMqTopology.EmailQueue,
+            autoAck: false,
+            consumer: consumer);
+
+        // Assert — 1 initial delivery + the allowed redeliveries, then the parking lot
+        BasicGetResult? dead = await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, DeliveryTimeout);
+        await consumerChannel.BasicCancelAsync(consumerTag);
+
+        dead.ShouldNotBeNull($"after {Volatile.Read(ref deliveries)} deliveries nothing was dead-lettered");
+        Volatile.Read(ref deliveries).ShouldBe(RabbitMqTopology.EmailDeliveryLimit + 1);
+        dead.Body.ToArray().ShouldBe(body);
+        FirstDeathReason(dead.BasicProperties).ShouldBe("delivery_limit");
+    }
+
+    [Fact]
+    public async Task Broker_ShouldLeaveDeadLetterQueueEmpty_WhenDeliveryIsAcked()
+    {
+        // Arrange
+        await PublishAsync(Encoding.UTF8.GetBytes("""{"happy":true}"""));
+        BasicGetResult delivery = (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, DeliveryTimeout)).ShouldNotBeNull();
+
+        // Act
+        await Channel.BasicAckAsync(delivery.DeliveryTag, multiple: false);
+
+        // Assert
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, EmptyQueueGrace)).ShouldBeNull();
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    private async Task PublishAsync(byte[] body)
+    {
+        BasicProperties properties = new()
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            DeliveryMode = DeliveryModes.Persistent
+        };
+
+        await Channel.BasicPublishAsync(
+            exchange: RabbitMqTopology.EmailsExchange,
+            routingKey: RabbitMqTopology.EmailConfirmationRoutingKey,
+            mandatory: true,
+            basicProperties: properties,
+            body: body);
+    }
+
+    /// <summary>
+    /// Polls the queue until a delivery arrives or the timeout passes: dead-lettering and
+    /// requeueing are asynchronous inside the broker, so a single immediate get would race them.
+    /// </summary>
+    private async Task<BasicGetResult?> GetWithinTimeoutAsync(string queue, TimeSpan timeout)
+    {
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        while (true)
+        {
+            BasicGetResult? delivery = await Channel.BasicGetAsync(queue, autoAck: false);
+            if (delivery is not null)
+            {
+                return delivery;
+            }
+
+            if (elapsed.Elapsed >= timeout)
+            {
+                return null;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    /// <summary>
+    /// Reads the reason of the first (most recent) <c>x-death</c> entry the broker stamped on a
+    /// dead-lettered message.
+    /// </summary>
+    private static string? FirstDeathReason(IReadOnlyBasicProperties properties)
+    {
+        if (properties.Headers is not { } headers
+            || !headers.TryGetValue("x-death", out object? deathsRaw)
+            || deathsRaw is not IList { Count: > 0 } deaths
+            || deaths[0] is not IDictionary firstDeath
+            || !firstDeath.Contains("reason"))
+        {
+            return null;
+        }
+
+        return firstDeath["reason"] is byte[] reason ? Encoding.UTF8.GetString(reason) : null;
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/RabbitMqMessagePublisherTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/RabbitMqMessagePublisherTests.cs
@@ -1,0 +1,145 @@
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Exceptions;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Messaging;
+
+/// <summary>
+/// Exercises the real <see cref="RabbitMqMessagePublisher"/> against a real broker — the only
+/// suite where its lazy connect, topology declaration, publisher confirmations, mandatory
+/// returns and channel rebuild actually run (everywhere else the factory swaps in
+/// <c>SpyMessagePublisher</c>, and <c>DeadLetterTopologyTests</c> drives raw channels).
+/// </summary>
+public sealed class RabbitMqMessagePublisherTests : IClassFixture<RabbitMqBrokerFixture>, IAsyncLifetime
+{
+    private static readonly TimeSpan DeliveryTimeout = TimeSpan.FromSeconds(10);
+
+    private const string Payload = """{"IdentityUserId":"a3a2cbb0-0000-0000-0000-000000000001"}""";
+
+    private readonly RabbitMqBrokerFixture _broker;
+    private RabbitMqMessagePublisher _publisher = null!;
+
+    public RabbitMqMessagePublisherTests(RabbitMqBrokerFixture broker)
+    {
+        _broker = broker;
+    }
+
+    public Task InitializeAsync()
+    {
+        _publisher = new RabbitMqMessagePublisher(
+            Microsoft.Extensions.Options.Options.Create(_broker.BuildOptions()),
+            TimeProvider.System,
+            NullLogger<RabbitMqMessagePublisher>.Instance);
+
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _publisher.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task PublishAsync_ShouldDeliverThePersistentMessage_WhenTheRoutingKeyIsBound()
+    {
+        // Arrange
+        Guid messageId = Guid.CreateVersion7();
+
+        // Act — first publish on a fresh instance also opens the connection and declares topology
+        await _publisher.PublishAsync(
+            RabbitMqTopology.EmailConfirmationRoutingKey, Payload, messageId, CancellationToken.None);
+
+        // Assert — the broker took responsibility and the queue holds the exact wire message
+        BasicGetResult delivery = (await GetFromEmailQueueAsync()).ShouldNotBeNull();
+        Encoding.UTF8.GetString(delivery.Body.ToArray()).ShouldBe(Payload);
+        delivery.BasicProperties.MessageId.ShouldBe(messageId.ToString());
+        delivery.BasicProperties.DeliveryMode.ShouldBe(DeliveryModes.Persistent);
+        delivery.BasicProperties.ContentType.ShouldBe("application/json");
+        delivery.BasicProperties.ContentEncoding.ShouldBe(Encoding.UTF8.WebName);
+    }
+
+    [Fact]
+    public async Task PublishAsync_ShouldSurfaceTheReturn_WhenNoQueueIsBoundToTheRoutingKey()
+    {
+        // Act — "billing.invoice" matches no binding (the queue binds email.#), and the publisher
+        // sends mandatory with confirmation tracking, so the basic.return must fault this very call
+        // instead of silently dropping the message
+        Task publish = _publisher.PublishAsync(
+            "billing.invoice", Payload, Guid.CreateVersion7(), CancellationToken.None);
+
+        // Assert
+        await Should.ThrowAsync<PublishException>(publish);
+    }
+
+    [Fact]
+    public async Task PublishAsync_ShouldRebuildAndDeliver_WhenTheBrokerDropsEveryConnection()
+    {
+        // Arrange — a first publish so the long-lived connection and channel exist to be killed
+        await _publisher.PublishAsync(
+            RabbitMqTopology.EmailConfirmationRoutingKey, Payload, Guid.CreateVersion7(), CancellationToken.None);
+        (await GetFromEmailQueueAsync()).ShouldNotBeNull();
+
+        await _broker.CloseAllConnectionsAsync();
+
+        // Act — the relay's behavior on a failed pass is retry-with-backoff, so eventual success
+        // is the contract; the first attempt may still race the client noticing the dead socket
+        Guid messageId = Guid.CreateVersion7();
+        await PublishWithRetryAsync(messageId);
+
+        // Assert
+        BasicGetResult delivery = (await GetFromEmailQueueAsync()).ShouldNotBeNull();
+        delivery.BasicProperties.MessageId.ShouldBe(messageId.ToString());
+    }
+
+    private async Task PublishWithRetryAsync(Guid messageId)
+    {
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        while (true)
+        {
+            try
+            {
+                await _publisher.PublishAsync(
+                    RabbitMqTopology.EmailConfirmationRoutingKey, Payload, messageId, CancellationToken.None);
+                return;
+            }
+            catch (Exception) when (elapsed.Elapsed < DeliveryTimeout)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads one delivery off the e-mail queue over a fresh connection (the publisher under test
+    /// owns its own), polling because routing inside the broker is asynchronous.
+    /// </summary>
+    private async Task<BasicGetResult?> GetFromEmailQueueAsync()
+    {
+        await using IConnection connection = await _broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        while (true)
+        {
+            BasicGetResult? delivery = await channel.BasicGetAsync(RabbitMqTopology.EmailQueue, autoAck: true);
+            if (delivery is not null)
+            {
+                return delivery;
+            }
+
+            if (elapsed.Elapsed >= DeliveryTimeout)
+            {
+                return null;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/RabbitMqOptionsValidatorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Settings/RabbitMqOptionsValidatorTests.cs
@@ -1,0 +1,110 @@
+using FluentValidation.Results;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Settings;
+
+/// <summary>
+/// Pure unit coverage for the AuthSystem broker startup guard. It lives in the integration project only
+/// because the AuthSystem has no API unit project; it instantiates no factory and starts no container.
+/// </summary>
+public sealed class RabbitMqOptionsValidatorTests
+{
+    private readonly RabbitMqOptionsValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithCompleteValidOptions_Passes()
+    {
+        RabbitMqOptions options = Options();
+
+        ValidationResult result = _validator.Validate(options);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WithMissingHost_FailsNamingTheKey(string? host)
+    {
+        RabbitMqOptions options = Options(host: host!);
+
+        ValidationResult result = _validator.Validate(options);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(RabbitMqOptions.Host));
+        result.Errors.ShouldContain(error =>
+            error.ErrorMessage.Contains("RabbitMq:Host", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65536)]
+    public void Validate_WithPortOutsideTheValidRange_Fails(int port)
+    {
+        RabbitMqOptions options = Options(port: port);
+
+        ValidationResult result = _validator.Validate(options);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(RabbitMqOptions.Port));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WithMissingUsername_Fails(string? username)
+    {
+        RabbitMqOptions options = Options(username: username!);
+
+        ValidationResult result = _validator.Validate(options);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(RabbitMqOptions.Username));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WithMissingPassword_Fails(string? password)
+    {
+        RabbitMqOptions options = Options(password: password!);
+
+        ValidationResult result = _validator.Validate(options);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(RabbitMqOptions.Password));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WithMissingVirtualHost_Fails(string? virtualHost)
+    {
+        RabbitMqOptions options = Options(virtualHost: virtualHost!);
+
+        ValidationResult result = _validator.Validate(options);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(error => error.PropertyName == nameof(RabbitMqOptions.VirtualHost));
+    }
+
+    private static RabbitMqOptions Options(
+        string host = "localhost",
+        int port = 5672,
+        string username = "rabbitmq",
+        string password = "changeme",
+        string virtualHost = "/") => new()
+    {
+        Host = host,
+        Port = port,
+        Username = username,
+        Password = password,
+        VirtualHost = virtualHost
+    };
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Inbox/InboxMessageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Inbox/InboxMessageTests.cs
@@ -1,0 +1,35 @@
+using LotroKoniecDev.AuthSystem.Persistence.Inbox;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Inbox;
+
+public sealed class InboxMessageTests
+{
+    [Fact]
+    public void Create_WithValidArguments_SetsMessageIdAndProcessedOn()
+    {
+        // Arrange
+        Guid messageId = Guid.CreateVersion7();
+        DateTimeOffset processedOn = new(2026, 8, 3, 12, 0, 0, TimeSpan.Zero);
+
+        // Act
+        InboxMessage message = InboxMessage.Create(messageId, processedOn);
+
+        // Assert
+        message.MessageId.ShouldBe(messageId);
+        message.ProcessedOn.ShouldBe(processedOn);
+    }
+
+    [Fact]
+    public void Create_WithEmptyMessageId_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            InboxMessage.Create(Guid.Empty, DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void Create_WithDefaultProcessedOn_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            InboxMessage.Create(Guid.CreateVersion7(), default));
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/EmailConfirmationConsumerTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/EmailConfirmationConsumerTests.cs
@@ -1,5 +1,6 @@
 using LotroKoniecDev.AuthSystem.API.BackgroundServices;
 using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using RabbitMQ.Client;
 
 namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Messaging;
 
@@ -7,7 +8,9 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Messaging;
 /// Pins the two invariants the redelivery backoff ladder promises only in prose (ADR-0036):
 /// the ladder and <see cref="RabbitMqTopology.EmailDeliveryLimit"/> move together, and no rung
 /// may hold a delivery unacked long enough for the broker to kill the channel. Without these,
-/// <c>Math.Min</c> in the consumer silently absorbs any drift.
+/// <c>Math.Min</c> in the consumer silently absorbs any drift. Also pins the poison decision for
+/// unusable message ids (ADR-0037): a delivery the inbox cannot deduplicate must be rejected,
+/// not processed blind.
 /// </summary>
 public sealed class EmailConfirmationConsumerTests
 {
@@ -26,5 +29,38 @@ public sealed class EmailConfirmationConsumerTests
         TimeSpan consumerTimeout = TimeSpan.FromMinutes(30);
 
         EmailConfirmationConsumer.RedeliveryBackoffs.ShouldAllBe(pause => pause < consumerTimeout);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-guid")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    public void TryReadMessageId_WithUnusableValue_ReturnsFalse(string? rawMessageId)
+    {
+        // Arrange — BasicProperties implements IReadOnlyBasicProperties
+        BasicProperties properties = new() { MessageId = rawMessageId };
+
+        // Act
+        bool usable = EmailConfirmationConsumer.TryReadMessageId(properties, out Guid _);
+
+        // Assert
+        usable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryReadMessageId_WithGuidValue_ReturnsTheParsedId()
+    {
+        // Arrange
+        Guid messageId = Guid.CreateVersion7();
+        BasicProperties properties = new() { MessageId = messageId.ToString() };
+
+        // Act
+        bool usable = EmailConfirmationConsumer.TryReadMessageId(properties, out Guid parsed);
+
+        // Assert
+        usable.ShouldBeTrue();
+        parsed.ShouldBe(messageId);
     }
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/EmailConfirmationConsumerTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/EmailConfirmationConsumerTests.cs
@@ -1,0 +1,30 @@
+using LotroKoniecDev.AuthSystem.API.BackgroundServices;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Messaging;
+
+/// <summary>
+/// Pins the two invariants the redelivery backoff ladder promises only in prose (ADR-0036):
+/// the ladder and <see cref="RabbitMqTopology.EmailDeliveryLimit"/> move together, and no rung
+/// may hold a delivery unacked long enough for the broker to kill the channel. Without these,
+/// <c>Math.Min</c> in the consumer silently absorbs any drift.
+/// </summary>
+public sealed class EmailConfirmationConsumerTests
+{
+    [Fact]
+    public void RedeliveryBackoffs_ComparedToDeliveryLimit_HasOneEntryPerAllowedRedelivery()
+    {
+        EmailConfirmationConsumer.RedeliveryBackoffs.Length.ShouldBe(RabbitMqTopology.EmailDeliveryLimit);
+    }
+
+    [Fact]
+    public void RedeliveryBackoffs_EveryPause_StaysUnderTheBrokerConsumerTimeout()
+    {
+        // The broker kills the channel when an ack takes longer than consumer_timeout (30 min
+        // RabbitMQ default; compose does not override it) — a rung at or past it would turn a
+        // pause into a channel loss that burns a redelivery instead of waiting one out.
+        TimeSpan consumerTimeout = TimeSpan.FromMinutes(30);
+
+        EmailConfirmationConsumer.RedeliveryBackoffs.ShouldAllBe(pause => pause < consumerTimeout);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/RedeliveryCountTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/RedeliveryCountTests.cs
@@ -1,0 +1,89 @@
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Messaging;
+
+public sealed class RedeliveryCountTests
+{
+    private const string DeliveryCountHeader = "x-delivery-count";
+
+    [Fact]
+    public void Read_NullHeaders_ReturnsZero()
+    {
+        int count = RedeliveryCount.Read(null);
+
+        count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Read_HeaderAbsent_ReturnsZero()
+    {
+        Dictionary<string, object?> headers = new()
+        {
+            ["some-other-header"] = 7L
+        };
+
+        int count = RedeliveryCount.Read(headers);
+
+        count.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(0L, 0)]
+    [InlineData(3L, 3)]
+    [InlineData(-1L, 0)]
+    [InlineData(long.MaxValue, int.MaxValue)]
+    public void Read_LongValue_ClampsIntoIntRange(long headerValue, int expected)
+    {
+        Dictionary<string, object?> headers = new()
+        {
+            [DeliveryCountHeader] = headerValue
+        };
+
+        int count = RedeliveryCount.Read(headers);
+
+        count.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(2, 2)]
+    [InlineData(-5, 0)]
+    public void Read_IntValue_ClampsNegativeToZero(int headerValue, int expected)
+    {
+        Dictionary<string, object?> headers = new()
+        {
+            [DeliveryCountHeader] = headerValue
+        };
+
+        int count = RedeliveryCount.Read(headers);
+
+        count.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Read_ByteValue_ReturnsValue()
+    {
+        Dictionary<string, object?> headers = new()
+        {
+            [DeliveryCountHeader] = (byte)4
+        };
+
+        int count = RedeliveryCount.Read(headers);
+
+        count.ShouldBe(4);
+    }
+
+    [Theory]
+    [InlineData("3")]
+    [InlineData(null)]
+    public void Read_UnreadableValue_ReturnsZero(object? headerValue)
+    {
+        Dictionary<string, object?> headers = new()
+        {
+            [DeliveryCountHeader] = headerValue
+        };
+
+        int count = RedeliveryCount.Read(headers);
+
+        count.ShouldBe(0);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxMessageRoutingTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxMessageRoutingTests.cs
@@ -1,0 +1,30 @@
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Outbox;
+
+public sealed class OutboxMessageRoutingTests
+{
+    [Fact]
+    public void TryGetRoutingKey_EmailConfirmationRequested_MapsToConfirmationRoutingKey()
+    {
+        bool found = OutboxMessageRouting.TryGetRoutingKey(
+            nameof(EmailConfirmationRequested), out string? routingKey);
+
+        found.ShouldBeTrue();
+        routingKey.ShouldBe(RabbitMqTopology.EmailConfirmationRoutingKey);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("emailconfirmationrequested")]
+    [InlineData("email.confirmation")]
+    [InlineData("SomeFutureUnmappedEvent")]
+    public void TryGetRoutingKey_UnknownOrMiscasedType_ReturnsFalse(string type)
+    {
+        bool found = OutboxMessageRouting.TryGetRoutingKey(type, out string? routingKey);
+
+        found.ShouldBeFalse();
+        routingKey.ShouldBeNull();
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxSignalTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxSignalTests.cs
@@ -1,0 +1,67 @@
+using LotroKoniecDev.AuthSystem.API.Outbox;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Outbox;
+
+public sealed class OutboxSignalTests
+{
+    [Fact]
+    public async Task WaitAsync_NotifiedBeforehand_ReturnsTrueImmediately()
+    {
+        using OutboxSignal signal = new();
+
+        signal.Notify();
+
+        bool woken = await signal.WaitAsync(TimeSpan.Zero, CancellationToken.None);
+        woken.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task WaitAsync_NotifiedWhileWaiting_ReturnsTrue()
+    {
+        using OutboxSignal signal = new();
+
+        Task<bool> waiting = signal.WaitAsync(TimeSpan.FromSeconds(5), CancellationToken.None);
+        signal.Notify();
+
+        bool woken = await waiting;
+        woken.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task WaitAsync_NoNotification_ReturnsFalseAfterTimeout()
+    {
+        using OutboxSignal signal = new();
+
+        bool woken = await signal.WaitAsync(TimeSpan.Zero, CancellationToken.None);
+
+        woken.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Notify_CalledRepeatedly_CoalescesIntoSingleWakeUp()
+    {
+        using OutboxSignal signal = new();
+
+        signal.Notify();
+        signal.Notify();
+        signal.Notify();
+
+        bool firstWait = await signal.WaitAsync(TimeSpan.Zero, CancellationToken.None);
+        bool secondWait = await signal.WaitAsync(TimeSpan.Zero, CancellationToken.None);
+
+        firstWait.ShouldBeTrue();
+        secondWait.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task WaitAsync_CancelledWhileWaiting_ThrowsOperationCanceled()
+    {
+        using OutboxSignal signal = new();
+        using CancellationTokenSource cts = new();
+
+        Task<bool> waiting = signal.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () => await waiting);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailConfirmationRequestProcessorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailConfirmationRequestProcessorTests.cs
@@ -1,0 +1,112 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+using NSubstitute;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Services.Emails;
+
+public class EmailConfirmationRequestProcessorTests
+{
+    private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
+    private readonly IAccountConfirmationEmailSender _emailSender =
+        Substitute.For<IAccountConfirmationEmailSender>();
+
+    [Fact]
+    public async Task ProcessAsync_UserNoLongerExists_SucceedsWithoutSending()
+    {
+        Guid userId = Guid.NewGuid();
+        _userManager.FindByIdAsync(userId.ToString()).Returns((ApplicationUser?)null);
+        EmailConfirmationRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new EmailConfirmationRequested(userId), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendEmailConfirmationAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UserAlreadyConfirmed_SucceedsWithoutSending()
+    {
+        ApplicationUser user = CreateUser(emailConfirmed: true);
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        EmailConfirmationRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new EmailConfirmationRequested(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendEmailConfirmationAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UserHasNoEmailAddress_SucceedsWithoutSending()
+    {
+        ApplicationUser user = CreateUser(emailConfirmed: false);
+        user.Email = null;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        EmailConfirmationRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new EmailConfirmationRequested(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendEmailConfirmationAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UnconfirmedUser_SendsTheEmailWithAFreshlyMintedToken()
+    {
+        ApplicationUser user = CreateUser(emailConfirmed: false);
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GenerateEmailConfirmationTokenAsync(user).Returns("fresh-token");
+        _emailSender.SendEmailConfirmationAsync(user.Id, user.Email!, "fresh-token", Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        EmailConfirmationRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new EmailConfirmationRequested(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.Received(1)
+            .SendEmailConfirmationAsync(user.Id, user.Email!, "fresh-token", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SendingFails_PropagatesTheFailure()
+    {
+        ApplicationUser user = CreateUser(emailConfirmed: false);
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GenerateEmailConfirmationTokenAsync(user).Returns("fresh-token");
+        Error smtpError = new("Email.SendFailed", "SMTP relay refused the message.");
+        _emailSender.SendEmailConfirmationAsync(user.Id, user.Email!, "fresh-token", Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(smtpError));
+        EmailConfirmationRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new EmailConfirmationRequested(user.Id), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(smtpError);
+    }
+
+    private static ApplicationUser CreateUser(bool emailConfirmed) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserName = "frodo",
+            Email = "frodo@shire.me",
+            EmailConfirmed = emailConfirmed
+        };
+
+    private EmailConfirmationRequestProcessor CreateSut() =>
+        new(_userManager, _emailSender, NullLogger<EmailConfirmationRequestProcessor>.Instance);
+
+    private static UserManager<ApplicationUser> CreateUserManager() =>
+        Substitute.For<UserManager<ApplicationUser>>(
+            Substitute.For<IUserStore<ApplicationUser>>(),
+            null!, null!, null!, null!, null!, null!, null!, null!);
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailConfirmationRequestProcessorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailConfirmationRequestProcessorTests.cs
@@ -10,7 +10,7 @@ using Shouldly;
 
 namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Services.Emails;
 
-public class EmailConfirmationRequestProcessorTests
+public sealed class EmailConfirmationRequestProcessorTests
 {
     private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
     private readonly IAccountConfirmationEmailSender _emailSender =

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/AuthActions.cs
@@ -11,7 +11,9 @@ namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
 /// </summary>
 internal static class AuthActions
 {
-    private const string ConfirmationSubject = "Potwierdzenie konta";
+    // Contains-match against the real subject ("Potwierdź konto — <brand>", #541) — brand-agnostic
+    // on purpose, so a rename does not break the flow again.
+    private const string ConfirmationSubject = "Potwierdź konto";
     private const string ConfirmationLinkPath = "/Account/ConfirmEmail";
     private static readonly TimeSpan MailTimeout = TimeSpan.FromSeconds(45);
     private static readonly LocatorWaitForOptions LongWait = new() { Timeout = 30_000 };
@@ -34,8 +36,18 @@ internal static class AuthActions
 
     public static async Task ConfirmEmailAsync(IPage page, PlaywrightStackFixture fixture, TestUser user)
     {
-        string link = await MailpitClient.WaitForLinkAsync(
-            fixture.MailpitBaseUrl, user.Email, ConfirmationSubject, ConfirmationLinkPath, MailTimeout);
+        string link;
+        try
+        {
+            link = await MailpitClient.WaitForLinkAsync(
+                fixture.MailpitBaseUrl, user.Email, ConfirmationSubject, ConfirmationLinkPath, MailTimeout);
+        }
+        catch (TimeoutException ex)
+        {
+            // The e-mail rides outbox -> broker -> consumer -> Mailpit; only the auth-api logs
+            // say which leg failed, and the containers are gone by the time a human looks.
+            throw new TimeoutException($"{ex.Message}\n{await fixture.GetAuthApiLogsAsync()}", ex);
+        }
 
         await page.GotoAsync(link);
         await page.GetByTestId(TestIds.ConfirmEmailSuccess).WaitForAsync(LongWait);

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
@@ -386,6 +386,15 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
         }
     }
 
+    /// <summary>
+    /// auth-api container logs — the only visibility into the outbox relay and the broker
+    /// consumer when an e-mail fails to reach Mailpit (mirrors the TMS E2E fixture's helper).
+    /// </summary>
+    public async Task<string> GetAuthApiLogsAsync()
+    {
+        return await TryGetLogsAsync(_authApi);
+    }
+
     private static async Task<string> TryGetLogsAsync(IContainer container)
     {
         try

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
@@ -12,9 +12,9 @@ using Testcontainers.PostgreSql;
 namespace LotroKoniecDev.Frontend.E2E.Tests.Infrastructure;
 
 /// <summary>
-/// Boots the whole browser-facing stack — Postgres + the one-shot migrator + auth-api + tms-api +
-/// the Blazor SSR Frontend + Mailpit + a headless Chromium — as real containers on one private
-/// network, then connects Playwright to the in-network browser over WebSocket. (The browser
+/// Boots the whole browser-facing stack — Postgres + the one-shot migrator + RabbitMQ + auth-api +
+/// tms-api + the Blazor SSR Frontend + Mailpit + a headless Chromium — as real containers on one
+/// private network, then connects Playwright to the in-network browser over WebSocket. (The browser
 /// container is built by hand rather than via the <c>Testcontainers.Playwright</c> module — see
 /// <see cref="StartBrowserAsync"/> for why that module is unusable with current Playwright images.)
 /// Every service has a DNS alias, so
@@ -32,6 +32,14 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
     private const string FrontendImage = "lotrokoniecdev-frontend:fe-e2e";
     private const string MigratorImage = "lotrokoniecdev-migrator:fe-e2e";
     private const string MailpitImage = "axllent/mailpit:latest";
+
+    /// <summary>
+    /// Pinned in lockstep with the compose stacks and the integration suite's
+    /// RabbitMqBrokerFixture — the confirmation e-mail rides the outbox → broker → consumer
+    /// pipeline, so without a broker in this network Mailpit would never receive the link the
+    /// register flow waits for.
+    /// </summary>
+    private const string RabbitMqImage = "rabbitmq:4.3.4-alpine";
 
     private const int PlaywrightPort = 8080;
 
@@ -77,6 +85,11 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
     private const string AdminEmail = "fe-e2e-admin@lotro-translator.pl";
     private const string AdminPassword = "FeE2eAdminPass123!";
 
+    // The image's built-in guest account only connects from the broker's own host, so the
+    // in-network auth-api needs an explicit user — same reasoning as the compose stacks.
+    private const string RabbitMqUsername = "rabbitmq";
+    private const string RabbitMqPassword = "fe-e2e-rabbitmq-password";
+
     private string _certPem = null!;
     private string _keyPem = null!;
 
@@ -84,6 +97,7 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
     private PostgreSqlContainer _postgres = null!;
     private IContainer _migrator = null!;
     private IContainer _mailpit = null!;
+    private IContainer _rabbitMq = null!;
     private IContainer _authApi = null!;
     private IContainer _tmsApi = null!;
     private IContainer _frontend = null!;
@@ -116,6 +130,7 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
 
         await StartPostgresAsync();
         await StartMailpitAsync();
+        await StartRabbitMqAsync();
         await RunMigratorAsync();
         await StartAuthApiAsync();
         await StartTmsApiAsync();
@@ -149,6 +164,22 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
                 .UntilHttpRequestIsSucceeded(request => request.ForPath("/").ForPort(MailpitHttpPort)))
             .Build();
         await _mailpit.StartAsync();
+    }
+
+    private async Task StartRabbitMqAsync()
+    {
+        _rabbitMq = new ContainerBuilder(RabbitMqImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases("rabbitmq")
+            .WithEnvironment("RABBITMQ_DEFAULT_USER", RabbitMqUsername)
+            .WithEnvironment("RABBITMQ_DEFAULT_PASS", RabbitMqPassword)
+            // Log-based readiness rather than an exec probe: exec'ing into a container that is
+            // still starting throws out of the wait strategy under Docker load, failing the whole
+            // fixture. The auth-api consumer retries with backoff anyway, so "started" is enough.
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilMessageIsLogged("Server startup complete"))
+            .Build();
+        await _rabbitMq.StartAsync();
     }
 
     private async Task RunMigratorAsync()
@@ -198,11 +229,11 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
             .WithEnvironment("Email__Host", "mailpit")
             .WithEnvironment("Email__Port", MailpitSmtpPort.ToString(CultureInfo.InvariantCulture))
             .WithEnvironment("Email__Mode", "None")
-            // No broker in this network — the values only have to satisfy the unconditional
-            // RabbitMqOptionsValidator at startup.
-            .WithEnvironment("RabbitMq__Host", "localhost")
-            .WithEnvironment("RabbitMq__Username", "rabbitmq")
-            .WithEnvironment("RabbitMq__Password", "changeme")
+            // The confirmation e-mail travels outbox -> broker -> consumer -> Mailpit, so the
+            // register flow's link genuinely rides the whole pipeline this suite exists to prove.
+            .WithEnvironment("RabbitMq__Host", "rabbitmq")
+            .WithEnvironment("RabbitMq__Username", RabbitMqUsername)
+            .WithEnvironment("RabbitMq__Password", RabbitMqPassword)
             .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Path", "/certs/e2e.crt")
             .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__KeyPath", "/certs/e2e.key")
             .WithResourceMapping(Encoding.ASCII.GetBytes(_certPem), "/certs/e2e.crt")
@@ -465,6 +496,11 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
         if (_authApi is not null)
         {
             await _authApi.DisposeAsync();
+        }
+
+        if (_rabbitMq is not null)
+        {
+            await _rabbitMq.DisposeAsync();
         }
 
         if (_mailpit is not null)

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Infrastructure/PlaywrightStackFixture.cs
@@ -198,6 +198,11 @@ public sealed class PlaywrightStackFixture : IAsyncLifetime
             .WithEnvironment("Email__Host", "mailpit")
             .WithEnvironment("Email__Port", MailpitSmtpPort.ToString(CultureInfo.InvariantCulture))
             .WithEnvironment("Email__Mode", "None")
+            // No broker in this network — the values only have to satisfy the unconditional
+            // RabbitMqOptionsValidator at startup.
+            .WithEnvironment("RabbitMq__Host", "localhost")
+            .WithEnvironment("RabbitMq__Username", "rabbitmq")
+            .WithEnvironment("RabbitMq__Password", "changeme")
             .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Path", "/certs/e2e.crt")
             .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__KeyPath", "/certs/e2e.key")
             .WithResourceMapping(Encoding.ASCII.GetBytes(_certPem), "/certs/e2e.crt")

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestBase.cs
@@ -47,7 +47,11 @@ public abstract class E2ETestBase : IAsyncLifetime
         return token.AccessToken;
     }
 
-    /// <summary>Registers a fresh user (granted the Translator role, email auto-confirmed) and logs it in.</summary>
+    /// <summary>
+    /// Registers a fresh user (granted the Translator role), confirms its e-mail through the
+    /// fixture's database seam (this network has no broker, so the confirmation e-mail never
+    /// arrives) and logs it in.
+    /// </summary>
     protected async Task<RegisteredTranslator> RegisterAndLoginTranslatorAsync()
     {
         string username = $"translator{Faker.Random.AlphaNumeric(10)}";
@@ -62,6 +66,7 @@ public abstract class E2ETestBase : IAsyncLifetime
             AcceptedTermsOfService: true);
 
         IdentityId identityId = await AuthApi.RegisterAsync(request);
+        await Fixture.ConfirmUserEmailAsync(email);
         TokenResponse token = await AuthApi.LoginAsync(email, TranslatorPassword);
         return new RegisteredTranslator(identityId, username, email, token.AccessToken);
     }

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
@@ -168,6 +168,11 @@ public sealed class E2ETestFixture : IAsyncLifetime
             .WithEnvironment("Email__Sender", "lotro-translator.pl")
             .WithEnvironment("Email__Host", "localhost")
             .WithEnvironment("Email__Port", "2525")
+            // No broker in this network either — the values only have to satisfy the unconditional
+            // RabbitMqOptionsValidator at startup.
+            .WithEnvironment("RabbitMq__Host", "localhost")
+            .WithEnvironment("RabbitMq__Username", "rabbitmq")
+            .WithEnvironment("RabbitMq__Password", "changeme")
             .WithWaitStrategy(Wait.ForUnixContainer()
                 .UntilHttpRequestIsSucceeded(request => request.ForPath("/health/live").ForPort(8080)))
             .Build();

--- a/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.E2E.Tests/E2ETestFixture.cs
@@ -105,6 +105,29 @@ public sealed class E2ETestFixture : IAsyncLifetime
         }
     }
 
+    /// <summary>
+    /// Confirms a freshly-registered user's e-mail directly in the auth database. Since the
+    /// confirmation e-mail became an outbox message riding the broker, this network (no broker,
+    /// no mailpit) can never deliver it — and <c>RequireConfirmedEmail</c> blocks the password
+    /// grant until the address is confirmed. The genuine register → e-mail link → confirm journey
+    /// is the Frontend browser suite's concern; this suite's concern is real tokens against the
+    /// TMS loop, so it shortcuts the delivery leg the same way it resets data: through psql.
+    /// </summary>
+    public async Task ConfirmUserEmailAsync(string email)
+    {
+        ExecResult result = await _postgres.ExecAsync(
+        [
+            "psql", "-v", "ON_ERROR_STOP=1", "-U", PostgresUser, "-d", AuthDatabaseName,
+            "-c", $"UPDATE authsystem.\"Users\" SET \"EmailConfirmed\" = TRUE WHERE \"Email\" = '{email}';"
+        ]);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Failed to confirm user e-mail (exit code {result.ExitCode}).\nStdout:\n{result.Stdout}\nStderr:\n{result.Stderr}");
+        }
+    }
+
     public async Task<string> GetAuthApiLogsAsync()
     {
         (string? stdout, string? stderr) = await _authApi.GetLogsAsync();
@@ -160,10 +183,11 @@ public sealed class E2ETestFixture : IAsyncLifetime
             .WithEnvironment("AdminUser__Username", AdminUsername)
             .WithEnvironment("AdminUser__Email", AdminEmail)
             .WithEnvironment("AdminUser__Password", AdminPassword)
-            // No mailpit in this network: the confirmation-email send fails fast and registration auto-confirms,
-            // so a freshly-registered translator can log in without the email round-trip. The sender identity is
-            // no longer baked into base appsettings.json (M6-06), so it is injected here too — otherwise the
-            // unconditional EmailOptionsValidator would abort auth-api startup.
+            // No mailpit in this network: the confirmation e-mail (an outbox message since the broker
+            // landed) never gets delivered, so tests confirm accounts through ConfirmUserEmailAsync
+            // instead of an e-mail round-trip. The sender identity is no longer baked into base
+            // appsettings.json (M6-06), so it is injected here too — otherwise the unconditional
+            // EmailOptionsValidator would abort auth-api startup.
             .WithEnvironment("Email__SenderEmail", "noreply@lotro-translator.pl")
             .WithEnvironment("Email__Sender", "lotro-translator.pl")
             .WithEnvironment("Email__Host", "localhost")


### PR DESCRIPTION
## What this delivers

The confirmation e-mail now flows through a broker instead of being sent inline during registration:

- **Transactional outbox** (ADR-0035): registration commits an outbox row; a signal-driven relay (no polling — Neon-friendly) publishes it with publisher confirms over one long-lived channel.
- **Broker consumer**: a background service consumes `emails.send` (quorum queue, prefetch 1, manual acks) and sends the e-mail.
- **Broker-enforced dead-lettering** (ADR-0036): poison messages are parked immediately; transient failures retry behind an escalating backoff ladder until the broker-side delivery limit parks them in `emails.send.dlq`. Proven against a real broker in the integration suite.
- **Inbox deduplication** (ADR-0037): deliveries are deduplicated on the broker message id, so at-least-once never means two e-mails.

## Production readiness (this PR's final leg)

The application code was already resilient (lazy connect, automatic recovery, boots with the broker down), but no deployed stack ran a broker — and `RabbitMq` options validate fail-fast at startup, so merging without the deployment wiring would have taken auth-api down on both boxes. Now:

- `compose.hetzner.yaml` + `compose.prod.yaml` run the same pinned broker as dev/tests, feed auth-api its `RabbitMq__*` settings, pin the `hostname` (RabbitMQ keys on-disk state by node name — an unpinned recreation orphans the quorum queues), persist to a named volume, and expose the management UI on the box loopback only.
- A missing `RABBITMQ_PASSWORD` fails loudly (`:?` interpolation) inside `deploy.sh`'s config-validation step — the old release keeps serving.
- New `rabbitmq` check on auth's deep `/health` (untagged, mirroring the SMTP check) so the daily health ping sees a dead broker container.
- Runbook: env matrix + secrets rows, and a "Message broker" section with the DLQ replay ritual (ack-and-republish, never reject-requeue) and the rotation trap (`RABBITMQ_DEFAULT_PASS` is first-boot-only).

## ⚠️ Before merging

Append `RABBITMQ_PASSWORD` (`openssl rand -base64 24`) to `/opt/lotro/.env` on **both** boxes (staging + prod). Skipping it aborts the deploy loudly, but do it first anyway.

## Tests

- Full solution builds with zero warnings.
- Auth unit suite: 108 passed. Auth integration suite (real PostgreSQL + real broker for the topology tests): 308 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDoofeCnS5uZZmBHNyyy98