### PR TITLE
MSG-05: Resend confirmation — implement the ADR decision

### DIFF
--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ResendEmailConfirmation.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ResendEmailConfirmation.cs
@@ -89,6 +89,11 @@ internal sealed partial class ResendEmailConfirmation : IApiEndpoint
 
             string token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
 
+            // Deliberately synchronous and outbox-independent (ADR-0038 decision 4): resend is the
+            // user-driven escape hatch ADR-0035's 6 h orphan tail is priced on, so it must keep
+            // delivering when the pipeline itself (relay, broker, consumer) is what is stuck. It is
+            // the only intentional direct-SMTP call on a request path — do not migrate it to the
+            // outbox; that would silently invalidate ADR-0035's pricing.
             Result emailResult = await _accountConfirmationEmailSender.SendEmailConfirmationAsync(
                 user.Id, command.Email, token, cancellationToken);
             if (emailResult.IsFailure)

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResendEmailConfirmationEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResendEmailConfirmationEndpointTests.cs
@@ -1,7 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
 using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.EmailConfirmation;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 
 namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
 
@@ -197,5 +201,50 @@ public sealed class ResendEmailConfirmationEndpointTests : EndpointsTestBase
 
         // Assert — should fail because email is already confirmed
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ResendEmailConfirmation_ShouldSendDirectlyAndWriteNoOutboxRow_WhenBrokerIsDown()
+    {
+        // Arrange — resend is the deliberate escape hatch of ADR-0038 decision 4: it must keep
+        // delivering precisely when the pipeline is the thing that is broken, so the spy broker
+        // refuses every publish for the duration of the act.
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserUnconfirmedAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        AccountConfirmationEmailSpy.Reset();
+
+        SpyMessagePublisher messagePublisherSpy = Factory.Services.GetRequiredService<SpyMessagePublisher>();
+        int outboxRowsBeforeResend = await CountOutboxRowsAsync();
+
+        messagePublisherSpy.FailWith = new InvalidOperationException("broker down");
+
+        try
+        {
+            // Act
+            HttpResponseMessage response = await ApiClient.Http.PostAsJsonAsync(
+                new Uri("auth/resend-email-confirmation", UriKind.Relative),
+                new ResendEmailConfirmationRequest(request.Email));
+
+            // Assert — the e-mail was captured before the response returned (in-request, direct
+            // path) and the outbox grew by nothing: with zero new rows and a refusing broker, the
+            // pipeline cannot be what delivered it. A refactor routing resend through the outbox
+            // flips both assertions.
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            AccountConfirmationEmailSpy.CallCount.ShouldBe(1);
+            AccountConfirmationEmailSpy.LastEmail.ShouldBe(request.Email);
+            (await CountOutboxRowsAsync()).ShouldBe(outboxRowsBeforeResend);
+        }
+        finally
+        {
+            messagePublisherSpy.FailWith = null;
+        }
+    }
+
+    private async Task<int> CountOutboxRowsAsync()
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        return await db.OutboxMessages.AsNoTracking().CountAsync();
     }
 }


### PR DESCRIPTION
Closes #583

## What

ADR-0038 decision 4 rules that `ResendEmailConfirmation` stays synchronous — the deliberate, outbox-independent escape hatch ADR-0035's 6 h orphan tail is priced on. This PR implements the keep-branch of the ticket:

- A why-comment at the send site in `ResendEmailConfirmation.Handler`, pointing at ADR-0038 decision 4 and ADR-0035, so a future cleanup does not "helpfully" migrate the one intentional direct-SMTP call.
- An integration test pinning both properties: with the spy broker refusing every publish, resend still returns 200, the confirmation e-mail is captured in-request through the direct sender, and the outbox row count does not grow. A refactor routing resend through the outbox flips both assertions.

## Why

One deliberately non-migrated sender is the kind of inconsistency reviews love to erase (ADR-0038 accepted trade-off). Code and ADR now agree, and the test makes a silent flip impossible.

## Tests

- `dotnet build LotroKoniecDev.slnx` — 0 warnings
- Auth integration suite: 341/341 (includes the new pin; also proves the `FailWith` toggle does not leak into the shared collection)
- Patcher unit 277/277, auth unit 154/154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011546rzw4kCn61fLvGu3WF7