### PR TITLE
Tests: adopt the NaughtyStrings NuGet package for hostile-string edge cases

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,6 +80,7 @@
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
+    <PackageVersion Include="NaughtyStrings" Version="3.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageVersion Include="Testcontainers" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -59,10 +59,46 @@ per-project `stryker-config.json` after reviewing the baseline report.
 - **xUnit** — test framework (`Fact`, `Theory`, `InlineData`)
 - **Shouldly** — `.ShouldBe()`, `.ShouldBeTrue()`, `.ShouldContain()`, …
 - **NSubstitute** — mocking: `Substitute.For<IInterface>()`
+- **NaughtyStrings** — the Big List of Naughty Strings, for hostile-input theories (see below)
 - **NetArchTest.Rules** — architecture tests (assembly IL only; `LotroKoniecDev.Architecture.Tests.Unit`)
 - **Xunit.SkippableFact** — E2E tests that need Windows + a real DAT
 - **coverlet.collector** — code coverage
 - Versions: `Directory.Packages.props` is the single source of truth.
+
+## Hostile-string theories (`tests/Shared/NaughtyStringCases.cs` — #569)
+
+String-heavy seams are hardened with the **Big List of Naughty Strings** (the `NaughtyStrings`
+package): emoji and other surrogate pairs, RTL/bidi controls, zero-width and combining marks,
+quote/escape/injection soup, non-ASCII digits. The theory sources live in **one file**,
+`tests/Shared/NaughtyStringCases.cs`, **linked** (`<Compile Include="..\Shared\…" Link="Shared\…" />`)
+into every pure unit suite that needs them — `Tests.Unit`, `TranslationSystem.API.Tests.Unit`,
+`TranslationSystem.Domain.Tests.Unit`. Add the link + the `NaughtyStrings` PackageReference to a new
+suite rather than copy-pasting lists; add a category source there rather than inlining one in a test.
+
+Sources: `All` (everything), `UnicodeHazards` (UTF-16 length hazards), `DelimiterHazards` (collides
+with a delimited text format), `NonAsciiDigits` (id columns), `SubmittableText` / `BlankText` (what
+the API's `NotEmpty()` does and does not let through as translated text), plus `AllValues` — the raw
+list, for a suite that must filter the corpus down to what its seam accepts **before** building a
+`TheoryData`, so its assertion stays unconditional instead of hiding in an `if`. Entries are
+de-duplicated: the upstream list repeats two, and a duplicate logs a "Skipping test case with
+duplicate ID" line on every run.
+
+Both sides of the `||` contract carry hostile round-trip coverage:
+`TranslationFileParserNaughtyStringTests` + `FragmentNaughtyStringTests` (patcher — parser and the
+VarLen/UTF-16 binary writer), `TranslationFileNaughtyStringTests` + `ParserContractParityTests`
+(TMS — serializer, import parser and the cross-parser drift guard),
+`NaughtyStringValueObjectTests` (TMS domain — a VO factory answers with a `Result`, never an
+exception).
+
+**The corpus does not reach every interesting case.** It carries no empty string, no real newline,
+no literal `\r`/`\n` escape sequence and no entry ending in an odd run of `|` — exactly the
+delimiter collisions this format is weakest at. Those are composed by hand as explicit
+`[InlineData]` theories next to the corpus-driven ones; when you add a seam, check whether its
+hazard is actually present in the data before trusting a `MemberData` theory to cover it.
+
+Several tests pin **known-lossy** behavior on purpose, say so in-place, and name the defect ticket
+they document (#596 escape asymmetry, #597 odd trailing pipe, #598 over-long piece). Do not "fix"
+such a test — fix the defect, then change the assertion deliberately.
 
 ## Unit Tests (LotroKoniecDev.Tests.Unit)
 

--- a/tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj
@@ -15,6 +15,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Microsoft.Extensions.Logging"/>
+        <PackageReference Include="NaughtyStrings"/>
         <PackageReference Include="NSubstitute"/>
         <PackageReference Include="Shouldly" />
         <PackageReference Include="xunit"/>
@@ -28,6 +29,11 @@
         <Using Include="Xunit"/>
         <Using Include="Shouldly"/>
         <Using Include="NSubstitute"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Linked, not copied: one hostile-string theory source shared by every unit suite (#569). -->
+        <Compile Include="..\Shared\NaughtyStringCases.cs" Link="Shared\NaughtyStringCases.cs"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Models/FragmentNaughtyStringTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Models/FragmentNaughtyStringTests.cs
@@ -1,0 +1,166 @@
+using System.Text;
+using LotroKoniecDev.Domain.Core.Utilities;
+using LotroKoniecDev.Domain.Models;
+using LotroKoniecDev.Tests.Shared;
+
+namespace LotroKoniecDev.Tests.Unit.Tests.Models;
+
+/// <summary>
+/// Hostile-input coverage for the binary half of the patcher (#569): a fragment's UTF-16 pieces and
+/// argument strings are length-prefixed with <see cref="VarLenEncoder"/>, so anything that makes a
+/// character count disagree with its byte count — surrogate pairs, combining marks, astral-plane
+/// characters — corrupts every following fragment in the subfile, not just its own.
+/// </summary>
+public sealed class FragmentNaughtyStringTests
+{
+    private const int VarLenSingleByteCeiling = 127;
+    private const int VarLenTwoByteCeiling = 32767;
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void WriteThenParse_NaughtyPiece_ShouldRoundTripExactly(string naughty)
+    {
+        // Arrange
+        Fragment fragment = new() { Pieces = [naughty] };
+
+        // Act
+        Fragment parsed = RoundTrip(fragment);
+
+        // Assert
+        parsed.Pieces.ShouldBe([naughty]);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.UnicodeHazards), MemberType = typeof(NaughtyStringCases))]
+    public void WriteThenParse_NaughtyPiecesSplitAcrossOneFragment_ShouldRoundTripExactly(string naughty)
+    {
+        // Arrange — the game splits a single displayed text into several pieces; a length error in
+        // one of them desynchronises the reader for the rest of the fragment.
+        Fragment fragment = new() { Pieces = [naughty, string.Empty, naughty, "plain", naughty] };
+
+        // Act
+        Fragment parsed = RoundTrip(fragment);
+
+        // Assert
+        parsed.Pieces.ShouldBe([naughty, string.Empty, naughty, "plain", naughty]);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.UnicodeHazards), MemberType = typeof(NaughtyStringCases))]
+    public void WriteThenParse_NaughtyArgumentStrings_ShouldRoundTripExactly(string naughty)
+    {
+        // Arrange — argument string groups carry the same VarLen + UTF-16 encoding as pieces and are
+        // read after the argument references, so they desynchronise the reader just as badly.
+        Fragment fragment = new() { Pieces = ["Text with a placeholder"] };
+        fragment.ArgRefs.Add([0x01, 0x00, 0x00, 0x00]);
+        fragment.ArgStrings.Add([naughty, string.Empty]);
+
+        // Act
+        Fragment parsed = RoundTrip(fragment);
+
+        // Assert
+        parsed.ArgStrings.ShouldHaveSingleItem().ShouldBe([naughty, string.Empty]);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.UnicodeHazards), MemberType = typeof(NaughtyStringCases))]
+    public void WriteThenParse_NaughtyPieceRepeatedIntoATwoByteLength_ShouldRoundTripExactly(string naughty)
+    {
+        // Arrange — repeat until the length genuinely crosses the VarLen one-byte ceiling, so the
+        // prefix takes the two-byte high-bit path while the payload stays hostile. A fixed repeat
+        // count would not: a third of the hazard entries are one or two characters long. Repeating
+        // whole copies never splits a surrogate pair.
+        int repeats = VarLenSingleByteCeiling / naughty.Length + 1;
+        string repeated = string.Concat(Enumerable.Repeat(naughty, repeats));
+        Fragment fragment = new() { Pieces = [repeated] };
+
+        // Act
+        Fragment parsed = RoundTrip(fragment);
+
+        // Assert
+        repeated.Length.ShouldBeGreaterThan(VarLenSingleByteCeiling);
+        parsed.Pieces.ShouldBe([repeated]);
+    }
+
+    [Fact]
+    public void Write_PieceOfAstralPlaneCharacters_ShouldPrefixItWithItsUtf16CodeUnitCount()
+    {
+        // Arrange — the length prefix counts UTF-16 code units, NOT runes. These four emoji are
+        // eight code units; a rune-counting writer would halve the declared length and shred every
+        // following fragment in the subfile. The round-trip theories above would catch that too —
+        // this states the wire rule outright, on the one input where runes and code units differ.
+        const string naughty = "😀😀😀😀";
+        Fragment fragment = new() { Pieces = [naughty] };
+        using MemoryStream stream = new();
+
+        using (BinaryWriter writer = new(stream, Encoding.Unicode, leaveOpen: true))
+        {
+            fragment.Write(writer);
+        }
+
+        stream.Position = sizeof(ulong) + sizeof(int); // past FragmentId and the piece count
+        using BinaryReader reader = new(stream, Encoding.Unicode, leaveOpen: true);
+
+        // Act
+        int encodedLength = VarLenEncoder.Read(reader);
+
+        // Assert
+        encodedLength.ShouldBe(8);
+    }
+
+    [Theory]
+    [InlineData(VarLenSingleByteCeiling)]
+    [InlineData(VarLenSingleByteCeiling + 1)]
+    [InlineData(VarLenTwoByteCeiling)]
+    public void WriteThenParse_PieceAtAVarLenBoundary_ShouldRoundTripExactly(int length)
+    {
+        // Arrange — a non-ASCII BMP filler keeps the character count exact while still exercising
+        // the two-bytes-per-character payload maths.
+        string longPiece = new('ż', length);
+        Fragment fragment = new() { Pieces = [longPiece] };
+
+        // Act
+        Fragment parsed = RoundTrip(fragment);
+
+        // Assert
+        parsed.Pieces.ShouldBe([longPiece]);
+    }
+
+    [Fact]
+    public void Write_PieceLongerThanTheVarLenCeiling_ShouldThrow()
+    {
+        // Arrange — DOCUMENTED CURRENT BEHAVIOR. Refusing to write is right in itself: VarLen cannot
+        // express a length above 32767, and a truncated prefix would silently corrupt the subfile.
+        // What is NOT right is where the throw lands — nothing caps TranslatedText, and neither
+        // PatchingService nor its handler catches, so an over-long translation escapes as an
+        // unhandled exception mid-loop, after earlier subfiles were already written. Tracked as
+        // #598; pinned here so fixing it is a deliberate, visible change to this assertion.
+        Fragment fragment = new() { Pieces = [new string('ż', VarLenTwoByteCeiling + 1)] };
+        using MemoryStream stream = new();
+        using BinaryWriter writer = new(stream, Encoding.Unicode, leaveOpen: true);
+
+        // Act
+        Action write = () => fragment.Write(writer);
+
+        // Assert
+        write.ShouldThrow<ArgumentOutOfRangeException>();
+    }
+
+    private static Fragment RoundTrip(Fragment fragment)
+    {
+        using MemoryStream stream = new();
+
+        using (BinaryWriter writer = new(stream, Encoding.Unicode, leaveOpen: true))
+        {
+            fragment.Write(writer);
+        }
+
+        stream.Position = 0;
+        using BinaryReader reader = new(stream, Encoding.Unicode, leaveOpen: true);
+
+        Fragment parsed = new();
+        parsed.Parse(reader);
+
+        return parsed;
+    }
+}

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserNaughtyStringTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserNaughtyStringTests.cs
@@ -1,0 +1,201 @@
+using LotroKoniecDev.Application.Parsers;
+using LotroKoniecDev.Domain.Core.Monads;
+using LotroKoniecDev.Domain.Models;
+using LotroKoniecDev.Tests.Shared;
+
+namespace LotroKoniecDev.Tests.Unit.Tests.Parsers;
+
+/// <summary>
+/// Hostile-input coverage for the patcher's half of the <c>||</c> contract (#569): the Big List of
+/// Naughty Strings driven through the exact producer/consumer pair the CLI uses — the escape
+/// <c>ExportTextsQueryHandler</c> applies when writing <c>exported.txt</c>, and
+/// <see cref="TranslationFileParser.ParseLine"/> reading it back.
+/// </summary>
+/// <remarks>
+/// These tests pin CURRENT behavior. Changing the format itself still needs an ADR plus updated
+/// golden fixtures on both sides of the contract (CLAUDE.md).
+/// </remarks>
+public sealed class TranslationFileParserNaughtyStringTests
+{
+    private readonly TranslationFileParser _parser = new();
+
+    /// <summary>
+    /// The escape the exporter applies to every fragment before writing a line
+    /// (<c>ExportTextsQueryHandler</c>): real newlines become two-character sequences so a fragment
+    /// stays on one line.
+    /// </summary>
+    /// <remarks>
+    /// KEEP IN SYNC with <c>ExportTextsQueryHandler</c> — the handler escapes inline while streaming
+    /// to a file, so there is no seam to call and the rule is duplicated here. #596 changes that
+    /// escape; this copy must move with it or these theories will keep passing while describing a
+    /// pipeline that no longer exists.
+    /// </remarks>
+    private static string EscapeAsExporter(string text)
+        => text.Replace("\r", "\\r").Replace("\n", "\\n");
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void ParseLine_NaughtyContentWrittenByTheExporter_ShouldRoundTripExactly(string naughty)
+    {
+        // Arrange
+        string line = $"620756992||1001||{EscapeAsExporter(naughty)}||NULL||NULL||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(naughty);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.DelimiterHazards), MemberType = typeof(NaughtyStringCases))]
+    public void ParseLine_NaughtyContentCarryingTheFieldSeparator_ShouldRecoverExactContent(string naughty)
+    {
+        // Arrange — the separator is legal inside content; the parser anchors from both ends.
+        string content = $"{naughty}||{naughty}";
+        string line = $"620756992||1001||{EscapeAsExporter(content)}||NULL||NULL||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(content);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.DelimiterHazards), MemberType = typeof(NaughtyStringCases))]
+    public void ParseLine_NaughtyContentOpeningWithTheCommentMarker_ShouldStillParse(string naughty)
+    {
+        // Arrange — '#' only starts a comment at the start of a LINE; a content field never is one.
+        string content = $"#{naughty}";
+        string line = $"620756992||1001||{EscapeAsExporter(content)}||NULL||NULL||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(content);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.UnicodeHazards), MemberType = typeof(NaughtyStringCases))]
+    public void ParseLine_NaughtyContentSpanningRealNewlines_ShouldSurviveTheExporterEscape(string naughty)
+    {
+        // Arrange — the one transformation the contract mandates: a fragment holding real newlines
+        // is folded onto a single line on export and unfolded on import.
+        string content = $"{naughty}\r\n{naughty}\n{naughty}\r{naughty}";
+        string line = $"620756992||1001||{EscapeAsExporter(content)}||NULL||NULL||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(content);
+    }
+
+    [Theory]
+    [InlineData(@"C:\notes", "C:" + "\u000A" + "otes")]
+    [InlineData(@"backslash \n here", "backslash " + "\u000A" + " here")]
+    [InlineData(@"\r", "\u000D")]
+    [InlineData(@"\\n", "\\" + "\u000A")]
+    public void ParseLine_ContentCarryingALiteralBackslashEscapeSequence_ShouldBeLossy(string content, string expectedLossyContent)
+    {
+        // Arrange — DOCUMENTED CURRENT BEHAVIOR, not an endorsement: the exporter escapes only REAL
+        // newlines, so a backslash that the source text itself carries in front of 'r'/'n' reaches
+        // the parser indistinguishable from an escape and is unfolded into a control character.
+        // The transform is therefore not injective and this direction loses data. Tracked as #596;
+        // pinned here so fixing it is a deliberate, visible change to this assertion, never an
+        // accident.
+        string line = $"620756992||1001||{EscapeAsExporter(content)}||NULL||NULL||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(expectedLossyContent);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.DelimiterHazards), MemberType = typeof(NaughtyStringCases))]
+    public void ParseLine_NaughtyContentOpeningWithTheFieldSeparator_ShouldRecoverExactContent(string naughty)
+    {
+        // Arrange — a LEADING pipe run is safe in either parity, because the split is greedy from
+        // the left and the content boundary has already been fixed by then. Its trailing twin is
+        // not; that asymmetry is the point of the next test.
+        string content = $"|{naughty}";
+        string line = $"620756992||1001||{EscapeAsExporter(content)}||NULL||NULL||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(content);
+    }
+
+    [Theory]
+    [InlineData("abc|", "abc")]
+    [InlineData("abc|||", "abc||")]
+    [InlineData("|", "")]
+    [InlineData("|||", "||")]
+    public void ParseLine_ContentEndingInAnOddNumberOfPipes_ShouldLoseTheLastPipe(string content, string expectedLossyContent)
+    {
+        // Arrange — DOCUMENTED CURRENT BEHAVIOR, not an endorsement. Split is greedy left to right,
+        // so a trailing pipe merges with the separator that follows it and the content boundary
+        // lands one character early: the pipe is swallowed and reappears glued to the args column.
+        // No entry of the naughty list ends in an odd pipe run, so this collision has to be composed
+        // by hand. Tracked as #597; pinned here so fixing it is a deliberate, visible change to this
+        // assertion, never an accident.
+        string line = $"620756992||1001||{content}||NULL||NULL||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(expectedLossyContent);
+        result.Value.ArgsOrder.ShouldBeNull(); // "|NULL" is swallowed by ParseArgsArray's bare catch
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.NonAsciiDigits), MemberType = typeof(NaughtyStringCases))]
+    public void ParseLine_NonAsciiDigitsInTheFileIdColumn_ShouldFailInsteadOfMisParsing(string naughtyDigits)
+    {
+        // Act — a fullwidth or Arabic-Indic "number" addresses no real DAT subfile; silently
+        // resolving it to some other fragment would patch the wrong text.
+        Result<Translation> result = _parser.ParseLine($"{naughtyDigits}||1001||Content||NULL||NULL||1");
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translation.ParseError");
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.NonAsciiDigits), MemberType = typeof(NaughtyStringCases))]
+    public void ParseLine_NonAsciiDigitsInTheGossipIdColumn_ShouldFailInsteadOfMisParsing(string naughtyDigits)
+    {
+        // Act
+        Result<Translation> result = _parser.ParseLine($"620756992||{naughtyDigits}||Content||NULL||NULL||1");
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translation.ParseError");
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void ParseLine_NaughtyStringInEveryColumn_ShouldAnswerWithAResultInsteadOfThrowing(string naughty)
+    {
+        // Arrange — the whole line is hostile: both id columns, the content and both args columns.
+        string line = string.Join("||", naughty, naughty, naughty, naughty, naughty, naughty);
+
+        // Act & Assert — a per-line failure is a legitimate outcome (the parser warn-skips it);
+        // an escaping exception is not, because it would abort the whole patch run.
+        Should.NotThrow(() => _parser.ParseLine(line));
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/LotroKoniecDev.TranslationSystem.API.Tests.Unit.csproj
@@ -13,6 +13,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NaughtyStrings" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
         <PackageReference Include="xunit" />
@@ -29,6 +30,11 @@
 
     <ItemGroup>
         <Content Include="TestData\**\*.txt" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Linked, not copied: one hostile-string theory source shared by every unit suite (#569). -->
+        <Compile Include="..\Shared\NaughtyStringCases.cs" Link="Shared\NaughtyStringCases.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/ParserContractParityTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/ParserContractParityTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using LotroKoniecDev.Application.Parsers;
+using LotroKoniecDev.Tests.Shared;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
@@ -40,6 +41,51 @@ public sealed class ParserContractParityTests
         patcher.IsApproved.ShouldBe(tms.Approved);
         ReconstructArgs(patcher.ArgsOrder).ShouldBe(tms.ArgsOrder);
         ReconstructArgs(patcher.ArgsId).ShouldBe(tms.ArgsId);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public async Task BothParsers_OnNaughtyContent_ShouldCarveTheSameContractLineIdentically(string naughty)
+    {
+        // Arrange — hostile content is where two hand-written parsers of one format drift apart
+        // first (#569). No entry of the list carries a real newline or a literal backslash escape
+        // sequence, so the patcher's unescape stays a no-op here and the two contents compare
+        // directly; the escape asymmetry itself is pinned in the per-parser suites.
+        string line = $"620756992||1001||{naughty}||1-2||1-2||1";
+
+        LotroKoniecDev.Domain.Models.Translation patcher = new TranslationFileParser().ParseLine(line).Value;
+
+        ParsedExport tmsExport = await ParseAsync(line);
+        ParsedExportRow tms = tmsExport.Rows.ShouldHaveSingleItem();
+
+        // Assert
+        patcher.FileId.ShouldBe(tms.FileId);
+        ((long)patcher.GossipId).ShouldBe(tms.GossipId);
+        patcher.Content.ShouldBe(tms.Content);
+        patcher.IsApproved.ShouldBe(tms.Approved);
+        ReconstructArgs(patcher.ArgsOrder).ShouldBe(tms.ArgsOrder);
+        ReconstructArgs(patcher.ArgsId).ShouldBe(tms.ArgsId);
+    }
+
+    [Theory]
+    [InlineData(@"Line1\nLine2", "Line1\u000ALine2")]
+    [InlineData(@"Line1\rLine2", "Line1\u000DLine2")]
+    public async Task BothParsers_OnAnEscapeSequence_ShouldDivergeExactlyAsDesigned(string escapedContent, string unescapedContent)
+    {
+        // Arrange — the ONE deliberate difference between the two parsers, and the reason the theory
+        // above compares contents directly: the patcher unfolds the exporter's escape because it is
+        // about to write real characters into the DAT, while the TMS keeps the exported
+        // representation verbatim so the row round-trips byte-for-byte back out to the patcher.
+        // Nothing else pins this, and no naughty string reaches it (none carries such a sequence).
+        string line = $"620756992||1001||{escapedContent}||NULL||NULL||1";
+
+        // Act
+        LotroKoniecDev.Domain.Models.Translation patcher = new TranslationFileParser().ParseLine(line).Value;
+        ParsedExportRow tms = (await ParseAsync(line)).Rows.ShouldHaveSingleItem();
+
+        // Assert
+        patcher.Content.ShouldBe(unescapedContent);
+        tms.Content.ShouldBe(escapedContent);
     }
 
     private static async Task<ParsedExport> ParseAsync(string content)

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileNaughtyStringTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileNaughtyStringTests.cs
@@ -1,0 +1,196 @@
+using System.Text;
+using LotroKoniecDev.Tests.Shared;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
+
+/// <summary>
+/// Hostile-input coverage for the TMS half of the <c>||</c> contract (#569): the Big List of Naughty
+/// Strings driven through the producer/consumer pair the TMS owns — <see cref="TranslationFileSerializer"/>
+/// writing the distributed file and <see cref="TranslationExportParser"/> reading an uploaded
+/// <c>exported.txt</c> back.
+/// </summary>
+/// <remarks>
+/// These tests pin CURRENT behavior. Changing the format itself still needs an ADR plus updated
+/// golden fixtures on both sides of the contract (CLAUDE.md).
+/// </remarks>
+public sealed class TranslationFileNaughtyStringTests
+{
+    private readonly TranslationFileSerializer _serializer = new();
+    private readonly TranslationExportParser _parser = new();
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public async Task SerializeThenParse_NaughtyContent_ShouldRoundTripExactly(string naughty)
+    {
+        // Arrange
+        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, naughty, null, null)]);
+
+        // Act
+        ParsedExport parsed = await ParseAsync(file);
+
+        // Assert
+        parsed.Errors.ShouldBeEmpty();
+        parsed.Rows.ShouldHaveSingleItem().Content.ShouldBe(naughty);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.DelimiterHazards), MemberType = typeof(NaughtyStringCases))]
+    public async Task SerializeThenParse_NaughtyContentCarryingTheFieldSeparator_ShouldRecoverExactContent(string naughty)
+    {
+        // Arrange — the separator is legal inside content; the parser anchors from both ends.
+        string content = $"{naughty}||{naughty}";
+        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, content, "1-2", "1-2")]);
+
+        // Act
+        ParsedExport parsed = await ParseAsync(file);
+
+        // Assert
+        ParsedExportRow row = parsed.Rows.ShouldHaveSingleItem();
+        row.Content.ShouldBe(content);
+        row.ArgsOrder.ShouldBe("1-2");
+        row.ArgsId.ShouldBe("1-2");
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.DelimiterHazards), MemberType = typeof(NaughtyStringCases))]
+    public async Task SerializeThenParse_NaughtyContentOpeningWithTheCommentMarker_ShouldStillParse(string naughty)
+    {
+        // Arrange — '#' starts a comment only at the start of a LINE; a content field never is one.
+        string content = $"#{naughty}";
+        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, content, null, null)]);
+
+        // Act
+        ParsedExport parsed = await ParseAsync(file);
+
+        // Assert
+        parsed.Rows.ShouldHaveSingleItem().Content.ShouldBe(content);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.UnicodeHazards), MemberType = typeof(NaughtyStringCases))]
+    public async Task SerializeThenParse_ManyNaughtyRows_ShouldKeepEveryRowOnItsOwnLine(string naughty)
+    {
+        // Arrange — a real artifact is one long file; a length or terminator error in one row
+        // swallows its neighbours rather than just itself.
+        List<ArtifactRow> rows =
+        [
+            new(620756992, 1001, naughty, null, null),
+            new(620756992, 1002, $"{naughty}||{naughty}", "1", "1"),
+            new(620756993, 1003, $"#{naughty}", null, null)
+        ];
+        string file = _serializer.Serialize(rows);
+
+        // Act
+        ParsedExport parsed = await ParseAsync(file);
+
+        // Assert
+        parsed.Errors.ShouldBeEmpty();
+        parsed.Rows.Select(row => row.Content).ShouldBe([naughty, $"{naughty}||{naughty}", $"#{naughty}"]);
+    }
+
+    [Theory]
+    [InlineData("Polish\ntext")]
+    [InlineData("Polish\r\ntext")]
+    [InlineData("Polish\rtext")]
+    public async Task SerializeThenParse_ContentCarryingARealNewline_ShouldLoseTheRow(string content)
+    {
+        // Arrange — DOCUMENTED CURRENT BEHAVIOR, not an endorsement. The serializer emits content
+        // verbatim because imported source text arrives already escaped from the patcher's exporter.
+        // Translator-submitted Polish never passes through that escape (the editor is a multi-line
+        // textarea and the upsert slice only checks NotEmpty), so a newline in a translation splits
+        // one row into two malformed lines and the fragment silently disappears from the distributed
+        // file. Tracked as #596; pinned here so fixing it is a deliberate, visible change to this
+        // assertion, never an accident.
+        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, content, null, null)]);
+
+        // Act
+        ParsedExport parsed = await ParseAsync(file);
+
+        // Assert
+        parsed.Rows.ShouldBeEmpty();
+        parsed.Errors.ShouldNotBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("abc|", "abc")]
+    [InlineData("abc|||", "abc||")]
+    [InlineData("|", "")]
+    [InlineData("|||", "||")]
+    public async Task SerializeThenParse_ContentEndingInAnOddNumberOfPipes_ShouldLoseTheLastPipe(string content, string expectedLossyContent)
+    {
+        // Arrange — DOCUMENTED CURRENT BEHAVIOR, not an endorsement, and identical to the patcher's
+        // (the two parsers agree here, which is exactly why the parity guard cannot see it). Split
+        // is greedy left to right, so a trailing pipe merges with the separator that follows it: the
+        // pipe is swallowed and reappears glued to the args column. No entry of the naughty list
+        // ends in an odd pipe run, so this collision has to be composed by hand. Tracked as #597.
+        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, content, null, null)]);
+
+        // Act
+        ParsedExport parsed = await ParseAsync(file);
+
+        // Assert
+        ParsedExportRow row = parsed.Rows.ShouldHaveSingleItem();
+        row.Content.ShouldBe(expectedLossyContent);
+        row.ArgsOrder.ShouldBe("|NULL"); // the swallowed pipe, now polluting the args column
+    }
+
+    [Fact]
+    public async Task SerializeThenParse_EmptyContent_ShouldRoundTripAsEmpty()
+    {
+        // Arrange — an empty fragment is legal game content and must survive; the naughty list has
+        // no empty entry (its shortest is one character), so this case is composed by hand.
+        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, string.Empty, null, null)]);
+
+        // Act
+        ParsedExport parsed = await ParseAsync(file);
+
+        // Assert
+        parsed.Errors.ShouldBeEmpty();
+        parsed.Rows.ShouldHaveSingleItem().Content.ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.NonAsciiDigits), MemberType = typeof(NaughtyStringCases))]
+    public async Task ParseAsync_NonAsciiDigitsInTheFileIdColumn_ShouldRejectTheRow(string naughtyDigits)
+    {
+        // Act — a fullwidth or Arabic-Indic "number" addresses no real DAT subfile; accepting it
+        // would attach an import row to the wrong fragment.
+        ParsedExport parsed = await ParseAsync($"{naughtyDigits}||1001||Content||NULL||NULL||1\r\n");
+
+        // Assert
+        parsed.Rows.ShouldBeEmpty();
+        parsed.Errors.ShouldHaveSingleItem().Message.ShouldContain("not a valid integer");
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.NonAsciiDigits), MemberType = typeof(NaughtyStringCases))]
+    public async Task ParseAsync_NonAsciiDigitsInTheGossipIdColumn_ShouldRejectTheRow(string naughtyDigits)
+    {
+        // Act
+        ParsedExport parsed = await ParseAsync($"620756992||{naughtyDigits}||Content||NULL||NULL||1\r\n");
+
+        // Assert
+        parsed.Rows.ShouldBeEmpty();
+        parsed.Errors.ShouldHaveSingleItem().Message.ShouldContain("not a valid integer");
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public async Task ParseAsync_NaughtyStringInEveryColumn_ShouldAnswerWithErrorsInsteadOfThrowing(string naughty)
+    {
+        // Arrange — the whole uploaded line is hostile: both id columns, the content and both args.
+        string line = string.Join("||", naughty, naughty, naughty, naughty, naughty, naughty);
+
+        // Act & Assert — a per-line parse error is a legitimate outcome (it is reported back to the
+        // admin); an escaping exception is not, because it would abort the whole import.
+        await Should.NotThrowAsync(() => ParseAsync(line));
+    }
+
+    private async Task<ParsedExport> ParseAsync(string file)
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(file));
+
+        return await _parser.ParseAsync(stream, CancellationToken.None);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.csproj
@@ -14,6 +14,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NaughtyStrings"/>
         <PackageReference Include="Shouldly" />
         <PackageReference Include="xunit"/>
         <PackageReference Include="xunit.runner.visualstudio">
@@ -25,6 +26,11 @@
     <ItemGroup>
         <Using Include="Xunit"/>
         <Using Include="Shouldly"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Linked, not copied: one hostile-string theory source shared by every unit suite (#569). -->
+        <Compile Include="..\Shared\NaughtyStringCases.cs" Link="Shared\NaughtyStringCases.cs"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/NaughtyStringValueObjectTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/NaughtyStringValueObjectTests.cs
@@ -1,0 +1,157 @@
+using LotroKoniecDev.SharedKernel.Monads;
+using LotroKoniecDev.Tests.Shared;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+
+namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests;
+
+/// <summary>
+/// Hostile-input coverage for the constrained-string value objects (#569). Every one of them is fed
+/// from something a stranger controls — an uploaded export, an OIDC claim, a form post — so the
+/// house rule that business failures are values and exceptions are for programmer errors has to hold
+/// for the whole Big List of Naughty Strings, not just for the hand-picked cases in the per-VO
+/// suites: a factory that throws turns a 400 into a 500.
+/// </summary>
+public sealed class NaughtyStringValueObjectTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 5, 12, 0, 0, TimeSpan.Zero);
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void LotroNotationVersionCreate_NaughtyInput_ShouldAnswerWithAResultInsteadOfThrowing(string naughty)
+    {
+        // Act & Assert — a rejection is the expected outcome for almost every entry; what must never
+        // happen is an exception escaping the factory.
+        Should.NotThrow(() => LotroNotationVersion.Create(naughty));
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void DisplayNameCreate_NaughtyInput_ShouldAnswerWithAResultInsteadOfThrowing(string naughty)
+    {
+        // Act & Assert — the display name is lifted straight from the authenticated 'name' claim.
+        Should.NotThrow(() => DisplayName.Create(naughty));
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void EmailCreate_NaughtyInput_ShouldAnswerWithAResultInsteadOfThrowing(string naughty)
+    {
+        // Act & Assert — the email is lifted straight from the authenticated 'email' claim and is
+        // matched against a regex, the classic place for hostile input to blow up.
+        Should.NotThrow(() => Email.Create(naughty));
+    }
+
+    /// <summary>
+    /// The naughty strings a display name is allowed to be — non-blank and within the length limit.
+    /// Filtering here rather than branching inside the test keeps the assertion unconditional, so a
+    /// regression that rejected everything would fail it instead of passing vacuously.
+    /// </summary>
+    public static TheoryData<string> AcceptableDisplayNames
+    {
+        get
+        {
+            TheoryData<string> data = [];
+
+            foreach (string candidate in NaughtyStringCases.AllValues)
+            {
+                if (!string.IsNullOrWhiteSpace(candidate) && candidate.Trim().Length <= DisplayName.MaxLength)
+                {
+                    data.Add(candidate);
+                }
+            }
+
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AcceptableDisplayNames))]
+    public void DisplayNameCreate_NaughtyInputWithinTheRules_ShouldSucceedAndKeepItTrimmedButVerbatim(string naughty)
+    {
+        // Act
+        Result<DisplayName> result = DisplayName.Create(naughty);
+
+        // Assert — the blankness and length rules are DisplayNameTests' job; what this pins is that
+        // acceptance never mangles the value: no normalisation, no stripping, no case folding,
+        // because the string is rendered back to other translators exactly as stored.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Value.ShouldBe(naughty.Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void TranslationSourceCreate_NaughtyText_ShouldStoreItVerbatim(string naughty)
+    {
+        // Act — English source text is exported verbatim from the DAT, so the VO must not touch it:
+        // any normalisation here would read as a source change and mass-invalidate Polish rows.
+        Result<TranslationSource> result = TranslationSource.Create(naughty, null, null);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Text.ShouldBe(naughty);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.UnicodeHazards), MemberType = typeof(NaughtyStringCases))]
+    public void TranslationSourceEquality_NaughtyTextDifferingByAnInvisibleCodePoint_ShouldNotBeEqual(string naughty)
+    {
+        // Arrange — the import diff decides invalidation by comparing these values, so equality has
+        // to stay exact: two sources that RENDER identically but differ by a zero-width code point
+        // are still different English, and collapsing them would hide a real source change.
+        TranslationSource source = TranslationSource.Create(naughty, null, null).Value;
+        TranslationSource sameText = TranslationSource.Create(naughty, null, null).Value;
+        TranslationSource withZeroWidthSpace = TranslationSource.Create($"{naughty}\u200B", null, null).Value;
+
+        // Assert
+        source.ShouldBe(sameText);
+        source.ShouldNotBe(withZeroWidthSpace);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.SubmittableText), MemberType = typeof(NaughtyStringCases))]
+    public void ProvideTranslation_NaughtyPolishAroundAPlaceholder_ShouldStoreItVerbatim(string naughty)
+    {
+        // Arrange — whatever a translator types lands in the distributed file unchanged, so the
+        // aggregate must not normalise it, and the <--DO_NOT_TOUCH!--> argument marker must survive
+        // being surrounded by hostile text: mangling it detaches the fragment's arguments in-game.
+        Translation translation = Translation.CreateUntranslated(
+            FragmentKey.Create(620756992, 1001).Value,
+            TranslationSource.Create("Old English", null, null).Value,
+            GameVersionId.Create(),
+            Now).Value;
+
+        string polish = $"{naughty}<--DO_NOT_TOUCH!-->{naughty}";
+
+        // Act
+        translation.ProvideTranslation(polish, TranslatorId.Create(), Now);
+
+        // Assert
+        translation.TranslatedText.ShouldBe(polish);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.BlankText), MemberType = typeof(NaughtyStringCases))]
+    public void ProvideTranslation_BlankPolish_ShouldThrowBecauseTheApiMustHaveRejectedItFirst(string blank)
+    {
+        // Arrange — this guard is for a PROGRAMMER error, not a business rule: the upsert slice's
+        // FluentValidation NotEmpty() already turns blank Polish into a 400, so reaching the
+        // aggregate with it means the validator was bypassed. Pinned so the guard is not quietly
+        // relaxed into accepting a translation that would publish an empty row.
+        Translation translation = Translation.CreateUntranslated(
+            FragmentKey.Create(620756992, 1001).Value,
+            TranslationSource.Create("Old English", null, null).Value,
+            GameVersionId.Create(),
+            Now).Value;
+
+        // Act
+        Action provide = () => translation.ProvideTranslation(blank, TranslatorId.Create(), Now);
+
+        // Assert
+        provide.ShouldThrow<ArgumentException>();
+    }
+}

--- a/tests/Shared/NaughtyStringCases.cs
+++ b/tests/Shared/NaughtyStringCases.cs
@@ -1,0 +1,119 @@
+using NaughtyStrings;
+
+namespace LotroKoniecDev.Tests.Shared;
+
+/// <summary>
+/// Shared xUnit theory sources over the Big List of Naughty Strings (the <c>NaughtyStrings</c>
+/// package, #569). The file is <em>linked</em> into every pure unit suite that hardens a
+/// string-heavy seam, so the hostile-input matrix is declared once instead of copy-pasted per
+/// project; a suite picks the narrowest source that still covers its seam.
+/// </summary>
+/// <remarks>
+/// The categories below are grouped by the hazard they pose to <em>this</em> codebase — a
+/// UTF-16 binary format on one side of the <c>||</c> contract and a line-oriented text file on the
+/// other — not by the taxonomy of the upstream list.
+/// </remarks>
+internal static class NaughtyStringCases
+{
+    /// <summary>
+    /// Every naughty string the package ships (550 distinct). The default source for round-trip
+    /// theories: nothing here may crash a parser, a serializer or a value object factory.
+    /// </summary>
+    /// <remarks>
+    /// The list carries no empty entry (its shortest is one character) and no entry ending in an
+    /// odd run of <c>|</c>, so the empty-content and pipe-boundary cases of the <c>||</c> contract
+    /// have to be composed by hand — see the explicit theories in the parser suites.
+    /// </remarks>
+    public static TheoryData<string> All => ToTheoryData(AllValues);
+
+    /// <summary>
+    /// The same list as <see cref="All"/>, raw — for a suite that has to filter the corpus down to
+    /// the inputs its seam actually accepts before building its own <see cref="TheoryData{T}"/>.
+    /// Filtering at the source keeps the resulting assertion unconditional, which a branch inside
+    /// the test would not.
+    /// </summary>
+    public static IReadOnlyList<string> AllValues { get; } =
+        TheNaughtyStrings.All.Distinct(StringComparer.Ordinal).ToList();
+
+    /// <summary>
+    /// Strings whose UTF-16 representation is the hazard: surrogate pairs (emoji), two-byte and
+    /// astral-plane characters, combining marks, bidi controls and invisible code points. These
+    /// are what a <c>char</c>-counting binary writer gets wrong.
+    /// </summary>
+    public static TheoryData<string> UnicodeHazards => ToTheoryData(
+    [
+        .. TheNaughtyStrings.Emoji,
+        .. TheNaughtyStrings.TwoByteCharacters,
+        .. TheNaughtyStrings.Stringswhichcontaintwobyteletters,
+        .. TheNaughtyStrings.SpecialUnicodeCharactersUnion,
+        .. TheNaughtyStrings.RightToLeftStrings,
+        .. TheNaughtyStrings.TrickUnicode,
+        .. TheNaughtyStrings.ZalgoText,
+        .. TheNaughtyStrings.UnicodeSubscriptSuperscriptAccents,
+        .. TheNaughtyStrings.UnicodeUpsidedown,
+        .. TheNaughtyStrings.Unicodefont,
+        .. TheNaughtyStrings.OghamText,
+        .. TheNaughtyStrings.Changinglengthwhenlowercased
+    ]);
+
+    /// <summary>
+    /// Quote, escape and punctuation soup — the strings most likely to collide with a delimited
+    /// text format: ASCII punctuation (including <c>|</c>, <c>#</c> and the backslash), smart and
+    /// misplaced quotation marks, injection payloads and terminal escape codes.
+    /// </summary>
+    public static TheoryData<string> DelimiterHazards => ToTheoryData(
+    [
+        .. TheNaughtyStrings.SpecialCharacters,
+        .. TheNaughtyStrings.QuotationMarks,
+        .. TheNaughtyStrings.UnicodeSymbols,
+        .. TheNaughtyStrings.SpecialWordCharacters,
+        .. TheNaughtyStrings.ScriptInjection,
+        .. TheNaughtyStrings.SQLInjection,
+        .. TheNaughtyStrings.ServerCodeInjection,
+        .. TheNaughtyStrings.CommandInjectionRuby,
+        .. TheNaughtyStrings.UnwantedInterpolation,
+        .. TheNaughtyStrings.FileInclusion,
+        .. TheNaughtyStrings.Terminalescapecodes
+    ]);
+
+    /// <summary>
+    /// Digits a human reads as a number but <see cref="int.TryParse(string, out int)"/> does not —
+    /// fullwidth, Arabic-Indic and other non-ASCII numerals. Aimed at the two id columns of the
+    /// <c>||</c> contract, which must reject them rather than mis-parse them into a wrong fragment.
+    /// </summary>
+    public static TheoryData<string> NonAsciiDigits => ToTheoryData(TheNaughtyStrings.UnicodeNumbers);
+
+    /// <summary>
+    /// Every naughty string that the API's <c>NotEmpty()</c> guard lets through as translated text
+    /// (i.e. not blank once whitespace is discounted) — the exact set a translator can actually get
+    /// into the <c>TranslatedText</c> column, and therefore into the distributed file.
+    /// </summary>
+    public static TheoryData<string> SubmittableText
+        => ToTheoryData(AllValues.Where(value => !string.IsNullOrWhiteSpace(value)));
+
+    /// <summary>
+    /// The mirror image of <see cref="SubmittableText"/>: the entries the API's <c>NotEmpty()</c>
+    /// guard rejects, and therefore the ones that must never reach a domain guard expecting
+    /// non-blank text.
+    /// </summary>
+    public static TheoryData<string> BlankText
+        => ToTheoryData(AllValues.Where(string.IsNullOrWhiteSpace));
+
+    /// <summary>
+    /// Distinct on purpose: the upstream list repeats two entries (<c>-</c> and a smart-quote tag),
+    /// and the merged category sources above overlap. xUnit derives a test-case id from the
+    /// argument, so a duplicate is dropped anyway — but only after logging a
+    /// "Skipping test case with duplicate ID" line on every single run.
+    /// </summary>
+    private static TheoryData<string> ToTheoryData(IEnumerable<string> values)
+    {
+        TheoryData<string> data = [];
+
+        foreach (string value in values.Distinct(StringComparer.Ordinal))
+        {
+            data.Add(value);
+        }
+
+        return data;
+    }
+}


### PR DESCRIPTION
Closes #569

## What

Adds the Big List of Naughty Strings (`NaughtyStrings` 3.0.0 — MIT, `netstandard2.0`, no transitive dependencies) to the three pure unit suites and uses it to harden both sides of the `||` contract plus the TMS value-object factories.

The theory sources live in **one** file, `tests/Shared/NaughtyStringCases.cs`, **linked** into each suite rather than copied — a new suite adds the link plus the package reference instead of pasting lists. Categories are grouped by the hazard they pose to this codebase (a UTF-16 binary format on one side, a line-oriented text file on the other), not by the upstream taxonomy.

**Test-only: no production code is touched.**

## Why it needed hand-written cases too

The corpus alone is not enough, and that turned out to be the interesting part. All 550 distinct entries round-trip cleanly through both parsers, because the list carries **no empty string, no real newline, no literal `\r`/`\n` escape sequence, and no entry ending in an odd run of `|`** — exactly the delimiter collisions this format is weakest at. Those cases are composed by hand as explicit `[InlineData]` theories next to the corpus-driven ones, which is what the ticket's "document the deliberate behavior for delimiter-colliding content" task actually required.

## Defects found — filed, not fixed (per the ticket's own rule)

| # | Severity | What |
|---|---|---|
| #596 | high | The `||` escape is applied by only one of the two writers and is not injective. A newline in translator-typed Polish splits the row and the fragment **silently disappears** from the distributed file (nothing escapes `TranslatedText` on its way to the artifact, and the editor is an 8-row `<textarea>`); separately, `C:\notes` is silently rewritten into a newline by the patcher's unescape. |
| #597 | high | Content ending in an **odd** number of `|` loses its last pipe **and** corrupts the `args_order` column (`abc\|` → content `abc`, args `\|NULL`). Both parsers do it identically — which is precisely why the parity guard cannot see it. |
| #598 | medium | Nothing caps `TranslatedText`, the DAT caps a piece at 32767 code units, and neither `PatchingService` nor its handler catches. An over-long translation escapes as an unhandled exception mid-loop, after earlier subfiles were already written — a partially patched DAT. |

Five tests pin this known-lossy behavior deliberately, say so in place, and name the ticket they document, so fixing any of them forces a visible assertion change rather than a silent one.

## Test

- `dotnet build LotroKoniecDev.slnx` — green, **0 warnings**.
- All seven pure unit suites green: patcher **3216**, TMS API **2562**, TMS domain **3511**, plus SharedKernel/Frontend/Auth/Logging. Each suite runs in under a second.
- `check-dockerfile-restore-graph.sh`, `check-ssr-purity.sh` and the `classify-changes` self-test all pass; the classifier returns `code=true` for this change set, so the full .NET gate runs on it.

## Notes

- **Windows is an inspection claim, not an executed one** — every CI runner is `ubuntu-24.04`. The tests are platform-honest by construction: no filesystem, no `Path`, no `Environment.NewLine`, culture-invariant `Trim`, and line terminators come from the serializer's explicit `\r\n`. `.gitattributes` forces LF checkout everywhere, so the escape-based `[InlineData]` rows are stable on both.
- `EscapeAsExporter` in the patcher suite duplicates `ExportTextsQueryHandler`'s inline escape, because the handler escapes while streaming to a file and exposes no seam. It carries a keep-in-sync marker; #596 changes that rule, so the copy must move with it. Closing that gap properly needs a production seam, which is out of scope for a test-only ticket.
- Unrelated observation while reading the parsers: the patcher uses `int.Parse`/`ulong.Parse` **without** `CultureInfo.InvariantCulture` while the TMS parser passes it explicitly. No practical impact (.NET never parses non-ASCII digits on any culture, and the new `NonAsciiDigits` theories pass either way), but it is a latent asymmetry between two parsers of one contract. Not filed — say the word and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179vSd5W2KHgTTRAkHWmJrd
