### PR TITLE
Retire the Serilog reloadable bootstrap logger in TMS API and Frontend

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -20,9 +20,17 @@ using OpenTelemetry.Trace;
 using Serilog;
 using Serilog.Sinks.OpenTelemetry;
 
+// Deliberately NOT CreateBootstrapLogger(): the reloadable bootstrap logger lives in the shared
+// static Log.Logger slot, and AddSerilog freezes it on the host's first logger resolution. Any
+// test run that boots a second host from this Program (a WithWebHostBuilder child, a second
+// class fixture) lets one host freeze the bootstrap logger another host just installed — the
+// second freeze then dies with "The logger is already frozen". A plain console logger keeps
+// startup logging (and the catch/finally below) working while AddSerilog builds each host its
+// own fully-configured pipeline; in production nothing changes — the single host's final logger
+// still replaces this one.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-    .CreateBootstrapLogger();
+    .CreateLogger();
 
 try
 {

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
@@ -20,9 +20,17 @@ using LotroKoniecDev.TranslationSystem.API.Settings;
 using LotroKoniecDev.TranslationSystem.Persistence.Settings;
 using LotroKoniecDev.Logging.Redaction;
 
+// Deliberately NOT CreateBootstrapLogger(): the reloadable bootstrap logger lives in the shared
+// static Log.Logger slot, and AddSerilog freezes it on the host's first logger resolution. Any
+// test run that boots a second host from this Program (a WithWebHostBuilder child, a second
+// class fixture) lets one host freeze the bootstrap logger another host just installed — the
+// second freeze then dies with "The logger is already frozen". A plain console logger keeps
+// startup logging (and the catch/finally below) working while AddSerilog builds each host its
+// own fully-configured pipeline; in production nothing changes — the single host's final logger
+// still replaces this one.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-    .CreateBootstrapLogger();
+    .CreateLogger();
 
 try
 {


### PR DESCRIPTION
Closes #587

## What

Replaces `CreateBootstrapLogger()` with a plain `CreateLogger()` console logger in `TranslationSystem.API/Program.cs` and `Frontend/Program.cs`, mirroring the auth-api fix that landed with PR #586 (including its explanatory comment, adapted to these hosts).

## Why

The reloadable bootstrap logger lives in the shared static `Log.Logger` slot and `AddSerilog` freezes it on the host's first logger resolution. When two hosts boot concurrently in one test process, the second freeze dies with `The logger is already frozen` — this burned the auth-api suite in PR #586. TMS API and Frontend carried the same pattern; this change removes it before any second test host re-arms the failure. Production behavior is unchanged: the single host's final logger still replaces the startup one, and the `catch`/`finally` `Log.Fatal` + `CloseAndFlushAsync` paths keep logging to console.

## Tests

- `dotnet build LotroKoniecDev.slnx` — 0 warnings.
- All unit suites green (1293 tests) and both integration suites green (205 TMS + 341 Auth), assertions untouched.
- `grep` confirms no `CreateBootstrapLogger()` call remains anywhere in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011546rzw4kCn61fLvGu3WF7