### PR TITLE
CD janitor cancels nothing — 'gh run cancel' is a no-op on waiting runs; use force-cancel

### DIFF
--- a/.github/workflows/cd-janitor.yml
+++ b/.github/workflows/cd-janitor.yml
@@ -14,6 +14,12 @@ name: CD janitor (expire stale deploy candidates)
 # Cutoff is measured from startedAt, not createdAt — a re-run of an old run resets startedAt, so a
 # deliberately re-run candidate gets a fresh 24 h window instead of being culled immediately.
 #
+# Cancelling goes through the force-cancel API endpoint, NOT `gh run cancel` (#592): the plain
+# cancel endpoint only *requests* cancellation, and a run held at an approval gate has no runner
+# to pick the request up, so it reports success while the run stays `waiting` forever — the UI
+# Cancel button fails the same way. The job verifies the status actually flipped and fails loudly
+# otherwise, so a green janitor always means the queue really was cleaned.
+#
 # Cron is UTC and deliberately off-hour (GitHub delays on-the-hour crons the most). Exact timing is
 # irrelevant here — anything roughly nightly keeps the queue clean.
 
@@ -80,15 +86,35 @@ jobs:
                 "$run_id" "$url" "$status" >> "$GITHUB_STEP_SUMMARY"
               continue
             fi
-            if gh run cancel "$run_id"; then
-              echo "Cancelled run ${run_id} (sha ${short_sha}, waiting since ${started_at})."
-              printf -- '- CANCELLED run [%s](%s) — sha `%s`, waiting since %s\n' \
-                "$run_id" "$url" "$short_sha" "$started_at" >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo "::error::Failed to cancel run ${run_id}: ${url}"
+            # force-cancel, not `gh run cancel`: the plain cancel endpoint returns success while
+            # leaving an approval-gated run `waiting` forever (#592). Same permission surface —
+            # `actions: write` covers force-cancel too.
+            if ! gh api -X POST "repos/${GH_REPO}/actions/runs/${run_id}/force-cancel" >/dev/null; then
+              echo "::error::force-cancel API call failed for run ${run_id}: ${url}"
               printf -- '- FAIL could not cancel run [%s](%s)\n' "$run_id" "$url" >> "$GITHUB_STEP_SUMMARY"
               failed=1
+              continue
             fi
+            # Trust nothing the cancel call says — the first version of this janitor was green
+            # for a week while cancelling nothing. Only a verified flip out of `waiting` counts;
+            # the endpoint is quick but asynchronous, hence the short poll.
+            for _ in 1 2 3 4 5; do
+              status="$(gh run view "$run_id" --json status --jq .status || echo unknown)"
+              if [ "$status" != "waiting" ]; then
+                break
+              fi
+              sleep 2
+            done
+            if [ "$status" = "waiting" ]; then
+              echo "::error::Run ${run_id} is still waiting after force-cancel: ${url}"
+              printf -- '- FAIL run [%s](%s) still `waiting` after force-cancel\n' \
+                "$run_id" "$url" >> "$GITHUB_STEP_SUMMARY"
+              failed=1
+              continue
+            fi
+            echo "Cancelled run ${run_id} (sha ${short_sha}, waiting since ${started_at})."
+            printf -- '- CANCELLED run [%s](%s) — sha `%s`, waiting since %s\n' \
+              "$run_id" "$url" "$short_sha" "$started_at" >> "$GITHUB_STEP_SUMMARY"
           done <<< "$stale"
 
           exit "$failed"

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -619,6 +619,11 @@ cancels any CD run left `waiting` at the `production` gate for more than 24 hour
 merge produces a fresh candidate, and any older commit can still be deployed explicitly via
 `cd.yml`'s `workflow_dispatch`.
 
+**Cancelling a `waiting` run by hand:** the UI *Cancel* button and `gh run cancel` do **not** work
+on approval-gated runs — they only file a cancellation request no runner will ever pick up, so the
+run stays `waiting` ("requested to cancel" forever, #592). Use the same call the janitor makes:
+`gh api -X POST repos/koniecdev/LotroKoniecDev/actions/runs/<run-id>/force-cancel`.
+
 ### What `deploy.yml` does
 
 **Prod leg only, first (#534 — the N-1 promotion gate):** promotion is batched, so the sha the

--- a/docs/tms-handbook.md
+++ b/docs/tms-handbook.md
@@ -1212,7 +1212,7 @@ containerized-OIDC problem dissolves in real production too.
 | `e2e` | manual + PRs touching package/Docker dependency manifests (so Dependabot bumps exercise it) | full-stack and browser E2E suites |
 | `smoke` | after deploys | health + a real OIDC token round-trip + file distribution |
 | `health-ping` | daily cron | probes the three public origins once a day (deep `/health`) — the only availability signal, and the one check that proves the (scale-to-zero) Neon database is reachable |
-| `cd-janitor` | nightly cron | cancels CD runs left `waiting` at the `production` approval gate for more than 24 h, so a stale-SHA candidate can never be approved by accident (#527) |
+| `cd-janitor` | nightly cron | cancels CD runs left `waiting` at the `production` approval gate for more than 24 h, so a stale-SHA candidate can never be approved by accident (#527) — via the force-cancel API endpoint, because a plain cancel is a silent no-op on approval-gated runs (#592) |
 | `codeql` | PRs + weekly schedule (no push — squash-merged code was already scanned on the PR, #526) | static security analysis |
 | `gitleaks` | PRs/pushes | secret scanning |
 | `actionlint` | every PR | lints `.github/workflows/` so workflow-only PRs cannot merge unparsed |


### PR DESCRIPTION
Closes #592

## What

- `cd-janitor.yml` now cancels stale deploy candidates through the force-cancel API endpoint (`POST /actions/runs/{id}/force-cancel`) instead of `gh run cancel`.
- After each cancel, the job polls the run status and fails loudly if the run is still `waiting` — the janitor can never again report success while doing nothing.
- Runbook gets a manual escape hatch note (the UI Cancel button cannot kill a `waiting` run either); handbook workflow table updated.

## Why

The plain cancel endpoint only files a cancellation request. A run held at the `production` approval gate has no runner to pick that request up, so it stays `waiting` forever while both the janitor and the UI report the cancel as accepted. The janitor was green since #527 but never actually cancelled anything.

## Test

- Empirically verified on stuck run 30346032700 (waiting since 2026-07-28, survived a janitor "cancel" that morning): plain cancel left it `waiting`; force-cancel flipped it to `completed`/`cancelled` immediately.
- `actionlint` (with shellcheck on the run block) clean locally; no .NET code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011546rzw4kCn61fLvGu3WF7