### PR TITLE
Tests: snapshot testing via Verify for API response contracts and SSR-rendered pages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,12 @@
 # Native interop binaries and DAT game files — never apply EOL normalization.
 *.dll binary
 *.dat binary
+
+# Verify snapshots (#571) — belt-and-braces, NOT load-bearing: `* text=auto eol=lf` above already
+# checks these out as LF everywhere, and Verify normalizes newlines internally before comparing, so
+# the Windows leg is covered twice over. Listed explicitly only so the intent survives an edit to the
+# catch-all rule; deleting these lines changes nothing on its own.
+*.verified.txt text eol=lf
+*.verified.json text eol=lf
+*.verified.html text eol=lf
+*.verified.xml text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -510,6 +510,10 @@ intel/
 # Stryker.NET mutation testing output
 StrykerOutput/
 
+# Verify snapshot testing (#571): *.verified.* files ARE the contract and are committed; the
+# *.received.* files a failing snapshot writes next to them are scratch output of that run.
+*.received.*
+
 # Terraform — the IaC itself was retired with Azure (ADR-0034 / #492); the only Terraform left in
 # the repo is the dead, never-to-be-applied copy under docs/deployment/azure-graveyard/. These rules
 # stay as a net: leftover local artifacts (.terraform/, tfplan) must never be swept into a commit by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,7 +507,19 @@ structure.
 - **AAA always; assertions inline in the test method.** DRY the Arrange (builders), never the
   Assert. One reason to fail per test.
 - **Tooling: xUnit + Shouldly + NSubstitute only.** Naming: `MethodName_Scenario_ExpectedResult`.
-  (`Architecture.Tests.Unit` additionally uses **NetArchTest.Rules** — architecture rules only.)
+  (`Architecture.Tests.Unit` additionally uses **NetArchTest.Rules** — architecture rules only;
+  the two snapshot suites use **Verify.Xunit** — see the next bullet.)
+- **Snapshots pin shape; they never replace an assert (#571).** Three tools, three jobs: **golden
+  fixtures** own the `||` file contract on both sides (a snapshot adds nothing there and must not
+  replace them), **plain asserts** own behavior across many inputs, and a **Verify snapshot** owns
+  "did anything about this large payload change" — TMS API response bodies (JSON incl. HATEOAS links
+  and ProblemDetails) and Blazor SSR rendered markup, where hand-written asserts only ever cover a
+  corner. The behavioral suites stay; deleting an assert because "the snapshot covers it" is the
+  wrong move. `*.verified.*` files are committed and ARE the pinned contract, `*.received.*` is
+  git-ignored scratch, and **re-accepting a verified file is a deliberate, reviewed act** — read the
+  diff, then land it in the same PR as the change that caused it. One shared scrubber set
+  (`tests/Shared/VerifyModuleInitializer.cs`, linked into every snapshot suite) keeps runs
+  deterministic; a snapshot that churns is worse than no snapshot. Details: `tests/CLAUDE.md`.
 - **The structural house rules are a TEST, not review memory.** `tests/LotroKoniecDev.Architecture.Tests.Unit`
   mechanically enforces the patcher dependency rule, no-mediator (ADR-0001), patcher/TMS bounded-context
   isolation, the Frontend's contracts-only reach, the persistence direction, the CQRS read/write split and

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,6 +81,11 @@
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="NaughtyStrings" Version="3.0.0" />
+    <!-- Snapshot testing (#571). Pulls Verify, Argon, DiffEngine and SimpleInfoName transitively; with
+         NuGetAudit=all + TreatWarningsAsErrors a moderate advisory in ANY of them fails the build
+         repo-wide, not just the two snapshot suites. Accepted cost — that is the same trade every
+         package here makes; noted so the next person hitting it knows where it comes from. -->
+    <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageVersion Include="Testcontainers" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -152,8 +152,8 @@ Two properties worth knowing before you add one:
   the **logical** contract (names, nesting, JSON types, values), not the transport's encoding of
   non-ASCII — so Polish reads as Polish in the verified file. Nothing else covers that encoding
   (`ContentNegotiationTests` pins the media type and `Vary`, not the bytes), so `ApiSnapshot`
-  carries its own `ShouldServeUtf8Async` assert on the **raw** body and every snapshot with Polish
-  in it calls that too.
+  carries its own `ShouldServeUnescapedUtf8Async` assert on the **raw** body and every snapshot with
+  Polish in it calls that too.
 - A markup snapshot is the component's **rendered body only**. bUnit's `Markup` does not include
   `<PageTitle>` / `<HeadContent>`, so head metadata needs its own assert.
 - A snapshot suite is the sanctioned exception to "unit tests are pure: no filesystem". It reads its

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -61,6 +61,7 @@ per-project `stryker-config.json` after reviewing the baseline report.
 - **NSubstitute** — mocking: `Substitute.For<IInterface>()`
 - **NaughtyStrings** — the Big List of Naughty Strings, for hostile-input theories (see below)
 - **NetArchTest.Rules** — architecture tests (assembly IL only; `LotroKoniecDev.Architecture.Tests.Unit`)
+- **Verify.Xunit** — snapshot tests for API response contracts and rendered SSR markup (see below)
 - **Xunit.SkippableFact** — E2E tests that need Windows + a real DAT
 - **coverlet.collector** — code coverage
 - Versions: `Directory.Packages.props` is the single source of truth.
@@ -99,6 +100,70 @@ hazard is actually present in the data before trusting a `MemberData` theory to 
 Several tests pin **known-lossy** behavior on purpose, say so in-place, and name the defect ticket
 they document (#596 escape asymmetry, #597 odd trailing pipe, #598 over-long piece). Do not "fix"
 such a test — fix the defect, then change the assertion deliberately.
+
+## Snapshot tests (Verify — #571)
+
+Snapshot testing is for **one specific shape of assertion**: the target is a large structured output
+that hand-written asserts only ever cover in part. Two seams qualify today, and the pilot lives in a
+`Snapshots/` folder in each:
+
+| Suite | Snapshots | Pins |
+|---|---|---|
+| `TranslationSystem.API.Tests.Integration/Tests/Snapshots/` | `TranslationContractSnapshotTests` (HATEOAS list, public list, middle page, empty envelope, HATEOAS detail, plain-JSON list), `ProblemDetailsSnapshotTests` (400/404/422 + 401/403) | the whole response body — property names, nesting, JSON types, the complete link set |
+| `Frontend.Tests.Unit/Snapshots/` | `HomeMarkupSnapshotTests` (4 states incl. zero-catalog), `TermsMarkupSnapshotTests` | the whole rendered SSR markup of the page |
+
+Seed for the shape you are pinning, not for the shape that is easy: the API fixture seeds three rows
+so a **middle page** (the only place `previous-page` and `next-page` both appear) and the **empty
+envelope** are covered, and the Home counters are five-figure so the NBSP group separator actually
+renders. A snapshot of the one well-formed happy payload is the easiest kind to write and the least
+worth having.
+
+**When a snapshot is the right tool:**
+
+- **Golden fixtures** own the `||` file contract on both sides. Snapshots add nothing there and must
+  never replace them — that format changes only via ADR, and its fixtures are round-tripped, not
+  compared.
+- **Plain asserts** own behavior: "an admin sees `approve`, a translator does not" is a statement
+  about many inputs, so it stays a `[Theory]`. A snapshot answers "did *anything* about this payload
+  change", which is a different question.
+- **Snapshots** own shape. They exist for the fields nobody thought to assert. They complement the
+  behavioral suites (`TranslationAggregateHateoasTests`, `ProblemDetailsContractTests`, `HomeTests`,
+  `TermsTests` all stay) — deleting an assert because "the snapshot covers it" is the wrong move.
+
+**Re-accepting a verified file is a deliberate, reviewed act.** `*.verified.*` files are committed
+and ARE the pinned contract; `*.received.*` files are that run's scratch output and are git-ignored.
+When a snapshot fails, read the diff: either the change was intended (rename the received file over
+the verified one, in the same PR, so the diff is reviewable) or you just found a regression. Never
+re-accept a batch of snapshots without reading each diff.
+
+Everything is configured once in **`tests/Shared/VerifyModuleInitializer.cs`**, linked into every
+snapshot suite (same idiom as `NaughtyStringCases.cs`) so all of them scrub identically — inline
+GUIDs, ISO-8601 instants, 64-char hex digests (the translation file's SHA-256, which is also the
+strong `ETag`) and the `traceId` ASP.NET Core stamps on every `ProblemDetails`. The diff-tool
+launcher is disabled there too: most runs are headless, and a GUI popping up would hang the run.
+
+Two properties worth knowing before you add one:
+
+- The scrubbers are **shape-matched**, not positional — a regex only fires on text that still looks
+  like a GUID / an instant / a digest. A contract regression that changes the shape (an instant
+  serialized as a Unix epoch) leaves the raw value in the snapshot and fails the test, which is the
+  point.
+- API snapshots go through `ApiSnapshot`, which re-indents the body via `JsonNode`. What is pinned is
+  the **logical** contract (names, nesting, JSON types, values), not the transport's encoding of
+  non-ASCII — so Polish reads as Polish in the verified file. Nothing else covers that encoding
+  (`ContentNegotiationTests` pins the media type and `Vary`, not the bytes), so `ApiSnapshot`
+  carries its own `ShouldServeUtf8Async` assert on the **raw** body and every snapshot with Polish
+  in it calls that too.
+- A markup snapshot is the component's **rendered body only**. bUnit's `Markup` does not include
+  `<PageTitle>` / `<HeadContent>`, so head metadata needs its own assert.
+- A snapshot suite is the sanctioned exception to "unit tests are pure: no filesystem". It reads its
+  `*.verified.*` from the source tree at runtime (and writes `*.received.*` on failure) — that file is
+  the pinned contract, not an assertion about generated output, so `Frontend.Tests.Unit` stays a pure
+  suite in every sense the rule is about.
+
+Add a snapshot when the payload is big and the existing asserts cover a corner of it. Do not add one
+to a small `Result` or a three-field DTO — a plain assert says more, and says it in the failure
+message.
 
 ## Unit Tests (LotroKoniecDev.Tests.Unit)
 

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/LotroKoniecDev.Frontend.Tests.Unit.csproj
@@ -21,6 +21,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
+        <PackageReference Include="Verify.Xunit" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
@@ -29,9 +30,16 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- One scrubber set for every snapshot suite (#571) — linked, never copy-pasted, exactly like
+             the NaughtyStrings theory sources (#569). -->
+        <Compile Include="..\Shared\VerifyModuleInitializer.cs" Link="Shared\VerifyModuleInitializer.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Using Include="Xunit" />
         <Using Include="Shouldly" />
         <Using Include="Bunit" />
+        <Using Include="VerifyXunit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.Render_AnonymousWithProgress_MatchesTheLandingPageMarkup.verified.html
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.Render_AnonymousWithProgress_MatchesTheLandingPageMarkup.verified.html
@@ -1,0 +1,70 @@
+﻿
+
+
+
+<section class="hero home-hero"><div class="container"><p class="eyebrow">Polskie tłumaczenie LOTRO</p>
+        <h1>The Lord of the Rings Online — <span class="hero-accent">po polsku</span></h1>
+        <p class="lede">
+            Społecznościowy projekt spolszczenia The Lord of the Rings Online: teksty prosto z plików
+            gry, tłumaczenie w przeglądarce z obiegiem zatwierdzania i gotowe spolszczenie do pobrania
+            dla każdego gracza.
+        </p>
+        <div class="hero-actions"><a class="btn btn-primary" href="/translations">Przeglądaj tłumaczenia</a>
+            <a class="btn btn-ghost" href="#dla-graczy">Pobierz spolszczenie</a>
+            <a class="btn btn-ghost" href="/auth/login">
+                        Dołącz jako tłumacz
+                    </a></div></div></section>
+
+<section class="container content-wrap"><section class="panel" id="postep"><header class="panel-head"><h2>Postęp tłumaczenia</h2><span class="panel-aside">Aktualne dla wersji 48.1</span></header>
+        <div class="panel-body"><div class="progress-hero"><span class="progress-hero-num">39%</span>
+                    <span class="progress-hero-lbl">tekstów gry ma zatwierdzone polskie tłumaczenie</span></div><div class="progress progress-duo" role="progressbar" aria-valuenow="39" aria-valuemin="0" aria-valuemax="100" aria-label="Zatwierdzone tłumaczenia"><div class="progress-bar" style="width: 39%;"></div>
+                    <div class="progress-bar progress-bar-awaiting" style="width: 35%;"></div></div><p class="progress-caption progress-legend"><span class="legend-chip"><span class="dot dot-approved" aria-hidden="true"></span>
+                        Zatwierdzone: <strong>4 800</strong></span>
+                    <span class="legend-chip"><span class="dot dot-awaiting" aria-hidden="true"></span>
+                        Czeka na zatwierdzenie: <strong>4 350</strong></span></p><section class="stats-grid"><article class="stat-tile"><span class="num ">12 400</span>
+                        <span class="lbl">Teksty w grze</span></article>
+                    <article class="stat-tile"><span class="num ">9 150</span>
+                        <span class="lbl">Przetłumaczone</span></article>
+                    <article class="stat-tile"><span class="num ok">4 800</span>
+                        <span class="lbl">Zatwierdzone</span></article></section></div></section>
+
+    <div class="home-duo"><section class="panel" id="dla-graczy"><header class="panel-head"><h2>Dla graczy</h2>
+                <span class="panel-aside">Spolszczenie</span></header>
+            <div class="panel-body"><ol class="steps"><li><strong>Pobierz patcher</strong> — narzędzie z GitHuba, które wgrywa polskie
+                        teksty prosto do plików gry.
+                    </li>
+                    <li><strong>Pobierz plik spolszczenia</strong> — aktualny
+                        <code class="mono">polish.txt</code> ze wszystkimi zatwierdzonymi tłumaczeniami.
+                    </li>
+                    <li><strong>Nałóż łatkę i graj</strong> — patcher podmienia teksty i uruchamia grę;
+                        spolszczenie przeżywa aktualizacje LOTRO.
+                    </li></ol>
+                <div class="editor-actions"><a class="btn btn-primary" href="/download/polish.txt" download="polish.txt">
+                        Pobierz polish.txt</a>
+                    <a class="btn btn-ghost" href="https://github.com/koniecdev/LotroKoniecDev" rel="noopener">Patcher na GitHubie</a></div>
+                <p class="risk-note">
+                    Spolszczenie modyfikuje pliki gry — formalnie regulamin LOTRO nie przewiduje
+                    takich modyfikacji, choć przez ponad dekadę działania analogicznych projektów
+                    (rosyjskiego i hiszpańskiego) nie odnotowano za nie banów. Korzystasz na własną
+                    odpowiedzialność. Szczegóły w <a href="/regulamin">regulaminie</a>.
+                </p></div></section>
+
+        <section class="panel" id="dla-tlumaczy"><header class="panel-head"><h2>Dla tłumaczy</h2>
+                <span class="panel-aside">Dołącz</span></header>
+            <div class="panel-body"><ol class="steps"><li><strong>Przeglądaj teksty</strong> — pełna lista z wyszukiwarką i filtrami,
+                        dostępna bez logowania.
+                    </li>
+                    <li><strong>Tłumacz w przeglądarce</strong> — edytor obok oryginału pilnuje
+                        placeholderów, niczego nie zepsujesz.
+                    </li>
+                    <li><strong>Zatwierdzone trafia do gry</strong> — po akceptacji tłumaczenie ląduje
+                        w pliku spolszczenia dla wszystkich graczy.
+                    </li></ol>
+                <div class="editor-actions"><a class="btn btn-primary" href="/auth/login">
+                                Zaloguj się lub załóż konto
+                            </a>
+                    <a class="btn btn-ghost" href="/translations">Zobacz listę tekstów</a></div></div></section></div>
+
+    <section class="home-tech"><p>
+            Projekt open source — .NET 10 · Blazor SSR · PostgreSQL.
+            Kod, patcher i historia zmian: <a href="https://github.com/koniecdev/LotroKoniecDev" rel="noopener">github.com/koniecdev/LotroKoniecDev</a></p></section></section>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.Render_WhenAuthenticated_MatchesTheSignedInLandingPageMarkup.verified.html
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.Render_WhenAuthenticated_MatchesTheSignedInLandingPageMarkup.verified.html
@@ -1,0 +1,66 @@
+﻿
+
+
+
+<section class="hero home-hero"><div class="container"><p class="eyebrow">Polskie tłumaczenie LOTRO</p>
+        <h1>The Lord of the Rings Online — <span class="hero-accent">po polsku</span></h1>
+        <p class="lede">
+            Społecznościowy projekt spolszczenia The Lord of the Rings Online: teksty prosto z plików
+            gry, tłumaczenie w przeglądarce z obiegiem zatwierdzania i gotowe spolszczenie do pobrania
+            dla każdego gracza.
+        </p>
+        <div class="hero-actions"><a class="btn btn-primary" href="/translations">Przeglądaj tłumaczenia</a>
+            <a class="btn btn-ghost" href="#dla-graczy">Pobierz spolszczenie</a>
+            <a class="btn btn-ghost" href="/dashboard">Przejdź do panelu</a></div></div></section>
+
+<section class="container content-wrap"><section class="panel" id="postep"><header class="panel-head"><h2>Postęp tłumaczenia</h2><span class="panel-aside">Aktualne dla wersji 48.1</span></header>
+        <div class="panel-body"><div class="progress-hero"><span class="progress-hero-num">39%</span>
+                    <span class="progress-hero-lbl">tekstów gry ma zatwierdzone polskie tłumaczenie</span></div><div class="progress progress-duo" role="progressbar" aria-valuenow="39" aria-valuemin="0" aria-valuemax="100" aria-label="Zatwierdzone tłumaczenia"><div class="progress-bar" style="width: 39%;"></div>
+                    <div class="progress-bar progress-bar-awaiting" style="width: 35%;"></div></div><p class="progress-caption progress-legend"><span class="legend-chip"><span class="dot dot-approved" aria-hidden="true"></span>
+                        Zatwierdzone: <strong>4 800</strong></span>
+                    <span class="legend-chip"><span class="dot dot-awaiting" aria-hidden="true"></span>
+                        Czeka na zatwierdzenie: <strong>4 350</strong></span></p><section class="stats-grid"><article class="stat-tile"><span class="num ">12 400</span>
+                        <span class="lbl">Teksty w grze</span></article>
+                    <article class="stat-tile"><span class="num ">9 150</span>
+                        <span class="lbl">Przetłumaczone</span></article>
+                    <article class="stat-tile"><span class="num ok">4 800</span>
+                        <span class="lbl">Zatwierdzone</span></article></section></div></section>
+
+    <div class="home-duo"><section class="panel" id="dla-graczy"><header class="panel-head"><h2>Dla graczy</h2>
+                <span class="panel-aside">Spolszczenie</span></header>
+            <div class="panel-body"><ol class="steps"><li><strong>Pobierz patcher</strong> — narzędzie z GitHuba, które wgrywa polskie
+                        teksty prosto do plików gry.
+                    </li>
+                    <li><strong>Pobierz plik spolszczenia</strong> — aktualny
+                        <code class="mono">polish.txt</code> ze wszystkimi zatwierdzonymi tłumaczeniami.
+                    </li>
+                    <li><strong>Nałóż łatkę i graj</strong> — patcher podmienia teksty i uruchamia grę;
+                        spolszczenie przeżywa aktualizacje LOTRO.
+                    </li></ol>
+                <div class="editor-actions"><a class="btn btn-primary" href="/download/polish.txt" download="polish.txt">
+                        Pobierz polish.txt</a>
+                    <a class="btn btn-ghost" href="https://github.com/koniecdev/LotroKoniecDev" rel="noopener">Patcher na GitHubie</a></div>
+                <p class="risk-note">
+                    Spolszczenie modyfikuje pliki gry — formalnie regulamin LOTRO nie przewiduje
+                    takich modyfikacji, choć przez ponad dekadę działania analogicznych projektów
+                    (rosyjskiego i hiszpańskiego) nie odnotowano za nie banów. Korzystasz na własną
+                    odpowiedzialność. Szczegóły w <a href="/regulamin">regulaminie</a>.
+                </p></div></section>
+
+        <section class="panel" id="dla-tlumaczy"><header class="panel-head"><h2>Dla tłumaczy</h2>
+                <span class="panel-aside">Dołącz</span></header>
+            <div class="panel-body"><ol class="steps"><li><strong>Przeglądaj teksty</strong> — pełna lista z wyszukiwarką i filtrami,
+                        dostępna bez logowania.
+                    </li>
+                    <li><strong>Tłumacz w przeglądarce</strong> — edytor obok oryginału pilnuje
+                        placeholderów, niczego nie zepsujesz.
+                    </li>
+                    <li><strong>Zatwierdzone trafia do gry</strong> — po akceptacji tłumaczenie ląduje
+                        w pliku spolszczenia dla wszystkich graczy.
+                    </li></ol>
+                <div class="editor-actions"><a class="btn btn-primary" href="/dashboard">Otwórz panel tłumacza</a>
+                    <a class="btn btn-ghost" href="/translations">Zobacz listę tekstów</a></div></div></section></div>
+
+    <section class="home-tech"><p>
+            Projekt open source — .NET 10 · Blazor SSR · PostgreSQL.
+            Kod, patcher i historia zmian: <a href="https://github.com/koniecdev/LotroKoniecDev" rel="noopener">github.com/koniecdev/LotroKoniecDev</a></p></section></section>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.Render_WhenProgressUnavailable_MatchesTheDegradedLandingPageMarkup.verified.html
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.Render_WhenProgressUnavailable_MatchesTheDegradedLandingPageMarkup.verified.html
@@ -1,0 +1,61 @@
+﻿
+
+
+
+<section class="hero home-hero"><div class="container"><p class="eyebrow">Polskie tłumaczenie LOTRO</p>
+        <h1>The Lord of the Rings Online — <span class="hero-accent">po polsku</span></h1>
+        <p class="lede">
+            Społecznościowy projekt spolszczenia The Lord of the Rings Online: teksty prosto z plików
+            gry, tłumaczenie w przeglądarce z obiegiem zatwierdzania i gotowe spolszczenie do pobrania
+            dla każdego gracza.
+        </p>
+        <div class="hero-actions"><a class="btn btn-primary" href="/translations">Przeglądaj tłumaczenia</a>
+            <a class="btn btn-ghost" href="#dla-graczy">Pobierz spolszczenie</a>
+            <a class="btn btn-ghost" href="/auth/login">
+                        Dołącz jako tłumacz
+                    </a></div></div></section>
+
+<section class="container content-wrap"><section class="panel" id="postep"><header class="panel-head"><h2>Postęp tłumaczenia</h2><span class="panel-aside">Na żywo</span></header>
+        <div class="panel-body"><p class="status-line status-warning" role="status"><span class="dot"></span> Statystyki są chwilowo niedostępne — odśwież stronę za chwilę.
+                </p></div></section>
+
+    <div class="home-duo"><section class="panel" id="dla-graczy"><header class="panel-head"><h2>Dla graczy</h2>
+                <span class="panel-aside">Spolszczenie</span></header>
+            <div class="panel-body"><ol class="steps"><li><strong>Pobierz patcher</strong> — narzędzie z GitHuba, które wgrywa polskie
+                        teksty prosto do plików gry.
+                    </li>
+                    <li><strong>Pobierz plik spolszczenia</strong> — aktualny
+                        <code class="mono">polish.txt</code> ze wszystkimi zatwierdzonymi tłumaczeniami.
+                    </li>
+                    <li><strong>Nałóż łatkę i graj</strong> — patcher podmienia teksty i uruchamia grę;
+                        spolszczenie przeżywa aktualizacje LOTRO.
+                    </li></ol>
+                <div class="editor-actions"><a class="btn btn-primary" href="/download/polish.txt" download="polish.txt">
+                        Pobierz polish.txt</a>
+                    <a class="btn btn-ghost" href="https://github.com/koniecdev/LotroKoniecDev" rel="noopener">Patcher na GitHubie</a></div>
+                <p class="risk-note">
+                    Spolszczenie modyfikuje pliki gry — formalnie regulamin LOTRO nie przewiduje
+                    takich modyfikacji, choć przez ponad dekadę działania analogicznych projektów
+                    (rosyjskiego i hiszpańskiego) nie odnotowano za nie banów. Korzystasz na własną
+                    odpowiedzialność. Szczegóły w <a href="/regulamin">regulaminie</a>.
+                </p></div></section>
+
+        <section class="panel" id="dla-tlumaczy"><header class="panel-head"><h2>Dla tłumaczy</h2>
+                <span class="panel-aside">Dołącz</span></header>
+            <div class="panel-body"><ol class="steps"><li><strong>Przeglądaj teksty</strong> — pełna lista z wyszukiwarką i filtrami,
+                        dostępna bez logowania.
+                    </li>
+                    <li><strong>Tłumacz w przeglądarce</strong> — edytor obok oryginału pilnuje
+                        placeholderów, niczego nie zepsujesz.
+                    </li>
+                    <li><strong>Zatwierdzone trafia do gry</strong> — po akceptacji tłumaczenie ląduje
+                        w pliku spolszczenia dla wszystkich graczy.
+                    </li></ol>
+                <div class="editor-actions"><a class="btn btn-primary" href="/auth/login">
+                                Zaloguj się lub załóż konto
+                            </a>
+                    <a class="btn btn-ghost" href="/translations">Zobacz listę tekstów</a></div></div></section></div>
+
+    <section class="home-tech"><p>
+            Projekt open source — .NET 10 · Blazor SSR · PostgreSQL.
+            Kod, patcher i historia zmian: <a href="https://github.com/koniecdev/LotroKoniecDev" rel="noopener">github.com/koniecdev/LotroKoniecDev</a></p></section></section>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.Render_WithEmptyCatalog_MatchesTheZeroStateMarkup.verified.html
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.Render_WithEmptyCatalog_MatchesTheZeroStateMarkup.verified.html
@@ -1,0 +1,70 @@
+﻿
+
+
+
+<section class="hero home-hero"><div class="container"><p class="eyebrow">Polskie tłumaczenie LOTRO</p>
+        <h1>The Lord of the Rings Online — <span class="hero-accent">po polsku</span></h1>
+        <p class="lede">
+            Społecznościowy projekt spolszczenia The Lord of the Rings Online: teksty prosto z plików
+            gry, tłumaczenie w przeglądarce z obiegiem zatwierdzania i gotowe spolszczenie do pobrania
+            dla każdego gracza.
+        </p>
+        <div class="hero-actions"><a class="btn btn-primary" href="/translations">Przeglądaj tłumaczenia</a>
+            <a class="btn btn-ghost" href="#dla-graczy">Pobierz spolszczenie</a>
+            <a class="btn btn-ghost" href="/auth/login">
+                        Dołącz jako tłumacz
+                    </a></div></div></section>
+
+<section class="container content-wrap"><section class="panel" id="postep"><header class="panel-head"><h2>Postęp tłumaczenia</h2><span class="panel-aside">Na żywo</span></header>
+        <div class="panel-body"><div class="progress-hero"><span class="progress-hero-num">0%</span>
+                    <span class="progress-hero-lbl">tekstów gry ma zatwierdzone polskie tłumaczenie</span></div><div class="progress progress-duo" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="Zatwierdzone tłumaczenia"><div class="progress-bar" style="width: 0%;"></div>
+                    <div class="progress-bar progress-bar-awaiting" style="width: 0%;"></div></div><p class="progress-caption progress-legend"><span class="legend-chip"><span class="dot dot-approved" aria-hidden="true"></span>
+                        Zatwierdzone: <strong>0</strong></span>
+                    <span class="legend-chip"><span class="dot dot-awaiting" aria-hidden="true"></span>
+                        Czeka na zatwierdzenie: <strong>0</strong></span></p><section class="stats-grid"><article class="stat-tile"><span class="num zero">0</span>
+                        <span class="lbl">Teksty w grze</span></article>
+                    <article class="stat-tile"><span class="num zero">0</span>
+                        <span class="lbl">Przetłumaczone</span></article>
+                    <article class="stat-tile"><span class="num zero">0</span>
+                        <span class="lbl">Zatwierdzone</span></article></section></div></section>
+
+    <div class="home-duo"><section class="panel" id="dla-graczy"><header class="panel-head"><h2>Dla graczy</h2>
+                <span class="panel-aside">Spolszczenie</span></header>
+            <div class="panel-body"><ol class="steps"><li><strong>Pobierz patcher</strong> — narzędzie z GitHuba, które wgrywa polskie
+                        teksty prosto do plików gry.
+                    </li>
+                    <li><strong>Pobierz plik spolszczenia</strong> — aktualny
+                        <code class="mono">polish.txt</code> ze wszystkimi zatwierdzonymi tłumaczeniami.
+                    </li>
+                    <li><strong>Nałóż łatkę i graj</strong> — patcher podmienia teksty i uruchamia grę;
+                        spolszczenie przeżywa aktualizacje LOTRO.
+                    </li></ol>
+                <div class="editor-actions"><a class="btn btn-primary" href="/download/polish.txt" download="polish.txt">
+                        Pobierz polish.txt</a>
+                    <a class="btn btn-ghost" href="https://github.com/koniecdev/LotroKoniecDev" rel="noopener">Patcher na GitHubie</a></div>
+                <p class="risk-note">
+                    Spolszczenie modyfikuje pliki gry — formalnie regulamin LOTRO nie przewiduje
+                    takich modyfikacji, choć przez ponad dekadę działania analogicznych projektów
+                    (rosyjskiego i hiszpańskiego) nie odnotowano za nie banów. Korzystasz na własną
+                    odpowiedzialność. Szczegóły w <a href="/regulamin">regulaminie</a>.
+                </p></div></section>
+
+        <section class="panel" id="dla-tlumaczy"><header class="panel-head"><h2>Dla tłumaczy</h2>
+                <span class="panel-aside">Dołącz</span></header>
+            <div class="panel-body"><ol class="steps"><li><strong>Przeglądaj teksty</strong> — pełna lista z wyszukiwarką i filtrami,
+                        dostępna bez logowania.
+                    </li>
+                    <li><strong>Tłumacz w przeglądarce</strong> — edytor obok oryginału pilnuje
+                        placeholderów, niczego nie zepsujesz.
+                    </li>
+                    <li><strong>Zatwierdzone trafia do gry</strong> — po akceptacji tłumaczenie ląduje
+                        w pliku spolszczenia dla wszystkich graczy.
+                    </li></ol>
+                <div class="editor-actions"><a class="btn btn-primary" href="/auth/login">
+                                Zaloguj się lub załóż konto
+                            </a>
+                    <a class="btn btn-ghost" href="/translations">Zobacz listę tekstów</a></div></div></section></div>
+
+    <section class="home-tech"><p>
+            Projekt open source — .NET 10 · Blazor SSR · PostgreSQL.
+            Kod, patcher i historia zmian: <a href="https://github.com/koniecdev/LotroKoniecDev" rel="noopener">github.com/koniecdev/LotroKoniecDev</a></p></section></section>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.cs
@@ -1,0 +1,114 @@
+using Bunit.Rendering;
+using Bunit.TestDoubles;
+using LotroKoniecDev.Frontend.Components.Pages.Home;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Progress;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using HomeComponent = LotroKoniecDev.Frontend.Components.Pages.Home.Home;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Snapshots;
+
+/// <summary>
+/// Pins the rendered markup of the landing page (#571). <c>HomeTests</c> asserts the handful of
+/// selectors each behavior is about; the snapshot covers everything between them — the section order,
+/// the CTA set, the meter segments, the download affordance — so an unintended markup regression on
+/// the public face of the project fails loudly instead of shipping.
+/// </summary>
+/// <remarks>
+/// The counters are deliberately five-figure: <c>HomeProgressView.Format</c> renders them through a
+/// fixed <c>NumberFormatInfo</c> whose NBSP group separator only appears above 999, and that separator
+/// exists precisely so the rendering never becomes culture-dependent — a snapshot seeded with small
+/// numbers would never see it. The zero-catalog state gets its own snapshot for the same reason: it is
+/// the branch that swaps the counter classes and collapses the meter.
+/// <para>
+/// The page is Static SSR, so its markup is a pure function of the stubbed progress result and the
+/// authentication state; nothing here depends on a clock, an ambient culture or a build fingerprint.
+/// Re-accepting a verified file is a deliberate, reviewed act — read the diff before you do it.
+/// </para>
+/// </remarks>
+public sealed class HomeMarkupSnapshotTests : BunitContext
+{
+    private readonly ITranslationSystemClient _client = Substitute.For<ITranslationSystemClient>();
+
+    public HomeMarkupSnapshotTests()
+    {
+        Services.AddSingleton(_client);
+        Services.AddScoped<HomeProgressLoader>();
+    }
+
+    [Fact]
+    public async Task Render_AnonymousWithProgress_MatchesTheLandingPageMarkup()
+    {
+        AddAuthorization().SetNotAuthorized();
+        StubProgress(ApiResult.Success(new PublicProgressResponse(
+            Total: 12_400, Translated: 9_150, Approved: 4_800, CurrentGameVersion: "48.1")));
+
+        IRenderedComponent<HomeComponent> component = RenderHome();
+
+        await Verifier.Verify(component.Markup, "html");
+    }
+
+    [Fact]
+    public async Task Render_WhenProgressUnavailable_MatchesTheDegradedLandingPageMarkup()
+    {
+        // The outage fallback is the state nobody looks at in a browser, so it is exactly the one a
+        // markup regression would reach production in.
+        AddAuthorization().SetNotAuthorized();
+        StubProgress(ApiResult.Failure<PublicProgressResponse>(
+            new ProblemDetails { Title = "API nieosiągalne", Status = 503 }));
+
+        IRenderedComponent<HomeComponent> component = RenderHome();
+
+        await Verifier.Verify(component.Markup, "html");
+    }
+
+    [Fact]
+    public async Task Render_WithEmptyCatalog_MatchesTheZeroStateMarkup()
+    {
+        // Before the first import every counter is zero: the tiles take their "zero" class and the
+        // meter has to collapse without dividing by zero.
+        AddAuthorization().SetNotAuthorized();
+        StubProgress(ApiResult.Success(new PublicProgressResponse(
+            Total: 0, Translated: 0, Approved: 0, CurrentGameVersion: null)));
+
+        IRenderedComponent<HomeComponent> component = RenderHome();
+
+        await Verifier.Verify(component.Markup, "html");
+    }
+
+    [Fact]
+    public async Task Render_WhenAuthenticated_MatchesTheSignedInLandingPageMarkup()
+    {
+        AddAuthorization().SetAuthorized("Frodo");
+        StubProgress(ApiResult.Success(new PublicProgressResponse(
+            Total: 12_400, Translated: 9_150, Approved: 4_800, CurrentGameVersion: "48.1")));
+
+        IRenderedComponent<HomeComponent> component = RenderHome();
+
+        await Verifier.Verify(component.Markup, "html");
+    }
+
+    private void StubProgress(ApiResult<PublicProgressResponse> result) =>
+        _client
+            .GetApiResultAsync<PublicProgressResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+    /// <summary>
+    /// Hosts the page inside a render fragment and resolves it via <c>FindComponent</c> — the page's
+    /// <c>AuthorizeView</c> resolves asynchronously, which the typed <c>Render&lt;Home&gt;</c>
+    /// discovery does not see on its first synchronous pass (same seam as <c>HomeTests</c>).
+    /// </summary>
+    private IRenderedComponent<HomeComponent> RenderHome()
+    {
+        IRenderedComponent<ContainerFragment> fragment = Render(builder =>
+        {
+            builder.OpenComponent<HomeComponent>(0);
+            builder.CloseComponent();
+        });
+
+        return fragment.FindComponent<HomeComponent>();
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/TermsMarkupSnapshotTests.Render_MatchesTheTermsOfServiceMarkup.verified.html
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/TermsMarkupSnapshotTests.Render_MatchesTheTermsOfServiceMarkup.verified.html
@@ -1,0 +1,209 @@
+﻿
+
+
+
+<section class="container page-head"><div><p class="eyebrow">Dokument prawny</p>
+        <h1>Regulamin serwisu</h1>
+        <p class="lede">
+            Zasady korzystania z platformy lotro-translator.pl.
+            Ostatnia aktualizacja: <span class="mono">12 lipca 2026 r.</span></p></div></section>
+
+<section class="container content-wrap"><div class="legal-grid"><article class="panel legal-doc"><div class="panel-body"><p class="legal-lede">
+                    Niniejszy regulamin określa zasady korzystania z serwisu lotro-translator.pl —
+                    społecznościowej, niekomercyjnej platformy polskiego tłumaczenia gry
+                    The Lord of the Rings Online. Rejestrując konto, akceptujesz postanowienia
+                    regulaminu, w tym licencję na wkład tłumaczeniowy opisaną w §&nbsp;5.
+                </p>
+
+                <section class="legal-sec" id="postanowienia-ogolne"><h2>§ 1. Postanowienia ogólne</h2>
+                    <ol><li>
+                            Operatorem serwisu lotro-translator.pl (dalej: <strong>Serwis</strong>) jest
+                            <strong>Artur Koniec</strong>, prowadzący niekomercyjny projekt lotro-translator.pl
+                            (dalej: <strong>Operator</strong>) — fanowski projekt polskiego tłumaczenia gry
+                            The Lord of the Rings Online.
+                            Kontakt z Operatorem: <a href="mailto:koniecdev@gmail.com">koniecdev@gmail.com</a>.
+                        </li>
+                        <li>
+                            Gra The Lord of the Rings Online, jej treści, znaki towarowe i pozostała własność
+                            intelektualna należą do Standing Stone Games LLC oraz Middle-earth Enterprises.
+                            <strong>Serwis nie jest powiązany ze Standing Stone Games, Middle-earth Enterprises
+                            ani żadnym oficjalnym podmiotem związanym z grą, nie jest przez nie wspierany ani
+                            autoryzowany.</strong></li>
+                        <li>
+                            Serwis działa niekomercyjnie: korzystanie z niego jest bezpłatne, a Operator nie
+                            czerpie przychodów z tłumaczenia ani z jego dystrybucji.
+                        </li>
+                        <li>
+                            Korzystanie z Serwisu — w tym założenie konta i wnoszenie wkładu tłumaczeniowego —
+                            oznacza akceptację niniejszego regulaminu.
+                        </li></ol></section>
+
+                <section class="legal-sec" id="definicje"><h2>§ 2. Definicje</h2>
+                    <ol><li><strong>Gra</strong> — The Lord of the Rings Online.</li>
+                        <li><strong>Użytkownik</strong> — każda osoba korzystająca z Serwisu.</li>
+                        <li><strong>Tłumacz</strong> — Użytkownik posiadający konto w Serwisie, wnoszący wkład
+                            tłumaczeniowy.
+                        </li>
+                        <li><strong>Wkład tłumaczeniowy</strong> — teksty tłumaczeń, ich poprawki i inne treści
+                            wprowadzone przez Tłumacza do Serwisu.
+                        </li>
+                        <li><strong>Plik spolszczenia</strong> — generowany przez Serwis plik z tłumaczeniami
+                            (<span class="mono">polish.txt</span>), udostępniany graczom do pobrania i do
+                            automatycznego pobierania przez narzędzia instalujące spolszczenie.
+                        </li></ol></section>
+
+                <section class="legal-sec" id="zasady-korzystania"><h2>§ 3. Zasady korzystania z Serwisu</h2>
+                    <ol><li>
+                            Serwis służy do wspólnego tłumaczenia tekstów Gry na język polski: przeglądania
+                            tekstów, proponowania tłumaczeń, ich weryfikacji i zatwierdzania oraz pobierania
+                            pliku spolszczenia.
+                        </li>
+                        <li>
+                            Niedozwolone jest: wprowadzanie treści bezprawnych, obraźliwych lub naruszających
+                            prawa osób trzecich (w tym treści skopiowanych z cudzych tłumaczeń bez uprawnienia),
+                            celowe wprowadzanie tłumaczeń błędnych lub szkodliwych, zautomatyzowane masowe
+                            pobieranie treści Serwisu poza udostępnionym plikiem spolszczenia, a także działania
+                            zakłócające pracę Serwisu lub próby nieuprawnionego dostępu.
+                        </li>
+                        <li>
+                            Obieg redakcyjny (w tym zatwierdzanie tłumaczeń, ich edycja i unieważnianie po
+                            aktualizacjach Gry) pozostaje w gestii Operatora i osób pełniących role redakcyjne.
+                            Wniesienie wkładu nie gwarantuje jego publikacji w pliku spolszczenia.
+                        </li>
+                        <li>
+                            Operator może ograniczyć lub zablokować konto naruszające regulamin; o ile to możliwe,
+                            wcześniej wezwie Użytkownika do zaprzestania naruszeń.
+                        </li></ol></section>
+
+                <section class="legal-sec" id="konta"><h2>§ 4. Konta</h2>
+                    <ol><li>
+                            Założenie konta wymaga podania nazwy użytkownika, adresu e-mail i hasła oraz
+                            potwierdzenia adresu e-mail. Konto jest osobiste — nie udostępniaj danych logowania
+                            innym osobom.
+                        </li>
+                        <li>
+                            Konto można usunąć samodzielnie w sekcji „Moje konto”. Usunięcie następuje po
+                            14-dniowym okresie ochronnym, w którym można je anulować linkiem otrzymanym
+                            e-mailem; szczegóły opisuje polityka prywatności.
+                        </li>
+                        <li>
+                            Po usunięciu konta dane osobowe są nieodwracalnie anonimizowane, a wkład
+                            tłumaczeniowy pozostaje w Serwisie w formie zanonimizowanej — na zasadach licencji
+                            z §&nbsp;5.
+                        </li></ol></section>
+
+                <section class="legal-sec" id="licencja"><h2>§ 5. Licencja na wkład tłumaczeniowy</h2>
+                    <ol><li>
+                            Tłumacz oświadcza, że wkład tłumaczeniowy jest wynikiem jego własnej pracy i nie
+                            narusza praw osób trzecich.
+                        </li>
+                        <li>
+                            Z chwilą wprowadzenia wkładu tłumaczeniowego do Serwisu Tłumacz udziela Operatorowi
+                            <strong>niewyłącznej, nieodpłatnej, nieograniczonej czasowo i terytorialnie oraz
+                            nieodwołalnej</strong> licencji na korzystanie z tego wkładu w zakresie:
+                            <ul><li>utrwalania i przechowywania w infrastrukturze Serwisu,</li>
+                                <li>
+                                    opracowania — redakcji, korekty, modyfikacji i łączenia z wkładem innych
+                                    Tłumaczy w ramach obiegu weryfikacji,
+                                </li>
+                                <li>
+                                    włączania do pliku spolszczenia (<span class="mono">polish.txt</span>) i jego
+                                    rozpowszechniania, w tym publicznego udostępniania przez API Serwisu oraz
+                                    narzędzia instalujące spolszczenie,
+                                </li>
+                                <li>
+                                    udzielania dalszych licencji (sublicencji) graczom — w zakresie niezbędnym do
+                                    pobrania spolszczenia i korzystania z niego w Grze.
+                                </li></ul></li>
+                        <li><strong>Licencja pozostaje w mocy po usunięciu konta.</strong> Wkład tłumaczeniowy
+                            pozostaje wówczas w Serwisie i w pliku spolszczenia w formie zanonimizowanej —
+                            bez możliwości powiązania go z osobą Tłumacza.
+                        </li>
+                        <li>
+                            Tłumaczenie jest dziełem zbiorowym społeczności i jest rozpowszechniane bez
+                            oznaczania autorstwa poszczególnych fragmentów. Tłumacz zobowiązuje się nie
+                            wykonywać wobec Operatora i graczy autorskiego prawa osobistego do oznaczania
+                            wkładu swoim autorstwem oraz upoważnia Operatora do udostępniania wkładu
+                            anonimowo.
+                        </li>
+                        <li>
+                            Licencja jest nieodpłatna — Tłumaczowi nie przysługuje wynagrodzenie za korzystanie
+                            z wkładu przez Operatora ani graczy.
+                        </li></ol></section>
+
+                <section class="legal-sec" id="dane-osobowe"><h2>§ 6. Dane osobowe</h2>
+                    <p>
+                        Zasady przetwarzania danych osobowych — w tym prawa Użytkownika, okresy retencji oraz
+                        przebieg usuwania konta — opisuje odrębna
+                        <a href="https://localhost:5003/Account/PrivacyPolicy" target="_blank" rel="noopener">polityka prywatności</a>.
+                        W razie rozbieżności w sprawach danych osobowych pierwszeństwo ma polityka prywatności.
+                    </p></section>
+
+                <section class="legal-sec" id="odpowiedzialnosc"><h2>§ 7. Odpowiedzialność, reklamacje i kontakt</h2>
+                    <ol><li>
+                            Serwis i plik spolszczenia są udostępniane bezpłatnie, w stanie „tak jak są”
+                            (as&nbsp;is). Operator dokłada starań, aby Serwis działał poprawnie, ale nie
+                            gwarantuje nieprzerwanej dostępności ani wolności tłumaczenia od błędów i nie
+                            odpowiada za skutki użycia spolszczenia w Grze.
+                        </li>
+                        <li>
+                            Korzystanie ze spolszczenia odbywa się na własną odpowiedzialność Użytkownika,
+                            z poszanowaniem regulaminu Gry.
+                        </li>
+                        <li>
+                            Reklamacje i zgłoszenia dotyczące działania Serwisu kieruj na adres
+                            <a href="mailto:koniecdev@gmail.com">koniecdev@gmail.com</a>. Odpowiadamy bez
+                            zbędnej zwłoki, najpóźniej w terminie 14 dni.
+                        </li>
+                        <li>
+                            Postanowienia regulaminu nie wyłączają ani nie ograniczają praw, które przysługują
+                            konsumentom na mocy bezwzględnie obowiązujących przepisów prawa.
+                        </li></ol></section>
+
+                <section class="legal-sec" id="wlasnosc-intelektualna"><h2>§ 8. Własność intelektualna i zgłoszenia naruszeń</h2>
+                    <ol><li>
+                            Operator respektuje prawa własności intelektualnej Standing Stone Games
+                            oraz Middle-earth Enterprises do Gry, jej treści i znaków towarowych.
+                        </li>
+                        <li>
+                            Angielskie teksty źródłowe Gry są przetwarzane w Serwisie wyłącznie w zakresie
+                            niezbędnym do stworzenia polskiego tłumaczenia i nie wchodzą w skład pliku
+                            spolszczenia. <strong>Plik spolszczenia zawiera wyłącznie polskie teksty
+                            stworzone przez społeczność</strong> — nigdy angielskie teksty źródłowe Gry.
+                        </li>
+                        <li>
+                            Uzasadnione żądania podmiotów uprawnionych z tytułu praw do Gry — w tym żądania
+                            usunięcia treści lub wstrzymania dystrybucji pliku spolszczenia — są realizowane
+                            niezwłocznie. Zgłoszenia naruszeń kieruj na adres
+                            <a href="mailto:koniecdev@gmail.com">koniecdev@gmail.com</a>.
+                        </li></ol></section>
+
+                <section class="legal-sec" id="postanowienia-koncowe"><h2>§ 9. Postanowienia końcowe</h2>
+                    <ol><li>
+                            Operator może zmienić regulamin z ważnych przyczyn, w szczególności przy zmianie
+                            przepisów prawa, funkcji Serwisu lub zasad dystrybucji spolszczenia. O istotnych
+                            zmianach zarejestrowani Użytkownicy zostaną powiadomieni e-mailem co najmniej
+                            <strong>14 dni</strong> przed ich wejściem w życie. Użytkownik, który nie akceptuje
+                            zmian, może w tym czasie usunąć konto.
+                        </li>
+                        <li>
+                            Aktualna treść regulaminu jest zawsze dostępna pod adresem
+                            <span class="mono">lotro-translator.pl/regulamin</span> wraz z datą ostatniej
+                            aktualizacji.
+                        </li>
+                        <li>Prawem właściwym dla regulaminu jest prawo polskie.</li>
+                        <li>
+                            Jeżeli którekolwiek postanowienie regulaminu okaże się nieważne lub bezskuteczne,
+                            pozostałe postanowienia pozostają w mocy.
+                        </li></ol></section></div></article>
+
+        <aside class="legal-side"><div class="panel"><div class="panel-head"><h2>Spis treści</h2></div>
+                <div class="panel-body"><nav class="legal-toc" aria-label="Spis treści regulaminu"><a href="#postanowienia-ogolne">§ 1. Postanowienia ogólne</a>
+                        <a href="#definicje">§ 2. Definicje</a>
+                        <a href="#zasady-korzystania">§ 3. Zasady korzystania z Serwisu</a>
+                        <a href="#konta">§ 4. Konta</a>
+                        <a href="#licencja">§ 5. Licencja na wkład tłumaczeniowy</a>
+                        <a href="#dane-osobowe">§ 6. Dane osobowe</a>
+                        <a href="#odpowiedzialnosc">§ 7. Odpowiedzialność, reklamacje i kontakt</a>
+                        <a href="#wlasnosc-intelektualna">§ 8. Własność intelektualna i zgłoszenia naruszeń</a>
+                        <a href="#postanowienia-koncowe">§ 9. Postanowienia końcowe</a></nav></div></div></aside></div></section>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/TermsMarkupSnapshotTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/TermsMarkupSnapshotTests.cs
@@ -1,0 +1,39 @@
+using LotroKoniecDev.Frontend.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using TermsComponent = LotroKoniecDev.Frontend.Components.Pages.Terms.Terms;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Snapshots;
+
+/// <summary>
+/// Pins the rendered markup of the terms-of-service page (#571). <c>TermsTests</c> asserts the load-
+/// bearing wording LEGAL-01/spec 0011 depends on; the snapshot pins the rest of the document, so a
+/// clause silently dropped, reordered or reworded — in a page nobody re-reads — shows up as a diff.
+/// </summary>
+/// <remarks>
+/// A legal text is the ideal snapshot target: it is long, entirely static, and its churn rate is
+/// meant to be near zero. Re-accepting this verified file is a deliberate act — it means the terms
+/// themselves changed.
+/// </remarks>
+public sealed class TermsMarkupSnapshotTests : BunitContext
+{
+    public TermsMarkupSnapshotTests()
+    {
+        Services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new AuthSystemSettings
+        {
+            BaseUrl = "https://localhost:5003/",
+            Authority = "https://localhost:5003",
+            ClientId = "lotrokoniecdev-web",
+            CallbackPath = "/callback",
+            SignedOutCallbackPath = "/signout-callback-oidc",
+            Scopes = ["openid", "profile", "api"]
+        }));
+    }
+
+    [Fact]
+    public async Task Render_MatchesTheTermsOfServiceMarkup()
+    {
+        IRenderedComponent<TermsComponent> component = Render<TermsComponent>();
+
+        await Verifier.Verify(component.Markup, "html");
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/LotroKoniecDev.TranslationSystem.API.Tests.Integration.csproj
@@ -18,12 +18,20 @@
         <PackageReference Include="Shouldly" />
         <PackageReference Include="Testcontainers" />
         <PackageReference Include="Testcontainers.PostgreSql"/>
+        <PackageReference Include="Verify.Xunit" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
     </ItemGroup>
 
     <ItemGroup>
+        <!-- One scrubber set for every snapshot suite (#571) — linked, never copy-pasted, exactly like
+             the NaughtyStrings theory sources (#569). -->
+        <Compile Include="..\Shared\VerifyModuleInitializer.cs" Link="Shared\VerifyModuleInitializer.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Using Include="Xunit"/>
+        <Using Include="VerifyXunit"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ApiSnapshot.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ApiSnapshot.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Headers;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using LotroKoniecDev.Hateoas.Abstractions;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Snapshots;
+
+/// <summary>
+/// The HTTP-to-snapshot seam shared by the response-contract suites (#571): issues the request with an
+/// explicit <c>Accept</c>, then re-indents the body so the verified file is reviewable line by line
+/// instead of one minified blob.
+/// </summary>
+/// <remarks>
+/// Re-indenting round-trips the payload through <see cref="JsonNode"/>, so what the snapshot pins is
+/// the <em>logical</em> contract — property names, nesting, ordering, JSON types (a quoted value stays
+/// quoted) and values. The round-trip is lossy in exactly one direction: it re-encodes with a relaxed
+/// encoder of its own, erasing how the transport encoded non-ASCII. Nothing else in the repo covers
+/// that (<c>ContentNegotiationTests</c> pins the media type and <c>Vary</c>, not the bytes), so
+/// <see cref="ShouldServeUnescapedUtf8Async"/> asserts it on the raw body and every snapshot test
+/// whose payload carries Polish calls it.
+/// </remarks>
+internal static class ApiSnapshot
+{
+    private static readonly JsonSerializerOptions IndentedJson = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    public static Task<HttpResponseMessage> GetHateoasAsync(HttpClient client, string url) =>
+        GetAsync(client, url, MediaTypes.HateoasJson);
+
+    public static async Task<HttpResponseMessage> GetAsync(HttpClient client, string url, string accept)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Get, url);
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+
+        return await client.SendAsync(request);
+    }
+
+    public static async Task<string> IndentAsync(HttpResponseMessage response)
+    {
+        string body = await response.Content.ReadAsStringAsync();
+        JsonNode node = JsonNode.Parse(body)
+                        ?? throw new InvalidOperationException($"Response body was not JSON: '{body}'.");
+        return node.ToJsonString(IndentedJson);
+    }
+
+    /// <summary>
+    /// Pins the wire encoding, which is the one thing <see cref="IndentAsync"/> normalizes away: the
+    /// response carries <em>no</em> charset parameter — JSON is UTF-8 by definition (RFC 8259 §8.1) —
+    /// and Polish goes out as literal UTF-8, never as <c>\uXXXX</c> escape sequences. Switching the
+    /// serializer to an escaping encoder would change the bytes every client parses while leaving the
+    /// snapshot byte-identical, so it needs an assertion of its own.
+    /// </summary>
+    public static async Task ShouldServeUnescapedUtf8Async(HttpResponseMessage response, string expectedLiteral)
+    {
+        response.Content.Headers.ContentType?.CharSet.ShouldBeNull();
+
+        string rawBody = await response.Content.ReadAsStringAsync();
+        rawBody.ShouldContain(expectedLiteral);
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.AdminEndpoint_AsTranslator_MatchesTheForbiddenProblemContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.AdminEndpoint_AsTranslator_MatchesTheForbiddenProblemContract.verified.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.4",
+  "title": "Forbidden",
+  "status": 403,
+  "traceId": "{TraceId}"
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.GetTranslation_WithUnknownId_MatchesTheNotFoundProblemContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.GetTranslation_WithUnknownId_MatchesTheNotFoundProblemContract.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "The translationentity with id: Guid_1 has not been found.",
+  "errorCode": "TranslationEntity.NotFound",
+  "traceId": "{TraceId}"
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.ProtectedEndpoint_WithoutToken_MatchesTheUnauthorizedProblemContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.ProtectedEndpoint_WithoutToken_MatchesTheUnauthorizedProblemContract.verified.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.2",
+  "title": "Unauthorized",
+  "status": 401,
+  "traceId": "{TraceId}"
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.RegisterGameVersion_WhenAlreadyTaken_MatchesTheDataConflictProblemContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.RegisterGameVersion_WhenAlreadyTaken_MatchesTheDataConflictProblemContract.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422",
+  "title": "Data Conflict",
+  "status": 422,
+  "detail": "The lotronotationversion value '48' is already taken.",
+  "errorCode": "GameVersionEntity.LotroNotationVersion.AlreadyTaken",
+  "traceId": "{TraceId}"
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.UpsertTranslation_WithBlankText_MatchesTheValidationProblemContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.UpsertTranslation_WithBlankText_MatchesTheValidationProblemContract.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+  "title": "Validation Error",
+  "status": 400,
+  "detail": "'Translated Text' must not be empty.",
+  "errorCode": "Translations.Validation",
+  "traceId": "{TraceId}"
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/ProblemDetailsSnapshotTests.cs
@@ -1,0 +1,123 @@
+using System.Net.Http.Headers;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Translations;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Snapshots;
+
+/// <summary>
+/// Pins the full <c>application/problem+json</c> body for every status family the error contract can
+/// produce (#571): the three domain failures <c>ErrorExtensions.ToProblemDetails</c> maps (400
+/// Validation, 404 NotFound, 422 DataConflict) plus the two auth rejections, which share the media
+/// type but carry no domain <c>errorCode</c>.
+/// </summary>
+/// <remarks>
+/// <c>ProblemDetailsContractTests</c> asserts the individual fields that carry meaning; these
+/// snapshots exist for the fields nobody thought to assert — a <c>type</c> URI silently changing, an
+/// extension appearing or disappearing, <c>detail</c> starting to leak internals (most likely on the
+/// 403, where the framework knows why the policy failed). A deliberate change re-accepts the verified
+/// file in the same PR.
+/// </remarks>
+[Collection("TranslationApi")]
+public sealed class ProblemDetailsSnapshotTests : IAsyncLifetime
+{
+    /// <summary>Fixed so the 404 request is byte-identical on every run, before scrubbing.</summary>
+    private static readonly Guid UnknownTranslationId = new("11111111-2222-3333-4444-555555555555");
+
+    private readonly TranslationSystemApiFactory _factory;
+
+    public ProblemDetailsSnapshotTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task UpsertTranslation_WithBlankText_MatchesTheValidationProblemContract()
+    {
+        using HttpClient client = TranslatorClient();
+
+        using HttpResponseMessage response = await client.PutAsJsonAsync(
+            "/api/v1/translations", new UpsertTranslationRequest(620756992, 1, "   "));
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task RegisterGameVersion_WhenAlreadyTaken_MatchesTheDataConflictProblemContract()
+    {
+        using HttpClient client = AdminClient();
+        (await client.PostAsJsonAsync("/api/v1/game-versions", new RegisterGameVersionRequest("48.0")))
+            .StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        using HttpResponseMessage response =
+            await client.PostAsJsonAsync("/api/v1/game-versions", new RegisterGameVersionRequest("48.0.0"));
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task GetTranslation_WithUnknownId_MatchesTheNotFoundProblemContract()
+    {
+        using HttpClient client = TranslatorClient();
+
+        using HttpResponseMessage response =
+            await client.GetAsync($"/api/v1/translations/{UnknownTranslationId}");
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithoutToken_MatchesTheUnauthorizedProblemContract()
+    {
+        // Authentication rejections are written by the framework, not by the domain error mapper —
+        // the snapshot is what proves the two surfaces stay indistinguishable to a client.
+        using HttpClient client = _factory.CreateClient();
+
+        using HttpResponseMessage response = await client.GetAsync("/api/v1/game-versions");
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task AdminEndpoint_AsTranslator_MatchesTheForbiddenProblemContract()
+    {
+        // The 403 body is where an authorization failure would leak the policy that rejected the
+        // caller; pinning it whole is the only way that stays visible.
+        using HttpClient client = TranslatorClient();
+
+        using HttpResponseMessage response =
+            await client.PostAsJsonAsync("/api/v1/game-versions", new RegisterGameVersionRequest("48.0"));
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+        await Verifier.Verify(body, "json");
+    }
+
+    private HttpClient TranslatorClient() => ClientForRole(AuthConstants.Roles.Translator);
+
+    private HttpClient AdminClient() => ClientForRole(AuthConstants.Roles.Admin);
+
+    private HttpClient ClientForRole(string role)
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(role));
+        return client;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.GetTranslation_AsAdmin_MatchesTheHateoasContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.GetTranslation_AsAdmin_MatchesTheHateoasContract.verified.json
@@ -1,0 +1,35 @@
+﻿{
+  "id": "Guid_1",
+  "fileId": 620756992,
+  "gossipId": 1,
+  "sourceText": "Welcome back to Middle-earth!",
+  "argsOrder": null,
+  "argsId": null,
+  "translatedText": "Witaj w Śródziemiu!",
+  "previousSourceText": "Welcome to Middle-earth!",
+  "submitter": {
+    "id": "Guid_2",
+    "displayName": "Seed Author"
+  },
+  "approver": null,
+  "status": "NeedsReview",
+  "createdAt": "{Timestamp}+00:00",
+  "updatedAt": "{Timestamp}+00:00",
+  "links": [
+    {
+      "href": "http://localhost/api/v1/translations/Guid_1",
+      "rel": "self",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations",
+      "rel": "upsert",
+      "method": "PUT"
+    },
+    {
+      "href": "http://localhost/api/v1/translations/Guid_1/approve",
+      "rel": "approve",
+      "method": "POST"
+    }
+  ]
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_Anonymously_MatchesThePublicHateoasContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_Anonymously_MatchesThePublicHateoasContract.verified.json
@@ -1,0 +1,60 @@
+﻿{
+  "items": [
+    {
+      "id": "Guid_1",
+      "fileId": 620756992,
+      "gossipId": 1,
+      "sourceText": "Welcome back to Middle-earth!",
+      "translatedText": "Witaj w Śródziemiu!",
+      "status": "NeedsReview",
+      "submitter": {
+        "id": "Guid_2",
+        "displayName": "Seed Author"
+      },
+      "updatedAt": "{Timestamp}+00:00"
+    },
+    {
+      "id": "Guid_3",
+      "fileId": 620756992,
+      "gossipId": 2,
+      "sourceText": "The road goes ever on.",
+      "translatedText": null,
+      "status": "Untranslated",
+      "submitter": null,
+      "updatedAt": "{Timestamp}+00:00"
+    },
+    {
+      "id": "Guid_4",
+      "fileId": 620756992,
+      "gossipId": 3,
+      "sourceText": "Not all those who wander are lost.",
+      "translatedText": null,
+      "status": "Untranslated",
+      "submitter": null,
+      "updatedAt": "{Timestamp}+00:00"
+    }
+  ],
+  "page": 1,
+  "pageSize": 50,
+  "totalCount": 3,
+  "totalPages": 1,
+  "hasNextPage": false,
+  "hasPreviousPage": false,
+  "links": [
+    {
+      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
+      "rel": "self",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
+      "rel": "first-page",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
+      "rel": "last-page",
+      "method": "GET"
+    }
+  ]
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_AsAdmin_MatchesTheHateoasContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_AsAdmin_MatchesTheHateoasContract.verified.json
@@ -1,0 +1,106 @@
+﻿{
+  "items": [
+    {
+      "id": "Guid_1",
+      "fileId": 620756992,
+      "gossipId": 1,
+      "sourceText": "Welcome back to Middle-earth!",
+      "translatedText": "Witaj w Śródziemiu!",
+      "status": "NeedsReview",
+      "submitter": {
+        "id": "Guid_2",
+        "displayName": "Seed Author"
+      },
+      "updatedAt": "{Timestamp}+00:00",
+      "links": [
+        {
+          "href": "http://localhost/api/v1/translations/Guid_1",
+          "rel": "self",
+          "method": "GET"
+        },
+        {
+          "href": "http://localhost/api/v1/translations",
+          "rel": "upsert",
+          "method": "PUT"
+        },
+        {
+          "href": "http://localhost/api/v1/translations/Guid_1/approve",
+          "rel": "approve",
+          "method": "POST"
+        }
+      ]
+    },
+    {
+      "id": "Guid_3",
+      "fileId": 620756992,
+      "gossipId": 2,
+      "sourceText": "The road goes ever on.",
+      "translatedText": null,
+      "status": "Untranslated",
+      "submitter": null,
+      "updatedAt": "{Timestamp}+00:00",
+      "links": [
+        {
+          "href": "http://localhost/api/v1/translations/Guid_3",
+          "rel": "self",
+          "method": "GET"
+        },
+        {
+          "href": "http://localhost/api/v1/translations",
+          "rel": "upsert",
+          "method": "PUT"
+        }
+      ]
+    },
+    {
+      "id": "Guid_4",
+      "fileId": 620756992,
+      "gossipId": 3,
+      "sourceText": "Not all those who wander are lost.",
+      "translatedText": null,
+      "status": "Untranslated",
+      "submitter": null,
+      "updatedAt": "{Timestamp}+00:00",
+      "links": [
+        {
+          "href": "http://localhost/api/v1/translations/Guid_4",
+          "rel": "self",
+          "method": "GET"
+        },
+        {
+          "href": "http://localhost/api/v1/translations",
+          "rel": "upsert",
+          "method": "PUT"
+        }
+      ]
+    }
+  ],
+  "page": 1,
+  "pageSize": 50,
+  "totalCount": 3,
+  "totalPages": 1,
+  "hasNextPage": false,
+  "hasPreviousPage": false,
+  "links": [
+    {
+      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
+      "rel": "self",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
+      "rel": "first-page",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
+      "rel": "last-page",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations/approve",
+      "rel": "bulk-approve",
+      "method": "POST"
+    }
+  ]
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_AsPlainJson_MatchesTheLinkLessContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_AsPlainJson_MatchesTheLinkLessContract.verified.json
@@ -1,0 +1,43 @@
+﻿{
+  "items": [
+    {
+      "id": "Guid_1",
+      "fileId": 620756992,
+      "gossipId": 1,
+      "sourceText": "Welcome back to Middle-earth!",
+      "translatedText": "Witaj w Śródziemiu!",
+      "status": "NeedsReview",
+      "submitter": {
+        "id": "Guid_2",
+        "displayName": "Seed Author"
+      },
+      "updatedAt": "{Timestamp}+00:00"
+    },
+    {
+      "id": "Guid_3",
+      "fileId": 620756992,
+      "gossipId": 2,
+      "sourceText": "The road goes ever on.",
+      "translatedText": null,
+      "status": "Untranslated",
+      "submitter": null,
+      "updatedAt": "{Timestamp}+00:00"
+    },
+    {
+      "id": "Guid_4",
+      "fileId": 620756992,
+      "gossipId": 3,
+      "sourceText": "Not all those who wander are lost.",
+      "translatedText": null,
+      "status": "Untranslated",
+      "submitter": null,
+      "updatedAt": "{Timestamp}+00:00"
+    }
+  ],
+  "page": 1,
+  "pageSize": 50,
+  "totalCount": 3,
+  "totalPages": 1,
+  "hasNextPage": false,
+  "hasPreviousPage": false
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_OnAMiddlePage_MatchesThePagedHateoasContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_OnAMiddlePage_MatchesThePagedHateoasContract.verified.json
@@ -1,0 +1,64 @@
+﻿{
+  "items": [
+    {
+      "id": "Guid_1",
+      "fileId": 620756992,
+      "gossipId": 2,
+      "sourceText": "The road goes ever on.",
+      "translatedText": null,
+      "status": "Untranslated",
+      "submitter": null,
+      "updatedAt": "{Timestamp}+00:00",
+      "links": [
+        {
+          "href": "http://localhost/api/v1/translations/Guid_1",
+          "rel": "self",
+          "method": "GET"
+        },
+        {
+          "href": "http://localhost/api/v1/translations",
+          "rel": "upsert",
+          "method": "PUT"
+        }
+      ]
+    }
+  ],
+  "page": 2,
+  "pageSize": 1,
+  "totalCount": 3,
+  "totalPages": 3,
+  "hasNextPage": true,
+  "hasPreviousPage": true,
+  "links": [
+    {
+      "href": "http://localhost/api/v1/translations?page=2&pageSize=1",
+      "rel": "self",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations?page=1&pageSize=1",
+      "rel": "first-page",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations?page=3&pageSize=1",
+      "rel": "last-page",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations?page=1&pageSize=1",
+      "rel": "previous-page",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations?page=3&pageSize=1",
+      "rel": "next-page",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations/approve",
+      "rel": "bulk-approve",
+      "method": "POST"
+    }
+  ]
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_WithNoMatches_MatchesTheEmptyEnvelopeContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_WithNoMatches_MatchesTheEmptyEnvelopeContract.verified.json
@@ -1,0 +1,21 @@
+﻿{
+  "items": [],
+  "page": 1,
+  "pageSize": 50,
+  "totalCount": 0,
+  "totalPages": 0,
+  "hasNextPage": false,
+  "hasPreviousPage": false,
+  "links": [
+    {
+      "href": "http://localhost/api/v1/translations?search=Balrog&page=1&pageSize=50",
+      "rel": "self",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations/approve",
+      "rel": "bulk-approve",
+      "method": "POST"
+    }
+  ]
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.cs
@@ -1,0 +1,191 @@
+using System.Net.Http.Headers;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.SharedKernel.StronglyTypedIds;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.GameVersionAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
+using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.ValueObjects;
+using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Snapshots;
+
+/// <summary>
+/// Pins the <em>whole</em> shape of the translation read endpoints (#571) — every property name, the
+/// nesting, the JSON types and the complete HATEOAS link set — where the behavioral suites assert only
+/// the handful of fields each of them is about. An accidental contract change (a renamed property, a
+/// dropped link, a nested object flattened) fails here until the verified file is re-accepted in the
+/// same PR, which makes the break visible in review instead of silent.
+/// </summary>
+/// <remarks>
+/// The seed is three rows on purpose, not one: it lets a single fixture cover the populated row, the
+/// null-heavy untranslated row, a middle page (where <c>previous-page</c> / <c>next-page</c> are the
+/// links most likely to regress unnoticed) and the empty envelope. Snapshots complement the behavioral
+/// asserts, they do not replace them — <c>TranslationAggregateHateoasTests</c> still owns the
+/// role-aware and state-aware link rules, because those are statements about behavior across many
+/// inputs, not about the shape of one payload.
+/// </remarks>
+[Collection("TranslationApi")]
+public sealed class TranslationContractSnapshotTests : IAsyncLifetime
+{
+    private const int FileId = 620756992;
+
+    /// <summary>The seeded Polish, reused by the wire-encoding assert so seed and assert cannot drift.</summary>
+    private const string SeededPolish = "Witaj w Śródziemiu!";
+    private static readonly DateTimeOffset Now = new(2026, 6, 13, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly TranslationSystemApiFactory _factory;
+    private GameVersionId _versionId;
+    private TranslatorId _translatorId;
+    private Guid _draftRowId;
+
+    public TranslationContractSnapshotTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync(
+            "TRUNCATE translation.\"Translations\", translation.\"GameVersions\", translation.\"TranslationArtifacts\", translation.\"Translators\" CASCADE;");
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create("48.0").Value, Now).Value;
+        dbContext.GameVersions.Add(gameVersion);
+        _versionId = gameVersion.Id;
+
+        Translator translator = Translator.Create(
+            IdentityId.Create(), DisplayName.Create("Seed Author").Value, email: null, Now).Value;
+        dbContext.Translators.Add(translator);
+        _translatorId = translator.Id;
+
+        // A translated draft awaiting review (carries a submitter, Polish and the superseded English)
+        // plus two untranslated rows (every nullable column empty), so one fixture covers the populated
+        // and the null-heavy shape and still has enough rows for a middle page.
+        Translation draft = Untranslated(gossipId: 1, "Welcome to Middle-earth!");
+        draft.ProvideTranslation(SeededPolish, _translatorId, Now);
+        draft.ApplySourceChange(
+            TranslationSource.Create("Welcome back to Middle-earth!", null, null).Value, _versionId, Now);
+        _draftRowId = draft.Id.Value;
+
+        dbContext.Translations.AddRange(
+            draft,
+            Untranslated(gossipId: 2, "The road goes ever on."),
+            Untranslated(gossipId: 3, "Not all those who wander are lost."));
+        await dbContext.SaveChangesAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ListTranslations_AsAdmin_MatchesTheHateoasContract()
+    {
+        using HttpClient client = AdminClient();
+
+        using HttpResponseMessage response =
+            await ApiSnapshot.GetHateoasAsync(client, "/api/v1/translations?page=1&pageSize=50");
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe(MediaTypes.HateoasJson);
+        await ApiSnapshot.ShouldServeUnescapedUtf8Async(response, SeededPolish);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task ListTranslations_Anonymously_MatchesThePublicHateoasContract()
+    {
+        // The public read-only list (#309) is a different payload, not the same one minus a field:
+        // items lose every action link while the envelope keeps its pagination navigation.
+        using HttpClient client = _factory.CreateClient();
+
+        using HttpResponseMessage response =
+            await ApiSnapshot.GetHateoasAsync(client, "/api/v1/translations?page=1&pageSize=50");
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task ListTranslations_OnAMiddlePage_MatchesThePagedHateoasContract()
+    {
+        // One row per page puts page 2 in the middle, which is the only shape where the envelope
+        // carries previous-page AND next-page and both boolean flags are true.
+        using HttpClient client = AdminClient();
+
+        using HttpResponseMessage response =
+            await ApiSnapshot.GetHateoasAsync(client, "/api/v1/translations?page=2&pageSize=1");
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task ListTranslations_WithNoMatches_MatchesTheEmptyEnvelopeContract()
+    {
+        // An empty result is its own contract: clients have to distinguish "no matches" from "broken",
+        // so items must stay an empty array and the counters must collapse coherently.
+        using HttpClient client = AdminClient();
+
+        using HttpResponseMessage response =
+            await ApiSnapshot.GetHateoasAsync(client, "/api/v1/translations?search=Balrog");
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task GetTranslation_AsAdmin_MatchesTheHateoasContract()
+    {
+        using HttpClient client = AdminClient();
+
+        using HttpResponseMessage response =
+            await ApiSnapshot.GetHateoasAsync(client, $"/api/v1/translations/{_draftRowId}");
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await ApiSnapshot.ShouldServeUnescapedUtf8Async(response, SeededPolish);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task ListTranslations_AsPlainJson_MatchesTheLinkLessContract()
+    {
+        // Plain application/json is the contract the CLI and any non-hypermedia client sees: the same
+        // payload with the links arrays stripped entirely, never left as empty arrays.
+        using HttpClient client = AdminClient();
+
+        using HttpResponseMessage response = await ApiSnapshot.GetAsync(
+            client, "/api/v1/translations?page=1&pageSize=50", MediaTypes.Json);
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe(MediaTypes.Json);
+        await Verifier.Verify(body, "json");
+    }
+
+    private Translation Untranslated(int gossipId, string source) =>
+        Translation.CreateUntranslated(
+            FragmentKey.Create(FileId, gossipId).Value,
+            TranslationSource.Create(source, null, null).Value,
+            _versionId,
+            Now).Value;
+
+    private HttpClient AdminClient()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Admin));
+        return client;
+    }
+}

--- a/tests/Shared/VerifyModuleInitializer.cs
+++ b/tests/Shared/VerifyModuleInitializer.cs
@@ -1,0 +1,89 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using DiffEngine;
+using VerifyTests;
+
+namespace LotroKoniecDev.Tests.Shared;
+
+/// <summary>
+/// The repo-wide Verify configuration (#571). The file is <em>linked</em> into every suite that
+/// snapshots something, so all of them scrub identically — same idiom as the shared naughty-string
+/// theory sources (#569, <see cref="NaughtyStringCases"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A snapshot that churns on every run is worse than no snapshot, so every value that varies between
+/// runs, machines or environments is scrubbed here. Each scrubber is deliberately <em>shape-matched</em>
+/// and replaces as little as it can get away with: a regex only fires on text that still looks like a
+/// GUID / an instant / a digest, and the parts that carry contract meaning are left in the snapshot.
+/// A regression that changes the shape therefore leaves the raw value in place and fails the test,
+/// which is the whole point of pinning the payload.
+/// </para>
+/// <para>
+/// Ordering note: the scrubbers run over the same text, so a future one must not be able to consume
+/// what an earlier one is meant to see. Today they cannot overlap — a W3C traceparent is 32/16 hex
+/// and <c>HttpContext.TraceIdentifier</c> is <c>0Hxxx:0000001</c>, so neither is GUID- nor
+/// 64-hex-shaped, and <see cref="TraceIdPattern"/> is anchored on the property name either way.
+/// </para>
+/// <para>
+/// Verify resolves a verified file from the test's <c>[CallerFilePath]</c>. That means enabling
+/// <c>ContinuousIntegrationBuild</c> (which turns on <c>DeterministicSourcePaths</c> and rewrites
+/// caller paths to <c>/_/…</c>) would break every snapshot suite at once with a misleading
+/// "file not found". Nothing in the repo sets it; if that ever changes, pin the location explicitly
+/// with <c>VerifierSettings.DerivePathInfo</c> off the MSBuild project directory instead.
+/// </para>
+/// </remarks>
+internal static partial class VerifyModuleInitializer
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        // Ids: identical values collapse to the same Guid_N marker, so the snapshot still proves that
+        // an item's id and the id inside its HATEOAS href are the same entity.
+        VerifierSettings.ScrubInlineGuids();
+
+        VerifierSettings.AddScrubber(builder => ReplaceAll(builder, TimestampPattern(), "{Timestamp}"));
+        VerifierSettings.AddScrubber(builder => ReplaceAll(builder, HexDigestPattern(), "{HexDigest}"));
+        VerifierSettings.AddScrubber(builder => ReplaceAll(builder, TraceIdPattern(), "$1{TraceId}$2"));
+
+        // Never launch a diff tool: most runs here are headless (CI, the backlog loop), and a GUI
+        // popping up mid-run would hang the session rather than report a failure.
+        DiffRunner.Disabled = true;
+    }
+
+    private static void ReplaceAll(StringBuilder builder, Regex pattern, string replacement)
+    {
+        string scrubbed = pattern.Replace(builder.ToString(), replacement);
+        builder.Clear();
+        builder.Append(scrubbed);
+    }
+
+    /// <summary>
+    /// The date-and-time half of an ISO-8601 instant as <c>System.Text.Json</c> writes
+    /// <c>DateTimeOffset</c> / <c>DateTime</c>. The trailing designator is matched by lookahead and
+    /// therefore <em>survives</em> into the snapshot: an instant that starts being serialized in
+    /// server-local time reads as <c>{Timestamp}+02:00</c> instead of <c>{Timestamp}Z</c> and fails
+    /// the test, which scrubbing the offset away would have hidden.
+    /// </summary>
+    [GeneratedRegex(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(?=Z|[+-]\d{2}:\d{2})")]
+    private static partial Regex TimestampPattern();
+
+    /// <summary>
+    /// Content digests: the translation file's SHA-256 hex, which is also served verbatim as the
+    /// strong <c>ETag</c> (AUDIT-SEC-01/#391), plus any other 64-char hex digest. Word-bounded, so a
+    /// longer hex run is left whole and visible instead of being half-replaced. Defensive — no
+    /// snapshot currently carries a digest, so this is not ETag coverage.
+    /// </summary>
+    [GeneratedRegex(@"\b[0-9a-fA-F]{64}\b")]
+    private static partial Regex HexDigestPattern();
+
+    /// <summary>
+    /// The <c>traceId</c> ASP.NET Core stamps on every <c>ProblemDetails</c> body. Matched by property
+    /// name rather than by shape on purpose: the value is a W3C traceparent when an <c>Activity</c> is
+    /// running and the raw <c>HttpContext.TraceIdentifier</c> when one is not, so which shape a run
+    /// produces depends on whether tracing is wired up in that environment.
+    /// </summary>
+    [GeneratedRegex(@"(""traceId""\s*:\s*"")[^""]*("")")]
+    private static partial Regex TraceIdPattern();
+}


### PR DESCRIPTION
Closes #571.

## What

Adopts `Verify.Xunit` for the one assertion shape hand-written asserts cover only in part: large structured outputs. 16 snapshots across two seams — TMS API response bodies and Blazor SSR rendered markup.

**Infrastructure.** `tests/Shared/VerifyModuleInitializer.cs` is linked into both suites (the `NaughtyStringCases.cs` idiom from #569) so they scrub identically. Every scrubber is shape-matched and replaces as little as it can, so a regression that changes the shape still fails:

- inline GUIDs collapse to `Guid_N` — the snapshot still proves an item's `id` and the id in its HATEOAS `href` are the same entity;
- an ISO-8601 instant keeps its trailing `Z`/offset (matched by lookahead), so a switch to server-local time reads `{Timestamp}+02:00` and fails instead of scrubbing into a false pass;
- 64-char hex digests (the translation file SHA-256, also the strong `ETag`);
- the `traceId` ASP.NET Core stamps on `ProblemDetails`, matched by property name because its shape depends on whether tracing is running.

The diff-tool launcher is disabled — most runs here are headless, and a GUI popping up would hang the run rather than report a failure.

**Pilot.** TMS: HATEOAS list, public link-less list, a middle page, the empty envelope, the detail payload, the plain-JSON list, and all five ProblemDetails status families (400/404/422/401/403). Frontend: the landing page in four states (progress, API outage, empty catalog, authenticated) and the terms-of-service page.

The fixture seeds three rows and five-figure counters deliberately. A middle page is the only shape carrying both `previous-page` and `next-page`; an empty result is its own contract; and `HomeProgressView`'s NBSP group separator — which exists to keep the markup culture-independent — never renders below 1000. Pinning one well-formed happy payload is the easiest snapshot to write and the least worth having.

**Snapshots pin shape; they do not replace asserts.** Every test still asserts its status code and media type, and the behavioral suites that own the role-aware link rules and the load-bearing legal wording are untouched. `ApiSnapshot` re-indents each body through `JsonNode` so verified files are reviewable line by line — that normalizes away the transport's non-ASCII encoding, and nothing else in the repo covered it (`ContentNegotiationTests` pins the media type and `Vary`, not the bytes), so `ShouldServeUnescapedUtf8Async` asserts on the raw body that JSON ships with no charset parameter and Polish stays literal UTF-8.

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| Green and deterministic, zero warnings | `dotnet build LotroKoniecDev.slnx` — 0 warnings; full sweep green (both integration suites incl.); both snapshot suites run twice back-to-back leave **zero** `*.received.*`. Cross-platform: files are LF (`.gitattributes`) and Verify normalizes newlines internally. |
| An intentional change fails until re-accepted | Verified by probe: a temporary `<h1>` edit in `Terms.razor` failed exactly the Terms snapshot; a temporary `"Data Conflict"` title edit in `ErrorExtensions.cs` failed exactly the 422 snapshot and left the other three green. Both reverted. |
| Golden fixtures untouched, no production code modified | `git status --porcelain src/` is empty; no `||` fixture touched. |

## Notes

- Touching `Directory.Packages.props` fires `e2e.yml` by design (CI-03/#433), so this PR exercises the Docker E2E stack.
- The `code-reviewer` gate ran on Opus — the configured Fable 5 model was out of credits. It returned REQUEST CHANGES on the first pass; every finding is folded in above (timestamp scrubber losing the offset, missing middle-page/empty-envelope/403/zero-catalog/grouped-number coverage, a missing status assert, and a docs claim about `ContentNegotiationTests` that was factually wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnVjDNLSTgYv8gQzvmmXn