### PR TITLE
Messaging edge tests: prove the e-mail pipeline against a real broker

### DIFF
--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -205,7 +205,7 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
         await deliveryProcessor.ProcessOnceAsync(payload, message.MessageId, CancellationToken.None);
     }
 
-    public async Task InitializeAsync()
+    public virtual async Task InitializeAsync()
     {
         await _postgresContainer.StartAsync();
         _connectionString = _postgresContainer.GetConnectionString();
@@ -221,7 +221,7 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
         await DatabaseSeederExtensions.SeedAuthDatabaseAsync(Services, environment);
     }
 
-    public new async Task DisposeAsync()
+    public new virtual async Task DisposeAsync()
     {
         await _postgresContainer.DisposeAsync();
     }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/BrokeredAuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/BrokeredAuthSystemApiFactory.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.BackgroundServices;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+
+/// <summary>
+/// The brokered twin of <see cref="AuthSystemApiFactory"/>: the base host swaps the publisher for
+/// a spy and removes the consumer (no broker in that suite), and this factory undoes exactly that
+/// against a real broker container — the real <see cref="RabbitMqMessagePublisher"/> returns, the
+/// real <see cref="EmailConfirmationConsumer"/> is put back, and the RabbitMq configuration points
+/// at the container. The SMTP seam stays spied, so tests still observe delivered e-mails without
+/// sending any. This is the only host where the full outbox → relay → broker → consumer pipeline
+/// exists in one process.
+/// </summary>
+public sealed class BrokeredAuthSystemApiFactory : AuthSystemApiFactory
+{
+    public RabbitMqBrokerFixture Broker { get; } = new();
+
+    /// <summary>
+    /// The broker container's coordinates, available once <see cref="InitializeAsync"/> started it
+    /// — tests use them to open raw assertion channels next to the host's own clients.
+    /// </summary>
+    public RabbitMqOptions BrokerOptions
+    {
+        get
+        {
+            return field ?? throw new InvalidOperationException("The broker container has not been started yet.");
+        }
+        private set;
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureAppConfiguration((_, configBuilder) =>
+        {
+            // Registered after the base's dead-port collection, so these keys win the merge.
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "RabbitMq:Host", BrokerOptions.Host },
+                { "RabbitMq:Port", BrokerOptions.Port.ToString(CultureInfo.InvariantCulture) },
+                { "RabbitMq:Username", BrokerOptions.Username },
+                { "RabbitMq:Password", BrokerOptions.Password },
+                { "RabbitMq:VirtualHost", BrokerOptions.VirtualHost }
+            });
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            ServiceDescriptor? spyPublisher = services
+                .FirstOrDefault(d => d.ServiceType == typeof(IMessagePublisher));
+            if (spyPublisher is not null)
+            {
+                services.Remove(spyPublisher);
+            }
+
+            services.AddSingleton<IMessagePublisher, RabbitMqMessagePublisher>();
+            services.AddHostedService<EmailConfirmationConsumer>();
+        });
+    }
+
+    public override async Task InitializeAsync()
+    {
+        // The broker must be up before the base touches Services: building the host runs the
+        // configuration callback above, which needs the container's mapped port.
+        await Broker.InitializeAsync();
+        BrokerOptions = Broker.BuildOptions();
+        await base.InitializeAsync();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await base.DisposeAsync();
+        await Broker.DisposeAsync();
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/CleanerService.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/CleanerService.cs
@@ -20,6 +20,9 @@ internal sealed class CleanerService
 
         // PostgreSQL preserves the casing of identifiers EF Core emits, so we have to quote them.
         // TRUNCATE ... CASCADE is faster than DELETE and handles FK chains in one statement.
+        // Outbox and inbox carry no FK to Users, so they must be listed explicitly — otherwise an
+        // unprocessed row left by one test (e.g. an unroutable type) keeps failing every relay
+        // pass of every later test in the collection.
         await db.Database.ExecuteSqlRawAsync("""
                                              TRUNCATE TABLE
                                                  authsystem."UserRoles",
@@ -28,7 +31,9 @@ internal sealed class CleanerService
                                                  authsystem."UserTokens",
                                                  authsystem."OpenIddictTokens",
                                                  authsystem."OpenIddictAuthorizations",
-                                                 authsystem."Users"
+                                                 authsystem."Users",
+                                                 authsystem."OutboxMessages",
+                                                 authsystem."InboxMessages"
                                              RESTART IDENTITY CASCADE;
                                              """);
     }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/OutboxRelayTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/OutboxRelayTests.cs
@@ -90,6 +90,35 @@ public sealed class OutboxRelayTests : EndpointsTestBase
     }
 
     [Fact]
+    public async Task Registration_ShouldCommitNoOutboxRow_WhenRegistrationFails()
+    {
+        // Arrange — a taken e-mail address makes the second registration fail inside the same
+        // transaction that would have written its outbox row
+        (RegisterRequest existingRequest, _) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        RegisterRequest duplicateRequest = new(
+            Faker.Random.AlphaNumeric(16),
+            existingRequest.Email,
+            "TestPass1!",
+            AcceptedPrivacyPolicy: true,
+            AcceptedDataProcessingConsent: true,
+            AcceptedTermsOfService: true);
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/register", UriKind.Relative), duplicateRequest);
+
+        // Assert — the failure rolled back atomically: only the first registration's row exists,
+        // so the pipeline can never send a confirmation e-mail for an account that was not created
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        (await db.OutboxMessages.AsNoTracking().CountAsync()).ShouldBe(1);
+    }
+
+    [Fact]
     public async Task Relay_ShouldMarkFailedWithoutPublishing_WhenTypeHasNoRoutingKey()
     {
         // Arrange

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/EmailConfirmationPipelineTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/EmailConfirmationPipelineTests.cs
@@ -1,0 +1,378 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using RabbitMQ.Client;
+using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Messaging;
+
+/// <summary>
+/// The only suite where the confirmation-e-mail pipeline runs end-to-end with nothing faked
+/// between the database and the SMTP seam: registration commits an outbox row, the real relay
+/// publishes it through the real <see cref="RabbitMqMessagePublisher"/> to a real broker, and the
+/// real <c>EmailConfirmationConsumer</c> consumes, deduplicates and dispatches to the spy e-mail
+/// sender. Everywhere else the broker hop is bridged in-process (<see cref="SpyMessagePublisher"/>),
+/// so the consumer's ack/reject decisions never actually meet broker semantics — here they do.
+/// </summary>
+/// <remarks>
+/// The consumer's transient-failure ladder is deliberately not driven at this level: its first
+/// rung pauses 30 s before the reject, and each piece is already pinned separately — the ladder's
+/// invariants in <c>EmailConfirmationConsumerTests</c>, the failed-processing inbox contract in
+/// <c>InboxDeduplicationTests</c>, and the delivery-limit parking in
+/// <c>DeadLetterTopologyTests</c>.
+/// </remarks>
+public sealed class EmailConfirmationPipelineTests : IClassFixture<BrokeredAuthSystemApiFactory>, IAsyncLifetime
+{
+    private static readonly TimeSpan DeliveryTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan EmptyQueueGrace = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan RecoveryTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly BrokeredAuthSystemApiFactory _factory;
+    private readonly TestApiClient _apiClient;
+    private readonly SpyAccountConfirmationEmailSender _confirmationEmailSpy;
+    private readonly Bogus.Faker _faker = new();
+
+    public EmailConfirmationPipelineTests(BrokeredAuthSystemApiFactory factory)
+    {
+        _factory = factory;
+        _confirmationEmailSpy = factory.Services.GetRequiredService<SpyAccountConfirmationEmailSender>();
+
+        JsonSerializerOptions jsonSerializerOptions =
+            factory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+        _apiClient = new TestApiClient(factory.CreateClient(), jsonSerializerOptions);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _confirmationEmailSpy.Reset();
+
+        await using AsyncServiceScope scope = _factory.Services.CreateAsyncScope();
+        CleanerService cleaner = scope.ServiceProvider.GetRequiredService<CleanerService>();
+        await cleaner.CleanAsync();
+
+        // The host's consumer declares the topology on startup, but the first test may reach this
+        // point before that attach finished — declaring here is idempotent (proven in
+        // DeadLetterTopologyTests) and guarantees the purges below have queues to purge.
+        await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+        await RabbitMqTopologyDeclaration.DeclareAsync(channel, CancellationToken.None);
+        await channel.QueuePurgeAsync(RabbitMqTopology.EmailQueue);
+        await channel.QueuePurgeAsync(RabbitMqTopology.EmailDeadLetterQueue);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Pipeline_ShouldDeliverExactlyOneConfirmationEmail_WhenRegistrationCommits()
+    {
+        // Act — registration is the only user-facing trigger of the whole pipeline
+        (RegisterRequest request, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            _apiClient, _faker, _confirmationEmailSpy);
+        await _confirmationEmailSpy.WaitForCaptureAsync(DeliveryTimeout);
+
+        // Assert — the e-mail went out once, to the registered address, with a usable token
+        _confirmationEmailSpy.LastEmail.ShouldBe(request.Email);
+        _confirmationEmailSpy.LastConfirmationToken.ShouldNotBeNullOrWhiteSpace();
+        _confirmationEmailSpy.CallCount.ShouldBe(1);
+
+        // The outbox row was published and marked on the first attempt
+        OutboxMessage? outboxRow = await WaitForOutboxRowAsync(
+            row => row.Payload.Contains(identityId.Value.ToString(), StringComparison.OrdinalIgnoreCase)
+                   && row.ProcessedOn != null);
+        outboxRow.ShouldNotBeNull();
+        outboxRow.Attempts.ShouldBe(0);
+        outboxRow.LastError.ShouldBeNull();
+
+        // The delivery was recorded for deduplication and nothing was left on the broker
+        (await CountInboxRowsAsync(outboxRow.Id)).ShouldBe(1);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, EmptyQueueGrace)).ShouldBeNull();
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Consumer_ShouldAckWithoutSecondEmail_WhenTheSameMessageIdIsDeliveredAgain()
+    {
+        // Arrange — a fully delivered registration, then its exact wire message published again
+        // (the relay's crash window: published but not yet marked processed → re-published later)
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            _apiClient, _faker, _confirmationEmailSpy);
+        await _confirmationEmailSpy.WaitForCaptureAsync(DeliveryTimeout);
+        OutboxMessage? outboxRow = await WaitForOutboxRowAsync(
+            row => row.Payload.Contains(identityId.Value.ToString(), StringComparison.OrdinalIgnoreCase)
+                   && row.ProcessedOn != null);
+        outboxRow.ShouldNotBeNull();
+        int sendsAfterFirstDelivery = _confirmationEmailSpy.CallCount;
+
+        // Act — same payload, same message id, over the real wire
+        IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(
+            RabbitMqTopology.EmailConfirmationRoutingKey, outboxRow.Payload, outboxRow.Id, CancellationToken.None);
+
+        // Assert — the duplicate is consumed (queue drains), acked (no parking) and suppressed
+        await WaitUntilQueueEmptyAsync(RabbitMqTopology.EmailQueue, DeliveryTimeout);
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        _confirmationEmailSpy.CallCount.ShouldBe(sendsAfterFirstDelivery);
+        (await CountInboxRowsAsync(outboxRow.Id)).ShouldBe(1);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("this is not json at all")]
+    [InlineData("{}")]
+    [InlineData("""{"IdentityUserId":"not-a-guid"}""")]
+    public async Task Consumer_ShouldParkDeliveryInDeadLetterQueue_WhenThePayloadIsPoison(string poisonPayload)
+    {
+        // Act — a valid message id, so the reject decision can only come from the payload
+        Guid messageId = Guid.CreateVersion7();
+        IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(
+            RabbitMqTopology.EmailConfirmationRoutingKey, poisonPayload, messageId, CancellationToken.None);
+
+        // Assert — parked on first sight, no e-mail, no dedup record
+        BasicGetResult dead =
+            (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, DeliveryTimeout)).ShouldNotBeNull();
+        Encoding.UTF8.GetString(dead.Body.ToArray()).ShouldBe(poisonPayload);
+        FirstDeathReason(dead.BasicProperties).ShouldBe("rejected");
+        _confirmationEmailSpy.CallCount.ShouldBe(0);
+        (await CountInboxRowsAsync(messageId)).ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("not-a-guid")]
+    public async Task Consumer_ShouldParkDeliveryInDeadLetterQueue_WhenTheMessageIdIsUnusable(string? rawMessageId)
+    {
+        // Arrange — a real unconfirmed user, so a processed delivery WOULD send an e-mail: the
+        // only thing broken about this message is the id the inbox would deduplicate on
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            _apiClient, _faker, _confirmationEmailSpy);
+        await _confirmationEmailSpy.WaitForCaptureAsync(DeliveryTimeout);
+        _confirmationEmailSpy.Reset();
+        string validPayload = JsonSerializer.Serialize(new EmailConfirmationRequested(identityId.Value));
+
+        // Act — raw publish: the real publisher always stamps a valid id, the wire does not
+        await PublishRawAsync(validPayload, rawMessageId);
+
+        // Assert — parked instead of processed blind, and no e-mail went out
+        BasicGetResult dead =
+            (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, DeliveryTimeout)).ShouldNotBeNull();
+        Encoding.UTF8.GetString(dead.Body.ToArray()).ShouldBe(validPayload);
+        FirstDeathReason(dead.BasicProperties).ShouldBe("rejected");
+        _confirmationEmailSpy.CallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Consumer_ShouldAckWithoutEmailAndWithoutParking_WhenTheUserNoLongerExists()
+    {
+        // Act — a payload whose user id matches no account (registered, then vanished): redelivery
+        // could never change the outcome, so the ack-and-record contract applies, not the DLQ
+        Guid messageId = Guid.CreateVersion7();
+        string payload = JsonSerializer.Serialize(new EmailConfirmationRequested(Guid.CreateVersion7()));
+        IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(
+            RabbitMqTopology.EmailConfirmationRoutingKey, payload, messageId, CancellationToken.None);
+
+        // Assert — the inbox record doubles as the "consumer finished" signal
+        int inboxRows = await WaitForInboxRowsAsync(messageId, DeliveryTimeout);
+        inboxRows.ShouldBe(1);
+        _confirmationEmailSpy.CallCount.ShouldBe(0);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, EmptyQueueGrace)).ShouldBeNull();
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Pipeline_ShouldRecoverAndDeliver_WhenTheBrokerDropsEveryConnection()
+    {
+        // Arrange — a warm pipeline (consumer attached, publisher connected), then the broker
+        // kills every client connection: the deploy/restart scenario both sides must survive
+        await UserFactory.RegisterRandomUserUnconfirmedAsync(_apiClient, _faker, _confirmationEmailSpy);
+        await _confirmationEmailSpy.WaitForCaptureAsync(DeliveryTimeout);
+        await _factory.Broker.CloseAllConnectionsAsync();
+
+        // Act — a registration right after the cut; its own nudge may race the dead connection
+        (RegisterRequest secondRequest, IdentityId secondIdentityId) =
+            await UserFactory.RegisterRandomUserUnconfirmedAsync(_apiClient, _faker, _confirmationEmailSpy);
+
+        // A spent nudge would leave the relay in its retry backoff (30 s first rung); production
+        // gets re-nudged by every later commit, so the wait re-nudges instead of paying that rung
+        // — what this test pins is recovery, the retry cadence is OutboxRelayTests' subject.
+        OutboxSignal outboxSignal = _factory.Services.GetRequiredService<OutboxSignal>();
+        using CancellationTokenSource recoveryWindow = new(RecoveryTimeout);
+        while (_confirmationEmailSpy.LastEmail is null && !recoveryWindow.IsCancellationRequested)
+        {
+            outboxSignal.Notify();
+            await Task.Delay(500);
+        }
+
+        // Assert — the second e-mail arrived through rebuilt connections, exactly once
+        _confirmationEmailSpy.LastEmail.ShouldBe(secondRequest.Email);
+        _confirmationEmailSpy.CallCount.ShouldBe(1);
+
+        OutboxMessage? recoveredRow = await WaitForOutboxRowAsync(
+            row => row.Payload.Contains(secondIdentityId.Value.ToString(), StringComparison.OrdinalIgnoreCase)
+                   && row.ProcessedOn != null);
+        recoveredRow.ShouldNotBeNull();
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, EmptyQueueGrace)).ShouldBeNull();
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetHealth_ShouldReportTheBrokerHealthy_WhenTheBrokerIsUp()
+    {
+        // Act — the base factory proves the Unhealthy side against a dead port; this host is the
+        // only one where RabbitMqHealthCheck can prove its Healthy verdict against a live broker
+        HttpResponseMessage response = await _apiClient.Http.GetAsync(new Uri("/health", UriKind.Relative));
+        string body = await response.Content.ReadAsStringAsync();
+
+        // Assert — overall status still reflects the deliberately dead SMTP port, so only the
+        // rabbitmq entry is this test's subject
+        using JsonDocument report = JsonDocument.Parse(body);
+        JsonElement rabbitMqCheck = report.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "rabbitmq");
+        rabbitMqCheck.GetProperty("status").GetString().ShouldBe("Healthy");
+    }
+
+    private async Task PublishRawAsync(string payload, string? messageId)
+    {
+        await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+
+        BasicProperties properties = new()
+        {
+            MessageId = messageId,
+            DeliveryMode = DeliveryModes.Persistent
+        };
+
+        await channel.BasicPublishAsync(
+            exchange: RabbitMqTopology.EmailsExchange,
+            routingKey: RabbitMqTopology.EmailConfirmationRoutingKey,
+            mandatory: true,
+            basicProperties: properties,
+            body: Encoding.UTF8.GetBytes(payload));
+    }
+
+    /// <summary>
+    /// Polls the queue until a delivery arrives or the timeout passes — routing and dead-lettering
+    /// are asynchronous inside the broker. The read is auto-acked: every caller either asserts on
+    /// the delivery (test over either way) or expects null.
+    /// </summary>
+    private async Task<BasicGetResult?> GetWithinTimeoutAsync(string queue, TimeSpan timeout)
+    {
+        await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        while (true)
+        {
+            BasicGetResult? delivery = await channel.BasicGetAsync(queue, autoAck: true);
+            if (delivery is not null)
+            {
+                return delivery;
+            }
+
+            if (elapsed.Elapsed >= timeout)
+            {
+                return null;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    private async Task WaitUntilQueueEmptyAsync(string queue, TimeSpan timeout)
+    {
+        await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        while (elapsed.Elapsed < timeout)
+        {
+            uint messageCount = await channel.MessageCountAsync(queue);
+            if (messageCount == 0)
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    /// <summary>
+    /// Polls the outbox until a row matches or the timeout passes, then returns the latest
+    /// snapshot (or null) — the assertions on it stay in the test body.
+    /// </summary>
+    private async Task<OutboxMessage?> WaitForOutboxRowAsync(Func<OutboxMessage, bool> predicate)
+    {
+        using CancellationTokenSource timeout = new(DeliveryTimeout);
+
+        while (true)
+        {
+            await using AsyncServiceScope scope = _factory.Services.CreateAsyncScope();
+            AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+            List<OutboxMessage> rows = await db.OutboxMessages.AsNoTracking().ToListAsync();
+            OutboxMessage? match = rows.FirstOrDefault(predicate);
+
+            if (match is not null || timeout.IsCancellationRequested)
+            {
+                return match;
+            }
+
+            await Task.Delay(100);
+        }
+    }
+
+    private async Task<int> WaitForInboxRowsAsync(Guid messageId, TimeSpan timeout)
+    {
+        using CancellationTokenSource waitWindow = new(timeout);
+
+        while (true)
+        {
+            int count = await CountInboxRowsAsync(messageId);
+            if (count > 0 || waitWindow.IsCancellationRequested)
+            {
+                return count;
+            }
+
+            await Task.Delay(100);
+        }
+    }
+
+    private async Task<int> CountInboxRowsAsync(Guid messageId)
+    {
+        await using AsyncServiceScope scope = _factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        return await db.InboxMessages.AsNoTracking().CountAsync(row => row.MessageId == messageId);
+    }
+
+    /// <summary>
+    /// Reads the reason of the first (most recent) <c>x-death</c> entry the broker stamped on a
+    /// dead-lettered message.
+    /// </summary>
+    private static string? FirstDeathReason(IReadOnlyBasicProperties properties)
+    {
+        if (properties.Headers is not { } headers
+            || !headers.TryGetValue("x-death", out object? deathsRaw)
+            || deathsRaw is not IList { Count: > 0 } deaths
+            || deaths[0] is not IDictionary firstDeath
+            || !firstDeath.Contains("reason"))
+        {
+            return null;
+        }
+
+        return firstDeath["reason"] is byte[] reason ? Encoding.UTF8.GetString(reason) : null;
+    }
+}


### PR DESCRIPTION
## What

Integration-test hardening for the RabbitMQ e-mail pipeline shipped in #575:

- **BrokeredAuthSystemApiFactory** — a twin of the auth integration host that swaps the publisher spy back for the real `RabbitMqMessagePublisher`, restores the real `EmailConfirmationConsumer`, and points `RabbitMq:*` at a real broker container. The SMTP seam stays spied.
- **EmailConfirmationPipelineTests** — the only suite where outbox → relay → broker → consumer → inbox dedup runs end-to-end in one process: exactly-once delivery, duplicate suppression via the inbox, poison + unusable-message-id parking in the DLQ, ack-without-e-mail for vanished users, recovery after the broker drops every connection, and the Healthy broker health-check verdict.
- **OutboxRelayTests** — pins that a failed registration commits no outbox row (atomic rollback).
- **CleanerService** now truncates `OutboxMessages`/`InboxMessages` (no FK to `Users`, so TRUNCATE CASCADE never reached them; a leftover unprocessed row would poison every later relay pass).

## Why a re-cut branch

The original `rabbitmq-messaging-edge-tests` branch predates the #575 squash and carries its pre-squash commits, which makes it permanently conflicting with `main` (known no-stacking pattern in this repo). This branch is the same test delta re-cut clean on top of `main`.

## Verification

Full `AuthSystem.API.Tests.Integration` suite on this branch: **322/322 passed** (local, Docker/Testcontainers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GntiUWk6XE5bf6fgaoGX7Z