### PR TITLE
MSG-04: Account-deletion e-mails through the broker

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -108,6 +108,10 @@ internal static class ApiDependencyInjection
                 nameof(EmailConfirmationRequested));
             services.AddKeyedScoped<IEmailMessageProcessor, PasswordResetRequestProcessor>(
                 nameof(PasswordResetRequested));
+            services.AddKeyedScoped<IEmailMessageProcessor, AccountDeletionScheduledProcessor>(
+                nameof(AccountDeletionScheduled));
+            services.AddKeyedScoped<IEmailMessageProcessor, AccountDeletionCancelledProcessor>(
+                nameof(AccountDeletionCancelled));
             services.AddScoped<EmailDeliveryProcessor>();
             services.AddHostedService<EmailDispatchConsumer>();
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -29,13 +29,14 @@ internal static class EventIds
     public const int GdprErasureArtifactsCleanupFailed = 2228;
     public const int GdprErasureEmergencyLockout = 2229;
     public const int GdprErasureEmergencyLockoutFailed = 2230;
+    // 2235 (GdprDeletionScheduledEmailFailed), 2236 (GdprDeletionCancelledEmailFailed) and
+    // 2237 (GdprDeletionScheduleUnwound) retired: the deletion e-mails left the request path for
+    // the outbox pipeline (ADR-0038), so the handlers no longer observe SMTP and the unwind
+    // compensation the failure triggered is gone (decision 5)
     public const int GdprDeletionScheduled = 2231;
     public const int GdprDeletionCancelled = 2232;
     public const int GdprDeletionFinalized = 2233;
     public const int GdprCancelTokenInvalid = 2234;
-    public const int GdprDeletionScheduledEmailFailed = 2235;
-    public const int GdprDeletionCancelledEmailFailed = 2236;
-    public const int GdprDeletionScheduleUnwound = 2237;
     public const int GdprDeletionFinalizerRunFailed = 2238;
     public const int GdprDeletionFinalizerUserFailed = 2239;
 
@@ -101,6 +102,17 @@ internal static class EventIds
     public const int PasswordResetAddressMissing = 2361;
     public const int PasswordResetDeletionScheduled = 2362;
 
+    // Deletion-Scheduled Dispatch (2370–2379)
+    public const int DeletionScheduledUserGone = 2370;
+    public const int DeletionScheduledScheduleGone = 2371;
+    public const int DeletionScheduledWindowOver = 2372;
+    public const int DeletionScheduledAddressMissing = 2373;
+
+    // Deletion-Cancelled Dispatch (2380–2389)
+    public const int DeletionCancelledUserGone = 2380;
+    public const int DeletionCancelledRescheduled = 2381;
+    public const int DeletionCancelledAddressMissing = 2382;
+
     // Middleware (2400–2499)
     public const int UnauthorizedAccessAttempt = 2400;
     public const int ForbiddenAccessAttempt = 2401;
@@ -119,13 +131,11 @@ internal static class EventIds
     public const int RegisterCompletedViaUi = 2640;
     public const int DeletionCancelledViaUi = 2650;
 
-    // GDPR Deletion Scheduling internals (2700–2709)
+    // GDPR Deletion Scheduling internals (2700–2709) — 2701–2703 and 2705 retired: the unwind
+    // compensation is gone (ADR-0038 decision 5) and both deletion flows now rotate the security
+    // stamp inside their single save (decision 2), so there is no separate stamp update to fail
     public const int GdprDeletionSchedulingUpdateFailed = 2700;
-    public const int GdprDeletionScheduleUnwindFailed = 2701;
-    public const int GdprDeletionScheduleUnwindException = 2702;
-    public const int GdprDeletionScheduleStampFailed = 2703;
     public const int GdprDeletionScheduleArtifactRevocationFailed = 2704;
-    public const int GdprDeletionCancelStampFailed = 2705;
 
     // Forgot/Reset Password deletion-window gates (2710–2719) — 2710
     // (ForgotPasswordDeletionScheduled) retired: the forgot-password gate moved to the dispatch

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/CancelAccountDeletion.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/CancelAccountDeletion.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Identity;
 using LotroKoniecDev.AuthSystem.API.ApiErrors;
 using LotroKoniecDev.AuthSystem.API.Common;
 using LotroKoniecDev.AuthSystem.API.Extensions;
-using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 using LotroKoniecDev.AuthSystem.Persistence.Identity;
@@ -20,6 +20,9 @@ namespace LotroKoniecDev.AuthSystem.API.Features.Auth;
 /// the whole grace window, so the emailed token is the only proof of ownership.
 /// Cancelling invalidates the current password (it may be the attacker's only asset)
 /// and hands back a fresh reset token that forces the password-reset flow.
+/// The courtesy notice travels through the outbox pipeline (ADR-0038): its row commits
+/// atomically with the cancellation, turning the former fire-and-forget send into a
+/// guaranteed delivery.
 /// </summary>
 internal sealed partial class CancelAccountDeletion : IApiEndpoint
 {
@@ -56,18 +59,18 @@ internal sealed partial class CancelAccountDeletion : IApiEndpoint
             new PasswordHasher<ApplicationUser>().HashPassword(new ApplicationUser(), "DummyP@ssw0rd!");
 
         private readonly UserManager<ApplicationUser> _userManager;
-        private readonly IAccountDeletionEmailSender _emailSender;
+        private readonly OutboxWriter _outboxWriter;
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
 
         public Handler(
             UserManager<ApplicationUser> userManager,
-            IAccountDeletionEmailSender emailSender,
+            OutboxWriter outboxWriter,
             IValidator<Command> validator,
             ILogger<Handler> logger)
         {
             _userManager = userManager;
-            _emailSender = emailSender;
+            _outboxWriter = outboxWriter;
             _validator = validator;
             _logger = logger;
         }
@@ -118,6 +121,14 @@ internal sealed partial class CancelAccountDeletion : IApiEndpoint
             user.AccessFailedCount = 0;
             user.PasswordHash = null;
 
+            // Rotating the stamp makes the cancel token single-use and kills any leftover
+            // sessions. Assigned INSIDE the same save that commits the outbox row (ADR-0038
+            // decision 2) — the notice carries no token, but the rule keeps every e-mail
+            // writer's stamp final before its row becomes visible to the relay.
+            user.SecurityStamp = Guid.NewGuid().ToString();
+
+            _outboxWriter.Enqueue(new AccountDeletionCancelled(user.Id));
+
             IdentityResult updateResult = await _userManager.UpdateAsync(user);
             if (!updateResult.Succeeded)
             {
@@ -125,22 +136,11 @@ internal sealed partial class CancelAccountDeletion : IApiEndpoint
                 return Result.Failure<CancelledDeletion>(AuthErrors.CancelDeletionFailed(errors));
             }
 
-            // Rotating the stamp makes the cancel token single-use and kills any leftover
-            // sessions; the reset token must be generated AFTER the rotation to stay valid.
-            IdentityResult stampResult = await _userManager.UpdateSecurityStampAsync(user);
-            if (!stampResult.Succeeded)
-            {
-                LogSecurityStampUpdateFailed(_logger, user.Id);
-            }
+            _outboxWriter.NotifyEnqueuedCommitted();
 
+            // Minted AFTER the commit, against the committed stamp — a token minted before the
+            // save would die with the rotation it travels next to.
             string passwordResetToken = await _userManager.GeneratePasswordResetTokenAsync(user);
-
-            Result emailResult = await _emailSender.SendDeletionCancelledEmailAsync(
-                user.Id, user.Email!, cancellationToken);
-            if (emailResult.IsFailure)
-            {
-                LogCancelledEmailFailed(_logger, user.Id, emailResult.Error.Message);
-            }
 
             LogDeletionCancelled(_logger, user.Id, command.IpAddress, command.UserAgent);
 
@@ -152,12 +152,6 @@ internal sealed partial class CancelAccountDeletion : IApiEndpoint
 
         [LoggerMessage(EventId = EventIds.GdprCancelTokenInvalid, Level = LogLevel.Warning, Message = "Invalid cancel-deletion token presented for {MaskedEmail}. IP: {IpAddress}, UserAgent: {UserAgent}")]
         private static partial void LogCancelTokenInvalid(ILogger logger, string maskedEmail, string? ipAddress, string? userAgent);
-
-        [LoggerMessage(EventId = EventIds.GdprDeletionCancelledEmailFailed, Level = LogLevel.Error, Message = "Failed to send the deletion-cancelled confirmation email for user {UserId}: {Error}")]
-        private static partial void LogCancelledEmailFailed(ILogger logger, Guid userId, string error);
-
-        [LoggerMessage(EventId = EventIds.GdprDeletionCancelStampFailed, Level = LogLevel.Error, Message = "Failed to update security stamp for user {UserId} while cancelling deletion")]
-        private static partial void LogSecurityStampUpdateFailed(ILogger logger, Guid userId);
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/DeleteAccount.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/DeleteAccount.cs
@@ -7,11 +7,10 @@ using OpenIddict.Abstractions;
 using LotroKoniecDev.AuthSystem.API.ApiErrors;
 using LotroKoniecDev.AuthSystem.API.Common;
 using LotroKoniecDev.AuthSystem.API.Extensions;
-using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Settings;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
-using LotroKoniecDev.AuthSystem.Persistence.Identity;
 using LotroKoniecDev.SharedKernel.Messaging;
 using LotroKoniecDev.SharedKernel.Monads;
 
@@ -22,6 +21,9 @@ namespace LotroKoniecDev.AuthSystem.API.Features.Auth;
 /// the account is locked for the grace period and a one-time cancellation link is emailed,
 /// so a stolen password alone can no longer erase an account irreversibly.
 /// The deletion finalizer performs the actual erasure once the grace period elapses.
+/// The cancel e-mail travels through the outbox pipeline (ADR-0038): its row commits atomically
+/// with the schedule, so "scheduled but no e-mail ever recorded" cannot exist, and delivery
+/// failures are the pipeline's to retry — not this handler's to compensate.
 /// </summary>
 internal sealed partial class DeleteAccount : IApiEndpoint
 {
@@ -52,7 +54,7 @@ internal sealed partial class DeleteAccount : IApiEndpoint
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IOpenIddictTokenManager _tokenManager;
         private readonly IOpenIddictAuthorizationManager _authorizationManager;
-        private readonly IAccountDeletionEmailSender _emailSender;
+        private readonly OutboxWriter _outboxWriter;
         private readonly TimeProvider _timeProvider;
         private readonly GdprSettings _gdprSettings;
         private readonly IValidator<Command> _validator;
@@ -62,7 +64,7 @@ internal sealed partial class DeleteAccount : IApiEndpoint
             UserManager<ApplicationUser> userManager,
             IOpenIddictTokenManager tokenManager,
             IOpenIddictAuthorizationManager authorizationManager,
-            IAccountDeletionEmailSender emailSender,
+            OutboxWriter outboxWriter,
             TimeProvider timeProvider,
             IOptions<GdprSettings> gdprSettings,
             IValidator<Command> validator,
@@ -71,7 +73,7 @@ internal sealed partial class DeleteAccount : IApiEndpoint
             _userManager = userManager;
             _tokenManager = tokenManager;
             _authorizationManager = authorizationManager;
-            _emailSender = emailSender;
+            _outboxWriter = outboxWriter;
             _timeProvider = timeProvider;
             _gdprSettings = gdprSettings.Value;
             _validator = validator;
@@ -103,10 +105,6 @@ internal sealed partial class DeleteAccount : IApiEndpoint
                 return Result.Failure<ScheduledDeletion>(AuthErrors.DeletionAlreadyScheduled);
             }
 
-            // The still-real email address; captured before any mutation so the
-            // cancellation link always reaches the legitimate owner.
-            string email = user.Email!;
-
             DateTimeOffset scheduledAt = _timeProvider.GetUtcNow();
             DateTimeOffset finalizesAt = scheduledAt + _gdprSettings.DeletionGracePeriod;
 
@@ -117,6 +115,14 @@ internal sealed partial class DeleteAccount : IApiEndpoint
             user.LockoutEnabled = true;
             user.LockoutEnd = finalizesAt;
 
+            // Invalidate all sessions by assigning the fresh stamp INSIDE the same save that
+            // commits the outbox row (ADR-0038 decision 2): the relay is signal-driven, so the
+            // dispatch processor can mint the cancel token milliseconds after commit — a stamp
+            // rotated in a later save would kill the emailed link it just minted.
+            user.SecurityStamp = Guid.NewGuid().ToString();
+
+            _outboxWriter.Enqueue(new AccountDeletionScheduled(user.Id));
+
             IdentityResult updateResult = await _userManager.UpdateAsync(user);
             if (!updateResult.Succeeded)
             {
@@ -125,31 +131,9 @@ internal sealed partial class DeleteAccount : IApiEndpoint
                 return Result.Failure<ScheduledDeletion>(AuthErrors.DeletionSchedulingFailed);
             }
 
-            // Invalidate all sessions; the cancel token must be generated AFTER the stamp
-            // rotation because it binds to the security stamp (one-time-use guarantee).
-            IdentityResult stampResult = await _userManager.UpdateSecurityStampAsync(user);
-            if (!stampResult.Succeeded)
-            {
-                LogSecurityStampUpdateFailed(_logger, user.Id);
-            }
+            _outboxWriter.NotifyEnqueuedCommitted();
 
             await TryRevokeOpenIddictArtifactsAsync(user, cancellationToken);
-
-            string cancelToken = await _userManager.GenerateUserTokenAsync(
-                user,
-                AccountDeletionCancellationTokenProvider.ProviderName,
-                AccountDeletionCancellationTokenProvider.CancelDeletionPurpose);
-
-            Result emailResult = await _emailSender.SendDeletionScheduledEmailAsync(
-                user.Id, email, cancelToken, finalizesAt, cancellationToken);
-            if (emailResult.IsFailure)
-            {
-                // Without the emailed link the owner has no way to cancel, so the schedule
-                // is unwound and the user is asked to retry once mail delivery recovers.
-                LogScheduledEmailFailed(_logger, user.Id, emailResult.Error.Message);
-                await TryUnwindScheduleAsync(user);
-                return Result.Failure<ScheduledDeletion>(AuthErrors.DeletionSchedulingFailed);
-            }
 
             LogDeletionScheduled(_logger, user.Id, finalizesAt, command.IpAddress, command.UserAgent);
 
@@ -180,49 +164,11 @@ internal sealed partial class DeleteAccount : IApiEndpoint
             }
         }
 
-        private async Task TryUnwindScheduleAsync(ApplicationUser user)
-        {
-            try
-            {
-                user.DeletionScheduledAt = null;
-                user.LockoutEnd = null;
-
-                IdentityResult updateResult = await _userManager.UpdateAsync(user);
-                if (updateResult.Succeeded)
-                {
-                    LogScheduleUnwound(_logger, user.Id);
-                    return;
-                }
-
-                string errors = string.Join(", ", updateResult.Errors.Select(e => e.Description));
-                LogScheduleUnwindFailed(_logger, user.Id, errors);
-            }
-            catch (Exception ex)
-            {
-                LogScheduleUnwindException(_logger, ex, user.Id);
-            }
-        }
-
         [LoggerMessage(EventId = EventIds.GdprDeletionScheduled, Level = LogLevel.Information, Message = "GDPR deletion scheduled for user {UserId}; finalizes at {FinalizesAt}. IP: {IpAddress}, UserAgent: {UserAgent}")]
         private static partial void LogDeletionScheduled(ILogger logger, Guid userId, DateTimeOffset finalizesAt, string? ipAddress, string? userAgent);
 
-        [LoggerMessage(EventId = EventIds.GdprDeletionScheduledEmailFailed, Level = LogLevel.Error, Message = "Failed to send the deletion-scheduled email for user {UserId}: {Error}. Unwinding the schedule.")]
-        private static partial void LogScheduledEmailFailed(ILogger logger, Guid userId, string error);
-
-        [LoggerMessage(EventId = EventIds.GdprDeletionScheduleUnwound, Level = LogLevel.Warning, Message = "Deletion schedule unwound for user {UserId} because the cancellation email could not be sent")]
-        private static partial void LogScheduleUnwound(ILogger logger, Guid userId);
-
-        [LoggerMessage(EventId = EventIds.GdprDeletionScheduleUnwindFailed, Level = LogLevel.Critical, Message = "Failed to unwind the deletion schedule for user {UserId}: {Errors}. Account stays locked with a schedule but without a cancellation email. Manual intervention required.")]
-        private static partial void LogScheduleUnwindFailed(ILogger logger, Guid userId, string errors);
-
-        [LoggerMessage(EventId = EventIds.GdprDeletionScheduleUnwindException, Level = LogLevel.Critical, Message = "Exception while unwinding the deletion schedule for user {UserId}. Manual intervention required.")]
-        private static partial void LogScheduleUnwindException(ILogger logger, Exception exception, Guid userId);
-
         [LoggerMessage(EventId = EventIds.GdprDeletionSchedulingUpdateFailed, Level = LogLevel.Error, Message = "Failed to persist the deletion schedule for user {UserId}: {Errors}")]
         private static partial void LogSchedulingUpdateFailed(ILogger logger, Guid userId, string errors);
-
-        [LoggerMessage(EventId = EventIds.GdprDeletionScheduleStampFailed, Level = LogLevel.Error, Message = "Failed to update security stamp for user {UserId} while scheduling deletion")]
-        private static partial void LogSecurityStampUpdateFailed(ILogger logger, Guid userId);
 
         [LoggerMessage(EventId = EventIds.GdprDeletionScheduleArtifactRevocationFailed, Level = LogLevel.Warning, Message = "Failed to revoke OpenIddict artifacts for user {UserId} while scheduling deletion. Refresh tokens may stay valid until expiry.")]
         private static partial void LogArtifactRevocationFailed(ILogger logger, Exception exception, Guid userId);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/AccountDeletionCancelled.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/AccountDeletionCancelled.cs
@@ -1,0 +1,13 @@
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// Outbox payload contract for "send this user the deletion-cancelled courtesy notice",
+/// serialised by the producer and deserialised by the relay and the consumer.
+/// </summary>
+/// <remarks>
+/// Carries the user id alone (ADR-0038 decision 2) — and deliberately no token: the e-mail is a
+/// courtesy notice pointing at the password-reset form, while the forced-reset token itself
+/// travels in the cancel endpoint's response, minted by the handler after its commit. Epic #578's
+/// table overstated this e-mail's content; the ADR's code-verified inventory is authoritative.
+/// </remarks>
+public sealed record AccountDeletionCancelled(Guid IdentityUserId);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/AccountDeletionScheduled.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/AccountDeletionScheduled.cs
@@ -1,0 +1,16 @@
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// Outbox payload contract for "send this user their deletion-scheduled e-mail with the cancel
+/// link", serialised by the producer and deserialised by the relay and the consumer.
+/// </summary>
+/// <remarks>
+/// Carries the user id alone, on purpose (ADR-0038 decision 2). The cancel token is minted at
+/// delivery — a live token must never persist in an outbox row, a broker frame, or a DLQ-parked
+/// message, and minting late keeps it bound to the <em>current</em> security stamp (final before
+/// the row became visible: the writer rotates the stamp in the same save that commits this row).
+/// The e-mailed deletion date is derivable state, so it is recomputed at delivery too:
+/// <c>DeletionScheduledAt + GdprSettings.DeletionGracePeriod</c>, the finalizer's own formula —
+/// snapshotting it here could drift from what the finalizer will actually do.
+/// </remarks>
+public sealed record AccountDeletionScheduled(Guid IdentityUserId);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxMessageRouting.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxMessageRouting.cs
@@ -14,7 +14,9 @@ internal static class OutboxMessageRouting
     private static readonly Dictionary<string, string> RoutingKeysByType = new(StringComparer.Ordinal)
     {
         [nameof(EmailConfirmationRequested)] = RabbitMqTopology.EmailConfirmationRoutingKey,
-        [nameof(PasswordResetRequested)] = RabbitMqTopology.PasswordResetRoutingKey
+        [nameof(PasswordResetRequested)] = RabbitMqTopology.PasswordResetRoutingKey,
+        [nameof(AccountDeletionScheduled)] = RabbitMqTopology.DeletionScheduledRoutingKey,
+        [nameof(AccountDeletionCancelled)] = RabbitMqTopology.DeletionCancelledRoutingKey
     };
 
     public static bool TryGetRoutingKey(string type, [NotNullWhen(true)] out string? routingKey)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountDeletionCancelledProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountDeletionCancelledProcessor.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// The business reaction to a consumed <see cref="AccountDeletionCancelled"/> message: load the
+/// user and dispatch the courtesy notice — no token to mint, the forced-reset token travels in
+/// the cancel endpoint's response (see the payload's remarks). Carries the mirror of the
+/// deletion-scheduled drift guard (ADR-0038 decision 2): if deletion is scheduled again by the
+/// time this is processed, "your account was kept" is a lie and the message is acknowledged
+/// without sending.
+/// </summary>
+/// <remarks>
+/// Delivery is at-least-once (ADR-0035), so this must stay idempotent. It is: the e-mail carries
+/// no state and no token, so a redelivered message at worst repeats the notice — annoying, never
+/// harmful — and every skip branch reads current state, so replays converge on the same decision.
+/// </remarks>
+internal sealed partial class AccountDeletionCancelledProcessor : IEmailMessageProcessor
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IAccountDeletionEmailSender _accountDeletionEmailSender;
+    private readonly ILogger<AccountDeletionCancelledProcessor> _logger;
+
+    public AccountDeletionCancelledProcessor(
+        UserManager<ApplicationUser> userManager,
+        IAccountDeletionEmailSender accountDeletionEmailSender,
+        ILogger<AccountDeletionCancelledProcessor> logger)
+    {
+        _userManager = userManager;
+        _accountDeletionEmailSender = accountDeletionEmailSender;
+        _logger = logger;
+    }
+
+    public object? TryDeserialize(ReadOnlySpan<byte> body)
+    {
+        try
+        {
+            AccountDeletionCancelled? message = JsonSerializer.Deserialize<AccountDeletionCancelled>(body);
+            return message is null || message.IdentityUserId == Guid.Empty ? null : message;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public Task<Result> ProcessAsync(object message, CancellationToken cancellationToken)
+    {
+        return ProcessAsync((AccountDeletionCancelled)message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Handles one consumed message end-to-end and returns the acknowledgement decision.
+    /// </summary>
+    /// <returns>
+    /// NOT a business outcome — the answer to "does this message need redelivery?". Success means
+    /// "ack, drop it from the queue": either the e-mail went out, or redelivery can never change
+    /// the outcome (user vanished, deletion scheduled again in the gap, no address on the
+    /// account) — nacking those would loop the same message forever. Failure means "worth
+    /// retrying" (e.g. the SMTP relay is down) and drives the consumer's reject + requeue.
+    /// </returns>
+    public async Task<Result> ProcessAsync(AccountDeletionCancelled message, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationUser? user = await _userManager.FindByIdAsync(message.IdentityUserId.ToString());
+        if (user is null)
+        {
+            LogUserGone(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        // The mirror drift guard — also what stops a post-finalization DLQ replay: erasure keeps
+        // DeletionScheduledAt set as its audit trace, so an anonymized account lands here too.
+        if (user.DeletionScheduledAt is not null)
+        {
+            LogDeletionRescheduled(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            LogEmailMissing(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        Result sendDeletionCancelledResult = await _accountDeletionEmailSender.SendDeletionCancelledEmailAsync(
+            user.Id,
+            user.Email,
+            cancellationToken);
+        return sendDeletionCancelledResult;
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.DeletionCancelledUserGone,
+        Level = LogLevel.Information,
+        Message = "Skipping deletion-cancelled e-mail for user {UserId}: the account no longer exists")]
+    private static partial void LogUserGone(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.DeletionCancelledRescheduled,
+        Level = LogLevel.Information,
+        Message = "Skipping deletion-cancelled e-mail for user {UserId}: deletion is scheduled again")]
+    private static partial void LogDeletionRescheduled(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.DeletionCancelledAddressMissing,
+        Level = LogLevel.Warning,
+        Message = "Skipping deletion-cancelled e-mail for user {UserId}: the account carries no e-mail address")]
+    private static partial void LogEmailMissing(ILogger logger, Guid userId);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountDeletionScheduledProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/AccountDeletionScheduledProcessor.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Settings;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// The business reaction to a consumed <see cref="AccountDeletionScheduled"/> message: load the
+/// user, recompute the deletion date, mint the cancel token at send time (see the payload's
+/// remarks on token lifetime), and dispatch the e-mail with the cancel link. The drift guard
+/// lives here (ADR-0038 decision 2): a cancellation racing this message wins — a stale "your
+/// account will be deleted" must never go out after the schedule is gone.
+/// </summary>
+/// <remarks>
+/// Delivery is at-least-once (ADR-0035), so this must stay idempotent. It is: a redelivered
+/// message at worst re-sends the e-mail with a fresh, equally valid cancel token — annoying,
+/// never harmful — and every skip branch reads current state, so replays converge on the same
+/// decision.
+/// </remarks>
+internal sealed partial class AccountDeletionScheduledProcessor : IEmailMessageProcessor
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IAccountDeletionEmailSender _accountDeletionEmailSender;
+    private readonly TimeProvider _timeProvider;
+    private readonly GdprSettings _gdprSettings;
+    private readonly ILogger<AccountDeletionScheduledProcessor> _logger;
+
+    public AccountDeletionScheduledProcessor(
+        UserManager<ApplicationUser> userManager,
+        IAccountDeletionEmailSender accountDeletionEmailSender,
+        TimeProvider timeProvider,
+        IOptions<GdprSettings> gdprSettings,
+        ILogger<AccountDeletionScheduledProcessor> logger)
+    {
+        _userManager = userManager;
+        _accountDeletionEmailSender = accountDeletionEmailSender;
+        _timeProvider = timeProvider;
+        _gdprSettings = gdprSettings.Value;
+        _logger = logger;
+    }
+
+    public object? TryDeserialize(ReadOnlySpan<byte> body)
+    {
+        try
+        {
+            AccountDeletionScheduled? message = JsonSerializer.Deserialize<AccountDeletionScheduled>(body);
+            return message is null || message.IdentityUserId == Guid.Empty ? null : message;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public Task<Result> ProcessAsync(object message, CancellationToken cancellationToken)
+    {
+        return ProcessAsync((AccountDeletionScheduled)message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Handles one consumed message end-to-end and returns the acknowledgement decision.
+    /// </summary>
+    /// <returns>
+    /// NOT a business outcome — the answer to "does this message need redelivery?". Success means
+    /// "ack, drop it from the queue": either the e-mail went out, or redelivery can never change
+    /// the outcome (user vanished, schedule cancelled in the gap, deletion window already over,
+    /// no address on the account) — nacking those would loop the same message forever. Failure
+    /// means "worth retrying" (e.g. the SMTP relay is down) and drives the consumer's reject +
+    /// requeue.
+    /// </returns>
+    public async Task<Result> ProcessAsync(AccountDeletionScheduled message, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationUser? user = await _userManager.FindByIdAsync(message.IdentityUserId.ToString());
+        if (user is null)
+        {
+            LogUserGone(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        if (user.DeletionScheduledAt is null)
+        {
+            LogScheduleGone(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        // Guards against a much-delayed delivery (a DLQ replay long after the fact): once the
+        // grace window is over the e-mail's "cancel until <date>" is a lie — and erasure keeps
+        // DeletionScheduledAt as its audit trace with a synthetic address on the row, so the
+        // schedule-gone guard above alone would let a post-finalization replay mint a working
+        // cancel token for an anonymized account.
+        DateTimeOffset finalizesAt = user.DeletionScheduledAt.Value + _gdprSettings.DeletionGracePeriod;
+        if (finalizesAt <= _timeProvider.GetUtcNow())
+        {
+            LogWindowOver(_logger, message.IdentityUserId, finalizesAt);
+            return Result.Success();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            LogEmailMissing(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        string cancelToken = await _userManager.GenerateUserTokenAsync(
+            user,
+            AccountDeletionCancellationTokenProvider.ProviderName,
+            AccountDeletionCancellationTokenProvider.CancelDeletionPurpose);
+
+        Result sendDeletionScheduledResult = await _accountDeletionEmailSender.SendDeletionScheduledEmailAsync(
+            user.Id,
+            user.Email,
+            cancelToken,
+            finalizesAt,
+            cancellationToken);
+        return sendDeletionScheduledResult;
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.DeletionScheduledUserGone,
+        Level = LogLevel.Information,
+        Message = "Skipping deletion-scheduled e-mail for user {UserId}: the account no longer exists")]
+    private static partial void LogUserGone(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.DeletionScheduledScheduleGone,
+        Level = LogLevel.Information,
+        Message = "Skipping deletion-scheduled e-mail for user {UserId}: the deletion is no longer scheduled")]
+    private static partial void LogScheduleGone(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.DeletionScheduledWindowOver,
+        Level = LogLevel.Warning,
+        Message = "Skipping deletion-scheduled e-mail for user {UserId}: the grace window ended at {FinalizesAt}")]
+    private static partial void LogWindowOver(ILogger logger, Guid userId, DateTimeOffset finalizesAt);
+
+    [LoggerMessage(
+        EventId = EventIds.DeletionScheduledAddressMissing,
+        Level = LogLevel.Warning,
+        Message = "Skipping deletion-scheduled e-mail for user {UserId}: the account carries no e-mail address")]
+    private static partial void LogEmailMissing(ILogger logger, Guid userId);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
@@ -39,6 +39,16 @@ public static class RabbitMqTopology
     public const string PasswordResetRoutingKey = "email.password-reset";
 
     /// <summary>
+    /// Routing key of the deletion-scheduled e-mail (the cancel link).
+    /// </summary>
+    public const string DeletionScheduledRoutingKey = "email.deletion-scheduled";
+
+    /// <summary>
+    /// Routing key of the deletion-cancelled courtesy e-mail.
+    /// </summary>
+    public const string DeletionCancelledRoutingKey = "email.deletion-cancelled";
+
+    /// <summary>
     /// Dead-letter exchange: the broker republishes here every message that
     /// <see cref="EmailQueue"/> gives up on — rejected as poison by the consumer, or past
     /// <see cref="EmailDeliveryLimit"/>. Fanout, because "everything that dies goes to the one

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountDeletionEmailSender.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyAccountDeletionEmailSender.cs
@@ -43,6 +43,37 @@ public sealed class SpyAccountDeletionEmailSender : IAccountDeletionEmailSender
         return Task.FromResult(Result.Success());
     }
 
+    /// <summary>
+    /// Blocks until a deletion-scheduled e-mail lands or the timeout passes. Scheduling stopped
+    /// being synchronous when the e-mail went through the outbox (commit -> relay -> delivery ->
+    /// this spy), so tests reading <see cref="LastCancelToken"/> right after the delete call must
+    /// wait on state, not assume immediacy. Returns silently either way — the assertions stay at
+    /// the call site.
+    /// </summary>
+    public async Task WaitForScheduledCaptureAsync(TimeSpan? timeout = null)
+    {
+        using CancellationTokenSource waitWindow = new(timeout ?? TimeSpan.FromSeconds(15));
+
+        while (LastCancelToken is null && !waitWindow.IsCancellationRequested)
+        {
+            await Task.Delay(50);
+        }
+    }
+
+    /// <summary>
+    /// Blocks until a deletion-cancelled e-mail lands or the timeout passes — the courtesy
+    /// notice travels the same asynchronous pipeline as the scheduled e-mail.
+    /// </summary>
+    public async Task WaitForCancelledCaptureAsync(TimeSpan? timeout = null)
+    {
+        using CancellationTokenSource waitWindow = new(timeout ?? TimeSpan.FromSeconds(15));
+
+        while (LastCancelledEmail is null && !waitWindow.IsCancellationRequested)
+        {
+            await Task.Delay(50);
+        }
+    }
+
     public void Reset()
     {
         LastScheduledEmail = null;

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/CancelAccountDeletionEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/CancelAccountDeletionEndpointTests.cs
@@ -85,14 +85,16 @@ public sealed class CancelAccountDeletionEndpointTests : EndpointsTestBase
     }
 
     [Fact]
-    public async Task CancelDeletion_ShouldSendConfirmationEmail()
+    public async Task CancelDeletion_ShouldDeliverConfirmationEmail()
     {
         // Arrange
         (RegisterRequest registerRequest, _) = await RegisterAndScheduleDeletionAsync();
         string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
 
-        // Act
+        // Act — the courtesy notice arrives through the pipeline, so the capture has to be
+        // awaited (ADR-0038)
         HttpResponseMessage response = await SendCancelRequestAsync(registerRequest.Email, cancelToken);
+        await AccountDeletionEmailSpy.WaitForCancelledCaptureAsync();
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -181,6 +183,9 @@ public sealed class CancelAccountDeletionEndpointTests : EndpointsTestBase
 
         HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        // The cancel token arrives through the pipeline (ADR-0038), not the request path
+        await AccountDeletionEmailSpy.WaitForScheduledCaptureAsync();
         AccountDeletionEmailSpy.LastCancelToken.ShouldNotBeNullOrWhiteSpace();
 
         return (registerRequest, identityId);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeleteAccountEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeleteAccountEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using LotroKoniecDev.AuthSystem.API.Features.Auth;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
@@ -9,6 +10,7 @@ using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
 using LotroKoniecDev.SharedKernel.StronglyTypedIds;
 
 namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
@@ -78,7 +80,7 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
     }
 
     [Fact]
-    public async Task DeleteAccount_ShouldSendCancellationEmail_WhenScheduling()
+    public async Task DeleteAccount_ShouldDeliverCancellationEmail_WhenScheduling()
     {
         // Arrange
         (RegisterRequest registerRequest, _) =
@@ -86,14 +88,42 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
 
         string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
 
-        // Act
+        // Act — the request only commits the outbox row; the e-mail arrives through the
+        // pipeline (relay -> delivery -> spy), so the capture has to be awaited (ADR-0038)
         HttpResponseMessage response = await SendDeleteRequestAsync(accessToken, TestPassword);
+        await AccountDeletionEmailSpy.WaitForScheduledCaptureAsync();
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         AccountDeletionEmailSpy.ScheduledCallCount.ShouldBe(1);
         AccountDeletionEmailSpy.LastScheduledEmail.ShouldBe(registerRequest.Email);
         AccountDeletionEmailSpy.LastCancelToken.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task DeleteAccount_ShouldWriteAnIdOnlyOutboxRow_WhenScheduling()
+    {
+        // Arrange
+        (RegisterRequest registerRequest, IdentityId identityId) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
+
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
+
+        // Act
+        HttpResponseMessage response = await SendDeleteRequestAsync(accessToken, TestPassword);
+        await AccountDeletionEmailSpy.WaitForScheduledCaptureAsync();
+
+        // Assert — the payload carries the user id and nothing else: the cancel token is minted
+        // at delivery and must never persist in an outbox row (ADR-0038 decision 2)
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            Factory, row => row.Type == nameof(AccountDeletionScheduled));
+        outboxRow.ShouldNotBeNull();
+        AccountDeletionScheduled payload = JsonSerializer.Deserialize<AccountDeletionScheduled>(outboxRow.Payload)
+            .ShouldNotBeNull();
+        payload.IdentityUserId.ShouldBe(identityId.Value);
+        AccountDeletionEmailSpy.LastCancelToken.ShouldNotBeNullOrEmpty();
+        outboxRow.Payload.ShouldNotContain(AccountDeletionEmailSpy.LastCancelToken);
     }
 
     [Fact]
@@ -144,11 +174,12 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
         string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
         HttpResponseMessage firstResponse = await SendDeleteRequestAsync(accessToken, TestPassword);
         firstResponse.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        await AccountDeletionEmailSpy.WaitForScheduledCaptureAsync();
 
         // Act — the JWT is self-contained, so it stays usable within its lifetime
         HttpResponseMessage secondResponse = await SendDeleteRequestAsync(accessToken, TestPassword);
 
-        // Assert
+        // Assert — the rejected retry must not have queued a second e-mail
         secondResponse.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
         string body = await secondResponse.Content.ReadAsStringAsync();
         body.ShouldContain("Auth.DeletionAlreadyScheduled");
@@ -190,7 +221,7 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
     }
 
     [Fact]
-    public async Task DeleteAccount_ShouldUnwindSchedule_WhenCancellationEmailFails()
+    public async Task DeleteAccount_ShouldKeepScheduleAndSucceed_WhenCancellationEmailFails()
     {
         // Arrange
         (RegisterRequest registerRequest, IdentityId identityId) =
@@ -204,18 +235,19 @@ public sealed class DeleteAccountEndpointTests : EndpointsTestBase
         {
             // Act
             HttpResponseMessage response = await SendDeleteRequestAsync(accessToken, TestPassword);
+            await AccountDeletionEmailSpy.WaitForScheduledCaptureAsync(TimeSpan.FromSeconds(5));
 
-            // Assert — without the emailed cancel link the owner couldn't cancel,
-            // so the schedule is rolled back and the account stays usable.
-            response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
-            string body = await response.Content.ReadAsStringAsync();
-            body.ShouldContain("Auth.DeletionSchedulingFailed");
+            // Assert — the unwind compensation is gone (ADR-0038 decision 5): the request only
+            // commits the outbox row atomically with the schedule, so an SMTP failure neither
+            // fails the request nor unwinds the schedule — redelivery (or a DLQ replay) owns it.
+            response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
 
             ApplicationUser user = await GetUserAsync(identityId.Value);
-            user.DeletionScheduledAt.ShouldBeNull();
+            user.DeletionScheduledAt.ShouldNotBeNull();
 
-            HttpResponseMessage loginResponse = await RequestTokenAsync(registerRequest.Email, TestPassword);
-            loginResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+            OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+                Factory, row => row.Type == nameof(AccountDeletionScheduled));
+            outboxRow.ShouldNotBeNull();
         }
         finally
         {

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeletionGraceWindowTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeletionGraceWindowTests.cs
@@ -139,6 +139,9 @@ public sealed partial class DeletionGraceWindowTests : AsyncLifetimeTestBase
         await ScheduleDeletionAsync(registerRequest.Email);
         string cancelToken = AccountDeletionEmailSpy.LastCancelToken!;
 
+        // The cancel token above was minted at delivery against the post-schedule stamp
+        // (ADR-0038 decision 2) — the attack below must not be able to invalidate it.
+
         ChangePasswordRequest changeRequest = new(TestPassword, "AttackerNewPass1!");
         using HttpRequestMessage request = new(HttpMethod.Post, "auth/change-password");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", preScheduleAccessToken);
@@ -292,6 +295,10 @@ public sealed partial class DeletionGraceWindowTests : AsyncLifetimeTestBase
 
         HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        // The cancel token arrives through the pipeline (ADR-0038), not the request path —
+        // callers read it off the spy right after this returns, so wait for the delivery here
+        await AccountDeletionEmailSpy.WaitForScheduledCaptureAsync();
     }
 
     private async Task<string> GetAccessTokenAsync(string email)

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/AccountDeletionPipelineTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/AccountDeletionPipelineTests.cs
@@ -1,0 +1,332 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Infrastructure.Messaging;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using RabbitMQ.Client;
+using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Messaging;
+
+/// <summary>
+/// The account-deletion legs of the brokered pipeline (MSG-04, ADR-0038): scheduling and
+/// cancelling each commit an id-only outbox row atomically with their state change, the real
+/// relay publishes to a real broker, and the real consumer selects the per-type processor by the
+/// AMQP <c>type</c> property. The legs mirror <see cref="PasswordResetPipelineTests"/> where the
+/// machinery is shared and add what is specific to these types: the cancel token is minted at
+/// delivery and must actually cancel the deletion, the deletion-cancelled response token must
+/// actually complete the recovery, and the drift guards ack a message whose precondition
+/// vanished between commit and delivery.
+/// </summary>
+public sealed class AccountDeletionPipelineTests : IClassFixture<BrokeredAuthSystemApiFactory>, IAsyncLifetime
+{
+    private const string TestPassword = "TestPass1!";
+
+    private static readonly TimeSpan DeliveryTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan EmptyQueueGrace = TimeSpan.FromSeconds(2);
+
+    private readonly BrokeredAuthSystemApiFactory _factory;
+    private readonly TestApiClient _apiClient;
+    private readonly SpyAccountConfirmationEmailSender _confirmationEmailSpy;
+    private readonly SpyAccountDeletionEmailSender _deletionEmailSpy;
+    private readonly Bogus.Faker _faker = new();
+
+    public AccountDeletionPipelineTests(BrokeredAuthSystemApiFactory factory)
+    {
+        _factory = factory;
+        _confirmationEmailSpy = factory.Services.GetRequiredService<SpyAccountConfirmationEmailSender>();
+        _deletionEmailSpy = factory.Services.GetRequiredService<SpyAccountDeletionEmailSender>();
+
+        JsonSerializerOptions jsonSerializerOptions =
+            factory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+        _apiClient = new TestApiClient(factory.CreateClient(), jsonSerializerOptions);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _confirmationEmailSpy.Reset();
+        _deletionEmailSpy.Reset();
+
+        await using AsyncServiceScope scope = _factory.Services.CreateAsyncScope();
+        CleanerService cleaner = scope.ServiceProvider.GetRequiredService<CleanerService>();
+        await cleaner.CleanAsync();
+
+        // The host's consumer declares the topology on startup, but the first test may reach this
+        // point before that attach finished — declaring here is idempotent (proven in
+        // DeadLetterTopologyTests) and guarantees the purges below have queues to purge.
+        await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+        await RabbitMqTopologyDeclaration.DeclareAsync(channel, CancellationToken.None);
+        await channel.QueuePurgeAsync(RabbitMqTopology.EmailQueue);
+        await channel.QueuePurgeAsync(RabbitMqTopology.EmailDeadLetterQueue);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Pipeline_ShouldDeliverAScheduledEmailWhoseCancelLinkWorks_WhenDeleteAccountCommits()
+    {
+        // Arrange — a confirmed account, so the only pipeline traffic left is the deletion e-mail
+        (RegisterRequest request, IdentityId identityId) = await UserFactory.RegisterRandomUserWithRequestAsync(
+            _apiClient, _faker, _confirmationEmailSpy, TestPassword);
+        string accessToken = await GetAccessTokenAsync(request.Email);
+
+        // Act — deleting the account is the user-facing trigger of the whole pipeline
+        HttpResponseMessage deleteResponse = await SendDeleteRequestAsync(accessToken);
+        await _deletionEmailSpy.WaitForScheduledCaptureAsync(DeliveryTimeout);
+
+        // Assert — the e-mail went out once, to the registered address, with the recomputed date
+        deleteResponse.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        _deletionEmailSpy.LastScheduledEmail.ShouldBe(request.Email);
+        _deletionEmailSpy.LastCancelToken.ShouldNotBeNullOrWhiteSpace();
+        _deletionEmailSpy.LastFinalizesAt.ShouldNotBeNull();
+        _deletionEmailSpy.ScheduledCallCount.ShouldBe(1);
+
+        // The delivered token really cancels the deletion — the end-to-end proof that minting at
+        // delivery produced a link the owner can use
+        HttpResponseMessage cancelResponse = await _apiClient.Http.PostAsJsonAsync(
+            new Uri("auth/account/cancel-deletion", UriKind.Relative),
+            new CancelAccountDeletionRequest(request.Email, _deletionEmailSpy.LastCancelToken!));
+        cancelResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // The outbox row was published and marked on the first attempt — and carries the user id
+        // alone: no cancel token may ever persist in an outbox row (ADR-0038 decision 2)
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            _factory,
+            row => row.Type == nameof(AccountDeletionScheduled) && row.ProcessedOn != null,
+            DeliveryTimeout);
+        outboxRow.ShouldNotBeNull();
+        outboxRow.Attempts.ShouldBe(0);
+        outboxRow.LastError.ShouldBeNull();
+        AccountDeletionScheduled payload = JsonSerializer.Deserialize<AccountDeletionScheduled>(outboxRow.Payload)
+            .ShouldNotBeNull();
+        payload.IdentityUserId.ShouldBe(identityId.Value);
+        outboxRow.Payload.ShouldNotContain(_deletionEmailSpy.LastCancelToken!);
+
+        // The delivery was recorded for deduplication and nothing was left on the broker
+        (await OutboxAssertions.CountInboxRowsAsync(_factory, outboxRow.Id)).ShouldBe(1);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Pipeline_ShouldDeliverACancelledEmailAndTheResponseTokenMustCompleteRecovery_WhenCancelCommits()
+    {
+        // Arrange — a scheduled deletion whose cancel link already arrived through the broker
+        (RegisterRequest request, IdentityId identityId) = await UserFactory.RegisterRandomUserWithRequestAsync(
+            _apiClient, _faker, _confirmationEmailSpy, TestPassword);
+        string accessToken = await GetAccessTokenAsync(request.Email);
+        (await SendDeleteRequestAsync(accessToken)).StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        await _deletionEmailSpy.WaitForScheduledCaptureAsync(DeliveryTimeout);
+
+        // Act — cancelling is the second user-facing trigger; the courtesy notice rides the
+        // pipeline while the forced-reset token travels in the response (ADR-0038)
+        HttpResponseMessage cancelResponse = await _apiClient.Http.PostAsJsonAsync(
+            new Uri("auth/account/cancel-deletion", UriKind.Relative),
+            new CancelAccountDeletionRequest(request.Email, _deletionEmailSpy.LastCancelToken!));
+        await _deletionEmailSpy.WaitForCancelledCaptureAsync(DeliveryTimeout);
+
+        // Assert — the courtesy notice went out once, to the registered address
+        cancelResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        _deletionEmailSpy.LastCancelledEmail.ShouldBe(request.Email);
+        _deletionEmailSpy.CancelledCallCount.ShouldBe(1);
+
+        // The response's reset token really completes the recovery — new password, working login
+        CancelAccountDeletionResponse cancelBody = (await cancelResponse.Content
+            .ReadFromJsonAsync<CancelAccountDeletionResponse>(_apiClient.JsonOptions))!;
+        cancelBody.PasswordResetToken.ShouldNotBeNullOrWhiteSpace();
+        const string newPassword = "BrandNewPass1!";
+        HttpResponseMessage resetResponse = await _apiClient.Http.PostAsJsonAsync(
+            new Uri("auth/reset-password", UriKind.Relative),
+            new ResetPasswordRequest(request.Email, cancelBody.PasswordResetToken, newPassword));
+        resetResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await RequestTokenAsync(request.Email, newPassword)).StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // The outbox row carries the user id alone — and in particular NOT the response's reset
+        // token, which must never persist in an outbox row (ADR-0038 decision 2)
+        OutboxMessage? outboxRow = await OutboxAssertions.WaitForOutboxRowAsync(
+            _factory,
+            row => row.Type == nameof(AccountDeletionCancelled) && row.ProcessedOn != null,
+            DeliveryTimeout);
+        outboxRow.ShouldNotBeNull();
+        AccountDeletionCancelled payload = JsonSerializer.Deserialize<AccountDeletionCancelled>(outboxRow.Payload)
+            .ShouldNotBeNull();
+        payload.IdentityUserId.ShouldBe(identityId.Value);
+        outboxRow.Payload.ShouldNotContain(cancelBody.PasswordResetToken);
+
+        // The delivery was recorded for deduplication and nothing was left on the broker
+        (await OutboxAssertions.CountInboxRowsAsync(_factory, outboxRow.Id)).ShouldBe(1);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Consumer_ShouldAckWithoutEmailAndWithoutParking_WhenTheScheduleIsGoneAtDelivery()
+    {
+        // Arrange — a user who is NOT deletion-scheduled: the deterministic construction of "the
+        // cancellation raced the scheduled message and won" (the drift guard's reason to exist)
+        (_, IdentityId identityId) = await UserFactory.RegisterRandomUserWithRequestAsync(
+            _apiClient, _faker, _confirmationEmailSpy, TestPassword);
+
+        // Act — the exact wire shape a stale scheduled message would have
+        Guid messageId = Guid.CreateVersion7();
+        IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(
+            RabbitMqTopology.DeletionScheduledRoutingKey,
+            nameof(AccountDeletionScheduled),
+            JsonSerializer.Serialize(new AccountDeletionScheduled(identityId.Value)),
+            messageId,
+            CancellationToken.None);
+
+        // Assert — acked and recorded, but no stale "your account will be deleted" went out
+        (await OutboxAssertions.WaitForInboxRowsAsync(_factory, messageId, DeliveryTimeout)).ShouldBe(1);
+        _deletionEmailSpy.ScheduledCallCount.ShouldBe(0);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, EmptyQueueGrace)).ShouldBeNull();
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Consumer_ShouldAckWithoutEmailAndWithoutParking_WhenDeletionIsScheduledAgainAtDelivery()
+    {
+        // Arrange — a user who IS deletion-scheduled: the mirror drift — a cancelled notice
+        // delivered after deletion was scheduled again would announce the opposite of the truth
+        (RegisterRequest request, IdentityId identityId) = await UserFactory.RegisterRandomUserWithRequestAsync(
+            _apiClient, _faker, _confirmationEmailSpy, TestPassword);
+        string accessToken = await GetAccessTokenAsync(request.Email);
+        (await SendDeleteRequestAsync(accessToken)).StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        await _deletionEmailSpy.WaitForScheduledCaptureAsync(DeliveryTimeout);
+
+        // Act
+        Guid messageId = Guid.CreateVersion7();
+        IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(
+            RabbitMqTopology.DeletionCancelledRoutingKey,
+            nameof(AccountDeletionCancelled),
+            JsonSerializer.Serialize(new AccountDeletionCancelled(identityId.Value)),
+            messageId,
+            CancellationToken.None);
+
+        // Assert — acked and recorded, but no "your account was kept" went out
+        (await OutboxAssertions.WaitForInboxRowsAsync(_factory, messageId, DeliveryTimeout)).ShouldBe(1);
+        _deletionEmailSpy.CancelledCallCount.ShouldBe(0);
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailQueue, EmptyQueueGrace)).ShouldBeNull();
+        (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, EmptyQueueGrace)).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(nameof(AccountDeletionScheduled), RabbitMqTopology.DeletionScheduledRoutingKey)]
+    [InlineData(nameof(AccountDeletionCancelled), RabbitMqTopology.DeletionCancelledRoutingKey)]
+    public async Task Consumer_ShouldParkDeliveryInDeadLetterQueue_WhenThePayloadIsPoison(
+        string messageType,
+        string routingKey)
+    {
+        // Act — a valid message id and a registered deletion type, so the reject decision can
+        // only come from the payload
+        const string poisonPayload = """{"IdentityUserId":"not-a-guid"}""";
+        Guid messageId = Guid.CreateVersion7();
+        IMessagePublisher publisher = _factory.Services.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(
+            routingKey,
+            messageType,
+            poisonPayload,
+            messageId,
+            CancellationToken.None);
+
+        // Assert — parked on first sight, no e-mail, no dedup record
+        BasicGetResult dead =
+            (await GetWithinTimeoutAsync(RabbitMqTopology.EmailDeadLetterQueue, DeliveryTimeout)).ShouldNotBeNull();
+        Encoding.UTF8.GetString(dead.Body.ToArray()).ShouldBe(poisonPayload);
+        FirstDeathReason(dead.BasicProperties).ShouldBe("rejected");
+        _deletionEmailSpy.ScheduledCallCount.ShouldBe(0);
+        _deletionEmailSpy.CancelledCallCount.ShouldBe(0);
+        (await OutboxAssertions.CountInboxRowsAsync(_factory, messageId)).ShouldBe(0);
+    }
+
+    private async Task<HttpResponseMessage> SendDeleteRequestAsync(string accessToken)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/delete");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Content = JsonContent.Create(new DeleteAccountRequest(TestPassword));
+
+        return await _apiClient.Http.SendAsync(request);
+    }
+
+    private async Task<string> GetAccessTokenAsync(string email)
+    {
+        HttpResponseMessage tokenResponse = await RequestTokenAsync(email, TestPassword);
+        tokenResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string content = await tokenResponse.Content.ReadAsStringAsync();
+        using JsonDocument json = JsonDocument.Parse(content);
+        return json.RootElement.GetProperty("access_token").GetString()!;
+    }
+
+    private async Task<HttpResponseMessage> RequestTokenAsync(string email, string password)
+    {
+        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = email,
+            ["password"] = password,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api"
+        });
+
+        return await _apiClient.Http.PostAsync(new Uri("connect/token", UriKind.Relative), tokenRequest);
+    }
+
+    /// <summary>
+    /// Polls the queue until a delivery arrives or the timeout passes — routing and dead-lettering
+    /// are asynchronous inside the broker. The read is auto-acked: every caller either asserts on
+    /// the delivery (test over either way) or expects null.
+    /// </summary>
+    private async Task<BasicGetResult?> GetWithinTimeoutAsync(string queue, TimeSpan timeout)
+    {
+        await using IConnection connection = await _factory.Broker.ConnectAsync(CancellationToken.None);
+        await using IChannel channel = await connection.CreateChannelAsync();
+
+        Stopwatch elapsed = Stopwatch.StartNew();
+
+        while (true)
+        {
+            BasicGetResult? delivery = await channel.BasicGetAsync(queue, autoAck: true);
+            if (delivery is not null)
+            {
+                return delivery;
+            }
+
+            if (elapsed.Elapsed >= timeout)
+            {
+                return null;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    /// <summary>
+    /// Reads the reason of the first (most recent) <c>x-death</c> entry the broker stamped on a
+    /// dead-lettered message.
+    /// </summary>
+    private static string? FirstDeathReason(IReadOnlyBasicProperties properties)
+    {
+        if (properties.Headers is not { } headers
+            || !headers.TryGetValue("x-death", out object? deathsRaw)
+            || deathsRaw is not IList { Count: > 0 } deaths
+            || deaths[0] is not IDictionary firstDeath
+            || !firstDeath.Contains("reason"))
+        {
+            return null;
+        }
+
+        return firstDeath["reason"] is byte[] reason ? Encoding.UTF8.GetString(reason) : null;
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxMessageRoutingTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxMessageRoutingTests.cs
@@ -25,12 +25,36 @@ public sealed class OutboxMessageRoutingTests
         routingKey.ShouldBe(RabbitMqTopology.PasswordResetRoutingKey);
     }
 
+    [Fact]
+    public void TryGetRoutingKey_AccountDeletionScheduled_MapsToDeletionScheduledRoutingKey()
+    {
+        bool found = OutboxMessageRouting.TryGetRoutingKey(
+            nameof(AccountDeletionScheduled), out string? routingKey);
+
+        found.ShouldBeTrue();
+        routingKey.ShouldBe(RabbitMqTopology.DeletionScheduledRoutingKey);
+    }
+
+    [Fact]
+    public void TryGetRoutingKey_AccountDeletionCancelled_MapsToDeletionCancelledRoutingKey()
+    {
+        bool found = OutboxMessageRouting.TryGetRoutingKey(
+            nameof(AccountDeletionCancelled), out string? routingKey);
+
+        found.ShouldBeTrue();
+        routingKey.ShouldBe(RabbitMqTopology.DeletionCancelledRoutingKey);
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("emailconfirmationrequested")]
     [InlineData("email.confirmation")]
     [InlineData("passwordresetrequested")]
     [InlineData("email.password-reset")]
+    [InlineData("accountdeletionscheduled")]
+    [InlineData("email.deletion-scheduled")]
+    [InlineData("accountdeletioncancelled")]
+    [InlineData("email.deletion-cancelled")]
     [InlineData("SomeFutureUnmappedEvent")]
     public void TryGetRoutingKey_UnknownOrMiscasedType_ReturnsFalse(string type)
     {

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/AccountDeletionCancelledProcessorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/AccountDeletionCancelledProcessorTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+using NSubstitute;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Services.Emails;
+
+public sealed class AccountDeletionCancelledProcessorTests
+{
+    private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
+    private readonly IAccountDeletionEmailSender _emailSender =
+        Substitute.For<IAccountDeletionEmailSender>();
+
+    [Fact]
+    public async Task ProcessAsync_UserNoLongerExists_SucceedsWithoutSending()
+    {
+        Guid userId = Guid.NewGuid();
+        _userManager.FindByIdAsync(userId.ToString()).Returns((ApplicationUser?)null);
+        AccountDeletionCancelledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionCancelled(userId), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendDeletionCancelledEmailAsync(default, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_DeletionIsScheduledAgain_SucceedsWithoutSending()
+    {
+        // The mirror drift guard (ADR-0038 decision 2): if deletion was re-scheduled in the gap,
+        // "your account was kept" is a lie — and post-finalization DLQ replays land here too,
+        // because erasure keeps DeletionScheduledAt set as its audit trace.
+        ApplicationUser user = CreateUser();
+        user.DeletionScheduledAt = DateTimeOffset.UtcNow;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        AccountDeletionCancelledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionCancelled(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendDeletionCancelledEmailAsync(default, default!, default);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ProcessAsync_UserHasNoEmailAddress_SucceedsWithoutSending(string? email)
+    {
+        ApplicationUser user = CreateUser();
+        user.Email = email;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        AccountDeletionCancelledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionCancelled(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendDeletionCancelledEmailAsync(default, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_CancelledUser_SendsTheCourtesyNotice()
+    {
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _emailSender.SendDeletionCancelledEmailAsync(user.Id, user.Email!, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        AccountDeletionCancelledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionCancelled(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.Received(1)
+            .SendDeletionCancelledEmailAsync(user.Id, user.Email!, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SendingFails_PropagatesTheFailure()
+    {
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        Error smtpError = new("Email.SendFailed", "SMTP relay refused the message.");
+        _emailSender.SendDeletionCancelledEmailAsync(user.Id, user.Email!, Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(smtpError));
+        AccountDeletionCancelledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionCancelled(user.Id), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(smtpError);
+    }
+
+    [Theory]
+    [InlineData("this is not json at all")]
+    [InlineData("{}")]
+    [InlineData("""{"IdentityUserId":"not-a-guid"}""")]
+    public void TryDeserialize_PoisonPayload_ReturnsTheNullVerdict(string poisonPayload)
+    {
+        AccountDeletionCancelledProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(System.Text.Encoding.UTF8.GetBytes(poisonPayload));
+
+        message.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_ValidPayload_ReturnsTheTypedMessage()
+    {
+        Guid userId = Guid.CreateVersion7();
+        AccountDeletionCancelledProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(
+            System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new AccountDeletionCancelled(userId)));
+
+        AccountDeletionCancelled typed = message.ShouldBeOfType<AccountDeletionCancelled>();
+        typed.IdentityUserId.ShouldBe(userId);
+    }
+
+    private static ApplicationUser CreateUser() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserName = "frodo",
+            Email = "frodo@shire.me"
+        };
+
+    private AccountDeletionCancelledProcessor CreateSut() =>
+        new(_userManager, _emailSender, NullLogger<AccountDeletionCancelledProcessor>.Instance);
+
+    private static UserManager<ApplicationUser> CreateUserManager() =>
+        Substitute.For<UserManager<ApplicationUser>>(
+            Substitute.For<IUserStore<ApplicationUser>>(),
+            null!, null!, null!, null!, null!, null!, null!, null!);
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/AccountDeletionScheduledProcessorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/AccountDeletionScheduledProcessorTests.cs
@@ -1,0 +1,195 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.API.Settings;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+using NSubstitute;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Services.Emails;
+
+public sealed class AccountDeletionScheduledProcessorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 4, 12, 0, 0, TimeSpan.Zero);
+    private static readonly GdprSettings Gdpr = new();
+
+    private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
+    private readonly IAccountDeletionEmailSender _emailSender =
+        Substitute.For<IAccountDeletionEmailSender>();
+    private readonly TimeProvider _timeProvider = CreateTimeProvider();
+
+    [Fact]
+    public async Task ProcessAsync_UserNoLongerExists_SucceedsWithoutSending()
+    {
+        Guid userId = Guid.NewGuid();
+        _userManager.FindByIdAsync(userId.ToString()).Returns((ApplicationUser?)null);
+        AccountDeletionScheduledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionScheduled(userId), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendDeletionScheduledEmailAsync(default, default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ScheduleWasCancelledInTheGap_SucceedsWithoutSending()
+    {
+        // The drift guard (ADR-0038 decision 2): a cancellation racing this message wins — a
+        // stale "your account will be deleted" must never go out, and redelivery cannot change
+        // the outcome.
+        ApplicationUser user = CreateUser();
+        user.DeletionScheduledAt = null;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        AccountDeletionScheduledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionScheduled(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendDeletionScheduledEmailAsync(default, default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_GraceWindowAlreadyOver_SucceedsWithoutSending()
+    {
+        // A DLQ replay long after the fact: erasure keeps DeletionScheduledAt as its audit trace,
+        // so the schedule-gone guard alone would let this mint a cancel token for an anonymized
+        // account. Once the window is over the e-mail is a lie either way.
+        ApplicationUser user = CreateUser();
+        user.DeletionScheduledAt = Now - Gdpr.DeletionGracePeriod - TimeSpan.FromDays(1);
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        AccountDeletionScheduledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionScheduled(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendDeletionScheduledEmailAsync(default, default!, default!, default, default);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ProcessAsync_UserHasNoEmailAddress_SucceedsWithoutSending(string? email)
+    {
+        ApplicationUser user = CreateUser();
+        user.DeletionScheduledAt = Now;
+        user.Email = email;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        AccountDeletionScheduledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionScheduled(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendDeletionScheduledEmailAsync(default, default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ScheduledUser_SendsTheEmailWithAFreshTokenAndTheRecomputedDate()
+    {
+        ApplicationUser user = CreateUser();
+        user.DeletionScheduledAt = Now - TimeSpan.FromHours(1);
+        DateTimeOffset expectedFinalizesAt = user.DeletionScheduledAt.Value + Gdpr.DeletionGracePeriod;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GenerateUserTokenAsync(
+                user,
+                AccountDeletionCancellationTokenProvider.ProviderName,
+                AccountDeletionCancellationTokenProvider.CancelDeletionPurpose)
+            .Returns("fresh-cancel-token");
+        _emailSender.SendDeletionScheduledEmailAsync(
+                user.Id, user.Email!, "fresh-cancel-token", expectedFinalizesAt, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        AccountDeletionScheduledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionScheduled(user.Id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.Received(1).SendDeletionScheduledEmailAsync(
+            user.Id, user.Email!, "fresh-cancel-token", expectedFinalizesAt, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SendingFails_PropagatesTheFailure()
+    {
+        ApplicationUser user = CreateUser();
+        user.DeletionScheduledAt = Now;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GenerateUserTokenAsync(
+                user,
+                AccountDeletionCancellationTokenProvider.ProviderName,
+                AccountDeletionCancellationTokenProvider.CancelDeletionPurpose)
+            .Returns("fresh-cancel-token");
+        Error smtpError = new("Email.SendFailed", "SMTP relay refused the message.");
+        _emailSender.SendDeletionScheduledEmailAsync(
+                user.Id, user.Email!, "fresh-cancel-token", Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(smtpError));
+        AccountDeletionScheduledProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(new AccountDeletionScheduled(user.Id), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(smtpError);
+    }
+
+    [Theory]
+    [InlineData("this is not json at all")]
+    [InlineData("{}")]
+    [InlineData("""{"IdentityUserId":"not-a-guid"}""")]
+    public void TryDeserialize_PoisonPayload_ReturnsTheNullVerdict(string poisonPayload)
+    {
+        AccountDeletionScheduledProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(System.Text.Encoding.UTF8.GetBytes(poisonPayload));
+
+        message.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_ValidPayload_ReturnsTheTypedMessage()
+    {
+        Guid userId = Guid.CreateVersion7();
+        AccountDeletionScheduledProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(
+            System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new AccountDeletionScheduled(userId)));
+
+        AccountDeletionScheduled typed = message.ShouldBeOfType<AccountDeletionScheduled>();
+        typed.IdentityUserId.ShouldBe(userId);
+    }
+
+    private static ApplicationUser CreateUser() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserName = "frodo",
+            Email = "frodo@shire.me"
+        };
+
+    private AccountDeletionScheduledProcessor CreateSut() =>
+        new(
+            _userManager,
+            _emailSender,
+            _timeProvider,
+            Microsoft.Extensions.Options.Options.Create(Gdpr),
+            NullLogger<AccountDeletionScheduledProcessor>.Instance);
+
+    private static TimeProvider CreateTimeProvider()
+    {
+        TimeProvider timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(Now);
+        return timeProvider;
+    }
+
+    private static UserManager<ApplicationUser> CreateUserManager() =>
+        Substitute.For<UserManager<ApplicationUser>>(
+            Substitute.For<IUserStore<ApplicationUser>>(),
+            null!, null!, null!, null!, null!, null!, null!, null!);
+}


### PR DESCRIPTION
Route both GDPR deletion e-mails through the outbox pipeline (ADR-0038):

- New id-only contracts AccountDeletionScheduled/AccountDeletionCancelled,
  routing keys email.deletion-scheduled / email.deletion-cancelled.
- AccountDeletionScheduledProcessor mints the cancel token at delivery and
  recomputes finalizesAt from the user row; drift guards ack when the user
  is gone, the schedule was cancelled in the gap, the grace window is
  already over (DLQ replay after finalization), or no address exists.
- AccountDeletionCancelledProcessor sends the token-free courtesy notice;
  mirror guard acks when deletion is scheduled again.
- DeleteAccount drops the unwind compensation (decision 5): the outbox row,
  the schedule mutation and the security-stamp rotation commit in one save,
  so a send failure is the pipeline's to retry, not the request's to fail.
- CancelAccountDeletion swaps its fire-and-forget send for the same atomic
  outbox write; the response's reset token is minted after the commit,
  against the committed stamp.
- Tests: processor unit tests, routing entries, async-delivery updates to
  the endpoint suites, and brokered pipeline tests covering both happy
  legs, both state-drift ack cases and poison parking for both types.

Closes #582

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011Wgj7MoszZpKLC6eoXrpyn
