### PR TITLE
Tests: architecture tests via NetArchTest.Rules (dependency rule, no-mediator, naming/sealed conventions)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,6 +507,14 @@ structure.
 - **AAA always; assertions inline in the test method.** DRY the Arrange (builders), never the
   Assert. One reason to fail per test.
 - **Tooling: xUnit + Shouldly + NSubstitute only.** Naming: `MethodName_Scenario_ExpectedResult`.
+  (`Architecture.Tests.Unit` additionally uses **NetArchTest.Rules** — architecture rules only.)
+- **The structural house rules are a TEST, not review memory.** `tests/LotroKoniecDev.Architecture.Tests.Unit`
+  mechanically enforces the patcher dependency rule, no-mediator (ADR-0001), patcher/TMS bounded-context
+  isolation, the Frontend's contracts-only reach, the persistence direction, the CQRS read/write split and
+  the sealed/`internal`-handler/commands-only-validator conventions — over assembly IL, in the normal unit
+  gate, on every OS. **A new production project must join `ProductionAssemblies.All`** or it escapes every
+  rule (a self-test fails until it does). Changing a rule is an architecture decision: fix the code, or
+  write the ADR first — never weaken the test to green. Details: `tests/CLAUDE.md`.
 - Platform honesty: tests must pass on macOS AND Windows — `Path.Combine`, never hardcoded `C:\`.
 - **TMS test projects mirror KittySaver naming.** Unit (pure):
   `TranslationSystem.Domain.Tests.Unit`, `TranslationSystem.API.Tests.Unit`,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,6 +69,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="bunit" Version="2.9.0" />
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />

--- a/LotroKoniecDev.slnx
+++ b/LotroKoniecDev.slnx
@@ -95,6 +95,9 @@
     <Project Path="src/Utilities/LotroKoniecDev.Options/LotroKoniecDev.Options.csproj" />
   </Folder>
   <Folder Name="/tests/" />
+  <Folder Name="/tests/Architecture/">
+    <Project Path="tests/LotroKoniecDev.Architecture.Tests.Unit/LotroKoniecDev.Architecture.Tests.Unit.csproj" />
+  </Folder>
   <Folder Name="/tests/Patcher/">
     <Project Path="tests/LotroKoniecDev.Tests.Unit/LotroKoniecDev.Tests.Unit.csproj" />
     <Project Path="tests/LotroKoniecDev.Tests.Infrastructure/LotroKoniecDev.Tests.Infrastructure.csproj" />

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -12,11 +12,12 @@ dotnet test tests/LotroKoniecDev.Frontend.E2E.Tests          # browser stack via
 dotnet test --filter "FullyQualifiedName~Fragment"     # filter by name
 ```
 
-Full project inventory (13 projects):
+Full project inventory (14 projects):
 
 | Project | Kind | Needs |
 |---|---|---|
 | `LotroKoniecDev.Tests.Unit` | patcher unit | nothing (pure) |
+| `LotroKoniecDev.Architecture.Tests.Unit` | repo-wide structural rules over assembly IL (NetArchTest.Rules) | nothing (pure) |
 | `LotroKoniecDev.SharedKernel.Tests.Unit` | SharedKernel unit (monads, BuildingBlocks, Ensure, strongly-typed IDs) | nothing (pure); Stryker target |
 | `LotroKoniecDev.Logging.Tests.Unit` | `Utilities/Logging` redaction unit | nothing (pure) |
 | `LotroKoniecDev.TranslationSystem.Domain.Tests.Unit` | TMS domain unit | nothing (pure); Stryker target |
@@ -58,6 +59,7 @@ per-project `stryker-config.json` after reviewing the baseline report.
 - **xUnit** — test framework (`Fact`, `Theory`, `InlineData`)
 - **Shouldly** — `.ShouldBe()`, `.ShouldBeTrue()`, `.ShouldContain()`, …
 - **NSubstitute** — mocking: `Substitute.For<IInterface>()`
+- **NetArchTest.Rules** — architecture tests (assembly IL only; `LotroKoniecDev.Architecture.Tests.Unit`)
 - **Xunit.SkippableFact** — E2E tests that need Windows + a real DAT
 - **coverlet.collector** — code coverage
 - Versions: `Directory.Packages.props` is the single source of truth.
@@ -101,6 +103,37 @@ Command handlers are constructed with their **real FluentValidation validator** 
 dependency-free) and mocked ports. Unit tests are **pure**: no filesystem assertions, no network,
 no real DAT — and **platform-agnostic** (build paths with `Path.Combine`, never hardcode `C:\`;
 the suite runs on macOS too).
+
+## Architecture Tests (LotroKoniecDev.Architecture.Tests.Unit)
+
+**The mechanical guard for the structural house rules** — the ones CLAUDE.md and the ADRs state in prose
+and code review used to be the only thing enforcing. Pure assembly reflection (no DB, no filesystem, no
+network), so it runs in the normal unit gate on every OS.
+
+| File | Rule |
+|---|---|
+| `PatcherLayeringTests` | Cli / Infrastructure -> Application -> Domain -> Primitives; the lower layer never reaches up |
+| `NoMediatorTests` | ADR-0001 — no `Mediator` / `MediatR` type anywhere in production IL |
+| `BoundedContextIsolationTests` | patcher <-> TMS share the `\|\|` file, never code; the Frontend sees `Contracts`, never a domain or DbContext; the TMS never links the auth server internals |
+| `PersistenceDirectionTests` | patcher/TMS domain, read models and contracts carry no EF Core or Npgsql |
+| `CqrsSeparationTests` | a query handler never injects a repository, `IUnitOfWork` or the write DbContext; a command handler injects `IValidator<TCommand>` |
+| `HandlerConventionTests` | handlers are `internal sealed`; no `IValidator<TQuery>` (validators are command-only) |
+| `SealedConventionTests` | every class is sealed unless another production type derives from it |
+| `SuiteSelfTests` | the suite can still say "no" — pins a dependency that genuinely exists, and fails when a production project escapes the search set |
+
+Two mechanisms, on purpose: **NetArchTest.Rules** for dependency rules (it scans the full IL of every
+member), **plain reflection** for convention rules its predicate DSL cannot express ("sealed unless
+something inherits it", a validator's generic argument).
+
+Adding a production project? Add the `ProjectReference` **and** the entry in
+`Shared/ProductionAssemblies.All` — `SuiteSelfTests` fails until you do. The two patcher
+`net10.0-windows` assemblies (Infrastructure, Cli) are absent on purpose: a `net10.0` project cannot
+reference them, and they sit at the TOP of the layering, so rules about them are stated as forbidden
+namespaces on the assemblies below.
+
+`SealedConventionTests.KnownViolations` quarantines pre-existing violations, each keyed to its own
+ticket (#570 is a test-only change). The list is **self-cleaning** — a second test fails once an entry
+stops violating, so a fix cannot land without removing it.
 
 ## Infrastructure Tests (LotroKoniecDev.Tests.Infrastructure)
 

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/LotroKoniecDev.Architecture.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/LotroKoniecDev.Architecture.Tests.Unit.csproj
@@ -1,0 +1,60 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>LotroKoniecDev.Architecture.Tests.Unit</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NetArchTest.Rules" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+        <Using Include="Shouldly"/>
+    </ItemGroup>
+
+    <!-- Every cross-platform production assembly is referenced so the rules run against real IL.
+         The two patcher `net10.0-windows` assemblies (Infrastructure, Cli) cannot be referenced from
+         this `net10.0` project; they are the TOP of the patcher layering, so every rule about them is
+         expressed as a forbidden NAMESPACE on the assemblies below — no reference required. -->
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\SharedKernel\LotroKoniecDev.SharedKernel\LotroKoniecDev.SharedKernel.csproj" />
+        <ProjectReference Include="..\..\src\Patcher\LotroKoniecDev.Primitives\LotroKoniecDev.Primitives.csproj" />
+        <ProjectReference Include="..\..\src\Patcher\LotroKoniecDev.Domain\LotroKoniecDev.Domain.csproj" />
+        <ProjectReference Include="..\..\src\Patcher\LotroKoniecDev.Application\LotroKoniecDev.Application.csproj" />
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.Primitives\LotroKoniecDev.TranslationSystem.Primitives.csproj" />
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.Domain\LotroKoniecDev.TranslationSystem.Domain.csproj" />
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.ReadModels\LotroKoniecDev.TranslationSystem.ReadModels.csproj" />
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework\LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework.csproj" />
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.Projections\LotroKoniecDev.TranslationSystem.Projections.csproj" />
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.Persistence\LotroKoniecDev.TranslationSystem.Persistence.csproj" />
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.Contracts\LotroKoniecDev.TranslationSystem.Contracts.csproj" />
+        <ProjectReference Include="..\..\src\TranslationSystem\LotroKoniecDev.TranslationSystem.API\LotroKoniecDev.TranslationSystem.API.csproj" />
+        <ProjectReference Include="..\..\src\AuthSystem\LotroKoniecDev.AuthSystem.Domain\LotroKoniecDev.AuthSystem.Domain.csproj" />
+        <ProjectReference Include="..\..\src\AuthSystem\LotroKoniecDev.AuthSystem.Contracts\LotroKoniecDev.AuthSystem.Contracts.csproj" />
+        <ProjectReference Include="..\..\src\AuthSystem\LotroKoniecDev.AuthSystem.Infrastructure\LotroKoniecDev.AuthSystem.Infrastructure.csproj" />
+        <ProjectReference Include="..\..\src\AuthSystem\LotroKoniecDev.AuthSystem.Persistence\LotroKoniecDev.AuthSystem.Persistence.csproj" />
+        <ProjectReference Include="..\..\src\AuthSystem\LotroKoniecDev.AuthSystem.API\LotroKoniecDev.AuthSystem.API.csproj" />
+        <ProjectReference Include="..\..\src\Frontend\LotroKoniecDev.Frontend\LotroKoniecDev.Frontend.csproj" />
+        <ProjectReference Include="..\..\src\Utilities\LotroKoniecDev.Hateoas.Abstractions\LotroKoniecDev.Hateoas.Abstractions.csproj" />
+        <ProjectReference Include="..\..\src\Utilities\LotroKoniecDev.Hateoas\LotroKoniecDev.Hateoas.csproj" />
+        <ProjectReference Include="..\..\src\Utilities\LotroKoniecDev.Logging\LotroKoniecDev.Logging.csproj" />
+        <ProjectReference Include="..\..\src\Utilities\LotroKoniecDev.Options\LotroKoniecDev.Options.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Shared/Namespaces.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Shared/Namespaces.cs
@@ -1,0 +1,56 @@
+namespace LotroKoniecDev.Architecture.Tests.Unit.Shared;
+
+/// <summary>
+/// Root namespace of every production assembly, plus the third-party roots the rules forbid.
+/// </summary>
+/// <remarks>
+/// NetArchTest matches a dependency when its full type name STARTS WITH the given string, so these
+/// constants are prefixes, not exact names: <see cref="Hateoas"/> also covers
+/// <see cref="HateoasAbstractions"/>, and <see cref="TranslationSystemReadModels"/> also covers
+/// <see cref="TranslationSystemReadModelsEntityFramework"/>. Pick the narrowest prefix that states
+/// the boundary a rule defends.
+/// </remarks>
+internal static class Namespaces
+{
+    internal const string PatcherPrimitives = "LotroKoniecDev.Primitives";
+    internal const string PatcherDomain = "LotroKoniecDev.Domain";
+    internal const string PatcherApplication = "LotroKoniecDev.Application";
+    internal const string PatcherInfrastructure = "LotroKoniecDev.Infrastructure";
+    internal const string PatcherCli = "LotroKoniecDev.Cli";
+
+    internal const string SharedKernel = "LotroKoniecDev.SharedKernel";
+
+    internal const string TranslationSystem = "LotroKoniecDev.TranslationSystem";
+    internal const string TranslationSystemPrimitives = "LotroKoniecDev.TranslationSystem.Primitives";
+    internal const string TranslationSystemDomain = "LotroKoniecDev.TranslationSystem.Domain";
+    internal const string TranslationSystemReadModels = "LotroKoniecDev.TranslationSystem.ReadModels";
+    internal const string TranslationSystemReadModelsEntityFramework = "LotroKoniecDev.TranslationSystem.ReadModels.EntityFramework";
+    internal const string TranslationSystemProjections = "LotroKoniecDev.TranslationSystem.Projections";
+    internal const string TranslationSystemPersistence = "LotroKoniecDev.TranslationSystem.Persistence";
+    internal const string TranslationSystemWriteDbContexts = "LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts";
+    internal const string TranslationSystemContracts = "LotroKoniecDev.TranslationSystem.Contracts";
+    internal const string TranslationSystemApi = "LotroKoniecDev.TranslationSystem.API";
+
+    internal const string AuthSystem = "LotroKoniecDev.AuthSystem";
+    internal const string AuthSystemDomain = "LotroKoniecDev.AuthSystem.Domain";
+    internal const string AuthSystemContracts = "LotroKoniecDev.AuthSystem.Contracts";
+    internal const string AuthSystemInfrastructure = "LotroKoniecDev.AuthSystem.Infrastructure";
+    internal const string AuthSystemPersistence = "LotroKoniecDev.AuthSystem.Persistence";
+    internal const string AuthSystemApi = "LotroKoniecDev.AuthSystem.API";
+
+    internal const string Frontend = "LotroKoniecDev.Frontend";
+
+    internal const string Hateoas = "LotroKoniecDev.Hateoas";
+    internal const string HateoasAbstractions = "LotroKoniecDev.Hateoas.Abstractions";
+    internal const string Logging = "LotroKoniecDev.Logging";
+    internal const string Options = "LotroKoniecDev.Options";
+
+    internal const string EntityFrameworkCore = "Microsoft.EntityFrameworkCore";
+    internal const string Npgsql = "Npgsql";
+
+    /// <summary>The two mediator packages ADR-0001 forbids repo-wide.</summary>
+    internal const string MediatR = "MediatR";
+
+    /// <inheritdoc cref="MediatR"/>
+    internal const string Mediator = "Mediator";
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Shared/ProductionAssemblies.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Shared/ProductionAssemblies.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Shared;
+
+/// <summary>
+/// Handles on every cross-platform production assembly, loaded by name out of the test output.
+/// </summary>
+/// <remarks>
+/// The two patcher <c>net10.0-windows</c> assemblies (Infrastructure, Cli) are missing on purpose — a
+/// <c>net10.0</c> project cannot reference them, and this suite must stay green on the Linux CI runner.
+/// They sit at the TOP of the patcher layering, so every rule about them is stated as a forbidden
+/// NAMESPACE on the assemblies below (see <see cref="Namespaces.PatcherInfrastructure"/>), which needs
+/// no reference at all.
+/// </remarks>
+internal static class ProductionAssemblies
+{
+    internal static Assembly PatcherPrimitives { get; } = Load(Namespaces.PatcherPrimitives);
+
+    internal static Assembly PatcherDomain { get; } = Load(Namespaces.PatcherDomain);
+
+    internal static Assembly PatcherApplication { get; } = Load(Namespaces.PatcherApplication);
+
+    internal static Assembly SharedKernel { get; } = Load(Namespaces.SharedKernel);
+
+    internal static Assembly TranslationSystemPrimitives { get; } = Load(Namespaces.TranslationSystemPrimitives);
+
+    internal static Assembly TranslationSystemDomain { get; } = Load(Namespaces.TranslationSystemDomain);
+
+    internal static Assembly TranslationSystemReadModels { get; } = Load(Namespaces.TranslationSystemReadModels);
+
+    internal static Assembly TranslationSystemReadModelsEntityFramework { get; } =
+        Load(Namespaces.TranslationSystemReadModelsEntityFramework);
+
+    internal static Assembly TranslationSystemProjections { get; } = Load(Namespaces.TranslationSystemProjections);
+
+    internal static Assembly TranslationSystemPersistence { get; } = Load(Namespaces.TranslationSystemPersistence);
+
+    internal static Assembly TranslationSystemContracts { get; } = Load(Namespaces.TranslationSystemContracts);
+
+    internal static Assembly TranslationSystemApi { get; } = Load(Namespaces.TranslationSystemApi);
+
+    internal static Assembly AuthSystemDomain { get; } = Load(Namespaces.AuthSystemDomain);
+
+    internal static Assembly AuthSystemContracts { get; } = Load(Namespaces.AuthSystemContracts);
+
+    internal static Assembly AuthSystemInfrastructure { get; } = Load(Namespaces.AuthSystemInfrastructure);
+
+    internal static Assembly AuthSystemPersistence { get; } = Load(Namespaces.AuthSystemPersistence);
+
+    internal static Assembly AuthSystemApi { get; } = Load(Namespaces.AuthSystemApi);
+
+    internal static Assembly Frontend { get; } = Load(Namespaces.Frontend);
+
+    internal static Assembly HateoasAbstractions { get; } = Load(Namespaces.HateoasAbstractions);
+
+    internal static Assembly Hateoas { get; } = Load(Namespaces.Hateoas);
+
+    internal static Assembly Logging { get; } = Load(Namespaces.Logging);
+
+    internal static Assembly Options { get; } = Load(Namespaces.Options);
+
+    /// <summary>Every assembly above — the search set for repo-wide rules.</summary>
+    internal static IReadOnlyList<Assembly> All { get; } =
+    [
+        PatcherPrimitives,
+        PatcherDomain,
+        PatcherApplication,
+        SharedKernel,
+        TranslationSystemPrimitives,
+        TranslationSystemDomain,
+        TranslationSystemReadModels,
+        TranslationSystemReadModelsEntityFramework,
+        TranslationSystemProjections,
+        TranslationSystemPersistence,
+        TranslationSystemContracts,
+        TranslationSystemApi,
+        AuthSystemDomain,
+        AuthSystemContracts,
+        AuthSystemInfrastructure,
+        AuthSystemPersistence,
+        AuthSystemApi,
+        Frontend,
+        HateoasAbstractions,
+        Hateoas,
+        Logging,
+        Options,
+    ];
+
+    private static Assembly Load(string assemblyName) => Assembly.Load(new AssemblyName(assemblyName));
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Shared/ProductionTypes.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Shared/ProductionTypes.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Shared;
+
+/// <summary>
+/// Hand-written types of the production assemblies — everything the compiler synthesised (closures,
+/// async state machines, <c>[GeneratedRegex]</c> helpers, the top-level-statement entry point) is
+/// dropped, because no house rule can bind code nobody wrote.
+/// </summary>
+/// <remarks>
+/// Reflection, not NetArchTest, backs the CONVENTION rules: NetArchTest's predicate DSL cannot express
+/// "sealed unless another production type inherits it", nor read a validator's generic argument. The
+/// DEPENDENCY rules stay on NetArchTest, which scans the full IL of every member.
+/// </remarks>
+internal static class ProductionTypes
+{
+    internal static IReadOnlyList<Type> All { get; } =
+        ProductionAssemblies.All.SelectMany(Of).ToList();
+
+    internal static IReadOnlyList<Type> Of(Assembly assembly) =>
+        assembly.GetTypes().Where(type => !IsCompilerGenerated(type)).ToList();
+
+    /// <summary>
+    /// Every production type closing at least one of <paramref name="openGenericInterfaces"/> — the way
+    /// to find "all query handlers" or "all validators" without guessing at type names.
+    /// </summary>
+    internal static IReadOnlyList<Type> ImplementingAny(params Type[] openGenericInterfaces) =>
+        All.Where(type => ClosedInterfacesOf(type, openGenericInterfaces).Count > 0).ToList();
+
+    internal static IReadOnlyList<Type> ClosedInterfacesOf(Type type, params Type[] openGenericInterfaces) =>
+        type.GetInterfaces()
+            .Where(candidate => candidate.IsGenericType
+                && openGenericInterfaces.Contains(candidate.GetGenericTypeDefinition()))
+            .ToList();
+
+    internal static bool Implements(Type type, Type openGenericInterface) =>
+        ClosedInterfacesOf(type, openGenericInterface).Count > 0;
+
+    private static bool IsCompilerGenerated(Type type)
+    {
+        for (Type? current = type; current is not null; current = current.DeclaringType)
+        {
+            if (current.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false) || current.Name.Contains('<'))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Shared/ViolationReport.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Shared/ViolationReport.cs
@@ -1,0 +1,18 @@
+using NetArchTest.Rules;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Shared;
+
+/// <summary>
+/// Formats a rule's offenders into the assertion message. Pure formatting — the assertion itself stays
+/// inline in the test method, per the repo's testing conventions.
+/// </summary>
+internal static class ViolationReport
+{
+    internal static string Describe(this TestResult result) =>
+        result.IsSuccessful
+            ? "no violating types"
+            : Format(result.FailingTypeNames);
+
+    internal static string Format(IEnumerable<string> violatingTypeNames) =>
+        string.Concat(violatingTypeNames.Order().Select(name => $"{Environment.NewLine}  - {name}"));
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/BoundedContextIsolationTests.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/BoundedContextIsolationTests.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using LotroKoniecDev.Architecture.Tests.Unit.Shared;
+using NetArchTest.Rules;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Tests;
+
+/// <summary>
+/// The patcher and the TMS are two bounded contexts in one repository. They share a DATA contract — the
+/// <c>||</c> translation file — never code: the TMS runs in Linux containers and must never reach the
+/// x86 Windows native interop, the patcher runs on a gaming box and must never reach the database.
+/// </summary>
+public sealed class BoundedContextIsolationTests
+{
+    private static readonly Assembly[] TranslationManagementAssemblies =
+    [
+        ProductionAssemblies.TranslationSystemPrimitives,
+        ProductionAssemblies.TranslationSystemDomain,
+        ProductionAssemblies.TranslationSystemReadModels,
+        ProductionAssemblies.TranslationSystemReadModelsEntityFramework,
+        ProductionAssemblies.TranslationSystemProjections,
+        ProductionAssemblies.TranslationSystemPersistence,
+        ProductionAssemblies.TranslationSystemContracts,
+        ProductionAssemblies.TranslationSystemApi,
+        ProductionAssemblies.AuthSystemDomain,
+        ProductionAssemblies.AuthSystemContracts,
+        ProductionAssemblies.AuthSystemInfrastructure,
+        ProductionAssemblies.AuthSystemPersistence,
+        ProductionAssemblies.AuthSystemApi,
+        ProductionAssemblies.Frontend,
+    ];
+
+    private static readonly Assembly[] PatcherAssemblies =
+    [
+        ProductionAssemblies.PatcherPrimitives,
+        ProductionAssemblies.PatcherDomain,
+        ProductionAssemblies.PatcherApplication,
+    ];
+
+    [Fact]
+    public void TranslationManagementAssemblies_Dependencies_NeverReachThePatcher()
+    {
+        TestResult result = Types.InAssemblies(TranslationManagementAssemblies)
+            .Should()
+            .NotHaveDependencyOnAny(
+                Namespaces.PatcherPrimitives,
+                Namespaces.PatcherDomain,
+                Namespaces.PatcherApplication,
+                Namespaces.PatcherInfrastructure,
+                Namespaces.PatcherCli)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"The TMS owns its own parser/serializer — it never links the patcher, least of all its native interop:{result.Describe()}");
+    }
+
+    [Fact]
+    public void PatcherAssemblies_Dependencies_NeverReachTheTranslationManagementSystem()
+    {
+        TestResult result = Types.InAssemblies(PatcherAssemblies)
+            .Should()
+            .NotHaveDependencyOnAny(
+                Namespaces.TranslationSystem,
+                Namespaces.AuthSystem,
+                Namespaces.Frontend,
+                Namespaces.SharedKernel)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"The patcher duplicates the few building blocks it needs on purpose — it never links the TMS side:{result.Describe()}");
+    }
+
+    [Fact]
+    public void FrontendAssembly_Dependencies_ReachTheContractsAndNothingBehindThem()
+    {
+        TestResult result = Types.InAssembly(ProductionAssemblies.Frontend)
+            .Should()
+            .NotHaveDependencyOnAny(
+                Namespaces.TranslationSystemDomain,
+                Namespaces.TranslationSystemReadModels,
+                Namespaces.TranslationSystemProjections,
+                Namespaces.TranslationSystemPersistence,
+                Namespaces.TranslationSystemApi,
+                Namespaces.AuthSystemDomain,
+                Namespaces.AuthSystemInfrastructure,
+                Namespaces.AuthSystemPersistence,
+                Namespaces.AuthSystemApi)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"The Frontend is an HTTP client — it sees Contracts (+ Primitives), never a domain or a DbContext:{result.Describe()}");
+    }
+
+    [Fact]
+    public void TranslationSystemAssemblies_Dependencies_NeverReachTheAuthServerInternals()
+    {
+        Assembly[] translationSystemAssemblies = TranslationManagementAssemblies
+            .Where(assembly => assembly.GetName().Name?.StartsWith(Namespaces.TranslationSystem, StringComparison.Ordinal) == true)
+            .ToArray();
+
+        TestResult result = Types.InAssemblies(translationSystemAssemblies)
+            .Should()
+            .NotHaveDependencyOnAny(
+                Namespaces.AuthSystemDomain,
+                Namespaces.AuthSystemInfrastructure,
+                Namespaces.AuthSystemPersistence,
+                Namespaces.AuthSystemApi)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"The TMS trusts the auth server over JWT/JWKS only — it never links its Identity model or its database:{result.Describe()}");
+    }
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/CqrsSeparationTests.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/CqrsSeparationTests.cs
@@ -1,0 +1,87 @@
+using System.Reflection;
+using FluentValidation;
+using LotroKoniecDev.Architecture.Tests.Unit.Shared;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
+using PatcherMessaging = LotroKoniecDev.Application.Abstractions.Messaging;
+using TranslationSystemMessaging = LotroKoniecDev.SharedKernel.Messaging;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Tests;
+
+/// <summary>
+/// The CQRS read/write split (ADR-0002 amendment): queries read POCO read models through
+/// <c>IApplicationReadDbContext</c>; commands load and mutate aggregates through repositories plus
+/// <c>IUnitOfWork</c>. Handlers use explicit constructor DI, so a constructor's parameters ARE the
+/// handler's dependency list.
+/// </summary>
+/// <remarks>
+/// The mirror-image rule — "a command handler may not see the read context" — is deliberately NOT
+/// asserted: <c>UpsertTranslation</c> re-reads the committed row through the read model so the response
+/// carries the joined submitter/approver display names (ADR-0004). The split that matters is
+/// one-directional: the write model never serves a query.
+/// </remarks>
+public sealed class CqrsSeparationTests
+{
+    private static readonly Type[] QueryHandlerInterfaces =
+    [
+        typeof(TranslationSystemMessaging.IQueryHandler<,>),
+        typeof(PatcherMessaging.IQueryHandler<,>),
+    ];
+
+    private static readonly Type[] CommandHandlerInterfaces =
+    [
+        typeof(TranslationSystemMessaging.ICommandHandler<,>),
+        typeof(PatcherMessaging.ICommandHandler<,>),
+    ];
+
+    [Fact]
+    public void QueryHandlers_ConstructorDependencies_NeverReachTheWriteSide()
+    {
+        IReadOnlyList<Type> queryHandlers = ProductionTypes.ImplementingAny(QueryHandlerInterfaces);
+        queryHandlers.ShouldNotBeEmpty("no query handler was discovered — the rule would pass vacuously");
+
+        List<string> violations = queryHandlers
+            .SelectMany(handler => DependenciesOf(handler)
+                .Where(IsWriteSide)
+                .Select(dependency => $"{handler.FullName} <- {dependency.Name}"))
+            .ToList();
+
+        violations.ShouldBeEmpty(
+            $"A query reads the read models — repositories, the unit of work and the write DbContext are the command side:{ViolationReport.Format(violations)}");
+    }
+
+    [Fact]
+    public void CommandHandlers_ConstructorDependencies_AlwaysIncludeTheValidatorOfTheirCommand()
+    {
+        IReadOnlyList<Type> commandHandlers = ProductionTypes.ImplementingAny(CommandHandlerInterfaces);
+        commandHandlers.ShouldNotBeEmpty("no command handler was discovered — the rule would pass vacuously");
+
+        List<string> violations = commandHandlers
+            .Where(handler => !InjectsItsOwnValidator(handler))
+            .Select(handler => handler.FullName!)
+            .ToList();
+
+        violations.ShouldBeEmpty(
+            $"FluentValidation is for commands: the handler injects IValidator<TCommand> and maps failures to a Result, never throws:{ViolationReport.Format(violations)}");
+    }
+
+    private static bool InjectsItsOwnValidator(Type handler)
+    {
+        IReadOnlyList<Type> dependencies = DependenciesOf(handler);
+
+        return ProductionTypes.ClosedInterfacesOf(handler, CommandHandlerInterfaces)
+            .Select(handlerInterface => typeof(IValidator<>).MakeGenericType(handlerInterface.GetGenericArguments()[0]))
+            .All(dependencies.Contains);
+    }
+
+    private static IReadOnlyList<Type> DependenciesOf(Type handler) =>
+        handler.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .SelectMany(constructor => constructor.GetParameters())
+            .Select(parameter => parameter.ParameterType)
+            .ToList();
+
+    private static bool IsWriteSide(Type dependency) =>
+        dependency == typeof(IUnitOfWork)
+        || ProductionTypes.Implements(dependency, typeof(IRepository<,>))
+        || dependency.Namespace?.StartsWith(Namespaces.TranslationSystemWriteDbContexts, StringComparison.Ordinal) == true;
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/HandlerConventionTests.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/HandlerConventionTests.cs
@@ -1,0 +1,59 @@
+using FluentValidation;
+using LotroKoniecDev.Architecture.Tests.Unit.Shared;
+using PatcherMessaging = LotroKoniecDev.Application.Abstractions.Messaging;
+using TranslationSystemMessaging = LotroKoniecDev.SharedKernel.Messaging;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Tests;
+
+/// <summary>
+/// Shape rules for the no-mediator slice (ADR-0001): a handler is an implementation detail of its slice,
+/// and FluentValidation is a command-side tool.
+/// </summary>
+public sealed class HandlerConventionTests
+{
+    private static readonly Type[] HandlerInterfaces =
+    [
+        typeof(TranslationSystemMessaging.ICommandHandler<,>),
+        typeof(TranslationSystemMessaging.IQueryHandler<,>),
+        typeof(PatcherMessaging.ICommandHandler<,>),
+        typeof(PatcherMessaging.IQueryHandler<,>),
+    ];
+
+    private static readonly Type[] QueryInterfaces =
+    [
+        typeof(TranslationSystemMessaging.IQuery<>),
+        typeof(PatcherMessaging.IQuery<>),
+    ];
+
+    [Fact]
+    public void CommandAndQueryHandlers_Declaration_IsSealedAndNotPubliclyVisible()
+    {
+        IReadOnlyList<Type> handlers = ProductionTypes.ImplementingAny(HandlerInterfaces);
+        handlers.ShouldNotBeEmpty("no handler was discovered — the rule would pass vacuously");
+
+        List<string> violations = handlers
+            .Where(handler => !handler.IsSealed || handler.IsVisible)
+            .Select(handler => handler.FullName!)
+            .ToList();
+
+        violations.ShouldBeEmpty(
+            $"Consumers inject the CLOSED handler interface, never the class — so a handler is internal and sealed:{ViolationReport.Format(violations)}");
+    }
+
+    [Fact]
+    public void FluentValidationValidators_ValidatedType_IsNeverAQuery()
+    {
+        IReadOnlyList<Type> validators = ProductionTypes.ImplementingAny(typeof(IValidator<>));
+        validators.ShouldNotBeEmpty("no validator was discovered — the rule would pass vacuously");
+
+        List<string> violations = validators
+            .SelectMany(validator => ProductionTypes.ClosedInterfacesOf(validator, typeof(IValidator<>))
+                .Select(closedValidator => closedValidator.GetGenericArguments()[0])
+                .Where(validatedType => ProductionTypes.ClosedInterfacesOf(validatedType, QueryInterfaces).Count > 0)
+                .Select(validatedType => $"{validator.FullName} -> {validatedType.Name}"))
+            .ToList();
+
+        violations.ShouldBeEmpty(
+            $"Validators are for commands only — a query validates inline in its own handler:{ViolationReport.Format(violations)}");
+    }
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/NoMediatorTests.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/NoMediatorTests.cs
@@ -1,0 +1,29 @@
+using LotroKoniecDev.Architecture.Tests.Unit.Shared;
+using NetArchTest.Rules;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Tests;
+
+/// <summary>
+/// ADR-0001: no mediator, repo-wide. Every lifted KittySaver slice is de-mediatorized on entry and the
+/// <c>Mediator</c> / <c>MediatR</c> packages are forbidden — one use case is one record plus one handler
+/// implementing the in-house <c>ICommandHandler</c> / <c>IQueryHandler</c>.
+/// </summary>
+/// <remarks>
+/// The rule is asserted over IL, so it catches USE of a mediator type. A package restored but never
+/// touched leaves no trace in IL and slips through — harmless on its own, and the moment anyone reaches
+/// for it this test goes red.
+/// </remarks>
+public sealed class NoMediatorTests
+{
+    [Fact]
+    public void ProductionAssemblies_Dependencies_NeverIncludeAMediator()
+    {
+        TestResult result = Types.InAssemblies(ProductionAssemblies.All)
+            .Should()
+            .NotHaveDependencyOnAny(Namespaces.MediatR, Namespaces.Mediator)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"ADR-0001 forbids Mediator/MediatR — inject the closed handler interface instead:{result.Describe()}");
+    }
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/PatcherLayeringTests.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/PatcherLayeringTests.cs
@@ -1,0 +1,62 @@
+using LotroKoniecDev.Architecture.Tests.Unit.Shared;
+using NetArchTest.Rules;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Tests;
+
+/// <summary>
+/// The patcher's Clean Architecture dependency rule: Cli / Infrastructure -> Application -> Domain ->
+/// Primitives. Only the forbidden direction is asserted; the allowed one is what the project references
+/// already spell out.
+/// </summary>
+public sealed class PatcherLayeringTests
+{
+    [Fact]
+    public void PrimitivesAssembly_Dependencies_ReachNoOtherProjectInTheRepository()
+    {
+        TestResult result = Types.InAssembly(ProductionAssemblies.PatcherPrimitives)
+            .Should()
+            .NotHaveDependencyOnAny(
+                Namespaces.PatcherDomain,
+                Namespaces.PatcherApplication,
+                Namespaces.PatcherInfrastructure,
+                Namespaces.PatcherCli,
+                Namespaces.SharedKernel,
+                Namespaces.TranslationSystem,
+                Namespaces.AuthSystem,
+                Namespaces.Frontend,
+                Namespaces.Hateoas,
+                Namespaces.Logging,
+                Namespaces.Options)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"Primitives is the bottom layer — constants and enums, zero dependencies:{result.Describe()}");
+    }
+
+    [Fact]
+    public void DomainAssembly_Dependencies_ReachNeitherApplicationInfrastructureNorCli()
+    {
+        TestResult result = Types.InAssembly(ProductionAssemblies.PatcherDomain)
+            .Should()
+            .NotHaveDependencyOnAny(
+                Namespaces.PatcherApplication,
+                Namespaces.PatcherInfrastructure,
+                Namespaces.PatcherCli)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"Domain sits below Application — it may only reach Primitives:{result.Describe()}");
+    }
+
+    [Fact]
+    public void ApplicationAssembly_Dependencies_ReachNeitherInfrastructureNorCli()
+    {
+        TestResult result = Types.InAssembly(ProductionAssemblies.PatcherApplication)
+            .Should()
+            .NotHaveDependencyOnAny(Namespaces.PatcherInfrastructure, Namespaces.PatcherCli)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"Application talks to infrastructure through its own Abstractions/ ports, never the adapters:{result.Describe()}");
+    }
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/PersistenceDirectionTests.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/PersistenceDirectionTests.cs
@@ -1,0 +1,76 @@
+using LotroKoniecDev.Architecture.Tests.Unit.Shared;
+using NetArchTest.Rules;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Tests;
+
+/// <summary>
+/// Persistence points one way: the domain and the outward-facing contracts know nothing about EF Core or
+/// PostgreSQL, and the POCO read models stay free of the EF configurations that map them.
+/// </summary>
+/// <remarks>
+/// <c>AuthSystem.Domain</c> is deliberately out of scope: it is a wholesale lift of an ASP.NET Core
+/// Identity model (<c>ApplicationUser : IdentityUser&lt;Guid&gt;</c>), so the Identity EF Core package IS
+/// its domain vocabulary. Removing it would mean rewriting the auth server, not fixing a leak.
+/// </remarks>
+public sealed class PersistenceDirectionTests
+{
+    [Fact]
+    public void PatcherDomainAssembly_Dependencies_IncludeNoPersistenceTechnology()
+    {
+        TestResult result = Types.InAssembly(ProductionAssemblies.PatcherDomain)
+            .Should()
+            .NotHaveDependencyOnAny(Namespaces.EntityFrameworkCore, Namespaces.Npgsql)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"The patcher domain models a binary file format — it has no database at all:{result.Describe()}");
+    }
+
+    [Fact]
+    public void TranslationSystemDomainAssembly_Dependencies_IncludeNoPersistenceTechnology()
+    {
+        TestResult result = Types.InAssembly(ProductionAssemblies.TranslationSystemDomain)
+            .Should()
+            .NotHaveDependencyOnAny(
+                Namespaces.EntityFrameworkCore,
+                Namespaces.Npgsql,
+                Namespaces.TranslationSystemPersistence)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"Aggregates stay persistence-ignorant — the mapping lives in Persistence, behind repositories:{result.Describe()}");
+    }
+
+    [Fact]
+    public void ReadModelsAssembly_Dependencies_IncludeNoPersistenceTechnology()
+    {
+        TestResult result = Types.InAssembly(ProductionAssemblies.TranslationSystemReadModels)
+            .Should()
+            .NotHaveDependencyOnAny(
+                Namespaces.EntityFrameworkCore,
+                Namespaces.Npgsql,
+                Namespaces.TranslationSystemDomain,
+                Namespaces.TranslationSystemPersistence)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"Read models are POCOs — their EF configurations live in the separate ReadModels.EntityFramework project:{result.Describe()}");
+    }
+
+    [Fact]
+    public void ContractsAssembly_Dependencies_IncludeNeitherPersistenceTechnologyNorTheDomain()
+    {
+        TestResult result = Types.InAssembly(ProductionAssemblies.TranslationSystemContracts)
+            .Should()
+            .NotHaveDependencyOnAny(
+                Namespaces.EntityFrameworkCore,
+                Namespaces.Npgsql,
+                Namespaces.TranslationSystemDomain,
+                Namespaces.TranslationSystemReadModels,
+                Namespaces.TranslationSystemPersistence)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeTrue(
+            $"Contracts is the wire format the Frontend references — anything leaking in leaks all the way out:{result.Describe()}");
+    }
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/SealedConventionTests.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/SealedConventionTests.cs
@@ -1,0 +1,98 @@
+using LotroKoniecDev.Architecture.Tests.Unit.Shared;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Tests;
+
+/// <summary>
+/// The house rule "seal every type unless there is explicit inheritance", stated mechanically: a class is
+/// sealed unless another production type actually derives from it.
+/// </summary>
+/// <remarks>
+/// Types whose SHAPE is dictated by a framework are out of scope — a generated EF migration, a Razor
+/// component, view or <c>_Imports</c> marker, and the top-level-statement <c>Program</c> marker cannot
+/// carry the modifier without hand-editing generated code. Everything else has to be sealed.
+/// </remarks>
+public sealed class SealedConventionTests
+{
+    private static readonly string[] FrameworkShapedBaseTypes =
+    [
+        "Microsoft.EntityFrameworkCore.Migrations.Migration",
+        "Microsoft.EntityFrameworkCore.Infrastructure.ModelSnapshot",
+        "Microsoft.AspNetCore.Components.ComponentBase",
+        "Microsoft.AspNetCore.Mvc.Razor.RazorPageBase",
+        "Microsoft.AspNetCore.Mvc.RazorPages.PageModel",
+    ];
+
+    /// <summary>
+    /// Real violations that predate this suite, each fixed under its own ticket — #570 is a test-only
+    /// change. Keyed by type full name, valued by the ticket that removes the entry.
+    /// </summary>
+    private static readonly Dictionary<string, string> KnownViolations = new(StringComparer.Ordinal)
+    {
+        ["LotroKoniecDev.Domain.Core.Monads.Result`1"] = "#599",
+    };
+
+    [Fact]
+    public void ProductionClasses_WithoutAnExplicitSubclass_AreSealed()
+    {
+        List<string> violations = UnsealedClassesNothingDerivesFrom()
+            .Where(typeName => !KnownViolations.ContainsKey(typeName))
+            .ToList();
+
+        violations.ShouldBeEmpty(
+            $"Seal it, or give it a subclass — the repo has no third option:{ViolationReport.Format(violations)}");
+    }
+
+    [Fact]
+    public void KnownViolations_EveryEntry_StillBreaksTheRule()
+    {
+        IReadOnlyList<string> currentViolations = UnsealedClassesNothingDerivesFrom();
+
+        List<string> staleEntries = KnownViolations
+            .Where(violation => !currentViolations.Contains(violation.Key))
+            .Select(violation => $"{violation.Key} (was to be fixed under {violation.Value})")
+            .ToList();
+
+        staleEntries.ShouldBeEmpty(
+            $"The quarantine is self-cleaning — a fixed type has to leave KnownViolations, or the rule stops covering it:{ViolationReport.Format(staleEntries)}");
+    }
+
+    private static IReadOnlyList<string> UnsealedClassesNothingDerivesFrom()
+    {
+        HashSet<Type> baseTypes = ProductionTypes.All
+            .Select(type => type.BaseType)
+            .OfType<Type>()
+            .Select(Normalize)
+            .ToHashSet();
+
+        return ProductionTypes.All
+            .Where(type => type.IsClass && !type.IsAbstract && !type.IsSealed)
+            .Where(type => !baseTypes.Contains(Normalize(type)))
+            .Where(type => !IsFrameworkShaped(type))
+            .Select(type => type.FullName!)
+            .ToList();
+    }
+
+    private static bool IsFrameworkShaped(Type type) =>
+        IsEntryPointMarker(type) || IsRazorImportsMarker(type) || InheritsFrameworkShape(type);
+
+    private static bool IsEntryPointMarker(Type type) =>
+        type.Namespace is null && type.Name is "Program";
+
+    /// <summary>Razor emits one empty marker class per <c>_Imports.razor</c>; it derives from nothing.</summary>
+    private static bool IsRazorImportsMarker(Type type) => type.Name is "_Imports";
+
+    private static bool InheritsFrameworkShape(Type type)
+    {
+        for (Type? current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (FrameworkShapedBaseTypes.Contains(Normalize(current).FullName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Type Normalize(Type type) => type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+}

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/SuiteSelfTests.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/SuiteSelfTests.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using LotroKoniecDev.Architecture.Tests.Unit.Shared;
+using NetArchTest.Rules;
+
+namespace LotroKoniecDev.Architecture.Tests.Unit.Tests;
+
+/// <summary>
+/// Proves the suite can still say "no". Every other test here asserts an ABSENCE, so a broken search set
+/// or a silently empty type scan would report a green that means nothing.
+/// </summary>
+public sealed class SuiteSelfTests
+{
+    [Fact]
+    public void DependencyRule_AgainstADependencyThatGenuinelyExists_Fails()
+    {
+        TestResult result = Types.InAssembly(ProductionAssemblies.Frontend)
+            .Should()
+            .NotHaveDependencyOn(Namespaces.TranslationSystemContracts)
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeFalse(
+            "the Frontend does reference TranslationSystem.Contracts — a rule that misses it detects nothing at all");
+    }
+
+    [Fact]
+    public void TypeScan_EveryProductionAssembly_ContributesAtLeastOneType()
+    {
+        List<string> emptyAssemblies = ProductionAssemblies.All
+            .Where(assembly => ProductionTypes.Of(assembly).Count == 0)
+            .Select(assembly => assembly.GetName().Name!)
+            .ToList();
+
+        emptyAssemblies.ShouldBeEmpty(
+            $"An assembly nothing was read from is an assembly no convention rule covers:{ViolationReport.Format(emptyAssemblies)}");
+    }
+
+    /// <summary>
+    /// Catches the half-done wiring: a new production project gets its <c>ProjectReference</c> here but
+    /// never joins <see cref="ProductionAssemblies.All"/>, so no rule ever sees it.
+    /// </summary>
+    /// <remarks>
+    /// Reads this suite's OWN build output — the same directory <c>Assembly.Load</c> already resolves from,
+    /// so it stays deterministic, order-free and cross-platform. <c>GetReferencedAssemblies()</c> cannot do
+    /// the job: it lists only the assemblies the compiler actually bound, and most of the search set is
+    /// reached by name, never by a compile-time reference.
+    /// </remarks>
+    [Fact]
+    public void SearchSet_EveryProductionAssemblyInTheBuildOutput_IsUnderRule()
+    {
+        HashSet<string> underRule = ProductionAssemblies.All
+            .Select(assembly => assembly.GetName().Name!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        List<string> unwatched = Directory
+            .GetFiles(AppContext.BaseDirectory, "LotroKoniecDev.*.dll")
+            .Select(Path.GetFileNameWithoutExtension)
+            .OfType<string>()
+            .Where(name => !name.EndsWith(".Tests.Unit", StringComparison.Ordinal))
+            .Where(name => !underRule.Contains(name))
+            .ToList();
+
+        unwatched.ShouldBeEmpty(
+            $"A new production project must join ProductionAssemblies.All, or it silently escapes every rule:{ViolationReport.Format(unwatched)}");
+    }
+}


### PR DESCRIPTION
Closes #570

## What

Adds `tests/LotroKoniecDev.Architecture.Tests.Unit` — the repo's structural house rules turned into failing tests instead of review memory. 21 tests, all green.

| File | Rule |
|---|---|
| `PatcherLayeringTests` | Cli / Infrastructure -> Application -> Domain -> Primitives; the lower layer never reaches up |
| `NoMediatorTests` | ADR-0001 — no `Mediator` / `MediatR` type anywhere in production IL |
| `BoundedContextIsolationTests` | patcher and TMS share the `||` file, never code; the Frontend sees `Contracts`, never a domain or DbContext; the TMS never links the auth server internals |
| `PersistenceDirectionTests` | patcher/TMS domain, read models and contracts carry no EF Core or Npgsql |
| `CqrsSeparationTests` | a query handler never injects a repository, `IUnitOfWork` or the write DbContext; a command handler injects `IValidator<TCommand>` |
| `HandlerConventionTests` | handlers are `internal sealed`; no `IValidator<TQuery>` |
| `SealedConventionTests` | every class is sealed unless another production type derives from it |
| `SuiteSelfTests` | the suite can still say "no" |

## Why these choices

**Two mechanisms.** NetArchTest.Rules for dependency rules — it scans the full IL of every member. Plain reflection for the convention rules its predicate DSL cannot express: "sealed unless another production type inherits it", and reading a validator's generic argument.

**The Windows-only patcher assemblies are not referenced.** A `net10.0` project cannot reference `net10.0-windows`, and the suite has to stay green on the Linux runner. Infrastructure and Cli sit at the TOP of the patcher layering, so every rule about them is stated as a forbidden namespace on the assemblies below — no reference needed.

**`SuiteSelfTests` exists because every other test asserts an absence.** A broken search set or an empty type scan would report a green that means nothing. It pins a dependency that genuinely exists (Frontend -> Contracts) and fails when a production assembly in the build output is missing from `ProductionAssemblies.All` — the likely half-mistake when a new project is added.

**One ticket rule was wrong and is not implemented.** #570 asked for "command handlers must not depend on `IApplicationReadDbContext`" as the mirror of the query rule. `UpsertTranslation` deliberately re-reads the committed row through the read model so the response carries the joined submitter/approver display names (ADR-0004). The split that matters is one-directional — the write model never serves a query — and that is what the test asserts. The reasoning is in the file's XML docs, not silently dropped.

**`AuthSystem.Domain` is out of scope for the no-EF-Core rule,** stated in the file: it is a wholesale lift of an ASP.NET Core Identity model (`ApplicationUser : IdentityUser<Guid>`), so the Identity EF Core package IS its domain vocabulary.

## One real violation found — filed as #599

`LotroKoniecDev.Domain.Core.Monads.Result<TValue>` is not sealed while its SharedKernel twin is, and nothing derives from it. #570 is a test-only change by its own acceptance criteria, so the type is quarantined in `SealedConventionTests.KnownViolations` with a link to #599 rather than fixed here.

The quarantine is **self-cleaning**: `KnownViolations_EveryEntry_StillBreaksTheRule` fails once an entry stops violating, so #599 cannot land without removing it.

## How it was tested

- `dotnet build LotroKoniecDev.slnx -c Release` — succeeded, **0 warnings** (`TreatWarningsAsErrors` is repo-wide).
- Every `*.Tests.Unit` suite — **1314 passed, 0 failed**, including the new 21.
- `scripts/check-dockerfile-restore-graph.sh` and `scripts/check-ssr-purity.sh` — both pass.
- **Mutation proof of the acceptance criterion "introducing a forbidden reference makes a test fail".** A throwaway file was added to `TranslationSystem.API` with an unsealed class, a publicly-visible query handler injecting `IUnitOfWork`, and an `IValidator<TQuery>`; `NoMediatorTests` was temporarily pointed at a namespace the code really uses. All five rules went red with the offending type named in the message. The file and the edit were reverted — the diff is test + docs only, no production code touched.

## CI

The suite joins the gate by naming convention — `pr-verify.yml` and `ci.yml` discover `tests/**/*.Tests.Unit.csproj`, so no workflow change. `scripts/ci/classify-changes.sh` already treats a `.csproj` under `tests/` as build-relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnVjDNLSTgYv8gQzvmmXn