### PR TITLE
MSG-02: Generalize the e-mail dispatch seam — no behavior change

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -91,17 +91,23 @@ internal static class ApiDependencyInjection
 
             services.AddScoped<IUserSessionRevoker, UserSessionRevoker>();
 
-            // Signal-driven outbox relay (ADR-0035): outbox writers nudge the singleton signal
-            // after their commit instead of the relay polling the database on an interval.
+            // Signal-driven outbox relay (ADR-0035): outbox writers stage rows through the shared
+            // writer and nudge the singleton signal after their commit instead of the relay
+            // polling the database on an interval.
             services.AddSingleton<OutboxSignal>();
+            services.AddScoped<OutboxWriter>();
             services.AddHostedService<OutboxRelay>();
 
-            // The consuming side of the same pipeline: broker deliveries -> confirmation e-mails.
-            // The processor is scoped because the consumer resolves it per message, mirroring how
-            // a request would; the pump itself is a singleton hosted service.
-            services.AddScoped<EmailConfirmationRequestProcessor>();
-            services.AddScoped<EmailConfirmationDeliveryProcessor>();
-            services.AddHostedService<EmailConfirmationConsumer>();
+            // The consuming side of the same pipeline: broker deliveries -> e-mails. The keyed
+            // registrations ARE the processor registry (ADR-0038): one line per message type,
+            // keyed by the outbox row's Type — an explicit, compile-visible inventory (ADR-0001,
+            // no assembly scanning). Processors are scoped because the consumer resolves them per
+            // message, mirroring how a request would; the pump itself is a singleton hosted
+            // service.
+            services.AddKeyedScoped<IEmailMessageProcessor, EmailConfirmationRequestProcessor>(
+                nameof(EmailConfirmationRequested));
+            services.AddScoped<EmailDeliveryProcessor>();
+            services.AddHostedService<EmailDispatchConsumer>();
 
             // PERF-02: reference refresh tokens accumulate one row per refresh and are never
             // deleted otherwise; prune expired/invalid tokens and authorizations daily.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailDispatchConsumer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/EmailDispatchConsumer.cs
@@ -1,6 +1,4 @@
-using System.Text.Json;
 using Microsoft.Extensions.Options;
-using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Services.Emails;
 using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
 using LotroKoniecDev.SharedKernel.BuildingBlocks;
@@ -11,8 +9,12 @@ using RabbitMQ.Client.Events;
 namespace LotroKoniecDev.AuthSystem.API.BackgroundServices;
 
 /// <summary>
-/// Consumes <see cref="RabbitMqTopology.EmailQueue"/> and turns each delivery into a confirmation
-/// e-mail via <see cref="EmailConfirmationRequestProcessor"/>. Push-based, not polled: after
+/// The single e-mail dispatch consumer (ADR-0038): consumes
+/// <see cref="RabbitMqTopology.EmailQueue"/> and hands each delivery to the
+/// <see cref="IEmailMessageProcessor"/> registered for the AMQP <c>type</c> property — the outbox
+/// row's <c>Type</c> the publisher stamps on the wire. Selection goes by that property, never by
+/// routing key: the type says what the payload is, the routing key says which bindings receive it
+/// (<c>OutboxMessageRouting</c>'s separation, end-to-end). Push-based, not polled: after
 /// <c>BasicConsumeAsync</c> registers the subscription, the broker pushes deliveries over the open
 /// connection and the client library invokes <see cref="OnDeliveredAsync"/> per message —
 /// <see cref="ExecuteAsync"/> only sets this up and then parks until shutdown.
@@ -21,10 +23,11 @@ namespace LotroKoniecDev.AuthSystem.API.BackgroundServices;
 /// Acknowledgement is manual (<c>autoAck: false</c>) and happens only after the processor
 /// finished: a crash mid-send leaves the delivery unacked, the broker returns it to the queue,
 /// and the next start redelivers — at-least-once, matching the outbox's own semantics
-/// (the processor stays idempotent, see its remarks). On top of that, deliveries are
+/// (the processors stay idempotent, see the seam's remarks). On top of that, deliveries are
 /// deduplicated on the broker message id through the inbox (ADR-0037), so a redelivery of an
 /// already-processed message acks without a second e-mail. Failures split three ways (ADR-0036):
-/// poison payloads are rejected into the dead-letter queue immediately, transient failures are
+/// poison payloads — including a missing or unregistered message type — are rejected into the
+/// dead-letter queue immediately, transient failures are
 /// requeued behind an escalating pause, and the broker itself parks a message that exhausts
 /// <see cref="RabbitMqTopology.EmailDeliveryLimit"/> — so no failure loops forever and none is
 /// silently lost. Failed deliveries use <c>basic.reject</c>, never <c>basic.nack</c>: since
@@ -35,7 +38,7 @@ namespace LotroKoniecDev.AuthSystem.API.BackgroundServices;
 /// happens here with escalating backoff, and the client's automatic recovery re-attaches the
 /// consumer if the connection drops later.
 /// </remarks>
-internal sealed partial class EmailConfirmationConsumer : BackgroundService
+internal sealed partial class EmailDispatchConsumer : BackgroundService
 {
     /// <summary>
     /// Escalating wait between initial connection attempts. The ceiling stays low (the broker is
@@ -75,15 +78,15 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
 
     private readonly RabbitMqOptions _settings;
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ILogger<EmailConfirmationConsumer> _logger;
+    private readonly ILogger<EmailDispatchConsumer> _logger;
 
     private IConnection? _connection;
     private IChannel? _channel;
 
-    public EmailConfirmationConsumer(
+    public EmailDispatchConsumer(
         IOptions<RabbitMqOptions> options,
         IServiceScopeFactory scopeFactory,
-        ILogger<EmailConfirmationConsumer> logger)
+        ILogger<EmailDispatchConsumer> logger)
     {
         _settings = options.Value;
         _scopeFactory = scopeFactory;
@@ -193,25 +196,44 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
                 return;
             }
 
-            EmailConfirmationRequested? message = TryDeserialize(delivery.Body.Span);
-            if (message is null || message.IdentityUserId == Guid.Empty)
-            {
-                // Poison: no amount of redelivery fixes an unreadable payload, so it is rejected
-                // on first sight — the broker dead-letters it into the parking lot for a human.
-                LogPoisonMessage(_logger, delivery.BasicProperties.MessageId);
-                await channel.BasicRejectAsync(
-                    delivery.DeliveryTag,
-                    requeue: false,
-                    cancellationToken: stoppingToken);
-                return;
-            }
-
             Result ackDecision;
             await using (AsyncServiceScope scope = _scopeFactory.CreateAsyncScope())
             {
-                EmailConfirmationDeliveryProcessor deliveryProcessor =
-                    scope.ServiceProvider.GetRequiredService<EmailConfirmationDeliveryProcessor>();
-                ackDecision = await deliveryProcessor.ProcessOnceAsync(message, messageId, stoppingToken);
+                string? messageType = delivery.BasicProperties.Type;
+                IEmailMessageProcessor? processor = string.IsNullOrWhiteSpace(messageType)
+                    ? null
+                    : scope.ServiceProvider.GetKeyedService<IEmailMessageProcessor>(messageType);
+                if (processor is null)
+                {
+                    // Poison: a missing or unregistered type means no processor can ever read
+                    // this delivery — no redelivery fixes that, so it parks for a human
+                    // (ADR-0038), exactly like an unusable message id.
+                    LogUnknownMessageType(_logger, delivery.BasicProperties.MessageId, messageType);
+                    await channel.BasicRejectAsync(
+                        delivery.DeliveryTag,
+                        requeue: false,
+                        cancellationToken: stoppingToken);
+                    return;
+                }
+
+                object? message = processor.TryDeserialize(delivery.Body.Span);
+                if (message is null)
+                {
+                    // Poison: no amount of redelivery fixes an unreadable payload, so it is
+                    // rejected on first sight — the broker dead-letters it into the parking lot
+                    // for a human.
+                    LogPoisonMessage(_logger, delivery.BasicProperties.MessageId);
+                    await channel.BasicRejectAsync(
+                        delivery.DeliveryTag,
+                        requeue: false,
+                        cancellationToken: stoppingToken);
+                    return;
+                }
+
+                EmailDeliveryProcessor deliveryProcessor =
+                    scope.ServiceProvider.GetRequiredService<EmailDeliveryProcessor>();
+                ackDecision = await deliveryProcessor.ProcessOnceAsync(
+                    processor, message, messageId, stoppingToken);
             }
 
             if (ackDecision.IsSuccess)
@@ -293,18 +315,6 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
         return Guid.TryParse(properties.MessageId, out messageId) && messageId != Guid.Empty;
     }
 
-    private static EmailConfirmationRequested? TryDeserialize(ReadOnlySpan<byte> body)
-    {
-        try
-        {
-            return JsonSerializer.Deserialize<EmailConfirmationRequested>(body);
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-    }
-
     private async Task CloseAsync()
     {
         IChannel? channel = _channel;
@@ -361,6 +371,12 @@ internal sealed partial class EmailConfirmationConsumer : BackgroundService
         Level = LogLevel.Error,
         Message = "Rejecting message with unusable message id {MessageId} into the dead-letter queue: the inbox cannot deduplicate a delivery without an id")]
     private static partial void LogMessageIdUnusable(ILogger logger, string? messageId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailConsumerUnknownMessageType,
+        Level = LogLevel.Error,
+        Message = "Rejecting message {MessageId} into the dead-letter queue: no processor is registered for message type {MessageType}")]
+    private static partial void LogUnknownMessageType(ILogger logger, string? messageId, string? messageType);
 
     [LoggerMessage(
         EventId = EventIds.EmailConsumerTransientFailure,

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/OutboxRelay.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/BackgroundServices/OutboxRelay.cs
@@ -165,7 +165,8 @@ internal sealed partial class OutboxRelay : BackgroundService
         {
             try
             {
-                await _messagePublisher.PublishAsync(routingKey, message.Payload, message.Id, stoppingToken);
+                await _messagePublisher.PublishAsync(
+                    routingKey, message.Type, message.Payload, message.Id, stoppingToken);
                 message.MarkAsProcessed(_timeProvider.GetUtcNow());
                 published = true;
             }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -75,7 +75,7 @@ internal static class EventIds
     public const int OutboxMessagePublishFailed = 2321;
     public const int OutboxMessageUnroutable = 2322;
 
-    // Email Confirmation Consumer (2330–2339)
+    // Email Dispatch Consumer (2330–2339)
     public const int EmailConsumerConnectFailed = 2330;
     public const int EmailConsumerStarted = 2331;
     public const int EmailConsumerPoisonMessage = 2332;
@@ -91,6 +91,7 @@ internal static class EventIds
     public const int EmailConsumerDuplicateSkipped = 2340;
     public const int EmailConsumerInboxRaceLost = 2341;
     public const int EmailConsumerMessageIdUnusable = 2342;
+    public const int EmailConsumerUnknownMessageType = 2343;
 
     // Startup (2350–2359)
     public const int StartupTransientDatabaseFailure = 2350;

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RegisterUser.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Identity;
@@ -10,7 +9,6 @@ using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
-using LotroKoniecDev.AuthSystem.Persistence.Outbox;
 using LotroKoniecDev.SharedKernel.Authorization;
 using LotroKoniecDev.SharedKernel.Constants;
 using LotroKoniecDev.SharedKernel.Messaging;
@@ -68,7 +66,7 @@ internal sealed partial class RegisterUser : IApiEndpoint
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
         private readonly AuthDbContext _db;
-        private readonly OutboxSignal _outboxSignal;
+        private readonly OutboxWriter _outboxWriter;
 
         public Handler(
             UserManager<ApplicationUser> userManager,
@@ -76,14 +74,14 @@ internal sealed partial class RegisterUser : IApiEndpoint
             IValidator<Command> validator,
             ILogger<Handler> logger,
             AuthDbContext db,
-            OutboxSignal outboxSignal)
+            OutboxWriter outboxWriter)
         {
             _userManager = userManager;
             _timeProvider = timeProvider;
             _validator = validator;
             _logger = logger;
             _db = db;
-            _outboxSignal = outboxSignal;
+            _outboxWriter = outboxWriter;
         }
 
         public async ValueTask<Result<IdentityId>> Handle(
@@ -167,20 +165,14 @@ internal sealed partial class RegisterUser : IApiEndpoint
                         string.Join(", ", roleIdentityResult.Errors.Select(e => e.Description))));
                 }
 
-                EmailConfirmationRequested emailConfirmationRequested = new(user.Id);
-                OutboxMessage outboxMessage = OutboxMessage.Create(
-                    type: nameof(EmailConfirmationRequested),
-                    payload: JsonSerializer.Serialize(emailConfirmationRequested),
-                    occurredOn: _timeProvider.GetUtcNow());
-
-                _db.OutboxMessages.Add(outboxMessage);
+                _outboxWriter.Enqueue(new EmailConfirmationRequested(user.Id));
                 await _db.SaveChangesAsync(cancellationToken);
 
                 await transaction.CommitAsync(cancellationToken);
 
                 // Only after the commit: the relay reads committed rows, so a nudge sent inside
                 // the transaction would race it into seeing nothing (ADR-0035).
-                _outboxSignal.Notify();
+                _outboxWriter.NotifyEnqueuedCommitted();
 
                 // No cross-context profile creation here (the KittySaver RegisterUser->CreatePerson
                 // saga is deliberately not lifted): the translator profile is provisioned lazily and

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxWriter.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxWriter.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// The one way a feature slice writes an e-mail message to the outbox: serializes the payload,
+/// stamps the row's <c>Type</c> with the contract's type name (the registry and routing key both
+/// select on it, so a writer can never typo the string), and carries the after-commit nudge —
+/// bundling the whole ADR-0035 §2 idiom in a single injected component so no future writer can
+/// reinvent half of it (ADR-0038 decision 6 keeps the nudge an explicit call, not an interceptor).
+/// </summary>
+/// <remarks>
+/// <see cref="Enqueue{TMessage}"/> only stages the row in the caller's unit of work — the caller
+/// commits it together with its own state change, which is the outbox pattern's whole point.
+/// After that commit (and only after: the relay reads committed rows, so a nudge sent inside the
+/// transaction would race it into seeing nothing) the caller calls
+/// <see cref="NotifyEnqueuedCommitted"/> exactly once.
+/// </remarks>
+internal sealed class OutboxWriter
+{
+    private readonly AuthDbContext _db;
+    private readonly OutboxSignal _outboxSignal;
+    private readonly TimeProvider _timeProvider;
+
+    public OutboxWriter(AuthDbContext db, OutboxSignal outboxSignal, TimeProvider timeProvider)
+    {
+        _db = db;
+        _outboxSignal = outboxSignal;
+        _timeProvider = timeProvider;
+    }
+
+    public void Enqueue<TMessage>(TMessage message) where TMessage : class
+    {
+        string type = typeof(TMessage).Name;
+
+        // Programmer-error guard: a contract nobody routed would commit fine and then jam the
+        // relay (OutboxMessageRouting fails its row loudly, but only after the fact) — failing
+        // the writer's own request surfaces the missing routing entry the moment it is written.
+        // The dedicated exception type keeps it out of writers' defensive catch filters.
+        if (!OutboxMessageRouting.TryGetRoutingKey(type, out _))
+        {
+            throw new UnroutableOutboxMessageTypeException(type);
+        }
+
+        OutboxMessage outboxMessage = OutboxMessage.Create(
+            type: type,
+            payload: JsonSerializer.Serialize(message),
+            occurredOn: _timeProvider.GetUtcNow());
+
+        _db.OutboxMessages.Add(outboxMessage);
+    }
+
+    public void NotifyEnqueuedCommitted()
+    {
+        _outboxSignal.Notify();
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/UnroutableOutboxMessageTypeException.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/UnroutableOutboxMessageTypeException.cs
@@ -1,0 +1,17 @@
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// Thrown when a feature slice enqueues an outbox message whose contract type has no routing key
+/// in <see cref="OutboxMessageRouting"/> — a programmer error (a forgotten routing entry)
+/// surfaced at write time instead of jamming the relay after commit. A dedicated type on
+/// purpose: writers defensively filter broad exception families (<c>RegisterUser</c> catches
+/// <see cref="InvalidOperationException"/> for an Identity lookup race), and this failure must
+/// crash loudly rather than be mistaken for a business outcome.
+/// </summary>
+internal sealed class UnroutableOutboxMessageTypeException : Exception
+{
+    public UnroutableOutboxMessageTypeException(string type)
+        : base($"Outbox message type '{type}' has no routing key mapped in {nameof(OutboxMessageRouting)}.")
+    {
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationRequestProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailConfirmationRequestProcessor.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Identity;
 using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
@@ -8,7 +9,8 @@ namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 /// <summary>
 /// The business reaction to a consumed <see cref="EmailConfirmationRequested"/> message: load the
 /// user, mint the confirmation token at send time (see the payload's remarks on token lifetime),
-/// and dispatch the e-mail.
+/// and dispatch the e-mail. The first entry of the <see cref="IEmailMessageProcessor"/> registry
+/// (ADR-0038).
 /// </summary>
 /// <remarks>
 /// Delivery is at-least-once (ADR-0035), so this must stay idempotent. Today that comes free:
@@ -16,7 +18,7 @@ namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 /// worst re-sends a confirmation e-mail — annoying, never harmful. A new message type must
 /// re-earn this property before it may reuse the pattern.
 /// </remarks>
-internal sealed partial class EmailConfirmationRequestProcessor
+internal sealed partial class EmailConfirmationRequestProcessor : IEmailMessageProcessor
 {
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IAccountConfirmationEmailSender _accountConfirmationEmailSender;
@@ -30,6 +32,24 @@ internal sealed partial class EmailConfirmationRequestProcessor
         _userManager = userManager;
         _accountConfirmationEmailSender = accountConfirmationEmailSender;
         _logger = logger;
+    }
+
+    public object? TryDeserialize(ReadOnlySpan<byte> body)
+    {
+        try
+        {
+            EmailConfirmationRequested? message = JsonSerializer.Deserialize<EmailConfirmationRequested>(body);
+            return message is null || message.IdentityUserId == Guid.Empty ? null : message;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public Task<Result> ProcessAsync(object message, CancellationToken cancellationToken)
+    {
+        return ProcessAsync((EmailConfirmationRequested)message, cancellationToken);
     }
 
     /// <summary>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailDeliveryProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailDeliveryProcessor.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
-using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using LotroKoniecDev.AuthSystem.Persistence.Inbox;
 using LotroKoniecDev.SharedKernel.Monads;
@@ -8,11 +7,12 @@ using LotroKoniecDev.SharedKernel.Monads;
 namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 
 /// <summary>
-/// The delivery-level wrapper around <see cref="EmailConfirmationRequestProcessor"/>: consults the
-/// inbox before doing any work and records the message id after success (ADR-0037). Both real
-/// delivery paths — <see cref="BackgroundServices.EmailConfirmationConsumer"/> and the integration
+/// The delivery-level wrapper around the per-type <see cref="IEmailMessageProcessor"/>: consults
+/// the inbox before doing any work and records the message id after success (ADR-0037). Both real
+/// delivery paths — <see cref="BackgroundServices.EmailDispatchConsumer"/> and the integration
 /// suite's broker-less bridge — resolve this one component, so the dedup logic cannot drift
-/// between them.
+/// between them. Type-agnostic on purpose: the inbox stays one undiscriminated table (ADR-0037
+/// §5 — message ids are outbox row ids, unique across types).
 /// </summary>
 /// <remarks>
 /// Returns the same ack-decision contract as the processor: success means "ack, drop it from the
@@ -22,27 +22,25 @@ namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 /// the consumer's existing transient path rejects the delivery and the broker's delivery limit
 /// bounds the loop (ADR-0037 Decision 4).
 /// </remarks>
-internal sealed partial class EmailConfirmationDeliveryProcessor
+internal sealed partial class EmailDeliveryProcessor
 {
     private readonly AuthDbContext _db;
-    private readonly EmailConfirmationRequestProcessor _processor;
     private readonly TimeProvider _timeProvider;
-    private readonly ILogger<EmailConfirmationDeliveryProcessor> _logger;
+    private readonly ILogger<EmailDeliveryProcessor> _logger;
 
-    public EmailConfirmationDeliveryProcessor(
+    public EmailDeliveryProcessor(
         AuthDbContext db,
-        EmailConfirmationRequestProcessor processor,
         TimeProvider timeProvider,
-        ILogger<EmailConfirmationDeliveryProcessor> logger)
+        ILogger<EmailDeliveryProcessor> logger)
     {
         _db = db;
-        _processor = processor;
         _timeProvider = timeProvider;
         _logger = logger;
     }
 
     public async Task<Result> ProcessOnceAsync(
-        EmailConfirmationRequested message,
+        IEmailMessageProcessor processor,
+        object message,
         Guid messageId,
         CancellationToken cancellationToken)
     {
@@ -54,7 +52,7 @@ internal sealed partial class EmailConfirmationDeliveryProcessor
             return Result.Success();
         }
 
-        Result ackDecision = await _processor.ProcessAsync(message, cancellationToken);
+        Result ackDecision = await processor.ProcessAsync(message, cancellationToken);
         if (ackDecision.IsFailure)
         {
             return ackDecision;

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IEmailMessageProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IEmailMessageProcessor.cs
@@ -1,0 +1,38 @@
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// The per-type seam of the e-mail dispatch pipeline (ADR-0038): one implementation per outbox
+/// message type, owning that type's payload deserialization and its business reaction (loading
+/// state, minting tokens at send time, dispatching the e-mail). The consumer selects the
+/// implementation from the keyed-service registry in the API's dependency injection — an
+/// explicit, compile-visible inventory keyed by the outbox row's <c>Type</c> (ADR-0001: no
+/// assembly scanning), which travels on the wire as the AMQP <c>type</c> property.
+/// </summary>
+/// <remarks>
+/// Delivery is at-least-once (ADR-0035), so every implementation must stay idempotent — a
+/// redelivered message must never do harm, only at worst repeat a harmless send. A new message
+/// type re-earns that property before it may join the registry.
+/// </remarks>
+internal interface IEmailMessageProcessor
+{
+    /// <summary>
+    /// Deserializes and validates one delivery's payload. <c>null</c> is the poison verdict:
+    /// the body cannot be read as this processor's contract (or fails its invariants), no
+    /// redelivery can fix it, and the consumer parks it in the dead-letter queue.
+    /// </summary>
+    object? TryDeserialize(ReadOnlySpan<byte> body);
+
+    /// <summary>
+    /// Handles one deserialized message end-to-end and returns the acknowledgement decision.
+    /// <paramref name="message"/> is the exact object a prior <see cref="TryDeserialize"/> call
+    /// returned — passing anything else is a programmer error.
+    /// </summary>
+    /// <returns>
+    /// NOT a business outcome — the answer to "does this message need redelivery?". Success
+    /// means "ack, drop it from the queue"; failure means "worth retrying" and drives the
+    /// consumer's reject + requeue ladder.
+    /// </returns>
+    Task<Result> ProcessAsync(object message, CancellationToken cancellationToken);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/IMessagePublisher.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/IMessagePublisher.cs
@@ -12,6 +12,12 @@ namespace LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
 public interface IMessagePublisher
 {
     /// <param name="routingKey">A key from <see cref="RabbitMqTopology"/>.</param>
+    /// <param name="type">
+    /// The outbox row's payload contract name, carried on the wire as the AMQP <c>type</c>
+    /// property so the consumer can select the processor that owns the payload (ADR-0038) —
+    /// deliberately separate from <paramref name="routingKey"/>, which only says which bindings
+    /// receive the message.
+    /// </param>
     /// <param name="payload">The serialized message body; UTF-8 JSON.</param>
     /// <param name="messageId">
     /// The outbox row's identifier, carried on the wire as the AMQP <c>message-id</c> so the
@@ -20,6 +26,7 @@ public interface IMessagePublisher
     /// <param name="cancellationToken">The cancellation token</param>
     Task PublishAsync(
         string routingKey,
+        string type,
         string payload,
         Guid messageId,
         CancellationToken cancellationToken);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqMessagePublisher.cs
@@ -47,20 +47,25 @@ internal sealed partial class RabbitMqMessagePublisher : IMessagePublisher, IAsy
 
     public async Task PublishAsync(
         string routingKey,
+        string type,
         string payload,
         Guid messageId,
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(routingKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(type);
         ArgumentException.ThrowIfNullOrWhiteSpace(payload);
         Ensure.NotEmpty(messageId);
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         IChannel channel = await GetChannelAsync(cancellationToken);
 
+        // Type is the consumer's processor-selection key (ADR-0038): what the payload IS, while
+        // the routing key only says which bindings receive it.
         BasicProperties properties = new()
         {
             MessageId = messageId.ToString(),
+            Type = type,
             ContentType = JsonContentType,
             ContentEncoding = Encoding.UTF8.WebName,
             DeliveryMode = DeliveryModes.Persistent,

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 using Testcontainers.PostgreSql;
 using LotroKoniecDev.AuthSystem.API.BackgroundServices;
 using LotroKoniecDev.AuthSystem.API.Extensions;
-using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Services.Emails;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
@@ -125,7 +124,7 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
             // tests via EmailConfirmationRequestProcessor).
             ServiceDescriptor? emailConsumer = services.FirstOrDefault(d =>
                 d.ServiceType == typeof(IHostedService)
-                && d.ImplementationType == typeof(EmailConfirmationConsumer));
+                && d.ImplementationType == typeof(EmailDispatchConsumer));
             if (emailConsumer is not null)
             {
                 services.Remove(emailConsumer);
@@ -178,31 +177,34 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
 
     /// <summary>
     /// The suite's stand-in for the broker-to-consumer hop: what the relay publishes is pushed
-    /// through the same <see cref="EmailConfirmationDeliveryProcessor"/> the real consumer runs,
-    /// in a fresh scope per message, exactly like <c>EmailConfirmationConsumer.OnDeliveredAsync</c>
-    /// — including the inbox deduplication of ADR-0037, which therefore runs under this suite's
-    /// real PostgreSQL.
+    /// through the same registry-selected <see cref="IEmailMessageProcessor"/> and
+    /// <see cref="EmailDeliveryProcessor"/> the real consumer runs, in a fresh scope per message,
+    /// exactly like <c>EmailDispatchConsumer.OnDeliveredAsync</c> — selection by the message type
+    /// (never the routing key, ADR-0038) and the inbox deduplication of ADR-0037 included, which
+    /// therefore both run under this suite's real PostgreSQL.
     /// </summary>
     private static async Task DeliverLikeTheConsumerWouldAsync(
         IServiceProvider services,
         SpyMessagePublisher.PublishedMessage message)
     {
-        if (message.RoutingKey != RabbitMqTopology.EmailConfirmationRoutingKey)
+        await using AsyncServiceScope scope = services.CreateAsyncScope();
+
+        IEmailMessageProcessor? processor =
+            scope.ServiceProvider.GetKeyedService<IEmailMessageProcessor>(message.Type);
+        if (processor is null)
         {
             return;
         }
 
-        EmailConfirmationRequested? payload =
-            System.Text.Json.JsonSerializer.Deserialize<EmailConfirmationRequested>(message.Payload);
+        object? payload = processor.TryDeserialize(System.Text.Encoding.UTF8.GetBytes(message.Payload));
         if (payload is null)
         {
             return;
         }
 
-        await using AsyncServiceScope scope = services.CreateAsyncScope();
-        EmailConfirmationDeliveryProcessor deliveryProcessor =
-            scope.ServiceProvider.GetRequiredService<EmailConfirmationDeliveryProcessor>();
-        await deliveryProcessor.ProcessOnceAsync(payload, message.MessageId, CancellationToken.None);
+        EmailDeliveryProcessor deliveryProcessor =
+            scope.ServiceProvider.GetRequiredService<EmailDeliveryProcessor>();
+        await deliveryProcessor.ProcessOnceAsync(processor, payload, message.MessageId, CancellationToken.None);
     }
 
     public virtual async Task InitializeAsync()

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/BrokeredAuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/BrokeredAuthSystemApiFactory.cs
@@ -12,7 +12,7 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 /// The brokered twin of <see cref="AuthSystemApiFactory"/>: the base host swaps the publisher for
 /// a spy and removes the consumer (no broker in that suite), and this factory undoes exactly that
 /// against a real broker container — the real <see cref="RabbitMqMessagePublisher"/> returns, the
-/// real <see cref="EmailConfirmationConsumer"/> is put back, and the RabbitMq configuration points
+/// real <see cref="EmailDispatchConsumer"/> is put back, and the RabbitMq configuration points
 /// at the container. The SMTP seam stays spied, so tests still observe delivered e-mails without
 /// sending any. This is the only host where the full outbox → relay → broker → consumer pipeline
 /// exists in one process.
@@ -61,7 +61,7 @@ public sealed class BrokeredAuthSystemApiFactory : AuthSystemApiFactory
             }
 
             services.AddSingleton<IMessagePublisher, RabbitMqMessagePublisher>();
-            services.AddHostedService<EmailConfirmationConsumer>();
+            services.AddHostedService<EmailDispatchConsumer>();
         });
     }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyMessagePublisher.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyMessagePublisher.cs
@@ -8,11 +8,11 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 /// publishes and, when <see cref="FailWith"/> is set, refuses every publish the way a dead
 /// broker would. The optional delivery bridge stands in for the broker-to-consumer hop:
 /// each accepted publish is handed straight to it, the way the real queue would push the
-/// message at <c>EmailConfirmationConsumer</c> (which the suite removes, having no broker).
+/// message at <c>EmailDispatchConsumer</c> (which the suite removes, having no broker).
 /// </summary>
 internal sealed class SpyMessagePublisher : IMessagePublisher
 {
-    internal sealed record PublishedMessage(string RoutingKey, string Payload, Guid MessageId);
+    internal sealed record PublishedMessage(string RoutingKey, string Type, string Payload, Guid MessageId);
 
     private readonly ConcurrentQueue<PublishedMessage> _published = new();
     private readonly Func<PublishedMessage, Task>? _deliverAsync;
@@ -28,6 +28,7 @@ internal sealed class SpyMessagePublisher : IMessagePublisher
 
     public async Task PublishAsync(
         string routingKey,
+        string type,
         string payload,
         Guid messageId,
         CancellationToken cancellationToken)
@@ -38,7 +39,7 @@ internal sealed class SpyMessagePublisher : IMessagePublisher
             throw failure;
         }
 
-        PublishedMessage message = new(routingKey, payload, messageId);
+        PublishedMessage message = new(routingKey, type, payload, messageId);
         _published.Enqueue(message);
 
         if (_deliverAsync is not null)

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/InboxDeduplicationTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/InboxDeduplicationTests.cs
@@ -13,7 +13,7 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
 
 /// <summary>
 /// Proves the inbox deduplication of ADR-0037 against real PostgreSQL, through
-/// <see cref="EmailConfirmationDeliveryProcessor"/> — the one component both real delivery paths
+/// <see cref="EmailDeliveryProcessor"/> — the one component both real delivery paths
 /// (the broker consumer and this suite's broker-less bridge) resolve: a processed message id is
 /// recorded, a duplicate of it is acknowledged without a second e-mail, and a failed processing
 /// leaves no record so redelivery genuinely retries.
@@ -92,10 +92,12 @@ public sealed class InboxDeduplicationTests : EndpointsTestBase
     private async Task<Result> ProcessOnceAsync(Guid identityUserId, Guid messageId)
     {
         await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
-        EmailConfirmationDeliveryProcessor deliveryProcessor =
-            scope.ServiceProvider.GetRequiredService<EmailConfirmationDeliveryProcessor>();
+        IEmailMessageProcessor processor = scope.ServiceProvider
+            .GetRequiredKeyedService<IEmailMessageProcessor>(nameof(EmailConfirmationRequested));
+        EmailDeliveryProcessor deliveryProcessor =
+            scope.ServiceProvider.GetRequiredService<EmailDeliveryProcessor>();
         return await deliveryProcessor.ProcessOnceAsync(
-            new EmailConfirmationRequested(identityUserId), messageId, CancellationToken.None);
+            processor, new EmailConfirmationRequested(identityUserId), messageId, CancellationToken.None);
     }
 
     private async Task<int> CountInboxRowsAsync(Guid messageId)

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/OutboxRelayTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/OutboxRelayTests.cs
@@ -56,6 +56,7 @@ public sealed class OutboxRelayTests : EndpointsTestBase
             .ShouldHaveSingleItem();
         published.MessageId.ShouldBe(message.Id);
         published.RoutingKey.ShouldBe(RabbitMqTopology.EmailConfirmationRoutingKey);
+        published.Type.ShouldBe(nameof(EmailConfirmationRequested));
         published.Payload.ShouldBe(message.Payload);
     }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/EmailConfirmationPipelineTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/EmailConfirmationPipelineTests.cs
@@ -21,14 +21,14 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Messaging;
 /// The only suite where the confirmation-e-mail pipeline runs end-to-end with nothing faked
 /// between the database and the SMTP seam: registration commits an outbox row, the real relay
 /// publishes it through the real <see cref="RabbitMqMessagePublisher"/> to a real broker, and the
-/// real <c>EmailConfirmationConsumer</c> consumes, deduplicates and dispatches to the spy e-mail
-/// sender. Everywhere else the broker hop is bridged in-process (<see cref="SpyMessagePublisher"/>),
+/// real <c>EmailDispatchConsumer</c> selects the registered processor, deduplicates and
+/// dispatches to the spy e-mail sender. Everywhere else the broker hop is bridged in-process (<see cref="SpyMessagePublisher"/>),
 /// so the consumer's ack/reject decisions never actually meet broker semantics — here they do.
 /// </summary>
 /// <remarks>
 /// The consumer's transient-failure ladder is deliberately not driven at this level: its first
 /// rung pauses 30 s before the reject, and each piece is already pinned separately — the ladder's
-/// invariants in <c>EmailConfirmationConsumerTests</c>, the failed-processing inbox contract in
+/// invariants in <c>EmailDispatchConsumerTests</c>, the failed-processing inbox contract in
 /// <c>InboxDeduplicationTests</c>, and the delivery-limit parking in
 /// <c>DeadLetterTopologyTests</c>.
 /// </remarks>
@@ -114,10 +114,14 @@ public sealed class EmailConfirmationPipelineTests : IClassFixture<BrokeredAuthS
         outboxRow.ShouldNotBeNull();
         int sendsAfterFirstDelivery = _confirmationEmailSpy.CallCount;
 
-        // Act — same payload, same message id, over the real wire
+        // Act — same payload, same type, same message id, over the real wire
         IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
         await publisher.PublishAsync(
-            RabbitMqTopology.EmailConfirmationRoutingKey, outboxRow.Payload, outboxRow.Id, CancellationToken.None);
+            RabbitMqTopology.EmailConfirmationRoutingKey,
+            outboxRow.Type,
+            outboxRow.Payload,
+            outboxRow.Id,
+            CancellationToken.None);
 
         // Assert — the duplicate is consumed (queue drains), acked (no parking) and suppressed
         await WaitUntilQueueEmptyAsync(RabbitMqTopology.EmailQueue, DeliveryTimeout);
@@ -133,11 +137,16 @@ public sealed class EmailConfirmationPipelineTests : IClassFixture<BrokeredAuthS
     [InlineData("""{"IdentityUserId":"not-a-guid"}""")]
     public async Task Consumer_ShouldParkDeliveryInDeadLetterQueue_WhenThePayloadIsPoison(string poisonPayload)
     {
-        // Act — a valid message id, so the reject decision can only come from the payload
+        // Act — a valid message id and a registered type, so the reject decision can only come
+        // from the payload
         Guid messageId = Guid.CreateVersion7();
         IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
         await publisher.PublishAsync(
-            RabbitMqTopology.EmailConfirmationRoutingKey, poisonPayload, messageId, CancellationToken.None);
+            RabbitMqTopology.EmailConfirmationRoutingKey,
+            nameof(EmailConfirmationRequested),
+            poisonPayload,
+            messageId,
+            CancellationToken.None);
 
         // Assert — parked on first sight, no e-mail, no dedup record
         BasicGetResult dead =
@@ -172,6 +181,34 @@ public sealed class EmailConfirmationPipelineTests : IClassFixture<BrokeredAuthS
         _confirmationEmailSpy.CallCount.ShouldBe(0);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("TypeNobodyRegistered")]
+    public async Task Consumer_ShouldParkDeliveryInDeadLetterQueue_WhenTheMessageTypeIsMissingOrUnregistered(
+        string? messageType)
+    {
+        // Arrange — a real unconfirmed user and a perfectly readable payload: the only thing
+        // broken about this delivery is the type property the registry selects processors by
+        // (ADR-0038), so a redelivery could never fix it
+        (RegisterRequest _, IdentityId identityId) = await UserFactory.RegisterRandomUserUnconfirmedAsync(
+            _apiClient, _faker, _confirmationEmailSpy);
+        await _confirmationEmailSpy.WaitForCaptureAsync(DeliveryTimeout);
+        _confirmationEmailSpy.Reset();
+        Guid messageId = Guid.CreateVersion7();
+        string validPayload = JsonSerializer.Serialize(new EmailConfirmationRequested(identityId.Value));
+
+        // Act — raw publish: the real publisher refuses to send without a type, the wire does not
+        await PublishRawAsync(validPayload, messageId.ToString(), messageType);
+
+        // Assert — parked on first sight, no e-mail, no dedup record
+        BasicGetResult dead =
+            (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, DeliveryTimeout)).ShouldNotBeNull();
+        Encoding.UTF8.GetString(dead.Body.ToArray()).ShouldBe(validPayload);
+        FirstDeathReason(dead.BasicProperties).ShouldBe("rejected");
+        _confirmationEmailSpy.CallCount.ShouldBe(0);
+        (await CountInboxRowsAsync(messageId)).ShouldBe(0);
+    }
+
     [Fact]
     public async Task Consumer_ShouldAckWithoutEmailAndWithoutParking_WhenTheUserNoLongerExists()
     {
@@ -181,7 +218,11 @@ public sealed class EmailConfirmationPipelineTests : IClassFixture<BrokeredAuthS
         string payload = JsonSerializer.Serialize(new EmailConfirmationRequested(Guid.CreateVersion7()));
         IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
         await publisher.PublishAsync(
-            RabbitMqTopology.EmailConfirmationRoutingKey, payload, messageId, CancellationToken.None);
+            RabbitMqTopology.EmailConfirmationRoutingKey,
+            nameof(EmailConfirmationRequested),
+            payload,
+            messageId,
+            CancellationToken.None);
 
         // Assert — the inbox record doubles as the "consumer finished" signal
         int inboxRows = await WaitForInboxRowsAsync(messageId, DeliveryTimeout);
@@ -243,7 +284,7 @@ public sealed class EmailConfirmationPipelineTests : IClassFixture<BrokeredAuthS
         rabbitMqCheck.GetProperty("status").GetString().ShouldBe("Healthy");
     }
 
-    private async Task PublishRawAsync(string payload, string? messageId)
+    private async Task PublishRawAsync(string payload, string? messageId, string? messageType = null)
     {
         await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
         await using IChannel channel = await connection.CreateChannelAsync();
@@ -251,6 +292,7 @@ public sealed class EmailConfirmationPipelineTests : IClassFixture<BrokeredAuthS
         BasicProperties properties = new()
         {
             MessageId = messageId,
+            Type = messageType,
             DeliveryMode = DeliveryModes.Persistent
         };
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/RabbitMqMessagePublisherTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/RabbitMqMessagePublisherTests.cs
@@ -20,6 +20,7 @@ public sealed class RabbitMqMessagePublisherTests : IClassFixture<RabbitMqBroker
     private static readonly TimeSpan DeliveryTimeout = TimeSpan.FromSeconds(10);
 
     private const string Payload = """{"IdentityUserId":"a3a2cbb0-0000-0000-0000-000000000001"}""";
+    private const string MessageType = "EmailConfirmationRequested";
 
     private readonly RabbitMqBrokerFixture _broker;
     private RabbitMqMessagePublisher _publisher = null!;
@@ -52,12 +53,13 @@ public sealed class RabbitMqMessagePublisherTests : IClassFixture<RabbitMqBroker
 
         // Act — first publish on a fresh instance also opens the connection and declares topology
         await _publisher.PublishAsync(
-            RabbitMqTopology.EmailConfirmationRoutingKey, Payload, messageId, CancellationToken.None);
+            RabbitMqTopology.EmailConfirmationRoutingKey, MessageType, Payload, messageId, CancellationToken.None);
 
         // Assert — the broker took responsibility and the queue holds the exact wire message
         BasicGetResult delivery = (await GetFromEmailQueueAsync()).ShouldNotBeNull();
         Encoding.UTF8.GetString(delivery.Body.ToArray()).ShouldBe(Payload);
         delivery.BasicProperties.MessageId.ShouldBe(messageId.ToString());
+        delivery.BasicProperties.Type.ShouldBe(MessageType);
         delivery.BasicProperties.DeliveryMode.ShouldBe(DeliveryModes.Persistent);
         delivery.BasicProperties.ContentType.ShouldBe("application/json");
         delivery.BasicProperties.ContentEncoding.ShouldBe(Encoding.UTF8.WebName);
@@ -70,7 +72,7 @@ public sealed class RabbitMqMessagePublisherTests : IClassFixture<RabbitMqBroker
         // sends mandatory with confirmation tracking, so the basic.return must fault this very call
         // instead of silently dropping the message
         Task publish = _publisher.PublishAsync(
-            "billing.invoice", Payload, Guid.CreateVersion7(), CancellationToken.None);
+            "billing.invoice", MessageType, Payload, Guid.CreateVersion7(), CancellationToken.None);
 
         // Assert
         await Should.ThrowAsync<PublishException>(publish);
@@ -81,7 +83,7 @@ public sealed class RabbitMqMessagePublisherTests : IClassFixture<RabbitMqBroker
     {
         // Arrange — a first publish so the long-lived connection and channel exist to be killed
         await _publisher.PublishAsync(
-            RabbitMqTopology.EmailConfirmationRoutingKey, Payload, Guid.CreateVersion7(), CancellationToken.None);
+            RabbitMqTopology.EmailConfirmationRoutingKey, MessageType, Payload, Guid.CreateVersion7(), CancellationToken.None);
         (await GetFromEmailQueueAsync()).ShouldNotBeNull();
 
         await _broker.CloseAllConnectionsAsync();
@@ -105,7 +107,7 @@ public sealed class RabbitMqMessagePublisherTests : IClassFixture<RabbitMqBroker
             try
             {
                 await _publisher.PublishAsync(
-                    RabbitMqTopology.EmailConfirmationRoutingKey, Payload, messageId, CancellationToken.None);
+                    RabbitMqTopology.EmailConfirmationRoutingKey, MessageType, Payload, messageId, CancellationToken.None);
                 return;
             }
             catch (Exception) when (elapsed.Elapsed < DeliveryTimeout)

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/EmailDispatchConsumerTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Messaging/EmailDispatchConsumerTests.cs
@@ -12,12 +12,12 @@ namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Messaging;
 /// unusable message ids (ADR-0037): a delivery the inbox cannot deduplicate must be rejected,
 /// not processed blind.
 /// </summary>
-public sealed class EmailConfirmationConsumerTests
+public sealed class EmailDispatchConsumerTests
 {
     [Fact]
     public void RedeliveryBackoffs_ComparedToDeliveryLimit_HasOneEntryPerAllowedRedelivery()
     {
-        EmailConfirmationConsumer.RedeliveryBackoffs.Length.ShouldBe(RabbitMqTopology.EmailDeliveryLimit);
+        EmailDispatchConsumer.RedeliveryBackoffs.Length.ShouldBe(RabbitMqTopology.EmailDeliveryLimit);
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public sealed class EmailConfirmationConsumerTests
         // pause into a channel loss that burns a redelivery instead of waiting one out.
         TimeSpan consumerTimeout = TimeSpan.FromMinutes(30);
 
-        EmailConfirmationConsumer.RedeliveryBackoffs.ShouldAllBe(pause => pause < consumerTimeout);
+        EmailDispatchConsumer.RedeliveryBackoffs.ShouldAllBe(pause => pause < consumerTimeout);
     }
 
     [Theory]
@@ -43,7 +43,7 @@ public sealed class EmailConfirmationConsumerTests
         BasicProperties properties = new() { MessageId = rawMessageId };
 
         // Act
-        bool usable = EmailConfirmationConsumer.TryReadMessageId(properties, out Guid _);
+        bool usable = EmailDispatchConsumer.TryReadMessageId(properties, out Guid _);
 
         // Assert
         usable.ShouldBeFalse();
@@ -57,7 +57,7 @@ public sealed class EmailConfirmationConsumerTests
         BasicProperties properties = new() { MessageId = messageId.ToString() };
 
         // Act
-        bool usable = EmailConfirmationConsumer.TryReadMessageId(properties, out Guid parsed);
+        bool usable = EmailDispatchConsumer.TryReadMessageId(properties, out Guid parsed);
 
         // Assert
         usable.ShouldBeTrue();

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxWriterTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxWriterTests.cs
@@ -1,0 +1,33 @@
+using LotroKoniecDev.AuthSystem.API.Outbox;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Outbox;
+
+/// <summary>
+/// Pins the write-time routability guard of <see cref="OutboxWriter"/>: a contract nobody mapped
+/// in <see cref="OutboxMessageRouting"/> must fail the writer's own request the moment it is
+/// enqueued — and with a dedicated exception type, because writers defensively filter broad
+/// exception families (<c>RegisterUser</c> catches <see cref="InvalidOperationException"/> for an
+/// Identity lookup race) and the crash must never be swallowed into a bogus business outcome.
+/// </summary>
+public sealed class OutboxWriterTests
+{
+    private sealed record ContractNobodyRouted(Guid UserId);
+
+    [Fact]
+    public void Enqueue_TypeWithoutRoutingKey_ThrowsBeforeTouchingTheUnitOfWork()
+    {
+        // Arrange — the guard must fire before any dependency is used, so the writer is built
+        // with a null context on purpose: reaching the database would NRE instead of throwing
+        using OutboxSignal outboxSignal = new();
+        OutboxWriter sut = new(db: null!, outboxSignal, TimeProvider.System);
+
+        // Act
+        Action enqueue = () => sut.Enqueue(new ContractNobodyRouted(Guid.CreateVersion7()));
+
+        // Assert
+        UnroutableOutboxMessageTypeException exception =
+            Should.Throw<UnroutableOutboxMessageTypeException>(enqueue);
+        exception.Message.ShouldContain(nameof(ContractNobodyRouted));
+        exception.ShouldNotBeAssignableTo<InvalidOperationException>();
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailConfirmationRequestProcessorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailConfirmationRequestProcessorTests.cs
@@ -93,6 +93,32 @@ public sealed class EmailConfirmationRequestProcessorTests
         result.Error.ShouldBe(smtpError);
     }
 
+    [Theory]
+    [InlineData("this is not json at all")]
+    [InlineData("{}")]
+    [InlineData("""{"IdentityUserId":"not-a-guid"}""")]
+    public void TryDeserialize_PoisonPayload_ReturnsTheNullVerdict(string poisonPayload)
+    {
+        EmailConfirmationRequestProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(System.Text.Encoding.UTF8.GetBytes(poisonPayload));
+
+        message.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_ValidPayload_ReturnsTheTypedMessage()
+    {
+        Guid userId = Guid.CreateVersion7();
+        EmailConfirmationRequestProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(
+            System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new EmailConfirmationRequested(userId)));
+
+        EmailConfirmationRequested typed = message.ShouldBeOfType<EmailConfirmationRequested>();
+        typed.IdentityUserId.ShouldBe(userId);
+    }
+
     private static ApplicationUser CreateUser(bool emailConfirmed) =>
         new()
         {


### PR DESCRIPTION
Closes #580

## What

The mechanical half of the ADR-0038 generalization: after this PR the outbox → relay → RabbitMQ → consumer → inbox pipeline can carry many message types, but still carries one (`EmailConfirmationRequested`). Zero user-visible change.

- **`IEmailMessageProcessor` seam** — each message type owns its payload deserialization (null = poison verdict) and its send. The registry is the explicit keyed-DI inventory in `ApiDependencyInjection`, keyed by the outbox row's `Type` (no assembly scanning, ADR-0001). `EmailConfirmationRequestProcessor` is the first entry, behavior byte-for-byte identical.
- **`EmailConfirmationConsumer` → `EmailDispatchConsumer`** — selects the processor by the AMQP `type` property, never the routing key. A missing or unregistered type is poison: immediate DLQ park (new EventId 2343), exactly like an unusable message id. The ack/reject machine, redelivery ladder, delivery limit and inbox dedup are unchanged.
- **Publisher stamps `type`** — `RabbitMqMessagePublisher` carries the outbox `Type` on the wire; `OutboxRelay` passes it through. `OutboxMessageRouting` unchanged in shape.
- **`EmailConfirmationDeliveryProcessor` → `EmailDeliveryProcessor`** — the inbox-dedup wrapper is type-agnostic (single undiscriminated inbox table, ADR-0037 §5 holds).
- **`OutboxWriter`** — extracts the serialize + insert + after-commit `Notify()` idiom from `RegisterUser` so future writers (MSG-03/04) cannot reinvent half of it. An unroutable contract type fails at write time with the dedicated `UnroutableOutboxMessageTypeException` — a type writers' defensive catch filters cannot swallow (code-review finding).

A second message type now costs: contract record + processor + routing entry + one keyed DI line — no consumer edits (the integration-suite bridge generalized too).

## Why

Ticket #580 / epic #578: MSG-03/04 migrate password-reset and deletion e-mails onto this seam; this PR makes the pipeline type-generic first, with the confirmation e-mail as the only user, so the behavior-preserving refactor and the behavior-changing migrations never share a diff.

## Tests

- Build 0 warnings; AuthSystem unit 113/113; AuthSystem integration 324/324 (real broker via Testcontainers); patcher + SharedKernel unit suites green.
- Existing assertions untouched (mechanical renames and Arrange-side signature updates only, as the ticket sanctions).
- New: brokered `Consumer_ShouldParkDeliveryInDeadLetterQueue_WhenTheMessageTypeIsMissingOrUnregistered` (null + unregistered type), `OutboxWriterTests` pinning the write-time guard (incl. not-assignable-to-`InvalidOperationException`), `TryDeserialize` unit theory on the seam template, `Type` stamp assertions in relay + publisher tests.
- `code-reviewer` gate: REQUEST CHANGES → fixed (dedicated exception + tests) → **APPROVE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUYfkk3mVyJ9mXUf8JaZnw