### PR TITLE
Infra: enable ValidateScopes + ValidateOnBuild in all environments on every host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,15 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 - **No mediator — slim SRP handlers (ADR-0001), repo-wide.** One use case = one record + one
   handler implementing the in-house `ICommandHandler<,>`/`IQueryHandler<,>`. Consumers inject the
   closed handler interface directly. Lifted KittySaver code is de-mediatorized on entry.
+- **DI validation is always on (#572).** Every composition root enables `ValidateScopes` +
+  `ValidateOnBuild` in ALL environments (`builder.Host.UseDefaultServiceProvider` on the three web
+  hosts; `ServiceProviderOptions` in the CLI `TypeRegistrar`) — a new host copies the pattern. It
+  validates registered services only, so endpoint integration tests stay the guard for a forgotten
+  closed handler registration. **In the CLI, Spectre command types are registered `AddScoped` and
+  resolved through a single process-lifetime scope in `TypeResolver`** — they inject scoped
+  handlers, so the old `AddSingleton` + root-provider resolve is a captive dependency that refuses
+  to build. A new CLI command follows suit. Nothing in CI covers that graph (the CLI is
+  `net10.0-windows/win-x86`), so changes to it need a Windows `export`/`patch`/`launch` smoke.
 - **CQRS read/write split, day 1 (ADR-0002 amendment).** Query handlers read POCO `ReadModels`
   through `IApplicationReadDbContext`; command handlers load and mutate aggregates via
   repositories + `IUnitOfWork`. The write model never serves list/search queries; every new

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -38,6 +38,17 @@ try
 
     WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+    // DI validation in EVERY environment, not just Development (#572): a captive dependency or an
+    // unresolvable constructor that only manifests under Production config fails the container at
+    // startup — where CD smokes the 0%-traffic candidate — instead of surfacing as a 500 on first
+    // hit. Registered-services-only: a forgotten closed handler registration is still resolved at
+    // request time, so endpoint integration tests remain the guard for that.
+    builder.Host.UseDefaultServiceProvider(static (_, options) =>
+    {
+        options.ValidateScopes = true;
+        options.ValidateOnBuild = true;
+    });
+
     // Optional, git-ignored per-developer overrides (e.g. AdminUser:* seed credentials), the same
     // machine-local file the EF design-time factories already read. It survives `docker compose
     // down -v`, so a local admin is re-seeded on the next host start.

--- a/src/Frontend/LotroKoniecDev.Frontend/Program.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Program.cs
@@ -38,6 +38,17 @@ try
 
     WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+    // DI validation in EVERY environment, not just Development (#572): a captive dependency or an
+    // unresolvable constructor that only manifests under Production config fails the container at
+    // startup — where CD smokes the 0%-traffic candidate — instead of surfacing as a 500 on first
+    // hit. Registered-services-only: a forgotten closed handler registration is still resolved at
+    // request time, so endpoint integration tests remain the guard for that.
+    builder.Host.UseDefaultServiceProvider(static (_, options) =>
+    {
+        options.ValidateScopes = true;
+        options.ValidateOnBuild = true;
+    });
+
     string? otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
 
     builder.Services.AddSerilog((serviceProvider, loggerConfiguration) =>

--- a/src/Patcher/LotroKoniecDev.Cli/DependencyInjection/TypeRegistrar.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/DependencyInjection/TypeRegistrar.cs
@@ -14,14 +14,24 @@ public sealed class TypeRegistrar : ITypeRegistrar
 
     public ITypeResolver Build()
     {
-        ServiceProvider provider = _services.BuildServiceProvider();
+        // DI validation regardless of environment (#572): a captive dependency or an unresolvable
+        // constructor fails the CLI at startup instead of mid-command, halfway through a DAT write.
+        ServiceProvider provider = _services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true
+        });
         TypeResolver typeResolver = new(provider);
         return typeResolver;
     }
 
+    // Spectre registers the command types (ExportCommand, PatchCommand, LaunchCommand) through this
+    // method, and every one of them injects scoped handlers. Registering them as singletons is a
+    // captive dependency: the container refuses to build once ValidateScopes is on. Scoped keeps the
+    // lifetimes honest — TypeResolver resolves everything from a single process-lifetime scope.
     public void Register(Type service, Type implementation)
     {
-        _services.AddSingleton(service, implementation);
+        _services.AddScoped(service, implementation);
     }
 
     public void RegisterInstance(Type service, object implementation)

--- a/src/Patcher/LotroKoniecDev.Cli/DependencyInjection/TypeResolver.cs
+++ b/src/Patcher/LotroKoniecDev.Cli/DependencyInjection/TypeResolver.cs
@@ -1,27 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
 
 namespace LotroKoniecDev.Cli.DependencyInjection;
 
 public sealed class TypeResolver : ITypeResolver, IDisposable
 {
-    private readonly IServiceProvider _provider;
+    private readonly ServiceProvider _provider;
+    private readonly IServiceScope _scope;
 
-    public TypeResolver(IServiceProvider provider)
+    public TypeResolver(ServiceProvider provider)
     {
         _provider = provider;
+        // One scope for the whole process: the CLI runs exactly one command per invocation, so the
+        // scope's lifetime is the command's. Resolving from the root provider instead would throw
+        // once ValidateScopes is on, because the commands depend on scoped handlers.
+        _scope = provider.CreateScope();
     }
 
     public object? Resolve(Type? type)
     {
-        object? result = type is null ? null : _provider.GetService(type);
+        object? result = type is null ? null : _scope.ServiceProvider.GetService(type);
         return result;
     }
 
     public void Dispose()
     {
-        if (_provider is IDisposable disposable)
-        {
-            disposable.Dispose();
-        }
+        _scope.Dispose();
+        _provider.Dispose();
     }
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Program.cs
@@ -38,6 +38,17 @@ try
 
     WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+    // DI validation in EVERY environment, not just Development (#572): a captive dependency or an
+    // unresolvable constructor that only manifests under Production config fails the container at
+    // startup — where CD smokes the 0%-traffic candidate — instead of surfacing as a 500 on first
+    // hit. Registered-services-only: a forgotten closed handler registration is still resolved at
+    // request time, so endpoint integration tests remain the guard for that.
+    builder.Host.UseDefaultServiceProvider(static (_, options) =>
+    {
+        options.ValidateScopes = true;
+        options.ValidateOnBuild = true;
+    });
+
     string? otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
 
     builder.Services.AddSerilog((services, lc) =>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Bases/EndpointsTestBase.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Bases/EndpointsTestBase.cs
@@ -12,7 +12,7 @@ public abstract class EndpointsTestBase : AsyncLifetimeTestBase
     protected EndpointsTestBase(AuthSystemApiFactory appFactory) : base(appFactory)
     {
         JsonSerializerOptions jsonSerializerOptions =
-            appFactory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+            appFactory.Services.GetRequiredService<IOptions<JsonOptions>>().Value.SerializerOptions;
 
         ApiClient = new TestApiClient(appFactory.CreateClient(), jsonSerializerOptions);
     }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AuthorizationCodeFlowTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AuthorizationCodeFlowTests.cs
@@ -26,7 +26,7 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
     public AuthorizationCodeFlowTests(AuthSystemApiFactory appFactory) : base(appFactory)
     {
         JsonSerializerOptions jsonSerializerOptions =
-            appFactory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+            appFactory.Services.GetRequiredService<IOptions<JsonOptions>>().Value.SerializerOptions;
 
         // Client that follows redirects (for normal API calls and registration)
         ApiClient = new TestApiClient(appFactory.CreateClient(), jsonSerializerOptions);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeletionGraceWindowTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/DeletionGraceWindowTests.cs
@@ -33,7 +33,7 @@ public sealed partial class DeletionGraceWindowTests : AsyncLifetimeTestBase
     public DeletionGraceWindowTests(AuthSystemApiFactory appFactory) : base(appFactory)
     {
         JsonSerializerOptions jsonSerializerOptions =
-            appFactory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+            appFactory.Services.GetRequiredService<IOptions<JsonOptions>>().Value.SerializerOptions;
 
         ApiClient = new TestApiClient(appFactory.CreateClient(), jsonSerializerOptions);
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/SecurityStampCookieValidationTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/SecurityStampCookieValidationTests.cs
@@ -23,7 +23,7 @@ public sealed partial class SecurityStampCookieValidationTests : AsyncLifetimeTe
     public SecurityStampCookieValidationTests(AuthSystemApiFactory appFactory) : base(appFactory)
     {
         JsonSerializerOptions jsonSerializerOptions =
-            appFactory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+            appFactory.Services.GetRequiredService<IOptions<JsonOptions>>().Value.SerializerOptions;
 
         ApiClient = new TestApiClient(appFactory.CreateClient(), jsonSerializerOptions);
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/ForwardedHeaders/ForwardedHeadersTrustTests.cs
@@ -176,7 +176,7 @@ public sealed class ForwardedHeadersTrustTests
         HttpRequestMessage request)
     {
         JsonSerializerOptions jsonSerializerOptions =
-            factory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+            factory.Services.GetRequiredService<IOptions<JsonOptions>>().Value.SerializerOptions;
 
         using HttpClient httpClient = factory.CreateClient();
         HttpResponseMessage httpResponse = await httpClient.SendAsync(request);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/AccountDeletionPipelineTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/AccountDeletionPipelineTests.cs
@@ -48,7 +48,7 @@ public sealed class AccountDeletionPipelineTests : IClassFixture<BrokeredAuthSys
         _deletionEmailSpy = factory.Services.GetRequiredService<SpyAccountDeletionEmailSender>();
 
         JsonSerializerOptions jsonSerializerOptions =
-            factory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+            factory.Services.GetRequiredService<IOptions<JsonOptions>>().Value.SerializerOptions;
         _apiClient = new TestApiClient(factory.CreateClient(), jsonSerializerOptions);
     }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/EmailConfirmationPipelineTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/EmailConfirmationPipelineTests.cs
@@ -49,7 +49,7 @@ public sealed class EmailConfirmationPipelineTests : IClassFixture<BrokeredAuthS
         _confirmationEmailSpy = factory.Services.GetRequiredService<SpyAccountConfirmationEmailSender>();
 
         JsonSerializerOptions jsonSerializerOptions =
-            factory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+            factory.Services.GetRequiredService<IOptions<JsonOptions>>().Value.SerializerOptions;
         _apiClient = new TestApiClient(factory.CreateClient(), jsonSerializerOptions);
     }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/PasswordResetPipelineTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Messaging/PasswordResetPipelineTests.cs
@@ -43,7 +43,7 @@ public sealed class PasswordResetPipelineTests : IClassFixture<BrokeredAuthSyste
         _passwordResetEmailSpy = factory.Services.GetRequiredService<SpyPasswordResetEmailSender>();
 
         JsonSerializerOptions jsonSerializerOptions =
-            factory.Services.GetRequiredService<IOptionsSnapshot<JsonOptions>>().Value.SerializerOptions;
+            factory.Services.GetRequiredService<IOptions<JsonOptions>>().Value.SerializerOptions;
         _apiClient = new TestApiClient(factory.CreateClient(), jsonSerializerOptions);
     }
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/TranslationSystemApiFactory.cs
@@ -80,11 +80,17 @@ public class TranslationSystemApiFactory : WebApplicationFactory<Program>, IAsyn
             });
 
             // AddDbContext calls compose (EF Core 9+): this appends the recording interceptors to
-            // the production registrations of the two contexts instead of replacing them.
-            services.AddDbContext<ApplicationReadDbContext>(options =>
-                options.AddInterceptors(ReadContextSqlRecorder));
-            services.AddDbContext<ApplicationWriteDbContext>(options =>
-                options.AddInterceptors(WriteContextSqlRecorder));
+            // the production registrations of the two contexts instead of replacing them. The
+            // production contexts are POOLED (singleton options), so the appended configuration must
+            // be singleton too — the default scoped optionsLifetime trips ValidateScopes (#572).
+            services.AddDbContext<ApplicationReadDbContext>(
+                options => options.AddInterceptors(ReadContextSqlRecorder),
+                contextLifetime: ServiceLifetime.Scoped,
+                optionsLifetime: ServiceLifetime.Singleton);
+            services.AddDbContext<ApplicationWriteDbContext>(
+                options => options.AddInterceptors(WriteContextSqlRecorder),
+                contextLifetime: ServiceLifetime.Scoped,
+                optionsLifetime: ServiceLifetime.Singleton);
         });
 
         builder.ConfigureLogging(logging =>


### PR DESCRIPTION
Closes #572

## What

Every composition root now builds its service provider with `ValidateScopes` and `ValidateOnBuild` enabled in **all** environments, not just Development:

- `builder.Host.UseDefaultServiceProvider` on auth-api, tms-api and the frontend
- `ServiceProviderOptions` in the patcher CLI's `TypeRegistrar`

## Why

Both options default to `true` only in Development. A DI defect that exists only under Production config — a captive dependency, or a registered service with an unresolvable constructor — used to show up as a 500 on the first request. With validation always on it becomes a startup failure instead, and CD smokes the 0%-traffic candidate before any traffic shift, so a broken container fails the deploy loudly rather than serving errors. The cost is one graph walk at startup, negligible at our service count.

`ValidateOnBuild` only checks **registered** services. A forgotten closed `ICommandHandler<,>`/`IQueryHandler<,>` registration is resolved by the route delegate at request time and is still not caught at startup — endpoint integration tests remain the guard for that.

## Violations the validation surfaced

**1. Patcher CLI — a real captive dependency (the important one).**

Spectre registers `ExportCommand`, `PatchCommand` and `LaunchCommand` through our own `TypeRegistrar`, which registered them as **singletons**, while all three inject **scoped** handlers from `ApplicationDependencyInjection` / `InfrastructureDependencyInjection`. `TypeResolver` also resolved from the root provider, which `ValidateScopes` rejects on its own. Turning validation on without fixing this would have broken `export`, `patch` and `launch` at startup.

Commands are now registered `AddScoped`, and `TypeResolver` resolves through a single scope that lives as long as the process. The CLI runs exactly one command per invocation, so that scope is the command's lifetime; instance counts do not change, because the scoped services were previously pinned to the root scope and behaved the same way. `RegisterInstance` and `RegisterLazy` stay singleton — they take a ready instance or a factory.

**2. Auth integration test hosts** read `JsonSerializerOptions` through `IOptionsSnapshot`, which is scoped, from the root provider. Switched to `IOptions`, the correct lifetime, same configured value.

**3. TMS integration test factory** appended its SQL-recording interceptors with `AddDbContext`, which defaults to a **scoped** options lifetime. Both production contexts use `AddDbContextPool`, whose options are **singleton**, so the composed registration has to be singleton too.

## How it was tested

- `dotnet build LotroKoniecDev.slnx` — succeeded, **0 warnings**.
- Full unit + integration suites (the same selection `pr-verify` runs): **1839 passed, 0 failed**. Both API integration suites boot the real hosts against real PostgreSQL, so auth-api and tms-api are proven to start green under validation.
- Guard scripts green: `check-ssr-purity.sh`, `check-dockerfile-restore-graph.sh`, `check-migration-safety.sh`.
- CLI: the two real source files (`TypeRegistrar.cs`, `TypeResolver.cs` — they depend only on Spectre + MS.DI, both cross-platform) were compiled verbatim into a small `net10.0` harness against the same Spectre 0.55.0 and a stub graph mirroring the real lifetimes. The pre-fix version fails **all three** commands at `TypeRegistrar.Build()` with `Cannot consume scoped service … from singleton …`; this version resolves and runs all three.

## Still to verify manually

- The CLI targets `net10.0-windows/win-x86` and cannot execute on macOS or the Linux CI runner, and no test project references it. **`export` / `patch` / `launch` need a smoke run on Windows before release.** CLAUDE.md now records that gap.
- The prod-parity stack (`compose.prod.yaml`) boot was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179vSd5W2KHgTTRAkHWmJrd