### PR TITLE
MSG-03: Password reset through the broker

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -106,6 +106,8 @@ internal static class ApiDependencyInjection
             // service.
             services.AddKeyedScoped<IEmailMessageProcessor, EmailConfirmationRequestProcessor>(
                 nameof(EmailConfirmationRequested));
+            services.AddKeyedScoped<IEmailMessageProcessor, PasswordResetRequestProcessor>(
+                nameof(PasswordResetRequested));
             services.AddScoped<EmailDeliveryProcessor>();
             services.AddHostedService<EmailDispatchConsumer>();
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -42,9 +42,9 @@ internal static class EventIds
     // Data Export (2240–2249)
     public const int ExportDataCompleted = 2241;
 
-    // Forgot Password (2250–2259)
+    // Forgot Password (2250–2259) — 2251 (ForgotPasswordEmailFailed) retired: the send left the
+    // request path for the outbox pipeline (ADR-0038), so the handler no longer observes SMTP
     public const int ForgotPasswordNonExistent = 2250;
-    public const int ForgotPasswordEmailFailed = 2251;
 
     // Logout (2260–2269)
     public const int UserLoggedOut = 2260;
@@ -96,13 +96,19 @@ internal static class EventIds
     // Startup (2350–2359)
     public const int StartupTransientDatabaseFailure = 2350;
 
+    // Password Reset Dispatch (2360–2369)
+    public const int PasswordResetUserGone = 2360;
+    public const int PasswordResetAddressMissing = 2361;
+    public const int PasswordResetDeletionScheduled = 2362;
+
     // Middleware (2400–2499)
     public const int UnauthorizedAccessAttempt = 2400;
     public const int ForbiddenAccessAttempt = 2401;
 
-    // Pages (2600–2699)
+    // Pages (2600–2699) — 2610 carried PasswordResetTokenGenerated until the page stopped minting
+    // tokens (ADR-0038); the id now marks the outbox write that replaced the in-request send
     public const int EmailConfirmedViaUi = 2600;
-    public const int PasswordResetTokenGenerated = 2610;
+    public const int PasswordResetRequestQueued = 2610;
     public const int LoginUserNotFound = 2620;
     public const int LoginAccountLockedOut = 2621;
     public const int LoginWrongPassword = 2622;
@@ -121,7 +127,8 @@ internal static class EventIds
     public const int GdprDeletionScheduleArtifactRevocationFailed = 2704;
     public const int GdprDeletionCancelStampFailed = 2705;
 
-    // Forgot/Reset Password deletion-window gates (2710–2719)
-    public const int ForgotPasswordDeletionScheduled = 2710;
+    // Forgot/Reset Password deletion-window gates (2710–2719) — 2710
+    // (ForgotPasswordDeletionScheduled) retired: the forgot-password gate moved to the dispatch
+    // processor (ADR-0038 decision 2), which logs 2362 instead
     public const int ResetPasswordDeletionScheduled = 2711;
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ForgotPassword.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ForgotPassword.cs
@@ -3,10 +3,10 @@ using FluentValidation.Results;
 using Microsoft.AspNetCore.Identity;
 using LotroKoniecDev.AuthSystem.API.Common;
 using LotroKoniecDev.AuthSystem.API.Extensions;
-using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
-
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using LotroKoniecDev.SharedKernel.Constants;
 using LotroKoniecDev.SharedKernel.Messaging;
 using LotroKoniecDev.SharedKernel.Monads;
@@ -39,18 +39,21 @@ internal sealed partial class ForgotPassword : IApiEndpoint
             new PasswordHasher<ApplicationUser>().HashPassword(new ApplicationUser(), "DummyP@ssw0rd!");
 
         private readonly UserManager<ApplicationUser> _userManager;
-        private readonly IPasswordResetEmailSender _emailSender;
+        private readonly AuthDbContext _db;
+        private readonly OutboxWriter _outboxWriter;
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
 
         public Handler(
             UserManager<ApplicationUser> userManager,
-            IPasswordResetEmailSender emailSender,
+            AuthDbContext db,
+            OutboxWriter outboxWriter,
             IValidator<Command> validator,
             ILogger<Handler> logger)
         {
             _userManager = userManager;
-            _emailSender = emailSender;
+            _db = db;
+            _outboxWriter = outboxWriter;
             _validator = validator;
             _logger = logger;
         }
@@ -65,12 +68,15 @@ internal sealed partial class ForgotPassword : IApiEndpoint
 
             ApplicationUser? user = await _userManager.FindByEmailAsync(command.Email);
 
+            // Every path pays the same PBKDF2 cost. Burning the dummy hash only on the
+            // not-found branch would make existing accounts answer measurably FASTER
+            // (their path is just a cheap outbox insert), turning response time into an
+            // inverted user-enumeration oracle (ADR-0038 decision 5).
+            _ = _userManager.PasswordHasher.VerifyHashedPassword(
+                new ApplicationUser(), DummyPasswordHash, "DummyP@ssw0rd!");
+
             if (user is null)
             {
-                // Perform dummy work to prevent timing-based user enumeration
-                _ = new PasswordHasher<ApplicationUser>()
-                    .VerifyHashedPassword(new ApplicationUser(), DummyPasswordHash, "DummyP@ssw0rd!");
-
                 string maskedEmail = command.Email.MaskEmail();
                 LogPasswordResetNonExistent(_logger, maskedEmail);
 
@@ -78,34 +84,19 @@ internal sealed partial class ForgotPassword : IApiEndpoint
                 return Result.Success();
             }
 
-            // While GDPR deletion is scheduled, the emailed cancel-deletion link is the only
-            // recovery path — a password reset would neither unlock the account nor stop the
-            // deletion. Pretend success so account state can't be probed.
-            if (user.DeletionScheduledAt is not null)
-            {
-                LogPasswordResetSkippedDeletionScheduled(_logger, user.Id);
-                return Result.Success();
-            }
+            // No token minting and no deletion-window check here: the payload carries the id
+            // alone, and the dispatch processor mints the token and owns the guard at delivery
+            // (ADR-0038 decision 2).
+            _outboxWriter.Enqueue(new PasswordResetRequested(user.Id));
+            await _db.SaveChangesAsync(cancellationToken);
 
-            string token = await _userManager.GeneratePasswordResetTokenAsync(user);
-
-            Result emailResult = await _emailSender.SendPasswordResetEmailAsync(user.Id, command.Email, token, cancellationToken);
-            if (emailResult.IsFailure)
-            {
-                LogPasswordResetEmailFailed(_logger, user.Id, emailResult.Error.Message);
-            }
+            _outboxWriter.NotifyEnqueuedCommitted();
 
             return Result.Success();
         }
 
         [LoggerMessage(EventId = EventIds.ForgotPasswordNonExistent, Level = LogLevel.Information, Message = "Password reset requested for non-existent email {Email}")]
         private static partial void LogPasswordResetNonExistent(ILogger logger, string email);
-
-        [LoggerMessage(EventId = EventIds.ForgotPasswordEmailFailed, Level = LogLevel.Error, Message = "Failed to send password reset email for user {UserId}: {Error}")]
-        private static partial void LogPasswordResetEmailFailed(ILogger logger, Guid userId, string error);
-
-        [LoggerMessage(EventId = EventIds.ForgotPasswordDeletionScheduled, Level = LogLevel.Information, Message = "Password reset skipped for user {UserId}: account deletion is scheduled")]
-        private static partial void LogPasswordResetSkippedDeletionScheduled(ILogger logger, Guid userId);
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxMessageRouting.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxMessageRouting.cs
@@ -13,7 +13,8 @@ internal static class OutboxMessageRouting
 {
     private static readonly Dictionary<string, string> RoutingKeysByType = new(StringComparer.Ordinal)
     {
-        [nameof(EmailConfirmationRequested)] = RabbitMqTopology.EmailConfirmationRoutingKey
+        [nameof(EmailConfirmationRequested)] = RabbitMqTopology.EmailConfirmationRoutingKey,
+        [nameof(PasswordResetRequested)] = RabbitMqTopology.PasswordResetRoutingKey
     };
 
     public static bool TryGetRoutingKey(string type, [NotNullWhen(true)] out string? routingKey)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/PasswordResetRequested.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/PasswordResetRequested.cs
@@ -1,0 +1,15 @@
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// Outbox payload contract for "send this user their password reset e-mail", serialised by the
+/// producer and deserialised by the relay and the consumer.
+/// </summary>
+/// <remarks>
+/// Carries the user id alone, on purpose (ADR-0038 decision 2). A live reset token must never
+/// persist in an outbox row, a broker frame, or a DLQ-parked message — minting it at delivery
+/// keeps it out of all three, keeps it valid against the <em>current</em> security stamp no matter
+/// how long the message waited, and makes the e-mail's "link expires in …" countdown start at
+/// delivery. The deletion-window guard lives at delivery too: the processor, not the writers,
+/// decides whether a reset may go out while account deletion is scheduled.
+/// </remarks>
+public sealed record PasswordResetRequested(Guid IdentityUserId);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ForgotPassword.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ForgotPassword.cshtml.cs
@@ -1,8 +1,9 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 
 namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
 
@@ -15,16 +16,19 @@ internal sealed partial class ForgotPasswordModel : PageModel
         new PasswordHasher<ApplicationUser>().HashPassword(new ApplicationUser(), "DummyP@ssw0rd!");
 
     private readonly UserManager<ApplicationUser> _userManager;
-    private readonly IPasswordResetEmailSender _emailSender;
+    private readonly AuthDbContext _db;
+    private readonly OutboxWriter _outboxWriter;
     private readonly ILogger<ForgotPasswordModel> _logger;
 
     public ForgotPasswordModel(
         UserManager<ApplicationUser> userManager,
-        IPasswordResetEmailSender emailSender,
+        AuthDbContext db,
+        OutboxWriter outboxWriter,
         ILogger<ForgotPasswordModel> logger)
     {
         _userManager = userManager;
-        _emailSender = emailSender;
+        _db = db;
+        _outboxWriter = outboxWriter;
         _logger = logger;
     }
 
@@ -48,17 +52,24 @@ internal sealed partial class ForgotPasswordModel : PageModel
 
         ApplicationUser? user = await _userManager.FindByEmailAsync(Email);
 
-        if (user is null)
+        // Every path pays the same PBKDF2 cost. Burning the dummy hash only on the
+        // not-found branch would make existing accounts answer measurably FASTER
+        // (their path is just a cheap outbox insert), turning response time into an
+        // inverted user-enumeration oracle (ADR-0038 decision 5).
+        _ = _userManager.PasswordHasher.VerifyHashedPassword(
+            new ApplicationUser(), DummyPasswordHash, "DummyP@ssw0rd!");
+
+        if (user is not null)
         {
-            // Perform dummy work to prevent timing-based user enumeration
-            _ = _userManager.PasswordHasher.VerifyHashedPassword(
-                new ApplicationUser(), DummyPasswordHash, "DummyP@ssw0rd!");
-        }
-        else
-        {
-            string token = await _userManager.GeneratePasswordResetTokenAsync(user);
-            await _emailSender.SendPasswordResetEmailAsync(user.Id, Email, token, HttpContext.RequestAborted);
-            LogPasswordResetTokenGenerated(_logger, user.Id);
+            // No token minting and no deletion-window check here: the payload carries the id
+            // alone, and the dispatch processor mints the token and owns the guard at delivery
+            // (ADR-0038 decision 2).
+            _outboxWriter.Enqueue(new PasswordResetRequested(user.Id));
+            await _db.SaveChangesAsync(HttpContext.RequestAborted);
+
+            _outboxWriter.NotifyEnqueuedCommitted();
+
+            LogPasswordResetRequestQueued(_logger, user.Id);
         }
 
         // Always show success to prevent email enumeration
@@ -66,6 +77,6 @@ internal sealed partial class ForgotPasswordModel : PageModel
         return Page();
     }
 
-    [LoggerMessage(EventId = EventIds.PasswordResetTokenGenerated, Level = LogLevel.Information, Message = "Password reset token generated for user {UserId}")]
-    private static partial void LogPasswordResetTokenGenerated(ILogger logger, Guid userId);
+    [LoggerMessage(EventId = EventIds.PasswordResetRequestQueued, Level = LogLevel.Information, Message = "Password reset request queued for user {UserId}")]
+    private static partial void LogPasswordResetRequestQueued(ILogger logger, Guid userId);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -20,9 +20,17 @@ using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Persistence.Settings;
 using LotroKoniecDev.Logging.Redaction;
 
+// Deliberately NOT CreateBootstrapLogger(): the reloadable bootstrap logger lives in the shared
+// static Log.Logger slot, and AddSerilog freezes it on the host's first logger resolution. The
+// integration suite boots several hosts from this Program concurrently (the shared factory plus a
+// brokered factory per pipeline suite), so one host can freeze the bootstrap logger another host
+// just installed — the second freeze then dies with "The logger is already frozen". A plain
+// console logger keeps startup logging (and the catch/finally below) working while AddSerilog
+// builds each host its own fully-configured pipeline; in production nothing changes — the single
+// host's final logger still replaces this one.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-    .CreateBootstrapLogger();
+    .CreateLogger();
 
 try
 {

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetRequestProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/PasswordResetRequestProcessor.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// The business reaction to a consumed <see cref="PasswordResetRequested"/> message: load the
+/// user, mint the reset token at send time (see the payload's remarks on token lifetime), and
+/// dispatch the e-mail. Also the single home of the deletion-window guard (ADR-0038 decision 2):
+/// while GDPR deletion is scheduled, the emailed cancel-deletion link is the only recovery path —
+/// a password reset would neither unlock the account nor stop the deletion, so the message is
+/// acknowledged without sending.
+/// </summary>
+/// <remarks>
+/// Delivery is at-least-once (ADR-0035), so this must stay idempotent. It does: a redelivered
+/// message at worst re-sends a reset e-mail with a fresh token — annoying, never harmful — and
+/// every skip branch reads current state, so replays converge on the same decision.
+/// </remarks>
+internal sealed partial class PasswordResetRequestProcessor : IEmailMessageProcessor
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IPasswordResetEmailSender _passwordResetEmailSender;
+    private readonly ILogger<PasswordResetRequestProcessor> _logger;
+
+    public PasswordResetRequestProcessor(
+        UserManager<ApplicationUser> userManager,
+        IPasswordResetEmailSender passwordResetEmailSender,
+        ILogger<PasswordResetRequestProcessor> logger)
+    {
+        _userManager = userManager;
+        _passwordResetEmailSender = passwordResetEmailSender;
+        _logger = logger;
+    }
+
+    public object? TryDeserialize(ReadOnlySpan<byte> body)
+    {
+        try
+        {
+            PasswordResetRequested? message = JsonSerializer.Deserialize<PasswordResetRequested>(body);
+            return message is null || message.IdentityUserId == Guid.Empty ? null : message;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public Task<Result> ProcessAsync(object message, CancellationToken cancellationToken)
+    {
+        return ProcessAsync((PasswordResetRequested)message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Handles one consumed message end-to-end and returns the acknowledgement decision.
+    /// </summary>
+    /// <returns>
+    /// NOT a business outcome — the answer to "does this message need redelivery?". Success means
+    /// "ack, drop it from the queue": either the e-mail went out, or redelivery can never change
+    /// the outcome (user vanished, deletion scheduled, no address on the account) — nacking those
+    /// would loop the same message forever. Failure means "worth retrying" (e.g. the SMTP relay
+    /// is down) and drives the consumer's reject + requeue.
+    /// </returns>
+    public async Task<Result> ProcessAsync(PasswordResetRequested message, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationUser? user = await _userManager.FindByIdAsync(message.IdentityUserId.ToString());
+        if (user is null)
+        {
+            LogUserGone(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        if (user.DeletionScheduledAt is not null)
+        {
+            LogDeletionScheduled(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            LogEmailMissing(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        string resetToken = await _userManager.GeneratePasswordResetTokenAsync(user);
+
+        Result sendPasswordResetResult = await _passwordResetEmailSender.SendPasswordResetEmailAsync(
+            user.Id,
+            user.Email,
+            resetToken,
+            cancellationToken);
+        return sendPasswordResetResult;
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.PasswordResetUserGone,
+        Level = LogLevel.Information,
+        Message = "Skipping password-reset e-mail for user {UserId}: the account no longer exists")]
+    private static partial void LogUserGone(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.PasswordResetDeletionScheduled,
+        Level = LogLevel.Information,
+        Message = "Skipping password-reset e-mail for user {UserId}: account deletion is scheduled")]
+    private static partial void LogDeletionScheduled(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.PasswordResetAddressMissing,
+        Level = LogLevel.Warning,
+        Message = "Skipping password-reset e-mail for user {UserId}: the account carries no e-mail address")]
+    private static partial void LogEmailMissing(ILogger logger, Guid userId);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
@@ -34,6 +34,11 @@ public static class RabbitMqTopology
     public const string EmailConfirmationRoutingKey = "email.confirmation";
 
     /// <summary>
+    /// Routing key of the password reset e-mail.
+    /// </summary>
+    public const string PasswordResetRoutingKey = "email.password-reset";
+
+    /// <summary>
     /// Dead-letter exchange: the broker republishes here every message that
     /// <see cref="EmailQueue"/> gives up on — rejected as poison by the consumer, or past
     /// <see cref="EmailDeliveryLimit"/>. Fanout, because "everything that dies goes to the one

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/OutboxAssertions.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/OutboxAssertions.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+
+/// <summary>
+/// Polling helpers over the outbox and inbox tables for tests that assert on the asynchronous
+/// tail of the e-mail pipeline: a request only commits the outbox row (ADR-0038), so everything
+/// after it — publish, delivery, the inbox record — has to be awaited as state, never assumed.
+/// </summary>
+internal static class OutboxAssertions
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Polls the outbox until a row matches or the timeout passes, then returns the latest
+    /// snapshot (or null) — the assertions on it stay in the test body.
+    /// </summary>
+    public static async Task<OutboxMessage?> WaitForOutboxRowAsync(
+        AuthSystemApiFactory factory,
+        Func<OutboxMessage, bool> predicate,
+        TimeSpan? timeout = null)
+    {
+        using CancellationTokenSource waitWindow = new(timeout ?? DefaultTimeout);
+
+        while (true)
+        {
+            await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+            AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+            List<OutboxMessage> rows = await db.OutboxMessages.AsNoTracking().ToListAsync();
+            OutboxMessage? match = rows.FirstOrDefault(predicate);
+
+            if (match is not null || waitWindow.IsCancellationRequested)
+            {
+                return match;
+            }
+
+            await Task.Delay(100);
+        }
+    }
+
+    /// <summary>
+    /// Waits until the inbox records the message as processed (the "consumer finished" marker)
+    /// and returns the row count — 0 when the timeout passes first.
+    /// </summary>
+    public static async Task<int> WaitForInboxRowsAsync(
+        AuthSystemApiFactory factory,
+        Guid messageId,
+        TimeSpan? timeout = null)
+    {
+        using CancellationTokenSource waitWindow = new(timeout ?? DefaultTimeout);
+
+        while (true)
+        {
+            int count = await CountInboxRowsAsync(factory, messageId);
+            if (count > 0 || waitWindow.IsCancellationRequested)
+            {
+                return count;
+            }
+
+            await Task.Delay(100);
+        }
+    }
+
+    public static async Task<int> CountInboxRowsAsync(AuthSystemApiFactory factory, Guid messageId)
+    {
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        return await db.InboxMessages.AsNoTracking().CountAsync(row => row.MessageId == messageId);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyEmailService.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyEmailService.cs
@@ -18,4 +18,20 @@ public sealed class SpyEmailService : IEmailService
         LastBody = body;
         return Task.FromResult(Result.Success());
     }
+
+    /// <summary>
+    /// Blocks until an e-mail lands or the timeout passes. E-mails leave the request path through
+    /// the outbox (commit -> relay -> delivery -> this spy, ADR-0038), so tests reading
+    /// <see cref="LastBody"/> right after the triggering call must wait on state, not assume
+    /// immediacy. Returns silently either way — the assertions stay at the call site.
+    /// </summary>
+    public async Task WaitForCaptureAsync(TimeSpan? timeout = null)
+    {
+        using CancellationTokenSource waitWindow = new(timeout ?? TimeSpan.FromSeconds(15));
+
+        while (LastBody is null && !waitWindow.IsCancellationRequested)
+        {
+            await Task.Delay(50);
+        }
+    }
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyPasswordResetEmailSender.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyPasswordResetEmailSender.cs
@@ -21,6 +21,23 @@ public sealed class SpyPasswordResetEmailSender : IPasswordResetEmailSender
         return Task.FromResult(Result.Success());
     }
 
+    /// <summary>
+    /// Blocks until a reset e-mail lands or the timeout passes. Forgot-password stopped being
+    /// synchronous when it went through the outbox (commit -> relay -> delivery -> this spy), so
+    /// tests reading <see cref="LastResetToken"/> right after the forgot-password call must wait
+    /// on state, not assume immediacy. Returns silently either way — the assertions stay at the
+    /// call site.
+    /// </summary>
+    public async Task WaitForCaptureAsync(TimeSpan? timeout = null)
+    {
+        using CancellationTokenSource waitWindow = new(timeout ?? TimeSpan.FromSeconds(15));
+
+        while (LastResetToken is null && !waitWindow.IsCancellationRequested)
+        {
+            await Task.Delay(50);
+        }
+    }
+
     public void Reset()
     {
         LastEmail = null;

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeletionGraceWindowTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeletionGraceWindowTests.cs
@@ -3,12 +3,14 @@ using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
 using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
 
 namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
@@ -84,8 +86,16 @@ public sealed partial class DeletionGraceWindowTests : AsyncLifetimeTestBase
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
 
-        // Assert — anti-enumeration success, but the reset email must not go out
+        // Assert — anti-enumeration success, but the reset email must not go out. The request
+        // now only commits an outbox row (ADR-0038) and the deletion-window guard fires in the
+        // dispatch processor, so wait until the delivery was actually consumed (the inbox row is
+        // the "processor finished" marker) — asserting right after the POST would race a broken
+        // guard into a false green.
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            Factory, row => row.Type == nameof(PasswordResetRequested));
+        outboxRow.ShouldNotBeNull();
+        (await OutboxAssertions.WaitForInboxRowsAsync(Factory, outboxRow.Id)).ShouldBe(1);
         PasswordResetEmailSpy.CallCount.ShouldBe(0);
     }
 
@@ -101,6 +111,7 @@ public sealed partial class DeletionGraceWindowTests : AsyncLifetimeTestBase
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
         forgotResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
         string preIssuedResetToken = PasswordResetEmailSpy.LastResetToken!;
 
         await ScheduleDeletionAsync(registerRequest.Email);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailLinkFactoryTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailLinkFactoryTests.cs
@@ -80,10 +80,13 @@ public sealed class EmailLinkFactoryTests : EndpointsTestBase
 
         apiClient.Http.DefaultRequestHeaders.Host = forgedHost;
 
-        // Act
+        // Act — the request only commits the outbox row; the real sender (and with it the link
+        // factory) runs at delivery, in a background scope no forged Host header can ever reach
+        // (ADR-0038), so the capture has to be awaited
         HttpResponseMessage response = await apiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
+        await emailServiceSpy.WaitForCaptureAsync();
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ForgotPasswordEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ForgotPasswordEndpointTests.cs
@@ -1,7 +1,11 @@
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 
 namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
 
@@ -55,7 +59,7 @@ public sealed class ForgotPasswordEndpointTests : EndpointsTestBase
     }
 
     [Fact]
-    public async Task ForgotPassword_ShouldSendEmail_WhenUserExists()
+    public async Task ForgotPassword_ShouldDeliverEmail_WhenUserExists()
     {
         // Arrange
         PasswordResetEmailSpy.Reset();
@@ -65,9 +69,11 @@ public sealed class ForgotPasswordEndpointTests : EndpointsTestBase
 
         ForgotPasswordRequest forgotRequest = new(request.Email);
 
-        // Act
+        // Act — the request only commits the outbox row; the e-mail arrives through the
+        // pipeline (relay -> delivery -> spy), so the capture has to be awaited (ADR-0038)
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative), forgotRequest);
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
 
         // Assert
         PasswordResetEmailSpy.CallCount.ShouldBe(1);
@@ -76,7 +82,33 @@ public sealed class ForgotPasswordEndpointTests : EndpointsTestBase
     }
 
     [Fact]
-    public async Task ForgotPassword_ShouldNotSendEmail_WhenUserDoesNotExist()
+    public async Task ForgotPassword_ShouldWriteAnIdOnlyOutboxRow_WhenUserExists()
+    {
+        // Arrange
+        PasswordResetEmailSpy.Reset();
+
+        (RegisterRequest request, IdentityId identityId) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        // Act
+        await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/forgot-password", UriKind.Relative), new ForgotPasswordRequest(request.Email));
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
+
+        // Assert — the payload carries the user id and nothing else: the reset token is minted
+        // at delivery and must never persist in an outbox row (ADR-0038 decision 2)
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            Factory, row => row.Type == nameof(PasswordResetRequested));
+        outboxRow.ShouldNotBeNull();
+        PasswordResetRequested payload = JsonSerializer.Deserialize<PasswordResetRequested>(outboxRow.Payload)
+            .ShouldNotBeNull();
+        payload.IdentityUserId.ShouldBe(identityId.Value);
+        PasswordResetEmailSpy.LastResetToken.ShouldNotBeNullOrEmpty();
+        outboxRow.Payload.ShouldNotContain(PasswordResetEmailSpy.LastResetToken);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_ShouldNotWriteAnOutboxRow_WhenUserDoesNotExist()
     {
         // Arrange
         PasswordResetEmailSpy.Reset();
@@ -87,7 +119,11 @@ public sealed class ForgotPasswordEndpointTests : EndpointsTestBase
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative), forgotRequest);
 
-        // Assert
+        // Assert — the row is written inside the request, so its absence after the response is
+        // definitive: nothing was queued, nothing will ever be delivered
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            Factory, row => row.Type == nameof(PasswordResetRequested), TimeSpan.FromSeconds(1));
+        outboxRow.ShouldBeNull();
         PasswordResetEmailSpy.CallCount.ShouldBe(0);
     }
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ForgotPasswordPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ForgotPasswordPageTests.cs
@@ -1,0 +1,113 @@
+using System.Text.RegularExpressions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+/// <summary>
+/// The SSR twin of the forgot-password API slice goes through the same outbox pipeline
+/// (ADR-0038): posting the form commits an id-only outbox row instead of minting a token
+/// in-request, and the anti-enumeration success panel shows either way.
+/// </summary>
+public sealed partial class ForgotPasswordPageTests : EndpointsTestBase
+{
+    public ForgotPasswordPageTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public async Task ForgotPasswordPage_ShouldDeliverEmailThroughThePipeline_WhenUserExists()
+    {
+        // Arrange
+        PasswordResetEmailSpy.Reset();
+
+        (RegisterRequest request, IdentityId identityId) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        // Act
+        HttpResponseMessage response = await PostToForgotPasswordPageAsync(request.Email);
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
+
+        // Assert — success panel plus a delivered e-mail whose token never touched the outbox row
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Jeśli konto istnieje");
+
+        PasswordResetEmailSpy.CallCount.ShouldBe(1);
+        PasswordResetEmailSpy.LastEmail.ShouldBe(request.Email);
+        PasswordResetEmailSpy.LastResetToken.ShouldNotBeNullOrEmpty();
+
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            Factory, row => row.Type == nameof(PasswordResetRequested));
+        outboxRow.ShouldNotBeNull();
+        PasswordResetRequested payload = JsonSerializer.Deserialize<PasswordResetRequested>(outboxRow.Payload)
+            .ShouldNotBeNull();
+        payload.IdentityUserId.ShouldBe(identityId.Value);
+        outboxRow.Payload.ShouldNotContain(PasswordResetEmailSpy.LastResetToken!);
+    }
+
+    [Fact]
+    public async Task ForgotPasswordPage_ShouldShowSuccessWithoutQueueingAnything_WhenUserDoesNotExist()
+    {
+        // Arrange
+        PasswordResetEmailSpy.Reset();
+
+        // Act
+        HttpResponseMessage response = await PostToForgotPasswordPageAsync("nobody@example.com");
+
+        // Assert — the anti-enumeration panel shows, but nothing was queued and nothing will send
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Jeśli konto istnieje");
+
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            Factory, row => row.Type == nameof(PasswordResetRequested), TimeSpan.FromSeconds(1));
+        outboxRow.ShouldBeNull();
+        PasswordResetEmailSpy.CallCount.ShouldBe(0);
+    }
+
+    private async Task<HttpResponseMessage> PostToForgotPasswordPageAsync(string email)
+    {
+        HttpResponseMessage pageResponse = await ApiClient.Http.GetAsync(
+            new Uri("/Account/ForgotPassword", UriKind.Relative));
+        pageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await pageResponse.Content.ReadAsStringAsync();
+        string? antiForgeryToken = ExtractAntiForgeryToken(html);
+
+        Dictionary<string, string> formFields = new()
+        {
+            ["Email"] = email
+        };
+        if (antiForgeryToken is not null)
+        {
+            formFields["__RequestVerificationToken"] = antiForgeryToken;
+        }
+
+        using FormUrlEncodedContent content = new(formFields);
+        using HttpRequestMessage request = new(HttpMethod.Post, "/Account/ForgotPassword");
+        request.Content = content;
+
+        if (pageResponse.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
+        {
+            foreach (string cookie in cookies)
+            {
+                request.Headers.Add("Cookie", cookie.Split(';')[0]);
+            }
+        }
+
+        return await ApiClient.Http.SendAsync(request);
+    }
+
+    private static string? ExtractAntiForgeryToken(string html)
+    {
+        Match match = AntiForgeryTokenRegex().Match(html);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [GeneratedRegex("""name="__RequestVerificationToken".*?value="([^"]+)""")]
+    private static partial Regex AntiForgeryTokenRegex();
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordEndpointTests.cs
@@ -24,6 +24,7 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
 
         string resetToken = PasswordResetEmailSpy.LastResetToken!;
 
@@ -52,6 +53,7 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
 
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/reset-password", UriKind.Relative),
@@ -93,6 +95,7 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
 
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/reset-password", UriKind.Relative),
@@ -146,6 +149,7 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
 
         HttpResponseMessage resetResponse = await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/reset-password", UriKind.Relative),
@@ -216,6 +220,7 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
 
         ResetPasswordRequest resetRequest = new(
             registerRequest.Email,
@@ -244,6 +249,7 @@ public sealed class ResetPasswordEndpointTests : EndpointsTestBase
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
 
         string resetToken = PasswordResetEmailSpy.LastResetToken!;
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResetPasswordPageTests.cs
@@ -42,6 +42,7 @@ public sealed partial class ResetPasswordPageTests : EndpointsTestBase
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(registerRequest.Email));
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
         string resetToken = PasswordResetEmailSpy.LastResetToken!;
 
         // Complete the reset through the browser Razor page

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/SecurityStampCookieValidationTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/SecurityStampCookieValidationTests.cs
@@ -129,6 +129,7 @@ public sealed partial class SecurityStampCookieValidationTests : AsyncLifetimeTe
         await ApiClient.Http.PostAsJsonAsync(
             new Uri("auth/forgot-password", UriKind.Relative),
             new ForgotPasswordRequest(email));
+        await PasswordResetEmailSpy.WaitForCaptureAsync();
         string resetToken = PasswordResetEmailSpy.LastResetToken!;
 
         HttpResponseMessage resetResponse = await PostToResetPasswordPageAsync(new Dictionary<string, string>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/PasswordResetPipelineTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/PasswordResetPipelineTests.cs
@@ -1,0 +1,264 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using RabbitMQ.Client;
+using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Messaging;
+
+/// <summary>
+/// The password-reset legs of the brokered pipeline (MSG-03, ADR-0038): forgot-password commits
+/// an id-only outbox row, the real relay publishes it to a real broker, and the real consumer
+/// selects <c>PasswordResetRequestProcessor</c> by the AMQP <c>type</c> property, mints the token
+/// at delivery and dispatches to the spy sender. The legs mirror
+/// <see cref="EmailConfirmationPipelineTests"/> where the machinery is shared and add what is
+/// specific to this type: the token must never appear in an outbox row or a parked message, and
+/// the delivered token must actually reset the password.
+/// </summary>
+public sealed class PasswordResetPipelineTests : IClassFixture<BrokeredAuthSystemApiFactory>, IAsyncLifetime
+{
+    private static readonly TimeSpan DeliveryTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan EmptyQueueGrace = TimeSpan.FromSeconds(2);
+
+    private readonly BrokeredAuthSystemApiFactory _factory;
+    private readonly TestApiClient _apiClient;
+    private readonly SpyAccountConfirmationEmailSender _confirmationEmailSpy;
+    private readonly SpyPasswordResetEmailSender _passwordResetEmailSpy;
+    private readonly Bogus.Faker _faker = new();
+
+    public PasswordResetPipelineTests(BrokeredAuthSystemApiFactory factory)
+    {
+        _factory = factory;
+        _confirmationEmailSpy = factory.Services.GetRequiredService<SpyAccountConfirmationEmailSender>();
+        _passwordResetEmailSpy = factory.Services.GetRequiredService<SpyPasswordResetEmailSender>();
+
+        JsonSerializerOptions jsonSerializerOptions =
+            factory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+        _apiClient = new TestApiClient(factory.CreateClient(), jsonSerializerOptions);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _confirmationEmailSpy.Reset();
+        _passwordResetEmailSpy.Reset();
+
+        await using AsyncServiceScope scope = _factory.Services.CreateAsyncScope();
+        CleanerService cleaner = scope.ServiceProvider.GetRequiredService<CleanerService>();
+        await cleaner.CleanAsync();
+
+        // The host's consumer declares the topology on startup, but the first test may reach this
+        // point before that attach finished — declaring here is idempotent (proven in
+        // DeadLetterTopologyTests) and guarantees the purges below have queues to purge.
+        await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+        await RabbitMqTopologyDeclaration.DeclareAsync(channel, CancellationToken.None);
+        await channel.QueuePurgeAsync(RabbitMqTopology.EmailQueue);
+        await channel.QueuePurgeAsync(RabbitMqTopology.EmailDeadLetterQueue);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Pipeline_ShouldDeliverAResetEmailWhoseTokenWorks_WhenForgotPasswordCommits()
+    {
+        // Arrange — a confirmed account, so the only pipeline traffic left is the reset e-mail
+        (RegisterRequest request, IdentityId identityId) = await UserFactory.RegisterRandomUserWithRequestAsync(
+            _apiClient, _faker, _confirmationEmailSpy);
+
+        // Act — forgot-password is the user-facing trigger of the whole pipeline
+        HttpResponseMessage forgotResponse = await _apiClient.Http.PostAsJsonAsync(
+            new Uri("auth/forgot-password", UriKind.Relative), new ForgotPasswordRequest(request.Email));
+        await _passwordResetEmailSpy.WaitForCaptureAsync(DeliveryTimeout);
+
+        // Assert — the e-mail went out once, to the registered address, with a usable token
+        forgotResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _passwordResetEmailSpy.LastEmail.ShouldBe(request.Email);
+        _passwordResetEmailSpy.LastResetToken.ShouldNotBeNullOrWhiteSpace();
+        _passwordResetEmailSpy.CallCount.ShouldBe(1);
+
+        // The delivered token really resets the password — the end-to-end proof that minting at
+        // delivery produced a link the user can use
+        HttpResponseMessage resetResponse = await _apiClient.Http.PostAsJsonAsync(
+            new Uri("auth/reset-password", UriKind.Relative),
+            new ResetPasswordRequest(request.Email, _passwordResetEmailSpy.LastResetToken!, "NewPass99!"));
+        resetResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // The outbox row was published and marked on the first attempt — and carries the user id
+        // alone: no reset token may ever persist in an outbox row (ADR-0038 decision 2)
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            _factory,
+            row => row.Type == nameof(PasswordResetRequested) && row.ProcessedOn != null,
+            DeliveryTimeout);
+        outboxRow.ShouldNotBeNull();
+        outboxRow.Attempts.ShouldBe(0);
+        outboxRow.LastError.ShouldBeNull();
+        PasswordResetRequested payload = JsonSerializer.Deserialize<PasswordResetRequested>(outboxRow.Payload)
+            .ShouldNotBeNull();
+        payload.IdentityUserId.ShouldBe(identityId.Value);
+        outboxRow.Payload.ShouldNotContain(_passwordResetEmailSpy.LastResetToken!);
+
+        // The delivery was recorded for deduplication and nothing was left on the broker
+        (await OutboxAssertions.CountInboxRowsAsync(_factory, outboxRow.Id)).ShouldBe(1);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, EmptyQueueGrace)).ShouldBeNull();
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Consumer_ShouldAckWithoutSecondEmail_WhenTheSameMessageIdIsDeliveredAgain()
+    {
+        // Arrange — a fully delivered reset request, then its exact wire message published again
+        // (the relay's crash window: published but not yet marked processed → re-published later)
+        (RegisterRequest request, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
+            _apiClient, _faker, _confirmationEmailSpy);
+        await _apiClient.Http.PostAsJsonAsync(
+            new Uri("auth/forgot-password", UriKind.Relative), new ForgotPasswordRequest(request.Email));
+        await _passwordResetEmailSpy.WaitForCaptureAsync(DeliveryTimeout);
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            _factory,
+            row => row.Type == nameof(PasswordResetRequested) && row.ProcessedOn != null,
+            DeliveryTimeout);
+        outboxRow.ShouldNotBeNull();
+        int sendsAfterFirstDelivery = _passwordResetEmailSpy.CallCount;
+
+        // Act — same payload, same type, same message id, over the real wire
+        IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(
+            RabbitMqTopology.PasswordResetRoutingKey,
+            outboxRow.Type,
+            outboxRow.Payload,
+            outboxRow.Id,
+            CancellationToken.None);
+
+        // Assert — the duplicate is consumed (queue drains), acked (no parking) and suppressed
+        await WaitUntilQueueEmptyAsync(RabbitMqTopology.EmailQueue, DeliveryTimeout);
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        _passwordResetEmailSpy.CallCount.ShouldBe(sendsAfterFirstDelivery);
+        (await OutboxAssertions.CountInboxRowsAsync(_factory, outboxRow.Id)).ShouldBe(1);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("this is not json at all")]
+    [InlineData("{}")]
+    [InlineData("""{"IdentityUserId":"not-a-guid"}""")]
+    public async Task Consumer_ShouldParkDeliveryInDeadLetterQueue_WhenThePayloadIsPoison(string poisonPayload)
+    {
+        // Act — a valid message id and the registered reset type, so the reject decision can only
+        // come from the payload
+        Guid messageId = Guid.CreateVersion7();
+        IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(
+            RabbitMqTopology.PasswordResetRoutingKey,
+            nameof(PasswordResetRequested),
+            poisonPayload,
+            messageId,
+            CancellationToken.None);
+
+        // Assert — parked on first sight, no e-mail, no dedup record
+        BasicGetResult dead =
+            (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, DeliveryTimeout)).ShouldNotBeNull();
+        Encoding.UTF8.GetString(dead.Body.ToArray()).ShouldBe(poisonPayload);
+        FirstDeathReason(dead.BasicProperties).ShouldBe("rejected");
+        _passwordResetEmailSpy.CallCount.ShouldBe(0);
+        (await OutboxAssertions.CountInboxRowsAsync(_factory, messageId)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Consumer_ShouldAckWithoutEmailAndWithoutParking_WhenTheUserNoLongerExists()
+    {
+        // Act — a payload whose user id matches no account (requested, then erased): redelivery
+        // could never change the outcome, so the ack-and-record contract applies, not the DLQ
+        Guid messageId = Guid.CreateVersion7();
+        string payload = JsonSerializer.Serialize(new PasswordResetRequested(Guid.CreateVersion7()));
+        IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(
+            RabbitMqTopology.PasswordResetRoutingKey,
+            nameof(PasswordResetRequested),
+            payload,
+            messageId,
+            CancellationToken.None);
+
+        // Assert — the inbox record doubles as the "consumer finished" signal
+        int inboxRows = await OutboxAssertions.WaitForInboxRowsAsync(_factory, messageId, DeliveryTimeout);
+        inboxRows.ShouldBe(1);
+        _passwordResetEmailSpy.CallCount.ShouldBe(0);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, EmptyQueueGrace)).ShouldBeNull();
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Polls the queue until a delivery arrives or the timeout passes — routing and dead-lettering
+    /// are asynchronous inside the broker. The read is auto-acked: every caller either asserts on
+    /// the delivery (test over either way) or expects null.
+    /// </summary>
+    private async Task<BasicGetResult?> GetWithinTimeoutAsync(string queue, TimeSpan timeout)
+    {
+        await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        while (true)
+        {
+            BasicGetResult? delivery = await channel.BasicGetAsync(queue, autoAck: true);
+            if (delivery is not null)
+            {
+                return delivery;
+            }
+
+            if (elapsed.Elapsed >= timeout)
+            {
+                return null;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    private async Task WaitUntilQueueEmptyAsync(string queue, TimeSpan timeout)
+    {
+        await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        while (elapsed.Elapsed < timeout)
+        {
+            uint messageCount = await channel.MessageCountAsync(queue);
+            if (messageCount == 0)
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    /// <summary>
+    /// Reads the reason of the first (most recent) <c>x-death</c> entry the broker stamped on a
+    /// dead-lettered message.
+    /// </summary>
+    private static string? FirstDeathReason(IReadOnlyBasicProperties properties)
+    {
+        if (properties.Headers is not { } headers
+            || !headers.TryGetValue("x-death", out object? deathsRaw)
+            || deathsRaw is not IList { Count: > 0 } deaths
+            || deaths[0] is not IDictionary firstDeath
+            || !firstDeath.Contains("reason"))
+        {
+            return null;
+        }
+
+        return firstDeath["reason"] is byte[] reason ? Encoding.UTF8.GetString(reason) : null;
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxMessageRoutingTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxMessageRoutingTests.cs
@@ -15,10 +15,22 @@ public sealed class OutboxMessageRoutingTests
         routingKey.ShouldBe(RabbitMqTopology.EmailConfirmationRoutingKey);
     }
 
+    [Fact]
+    public void TryGetRoutingKey_PasswordResetRequested_MapsToPasswordResetRoutingKey()
+    {
+        bool found = OutboxMessageRouting.TryGetRoutingKey(
+            nameof(PasswordResetRequested), out string? routingKey);
+
+        found.ShouldBeTrue();
+        routingKey.ShouldBe(RabbitMqTopology.PasswordResetRoutingKey);
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("emailconfirmationrequested")]
     [InlineData("email.confirmation")]
+    [InlineData("passwordresetrequested")]
+    [InlineData("email.password-reset")]
     [InlineData("SomeFutureUnmappedEvent")]
     public void TryGetRoutingKey_UnknownOrMiscasedType_ReturnsFalse(string type)
     {

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/PasswordResetRequestProcessorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/PasswordResetRequestProcessorTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+using NSubstitute;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Services.Emails;
+
+public sealed class PasswordResetRequestProcessorTests
+{
+    private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
+    private readonly IPasswordResetEmailSender _emailSender =
+        Substitute.For<IPasswordResetEmailSender>();
+
+    [Fact]
+    public async Task ProcessAsync_UserNoLongerExists_SucceedsWithoutSending()
+    {
+        Guid userId = Guid.NewGuid();
+        _userManager.FindByIdAsync(userId.ToString()).Returns((ApplicationUser?)null);
+        PasswordResetRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new PasswordResetRequested(userId), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendPasswordResetEmailAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_DeletionIsScheduled_SucceedsWithoutSending()
+    {
+        // While GDPR deletion is scheduled, the emailed cancel-deletion link is the only recovery
+        // path — the processor is the single home of this guard (ADR-0038 decision 2).
+        ApplicationUser user = CreateUser();
+        user.DeletionScheduledAt = DateTimeOffset.UtcNow;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        PasswordResetRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new PasswordResetRequested(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendPasswordResetEmailAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UserHasNoEmailAddress_SucceedsWithoutSending()
+    {
+        ApplicationUser user = CreateUser();
+        user.Email = null;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        PasswordResetRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new PasswordResetRequested(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendPasswordResetEmailAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ActiveUser_SendsTheEmailWithAFreshlyMintedToken()
+    {
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GeneratePasswordResetTokenAsync(user).Returns("fresh-token");
+        _emailSender.SendPasswordResetEmailAsync(user.Id, user.Email!, "fresh-token", Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        PasswordResetRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new PasswordResetRequested(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.Received(1)
+            .SendPasswordResetEmailAsync(user.Id, user.Email!, "fresh-token", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SendingFails_PropagatesTheFailure()
+    {
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GeneratePasswordResetTokenAsync(user).Returns("fresh-token");
+        Error smtpError = new("Email.SendFailed", "SMTP relay refused the message.");
+        _emailSender.SendPasswordResetEmailAsync(user.Id, user.Email!, "fresh-token", Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(smtpError));
+        PasswordResetRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new PasswordResetRequested(user.Id), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(smtpError);
+    }
+
+    [Theory]
+    [InlineData("this is not json at all")]
+    [InlineData("{}")]
+    [InlineData("""{"IdentityUserId":"not-a-guid"}""")]
+    public void TryDeserialize_PoisonPayload_ReturnsTheNullVerdict(string poisonPayload)
+    {
+        PasswordResetRequestProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(System.Text.Encoding.UTF8.GetBytes(poisonPayload));
+
+        message.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_ValidPayload_ReturnsTheTypedMessage()
+    {
+        Guid userId = Guid.CreateVersion7();
+        PasswordResetRequestProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(
+            System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new PasswordResetRequested(userId)));
+
+        PasswordResetRequested typed = message.ShouldBeOfType<PasswordResetRequested>();
+        typed.IdentityUserId.ShouldBe(userId);
+    }
+
+    private static ApplicationUser CreateUser() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserName = "frodo",
+            Email = "frodo@shire.me"
+        };
+
+    private PasswordResetRequestProcessor CreateSut() =>
+        new(_userManager, _emailSender, NullLogger<PasswordResetRequestProcessor>.Instance);
+
+    private static UserManager<ApplicationUser> CreateUserManager() =>
+        Substitute.For<UserManager<ApplicationUser>>(
+            Substitute.For<IUserStore<ApplicationUser>>(),
+            null!, null!, null!, null!, null!, null!, null!, null!);
+}


### PR DESCRIPTION
Closes #581

## What

Password reset e-mails now travel the outbox → relay → RabbitMQ → consumer pipeline instead of being sent synchronously in-request. Both call sites — the `auth/forgot-password` API slice and the `/Account/ForgotPassword` SSR page — commit an id-only `PasswordResetRequested` outbox row inside their request; the new `PasswordResetRequestProcessor` mints the reset token at delivery and sends through the existing `PasswordResetEmailSender`.

## Why

Per ADR-0038 (MSG-01) and epic #578: one delivery semantic for every transactional e-mail, no live token ever persisted in an outbox row, broker frame or DLQ-parked message, and the forgot-password timing leak closed — the SMTP round-trip paid only for existing accounts leaves the request path, and the PBKDF2 dummy verify now runs on both branches so the oracle cannot invert (decision 5). The `DeletionScheduledAt` guard moves into the processor (decision 2), its single home — this also fixes the SSR page having skipped that check entirely.

## How the acceptance criteria are met

- **No reset token in outbox/broker/DLQ:** payload carries the user id alone; pinned by outbox-row payload assertions at both call sites and in the brokered pipeline suite, plus poison-DLQ legs whose parked bodies are producer-side payloads only.
- **Identical response for existing and unknown accounts:** 200 + dummy verify on both branches; existing account additionally pays only the cheap outbox insert.
- **Delivered link works end-to-end:** the brokered pipeline test drives register → forgot-password → real broker delivery → captured token → `auth/reset-password` → 200.

## Tests

- Unit: `PasswordResetRequestProcessorTests` (user gone / deletion scheduled / no address ack-and-skip legs, fresh-token send, SMTP failure propagation, poison `TryDeserialize` matrix), routing map entry.
- Integration (real PostgreSQL): outbox-row written for existing accounts and absent for unknown ones on both call sites; new `ForgotPasswordPageTests` for the SSR twin; `DeletionGraceWindowTests` leg strengthened to wait for the inbox row so a broken guard cannot pass green.
- Integration (real RabbitMQ): new `PasswordResetPipelineTests` — exactly-once delivery with a usable token, duplicate-message-id dedup, poison parking, user-gone ack.
- Full solution builds with zero warnings; AuthSystem unit 125/125, integration 333/333, patcher + SharedKernel unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GntiUWk6XE5bf6fgaoGX7Z