### PR TITLE
Bug: the || file escape is applied by only one writer and is not injective — translations with newlines are silently dropped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,7 +294,13 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 
 - `<--DO_NOT_TOUCH!-->` = argument placeholder
 - `args_order`: `NULL` or `1-2-3` (1-indexed in file, 0-indexed internally)
-- `\r`, `\n` in content are unescaped by parser
+- **Content escape (ADR-0039): `\`→`\\`, CR→`\r`, LF→`\n`.** It escapes its own escape character, so
+  it is injective and `Unescape(Escape(x)) == x`. **Every writer escapes and every reader unescapes**
+  — all four ends (patcher exporter + parser, TMS serializer + import parser), each via its context's
+  own `TranslationLineEscaper`. Text held anywhere else — in the DAT, in `TranslationSource.Text`, in
+  `TranslatedText` — is always the RAW form; the escape exists only between `Serialize` and `Parse`.
+  A sequence no writer can produce (`\t`, a trailing lone `\`) reads back verbatim. The `||`
+  separator is deliberately **not** escaped: both parsers anchor from both ends instead.
 - Results sorted by FileId then GossipId for sequential DAT I/O
 - **Changing this format requires an ADR + updated golden fixtures in BOTH contexts** (patcher
   parser tests and TMS import/export tests).

--- a/docs/adr/0039-injective-backslash-escape-for-the-translation-file-format.md
+++ b/docs/adr/0039-injective-backslash-escape-for-the-translation-file-format.md
@@ -1,0 +1,165 @@
+# ADR-0039: An injective backslash escape for the `||` translation file, applied by every writer
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Solo maintainer
+**Related:** #596 (the defect), #569 (the hostile-string coverage that found it), CLAUDE.md "Translation file format — THE inter-context contract", `ExportTextsQueryHandler`, `TranslationFileParser`, `TranslationFileSerializer`, `TranslationExportParser`, spec 0001 (update lifecycle), spec 0006 (import redesign)
+
+## Context
+
+The `||` file is the only contract between the two bounded contexts
+(`file_id||gossip_id||content||args_order||args_id||approved`, one row per line). It has two
+writers and two readers, and each context owns its own implementation by design:
+
+| End | Component | Before this ADR |
+|---|---|---|
+| writer — `exported.txt` | patcher `ExportTextsQueryHandler` | escapes `CR`→`\r`, `LF`→`\n` |
+| reader — `exported.txt` | TMS `TranslationExportParser` | **no unescape** — stores the escaped form |
+| writer — `polish.txt` | TMS `TranslationFileSerializer` | **no escape** — emits content verbatim |
+| reader — `polish.txt` | patcher `TranslationFileParser` | unescapes `\r`→CR, `\n`→LF |
+
+One escape rule, applied at one of four ends and inverted at another. Two defects follow, and #569's
+hostile-string sweep pinned both as "documented current behavior" tests:
+
+1. **A newline in a translation silently drops the row.** Translator-submitted Polish never passes
+   through any escape: the editor field is a multi-line `<textarea rows="8">`, `UpsertTranslation`
+   only checks `NotEmpty()`, the aggregate stores the text verbatim, the projector selects it
+   straight into `ArtifactRow.Content`, and the serializer emits it verbatim. One row becomes two
+   malformed lines, both are rejected on read, the fragment never reaches the game, and nobody is
+   told. The CLI auto-downloads that same artifact, so the corruption reaches the DAT patch path.
+
+2. **The escape is not injective.** It never escapes its own escape character, so source text that
+   legitimately carries a backslash in front of `r`/`n` is indistinguishable from an escape:
+   `C:\notes` reads back as `C:` + LF + `otes`.
+
+The two are one root cause: the escape was treated as a property of *one caller* (the patcher's
+exporter) instead of a property of *the file format*.
+
+## Decision
+
+### 1. The escape is a property of the file, and it escapes its own escape character
+
+The transform, in full:
+
+| Value in memory / in the database | Bytes on the line |
+|---|---|
+| `\` (U+005C) | `\\` |
+| CR (U+000D) | `\r` |
+| LF (U+000A) | `\n` |
+
+Escaping is a single left-to-right pass, so a backslash emitted by the escape is never re-escaped.
+Unescaping is a single left-to-right scan: `\\`→`\`, `\r`→CR, `\n`→LF. Because the backslash is now
+escaped too, the transform is **injective** and `Unescape(Escape(x)) == x` for every string.
+
+**Unknown sequences pass through verbatim, and a trailing lone backslash is kept.** `\t` reads back
+as `\t`, two characters. Rejecting them would turn a legacy file into a hard failure for no gain, and
+the pair is only ever produced by a legacy writer — a conforming writer cannot emit it.
+
+Nothing else about the format changes: the field separator, the both-ends anchoring that lets `||`
+live inside content, `NULL` args, the comment marker and CRLF line endings are all untouched. In
+particular **the separator is deliberately NOT escaped** — anchoring from both ends already
+recovers it, both parsers already agree on it, and escaping it would break every `exported.txt` and
+every `polish.txt` in existence for a problem that does not exist. (The one true delimiter defect,
+content ending in an odd run of `|`, is #597 and is out of scope here.)
+
+### 2. All four ends apply it
+
+Both writers escape on write; both readers unescape on read. The asymmetry that caused the defect
+is gone by construction.
+
+### 3. The database stores raw text, never the escaped representation
+
+`TranslationSource.Text` and `Translation.TranslatedText` hold exactly what the DAT contains and
+exactly what the translator typed — real newlines, real backslashes. The escape exists only between
+`Serialize` and `Parse`.
+
+This is what makes the fix hold instead of moving the bug: with the escape at the file boundary,
+there is no caller that can forget it, no column whose meaning depends on which path wrote it, and
+no second representation to keep in sync. The alternative — rejecting newlines in
+`UpsertTranslation.Validator` — was declined: it pushes a file-format concern into every writer,
+tells the translator their perfectly legal text is invalid, and leaves the non-injectivity
+(defect 2) untouched.
+
+### 4. The rule lives in one type per context, not inline
+
+`TranslationLineEscaper` in the patcher's `Application/Parsers/` and in the TMS'
+`API/Parsing/` — a static `Escape`/`Unescape` pair each. The two contexts still share **no code**
+(CLAUDE.md: "share a data contract, not code"; the architecture suite enforces it), but within a
+context there is exactly one copy of the rule, callable from tests. Before this ADR the patcher's
+copy was inline in a `StreamWriter` loop with no seam, which forced
+`TranslationFileParserNaughtyStringTests` to keep a hand-maintained duplicate of it.
+
+`Translation.GetUnescapedContent()` (patcher domain) is **deleted**: a third copy of the old rule,
+unused by production code since the parser unescapes on parse, and a double-unescape trap for any
+future caller.
+
+### 5. Existing `TranslatedText` IS migrated; source text is not
+
+The two columns need opposite treatment, and the difference is not a matter of taste.
+
+**`Translation.TranslatedText` — backfilled** (`20260805122747_NormalizeTranslatedTextEscapeSequences`).
+Under the old pipeline the only way a translator could put a line break into the game was to type the
+two characters `\n`: the serializer emitted them verbatim and the patcher unescaped them
+unconditionally. `translations/polish.txt` shows that authoring convention in the wild. Escaping on
+write would turn every such row into a literal backslash-n in game — a silent meaning change to
+already-published translations, with no repair path (a re-import rewrites source rows, never
+translated ones). The old reader's rule is therefore applied to the column once, in SQL. This is
+**behavior-preserving, not a guess**: the old pipeline mapped `\n` to a line feed unconditionally, so
+no row can have meant "a literal backslash before n" — that was inexpressible. The transform is
+idempotent (the replacement is a control character, so no new escape sequence can be synthesized).
+
+**`TranslationSource.Text` / `PreviousSourceText` — not touched.** Here the stored form *is*
+ambiguous, exactly because the old escape was not injective, so any script would pick one reading and
+corrupt the other. The import pipeline owns the correct repair instead (below).
+
+### 6. Line endings submitted by the editor are kept as typed
+
+An HTML `<textarea>` submits CRLF, so a translator pressing Enter now stores `\r\n` and the DAT
+receives CR+LF where the game's own texts use a bare LF. It is **not** normalized here: #596's
+acceptance criteria require `\n`, `\r\n` and `\r` to survive the round trip *intact*, and silently
+rewriting a translator's text is a product decision, not a transport one. The transport is lossless
+either way. Whether the editor should normalize to LF on submit is left open on purpose — it needs a
+look at how the DAT renders a CR before anyone changes what translators type.
+
+## Consequences
+
+### Good
+
+- A translation containing newlines survives approve → artifact → download → patch with its line
+  structure intact. The editor already renders source text with `white-space: pre-wrap`, so real
+  newlines display correctly with no frontend change.
+- Content carrying a literal backslash round-trips byte-exact in both directions.
+- The two parsers now agree on escape sequences, so `ParserContractParityTests` — the drift guard —
+  can assert full agreement instead of documenting a deliberate divergence.
+- The two pinning tests from #569 flip to exact-round-trip assertions.
+
+### The migration cost, and why source text is repaired by re-import instead
+
+Existing `TranslationSource.Text` rows hold the **old escaped** representation. They cannot be
+converted correctly by a script: the old escape was not injective, so a stored `C:\notes` is
+genuinely ambiguous between "the DAT contains `C:\notes`" and "the DAT contains `C:`+LF+`otes`". Any
+`UPDATE … replace(…)` picks one reading and corrupts the other.
+
+The pipeline already owns the correct repair, so it is used instead: **re-export with the new CLI
+and re-import**. The new export is injectively escaped, the new import unescapes it, and the stored
+source becomes exactly what the DAT contains. Rows whose English text contains a newline will be
+reported as source-changed and their approved Polish flagged `NeedsReview` — the honest outcome,
+because the stored source for those rows really was wrong. No translation text is lost. The catalog
+is admin-imported and the product is pre-launch, so this is a one-off manual step, not an outage.
+
+Two smaller edges, both accepted:
+
+- Re-importing an **old** `exported.txt` through the new parser reproduces defect 2 for the rows
+  that trigger it (a file written before this ADR cannot be read unambiguously). Re-export first.
+- The mirror image: an **old CLI** downloading a **new** artifact collapses nothing, so a `\\` pair
+  reaches the DAT as two backslashes. Pre-launch with no installed base, and the CLI auto-downloads
+  from the same release train — a version gate would be over-engineering today.
+- The already-published `polish.txt` artifact keeps its old bytes until the next approve/import
+  reschedules a rebuild. It is regenerable and self-healing; nothing reads it as authoritative.
+
+### Neutral
+
+- Golden fixtures on both sides gain escape rows, and the fixture is now driven through **both**
+  parsers by the parity suite.
+- Escape/unescape is one linear scan over each content field, allocating only when a line actually
+  contains an escapable character — irrelevant next to the import's existing per-row work.

--- a/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
+++ b/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
@@ -84,7 +84,8 @@ player's patcher downloads a translation file that never shows outdated text in 
   as 64-bit (`long`, already mandated by #93).
 - An exported row is exactly: `file_id||gossip_id||text||args_order||args_id||approved`
   (`ExportTextsQueryHandler.cs:95`). On export: `text` = English pieces joined with
-  `<--DO_NOT_TOUCH!-->`, `\r`/`\n` escaped to literals; `args_order`/`args_id` = `NULL` when the
+  `<--DO_NOT_TOUCH!-->`, then run through the file's escape (`\`→`\\`, CR→`\r`, LF→`\n`; ADR-0039 —
+  the import unfolds it again, so the catalog stores the raw text); `args_order`/`args_id` = `NULL` when the
   fragment has no arguments, otherwise the identity order `1-2-…-N`; `approved` = constant `1`.
   There is **no other state in a row** — no hidden version, no category, no UI grouping; the DAT
   is one undifferentiated bag of texts.

--- a/docs/tms-handbook.md
+++ b/docs/tms-handbook.md
@@ -275,9 +275,13 @@ Rules worth knowing (they all exist for a reason):
 - **The content itself may contain `||`.** Parsers on both sides read the first two fields from
   the front, the last three fields from the back, and join everything in the middle back
   together as the content. Naive `split("||")` would corrupt such lines.
-- **Newlines are escaped.** A real line break inside game text is stored as `\r` / `\n`
-  literals. Only the **patcher** unescapes them (when writing into the DAT). The TMS stores and
-  redistributes content exactly as-is, byte for byte.
+- **Content is escaped in the file, raw everywhere else (ADR-0039).** A real line break becomes
+  `\r` / `\n` and a real backslash becomes `\\`, so one row is always one line and the transform is
+  reversible. **Every writer escapes and every reader unescapes** — the patcher's exporter and
+  parser, the TMS' serializer and import parser. What the database holds, what the editor shows and
+  what lands in the DAT is always the raw text; the escape exists only between them. (Before 2026-08
+  only the patcher's exporter escaped and only its parser unescaped, which is why a translation typed
+  with a line break used to vanish from the file — #596.)
 - **`args_order`**: `NULL` means no arguments. `2-1` means "swap the two inserted values"
   (1-indexed in the file; the patcher converts to 0-indexed internally).
 - **`approved`**: the patcher patches only rows with `1`. The export always writes `1`; the TMS

--- a/src/Patcher/LotroKoniecDev.Application/Features/Exporting/ExportTextsQueryHandler.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/Exporting/ExportTextsQueryHandler.cs
@@ -2,6 +2,7 @@
 using LotroKoniecDev.Application.Abstractions.DatFilesServices;
 using LotroKoniecDev.Application.Abstractions.Messaging;
 using LotroKoniecDev.Application.Extensions;
+using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.Domain.Core.BuildingBlocks;
 using LotroKoniecDev.Domain.Core.Errors;
 using LotroKoniecDev.Domain.Models;
@@ -76,9 +77,6 @@ internal sealed class ExportTextsQueryHandler : IQueryHandler<ExportTextsQuery, 
                     {
                         string text = string.Join(DatFileConstants.PieceSeparator, fragment.Pieces);
 
-                        // Escape newlines for single-line storage
-                        text = text.Replace("\r", "\\r").Replace("\n", "\\n");
-
                         // Generate default args_order and args_id if fragment has arguments
                         string argsOrder = "NULL";
                         string argsId = "NULL";
@@ -93,7 +91,7 @@ internal sealed class ExportTextsQueryHandler : IQueryHandler<ExportTextsQuery, 
                             argsId = argsOrder; // Default: same order
                         }
 
-                        await writer.WriteLineAsync($"{fileId}||{fragmentId}||{text}||{argsOrder}||{argsId}||1");
+                        await writer.WriteLineAsync(FormatRow(fileId, fragmentId, text, argsOrder, argsId));
 
                         fragmentCount++;
                     }
@@ -125,6 +123,16 @@ internal sealed class ExportTextsQueryHandler : IQueryHandler<ExportTextsQuery, 
         }
 
     }
+
+    /// <summary>
+    /// Composes one <c>exported.txt</c> row. The escape is applied here (ADR-0039), on the joined
+    /// text — the piece separator carries nothing escapable, so folding after the join leaves it
+    /// intact. A row is composed rather than interpolated inline so the file's format has a seam a
+    /// test can hold: the handler streams straight to disk, and a unit suite must not assert on real
+    /// file output.
+    /// </summary>
+    internal static string FormatRow(int fileId, ulong fragmentId, string text, string argsOrder, string argsId)
+        => $"{fileId}||{fragmentId}||{TranslationLineEscaper.Escape(text)}||{argsOrder}||{argsId}||1";
 
     private static async Task WriteHeaderAsync(StreamWriter writer)
     {

--- a/src/Patcher/LotroKoniecDev.Application/LotroKoniecDev.Application.csproj
+++ b/src/Patcher/LotroKoniecDev.Application/LotroKoniecDev.Application.csproj
@@ -14,6 +14,10 @@
     <ItemGroup>
         <InternalsVisibleTo Include="LotroKoniecDev.Tests.Infrastructure" />
         <InternalsVisibleTo Include="LotroKoniecDev.Tests.Unit" />
+        <!-- ParserContractParityTests is the || contract's cross-context drift guard: it drives the
+             patcher's escaper and parser against the TMS' own copies (ADR-0039). Test-only reach —
+             production code in the two contexts still shares the file, never code. -->
+        <InternalsVisibleTo Include="LotroKoniecDev.TranslationSystem.API.Tests.Unit" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\LotroKoniecDev.Domain\LotroKoniecDev.Domain.csproj"/>

--- a/src/Patcher/LotroKoniecDev.Application/Parsers/TranslationFileParser.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Parsers/TranslationFileParser.cs
@@ -10,6 +10,8 @@ namespace LotroKoniecDev.Application.Parsers;
 /// <remarks>
 /// File format: file_id||gossip_id||content||args_order||args_id||approved
 /// Lines starting with # are comments, empty lines are ignored.
+/// Content arrives escaped (ADR-0039) and is unfolded by <see cref="TranslationLineEscaper"/>, so
+/// <see cref="Translation.Content"/> always carries the raw text about to be written into the DAT.
 /// </remarks>
 public sealed class TranslationFileParser : ITranslationParser
 {
@@ -84,7 +86,7 @@ public sealed class TranslationFileParser : ITranslationParser
             {
                 FileId = int.Parse(parts[0]),
                 GossipId = ulong.Parse(parts[1]),
-                Content = UnescapeContent(content),
+                Content = TranslationLineEscaper.Unescape(content),
                 ArgsOrder = ParseArgsArray(parts[^3]),
                 ArgsId = ParseArgsArray(parts[^2]),
                 IsApproved = parts[^1] == "1"
@@ -104,12 +106,6 @@ public sealed class TranslationFileParser : ITranslationParser
     /// </summary>
     private static bool ShouldSkipLine(string line) =>
         string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#');
-
-    /// <summary>
-    /// Unescapes newline and carriage return sequences.
-    /// </summary>
-    private static string UnescapeContent(string content) =>
-        content.Replace("\\r", "\r").Replace("\\n", "\n");
 
     /// <summary>
     /// Parses an argument array in format "1-2-3" to 0-indexed integers.

--- a/src/Patcher/LotroKoniecDev.Application/Parsers/TranslationLineEscaper.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Parsers/TranslationLineEscaper.cs
@@ -1,0 +1,105 @@
+using System.Text;
+
+namespace LotroKoniecDev.Application.Parsers;
+
+/// <summary>
+/// The content escape of the <c>||</c> translation file (ADR-0039): <c>\</c> becomes <c>\\</c>,
+/// CR becomes <c>\r</c> and LF becomes <c>\n</c>, so a fragment carrying real newlines stays on one
+/// line and the transform stays injective. Every writer of the file escapes and every reader
+/// unescapes; text held in memory, in the DAT and in the TMS database is always the raw form.
+/// </summary>
+/// <remarks>
+/// The TMS owns an identical copy in its own <c>Parsing</c> namespace — the two bounded contexts
+/// share the file, never code (CLAUDE.md). The parity suites are what keep the copies honest.
+/// </remarks>
+internal static class TranslationLineEscaper
+{
+    private const char EscapeCharacter = '\\';
+    private const char CarriageReturnMarker = 'r';
+    private const char LineFeedMarker = 'n';
+
+    /// <summary>
+    /// Folds a raw content string into its single-line file representation.
+    /// </summary>
+    public static string Escape(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        if (content.AsSpan().IndexOfAny(EscapeCharacter, '\r', '\n') < 0)
+        {
+            return content;
+        }
+
+        StringBuilder builder = new(content.Length + 8);
+
+        foreach (char character in content)
+        {
+            switch (character)
+            {
+                case EscapeCharacter:
+                    builder.Append(EscapeCharacter).Append(EscapeCharacter);
+                    break;
+                case '\r':
+                    builder.Append(EscapeCharacter).Append(CarriageReturnMarker);
+                    break;
+                case '\n':
+                    builder.Append(EscapeCharacter).Append(LineFeedMarker);
+                    break;
+                default:
+                    builder.Append(character);
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Unfolds a file representation back into raw content. A sequence no writer can produce
+    /// (<c>\t</c>, a trailing lone backslash) is kept verbatim rather than rejected — only a file
+    /// written before ADR-0039 can contain one.
+    /// </summary>
+    public static string Unescape(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        if (!content.Contains(EscapeCharacter))
+        {
+            return content;
+        }
+
+        StringBuilder builder = new(content.Length);
+
+        for (int index = 0; index < content.Length; index++)
+        {
+            char character = content[index];
+
+            if (character != EscapeCharacter || index == content.Length - 1)
+            {
+                builder.Append(character);
+                continue;
+            }
+
+            switch (content[index + 1])
+            {
+                case EscapeCharacter:
+                    builder.Append(EscapeCharacter);
+                    index++;
+                    break;
+                case CarriageReturnMarker:
+                    builder.Append('\r');
+                    index++;
+                    break;
+                case LineFeedMarker:
+                    builder.Append('\n');
+                    index++;
+                    break;
+                default:
+                    builder.Append(character);
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Patcher/LotroKoniecDev.Domain/Models/Translation.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Models/Translation.cs
@@ -9,6 +9,11 @@ public sealed class Translation
 {
     public int FileId { get; init; }
     public ulong GossipId { get; init; }
+
+    /// <summary>
+    /// The raw fragment text, ready to be written into the DAT — the parser already unfolded the
+    /// file's escape sequences (ADR-0039), so this never carries a <c>\n</c> two-character pair.
+    /// </summary>
     public string Content { get; init; } = string.Empty;
     public int[]? ArgsOrder { get; init; }
     public int[]? ArgsId { get; init; }
@@ -32,13 +37,6 @@ public sealed class Translation
     /// <returns>Array of text pieces.</returns>
     public string[] GetPieces() =>
         Content.Split([DatFileConstants.PieceSeparator], StringSplitOptions.None);
-
-    /// <summary>
-    /// Unescapes special characters in the content.
-    /// </summary>
-    /// <returns>Content with newlines and carriage returns restored.</returns>
-    public string GetUnescapedContent() =>
-        Content.Replace("\\r", "\r").Replace("\\n", "\n");
 
     public override string ToString() =>
         $"Translation[File={FileId}, Gossip={GossipId}, Length={Content.Length}]";

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/ParsedExport.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/ParsedExport.cs
@@ -1,12 +1,12 @@
 namespace LotroKoniecDev.TranslationSystem.API.Parsing;
 
-/// <summary>One parsed row of an uploaded export, in the verbatim exported representation.</summary>
+/// <summary>One parsed row of an uploaded export.</summary>
 /// <remarks>
-/// Args columns are the raw <c>NULL</c>/<c>1-2-3</c> strings and <see cref="Content"/> keeps its
-/// escaped <c>\r</c>/<c>\n</c> — the TMS stores and redistributes texts byte-for-byte; only the
-/// patcher unescapes, when it injects into the DAT. <see cref="Approved"/> is retained for
-/// format symmetry but the import ignores it: the export's column is a constant and TMS approval
-/// state is owned by the editor loop, not the file.
+/// Args columns are the raw <c>NULL</c>/<c>1-2-3</c> strings (they carry nothing escapable), while
+/// <see cref="Content"/> is the RAW text — the parser unfolds the file's escape (ADR-0039) and the
+/// serializer re-applies it on the way out, so the escape never reaches the catalog.
+/// <see cref="Approved"/> is retained for format symmetry but the import ignores it: the export's
+/// column is a constant and TMS approval state is owned by the editor loop, not the file.
 /// </remarks>
 public sealed record ParsedExportRow(
     int FileId,

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationExportParser.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationExportParser.cs
@@ -6,8 +6,9 @@ namespace LotroKoniecDev.TranslationSystem.API.Parsing;
 
 /// <summary>
 /// Parses an uploaded <c>exported.txt</c> in the LOTRO <c>||</c> contract
-/// (<c>file_id||gossip_id||content||args_order||args_id||approved</c>). The TMS owns its own
-/// parser; golden fixtures + round-trip tests guard it against drift from the patcher's parser.
+/// (<c>file_id||gossip_id||content||args_order||args_id||approved</c>), unfolding the content escape
+/// (ADR-0039) so the catalog stores the raw source text rather than its file representation. The TMS
+/// owns its own parser; golden fixtures + round-trip tests guard it against drift from the patcher's.
 /// </summary>
 internal sealed class TranslationExportParser : ITranslationExportParser
 {
@@ -117,8 +118,9 @@ internal sealed class TranslationExportParser : ITranslationExportParser
 
         // Anchor from both ends (matches the patcher, #29/#106): file_id, gossip_id lead;
         // args_order, args_id, approved trail; everything between is content re-joined with the
-        // separator, so content may legally contain "||".
-        string content = string.Join(FieldSeparator, parts[2..^3]);
+        // separator, so content may legally contain "||". The escape is unfolded last (ADR-0039),
+        // so the row hands out the raw source text the DAT actually holds.
+        string content = TranslationLineEscaper.Unescape(string.Join(FieldSeparator, parts[2..^3]));
 
         row = new ParsedExportRow(
             FileId: fileId,

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationFileSerializer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationFileSerializer.cs
@@ -6,10 +6,11 @@ namespace LotroKoniecDev.TranslationSystem.API.Parsing;
 /// <summary>
 /// Produces the LOTRO <c>||</c> translation file
 /// (<c>file_id||gossip_id||content||args_order||args_id||approved</c>). Byte-compatible with the
-/// patcher's own writer: content is emitted verbatim (already <c>\r</c>/<c>\n</c>-escaped on import),
-/// absent args become <c>NULL</c>, the approved column is always <c>1</c>, and lines are CRLF-
-/// terminated for a deterministic content hash across platforms. A golden fixture + a cross-parser
-/// round-trip test guard the contract against drift from the patcher.
+/// patcher's own writer: content is escaped through <see cref="TranslationLineEscaper"/> (ADR-0039)
+/// so a translation carrying real newlines stays on one line, absent args become <c>NULL</c>, the
+/// approved column is always <c>1</c>, and lines are CRLF-terminated for a deterministic content
+/// hash across platforms. A golden fixture + a cross-parser round-trip test guard the contract
+/// against drift from the patcher.
 /// </summary>
 internal sealed class TranslationFileSerializer : ITranslationFileSerializer
 {
@@ -28,7 +29,7 @@ internal sealed class TranslationFileSerializer : ITranslationFileSerializer
             builder
                 .Append(row.FileId.ToString(CultureInfo.InvariantCulture)).Append(FieldSeparator)
                 .Append(row.GossipId.ToString(CultureInfo.InvariantCulture)).Append(FieldSeparator)
-                .Append(row.Content).Append(FieldSeparator)
+                .Append(TranslationLineEscaper.Escape(row.Content)).Append(FieldSeparator)
                 .Append(row.ArgsOrder ?? NullArgs).Append(FieldSeparator)
                 .Append(row.ArgsId ?? NullArgs).Append(FieldSeparator)
                 .Append('1').Append(LineTerminator);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationLineEscaper.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationLineEscaper.cs
@@ -1,0 +1,106 @@
+using System.Text;
+
+namespace LotroKoniecDev.TranslationSystem.API.Parsing;
+
+/// <summary>
+/// The content escape of the <c>||</c> translation file (ADR-0039): <c>\</c> becomes <c>\\</c>,
+/// CR becomes <c>\r</c> and LF becomes <c>\n</c>, so a row carrying real newlines stays on one line
+/// and the transform stays injective. <see cref="TranslationFileSerializer"/> escapes on write and
+/// <see cref="TranslationExportParser"/> unescapes on read, so the database always holds the raw
+/// text — exactly what the DAT contains and exactly what the translator typed.
+/// </summary>
+/// <remarks>
+/// The patcher owns an identical copy in its own <c>Parsers</c> namespace — the two bounded contexts
+/// share the file, never code (CLAUDE.md). The parity suites are what keep the copies honest.
+/// </remarks>
+internal static class TranslationLineEscaper
+{
+    private const char EscapeCharacter = '\\';
+    private const char CarriageReturnMarker = 'r';
+    private const char LineFeedMarker = 'n';
+
+    /// <summary>
+    /// Folds a raw content string into its single-line file representation.
+    /// </summary>
+    public static string Escape(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        if (content.AsSpan().IndexOfAny(EscapeCharacter, '\r', '\n') < 0)
+        {
+            return content;
+        }
+
+        StringBuilder builder = new(content.Length + 8);
+
+        foreach (char character in content)
+        {
+            switch (character)
+            {
+                case EscapeCharacter:
+                    builder.Append(EscapeCharacter).Append(EscapeCharacter);
+                    break;
+                case '\r':
+                    builder.Append(EscapeCharacter).Append(CarriageReturnMarker);
+                    break;
+                case '\n':
+                    builder.Append(EscapeCharacter).Append(LineFeedMarker);
+                    break;
+                default:
+                    builder.Append(character);
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Unfolds a file representation back into raw content. A sequence no writer can produce
+    /// (<c>\t</c>, a trailing lone backslash) is kept verbatim rather than rejected — only a file
+    /// written before ADR-0039 can contain one.
+    /// </summary>
+    public static string Unescape(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        if (!content.Contains(EscapeCharacter))
+        {
+            return content;
+        }
+
+        StringBuilder builder = new(content.Length);
+
+        for (int index = 0; index < content.Length; index++)
+        {
+            char character = content[index];
+
+            if (character != EscapeCharacter || index == content.Length - 1)
+            {
+                builder.Append(character);
+                continue;
+            }
+
+            switch (content[index + 1])
+            {
+                case EscapeCharacter:
+                    builder.Append(EscapeCharacter);
+                    index++;
+                    break;
+                case CarriageReturnMarker:
+                    builder.Append('\r');
+                    index++;
+                    break;
+                case LineFeedMarker:
+                    builder.Append('\n');
+                    index++;
+                    break;
+                default:
+                    builder.Append(character);
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/ValueObjects/TranslationSource.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/ValueObjects/TranslationSource.cs
@@ -6,9 +6,10 @@ namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregat
 /// <summary>
 /// The English source of a fragment as exported from the DAT — the unit the import diff compares.
 /// Text and the two argument columns are one value (spec 0001: a placeholder-structure change is
-/// a meaning change even without a text change), so equality covers all three. Stored verbatim in
-/// the exported representation (<c>\r</c>/<c>\n</c> kept escaped, args as the raw <c>NULL</c>/<c>1-2-3</c>
-/// column) so the distributed file round-trips byte-for-byte through the patcher.
+/// a meaning change even without a text change), so equality covers all three. Text is the RAW
+/// fragment text (real newlines, real backslashes): the file's escape is unfolded by the parser and
+/// re-applied by the serializer (ADR-0039), so it never leaks into the column. The args columns keep
+/// their file form (<c>1-2-3</c>, absent normalized to <c>null</c>) — they carry nothing escapable.
 /// </summary>
 public sealed class TranslationSource : ValueObject
 {
@@ -18,9 +19,9 @@ public sealed class TranslationSource : ValueObject
 
     public static Result<TranslationSource> Create(string text, string? argsOrder, string? argsId)
     {
-        // Source text is exported verbatim from the DAT — empty fragments are legal game content and
-        // must round-trip. A null here is never produced by the parser, so it is a programmer error,
-        // not a per-row validation failure.
+        // Source text comes straight from the DAT — empty fragments are legal game content and must
+        // round-trip. A null here is never produced by the parser, so it is a programmer error, not
+        // a per-row validation failure.
         ArgumentNullException.ThrowIfNull(text);
 
         TranslationSource instance = new(text, NormalizeArgs(argsOrder), NormalizeArgs(argsId));

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260805122747_NormalizeTranslatedTextEscapeSequences.Designer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260805122747_NormalizeTranslatedTextEscapeSequences.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationWriteDbContext))]
-    partial class ApplicationWriteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805122747_NormalizeTranslatedTextEscapeSequences")]
+    partial class NormalizeTranslatedTextEscapeSequences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260805122747_NormalizeTranslatedTextEscapeSequences.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260805122747_NormalizeTranslatedTextEscapeSequences.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
+{
+    /// <summary>
+    /// Data-only backfill for ADR-0039 / #596: converts the two-character <c>\r</c>/<c>\n</c>
+    /// sequences translators typed under the old pipeline into the real control characters the
+    /// column now holds.
+    /// </summary>
+    /// <remarks>
+    /// MIGRATION-SAFETY: acknowledged — this rewrites existing data and cannot be undone by Down().
+    /// It is behavior-PRESERVING rather than destructive: before ADR-0039 the serializer emitted
+    /// TranslatedText verbatim and the patcher unescaped it unconditionally, so a stored "\n" always
+    /// reached the DAT as a line feed. Escaping on write (the fix) would otherwise turn that same row
+    /// into a literal backslash-n in game. Applying the OLD reader to the column reproduces exactly
+    /// what the game already shows, and loses nothing that could ever have been expressed — the old
+    /// pipeline had no way to put a literal backslash-n into the DAT.
+    ///
+    /// Source columns are deliberately NOT converted: their stored form is genuinely ambiguous (the
+    /// old escape was not injective), and the import pipeline repairs them for real on the next
+    /// re-export + re-import. See ADR-0039, "The migration cost".
+    ///
+    /// N-1 note (ADR-0023): the previous revision serializes a real newline verbatim, so during a
+    /// deploy window a converted row can drop out of the artifact — the pre-existing #596 symptom,
+    /// transient, on a regenerable projection that the next write rebuilds.
+    /// </remarks>
+    public partial class NormalizeTranslatedTextEscapeSequences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Same order as the old TranslationFileParser.UnescapeContent: \r first, then \n.
+            //
+            // Two literal traps, both load-bearing:
+            //   * strpos, not LIKE — in a LIKE pattern PostgreSQL treats the backslash as the escape
+            //     character, so '%\r%' would silently mean "contains r" and rewrite every row.
+            //   * E'\\r', not '\r' — a plain literal means backslash+r only while
+            //     standard_conforming_strings is on. With it off, '\r' parses as a carriage RETURN,
+            //     the WHERE stops matching the rows that need converting, and the migration records
+            //     itself as applied having done nothing. The E'' form is backslash+r under both.
+            migrationBuilder.Sql(
+                """
+                UPDATE translation."Translations"
+                SET "TranslatedText" = replace(replace("TranslatedText", E'\\r', CHR(13)), E'\\n', CHR(10))
+                WHERE strpos("TranslatedText", E'\\r') > 0 OR strpos("TranslatedText", E'\\n') > 0;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Deliberately empty: migrations are forward-only (ADR-0023), and re-escaping would be a
+            // guess — a row may legitimately hold a real newline that was never a "\n" sequence.
+        }
+    }
+}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -98,8 +98,13 @@ delimiter collisions this format is weakest at. Those are composed by hand as ex
 hazard is actually present in the data before trusting a `MemberData` theory to cover it.
 
 Several tests pin **known-lossy** behavior on purpose, say so in-place, and name the defect ticket
-they document (#596 escape asymmetry, #597 odd trailing pipe, #598 over-long piece). Do not "fix"
-such a test — fix the defect, then change the assertion deliberately.
+they document (#597 odd trailing pipe, #598 over-long piece). Do not "fix" such a test — fix the
+defect, then change the assertion deliberately. That is what #596 did: the escape asymmetry it
+pinned is gone (ADR-0039), so both its tests now assert exact round trips, and
+`TranslationLineEscaperTests` exists **twice** — one suite per bounded context, over that context's
+own copy of the rule. The two copies are duplicated by design (the contexts share the file, never
+code), so the twin suites plus `ParserContractParityTests` are the only thing keeping them in step:
+change one escaper, change the other in the same commit.
 
 ## Snapshot tests (Verify — #571)
 

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Features/ExportTextsQueryHandlerTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Features/ExportTextsQueryHandlerTests.cs
@@ -1,6 +1,7 @@
 using LotroKoniecDev.Application;
 using LotroKoniecDev.Application.Abstractions.DatFilesServices;
 using LotroKoniecDev.Application.Features.Exporting;
+using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.Domain.Core.BuildingBlocks;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Primitives.Enums;
@@ -181,4 +182,26 @@ public sealed class ExportTextsQueryHandlerTests : IDisposable
         _mockHandler.Received(1).Close(42);
     }
 
+    [Theory]
+    [InlineData("plain", "620756992||1001||plain||NULL||NULL||1")]
+    [InlineData("Line1\nLine2", @"620756992||1001||Line1\nLine2||NULL||NULL||1")]
+    [InlineData("Line1\r\nLine2", @"620756992||1001||Line1\r\nLine2||NULL||NULL||1")]
+    [InlineData(@"C:\notes", @"620756992||1001||C:\\notes||NULL||NULL||1")]
+    public void FormatRow_WithEscapableText_ShouldFoldItOntoOneLine(string text, string expected)
+        => ExportTextsQueryHandler.FormatRow(620756992, 1001, text, "NULL", "NULL").ShouldBe(expected);
+
+    [Theory]
+    [InlineData("Line1\nLine2")]
+    [InlineData("Line1\r\nLine2")]
+    [InlineData(@"C:\notes")]
+    [InlineData("Tekst z <--DO_NOT_TOUCH!--> argumentem")]
+    [InlineData(@"a||b" + "\n" + "c")]
+    public void FormatRow_ThenParse_ShouldRecoverTheFragmentTextExactly(string text)
+    {
+        // The export half of the || round trip (ADR-0039): what the exporter writes is what the
+        // patcher's own parser reads back. Nothing else pins the handler's escape call.
+        string row = ExportTextsQueryHandler.FormatRow(620756992, 1001, text, "NULL", "NULL");
+
+        new TranslationFileParser().ParseLine(row).Value.Content.ShouldBe(text);
+    }
 }

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Models/TranslationTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Models/TranslationTests.cs
@@ -147,42 +147,6 @@ public sealed class TranslationTests
     }
 
     [Fact]
-    public void GetUnescapedContent_ShouldUnescapeNewlines()
-    {
-        // Arrange
-        Translation translation = new()
-        {
-            FileId = 1,
-            GossipId = 100,
-            Content = "Line1\\nLine2\\rLine3"
-        };
-
-        // Act
-        string unescaped = translation.GetUnescapedContent();
-
-        // Assert
-        unescaped.ShouldBe("Line1\nLine2\rLine3");
-    }
-
-    [Fact]
-    public void GetUnescapedContent_WithoutEscapes_ShouldReturnSameContent()
-    {
-        // Arrange
-        Translation translation = new()
-        {
-            FileId = 1,
-            GossipId = 100,
-            Content = "Normal content without escapes"
-        };
-
-        // Act
-        string unescaped = translation.GetUnescapedContent();
-
-        // Assert
-        unescaped.ShouldBe("Normal content without escapes");
-    }
-
-    [Fact]
     public void ToString_ShouldReturnFormattedString()
     {
         // Arrange

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserNaughtyStringTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserNaughtyStringTests.cs
@@ -12,26 +12,19 @@ namespace LotroKoniecDev.Tests.Unit.Tests.Parsers;
 /// <see cref="TranslationFileParser.ParseLine"/> reading it back.
 /// </summary>
 /// <remarks>
-/// These tests pin CURRENT behavior. Changing the format itself still needs an ADR plus updated
-/// golden fixtures on both sides of the contract (CLAUDE.md).
+/// Changing the format itself needs an ADR plus updated golden fixtures on both sides of the
+/// contract (CLAUDE.md) — ADR-0039 is the last one.
 /// </remarks>
 public sealed class TranslationFileParserNaughtyStringTests
 {
     private readonly TranslationFileParser _parser = new();
 
     /// <summary>
-    /// The escape the exporter applies to every fragment before writing a line
-    /// (<c>ExportTextsQueryHandler</c>): real newlines become two-character sequences so a fragment
-    /// stays on one line.
+    /// The escape the exporter applies to every fragment before writing a line — the real one
+    /// <c>ExportTextsQueryHandler</c> calls (ADR-0039), not a copy of it.
     /// </summary>
-    /// <remarks>
-    /// KEEP IN SYNC with <c>ExportTextsQueryHandler</c> — the handler escapes inline while streaming
-    /// to a file, so there is no seam to call and the rule is duplicated here. #596 changes that
-    /// escape; this copy must move with it or these theories will keep passing while describing a
-    /// pipeline that no longer exists.
-    /// </remarks>
     private static string EscapeAsExporter(string text)
-        => text.Replace("\r", "\\r").Replace("\n", "\\n");
+        => TranslationLineEscaper.Escape(text);
 
     [Theory]
     [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
@@ -98,18 +91,15 @@ public sealed class TranslationFileParserNaughtyStringTests
     }
 
     [Theory]
-    [InlineData(@"C:\notes", "C:" + "\u000A" + "otes")]
-    [InlineData(@"backslash \n here", "backslash " + "\u000A" + " here")]
-    [InlineData(@"\r", "\u000D")]
-    [InlineData(@"\\n", "\\" + "\u000A")]
-    public void ParseLine_ContentCarryingALiteralBackslashEscapeSequence_ShouldBeLossy(string content, string expectedLossyContent)
+    [InlineData(@"C:\notes")]
+    [InlineData(@"backslash \n here")]
+    [InlineData(@"\r")]
+    [InlineData(@"\\n")]
+    public void ParseLine_ContentCarryingALiteralBackslashEscapeSequence_ShouldRoundTripExactly(string content)
     {
-        // Arrange — DOCUMENTED CURRENT BEHAVIOR, not an endorsement: the exporter escapes only REAL
-        // newlines, so a backslash that the source text itself carries in front of 'r'/'n' reaches
-        // the parser indistinguishable from an escape and is unfolded into a control character.
-        // The transform is therefore not injective and this direction loses data. Tracked as #596;
-        // pinned here so fixing it is a deliberate, visible change to this assertion, never an
-        // accident.
+        // Arrange — the escape escapes its own escape character (ADR-0039), so a backslash the
+        // source text itself carries in front of 'r'/'n' is no longer indistinguishable from an
+        // escape sequence. This used to unfold into a control character and lose data (#596).
         string line = $"620756992||1001||{EscapeAsExporter(content)}||NULL||NULL||1";
 
         // Act
@@ -117,7 +107,7 @@ public sealed class TranslationFileParserNaughtyStringTests
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.Content.ShouldBe(expectedLossyContent);
+        result.Value.Content.ShouldBe(content);
     }
 
     [Theory]

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationLineEscaperTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationLineEscaperTests.cs
@@ -1,0 +1,99 @@
+using LotroKoniecDev.Application.Parsers;
+using LotroKoniecDev.Tests.Shared;
+
+namespace LotroKoniecDev.Tests.Unit.Tests.Parsers;
+
+/// <summary>
+/// The patcher's copy of the <c>||</c> file's content escape (ADR-0039, #596). The TMS owns an
+/// identical copy in its own assembly with a twin suite — the two contexts share the file, never
+/// code — and <c>ParserContractParityTests</c> asserts the two copies agree byte for byte.
+/// </summary>
+public sealed class TranslationLineEscaperTests
+{
+    [Theory]
+    [InlineData("plain text", "plain text")]
+    [InlineData("", "")]
+    [InlineData("a\rb", @"a\rb")]
+    [InlineData("a\nb", @"a\nb")]
+    [InlineData("a\r\nb", @"a\r\nb")]
+    [InlineData(@"C:\notes", @"C:\\notes")]
+    [InlineData(@"a\nb", @"a\\nb")]
+    [InlineData("\\", @"\\")]
+    public void Escape_WithAnEscapableCharacter_ShouldFoldIt(string raw, string expected)
+        => TranslationLineEscaper.Escape(raw).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("plain text", "plain text")]
+    [InlineData("", "")]
+    [InlineData(@"a\rb", "a\rb")]
+    [InlineData(@"a\nb", "a\nb")]
+    [InlineData(@"a\r\nb", "a\r\nb")]
+    [InlineData(@"C:\\notes", @"C:\notes")]
+    [InlineData(@"a\\nb", @"a\nb")]
+    public void Unescape_WithAnEscapeSequence_ShouldUnfoldIt(string escaped, string expected)
+        => TranslationLineEscaper.Unescape(escaped).ShouldBe(expected);
+
+    [Theory]
+    [InlineData(@"a\tb")]
+    [InlineData(@"a\qb")]
+    [InlineData(@"trailing\")]
+    [InlineData(@"\")]
+    public void Unescape_WithASequenceNoWriterCanProduce_ShouldKeepItVerbatim(string legacy)
+        => TranslationLineEscaper.Unescape(legacy).ShouldBe(legacy);
+
+    [Theory]
+    [InlineData(@"\\n", @"\n")]
+    [InlineData(@"path\\to", @"path\to")]
+    public void Unescape_OnAFileWrittenBeforeTheEscapeChange_ShouldDivergeFromTheOldReader(string legacy, string expected)
+    {
+        // ACCEPTED DIVERGENCE, pinned so a future change to it is deliberate. A pre-ADR-0039 writer
+        // never escaped the backslash, so a doubled backslash meant two characters; the old reader
+        // answered "\" + LF for the first case and left the second untouched. The new reader collapses
+        // the pair, which is the only reading a conforming writer can have meant. Re-export before
+        // re-importing a legacy file (ADR-0039, "The migration cost").
+        TranslationLineEscaper.Unescape(legacy).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("Line1\nLine2")]
+    [InlineData("Line1\r\nLine2")]
+    [InlineData("Line1\rLine2")]
+    [InlineData(@"C:\notes")]
+    [InlineData(@"\r")]
+    [InlineData(@"\n")]
+    [InlineData(@"\\n")]
+    [InlineData("\\")]
+    [InlineData("")]
+    [InlineData("Zażółć gęślą jaźń")]
+    [InlineData("Tekst z <--DO_NOT_TOUCH!--> argumentem")]
+    [InlineData(@"a||b" + "\n" + "c")]
+    public void EscapeThenUnescape_WithAHandComposedHazard_ShouldReturnTheOriginal(string raw)
+        => TranslationLineEscaper.Unescape(TranslationLineEscaper.Escape(raw)).ShouldBe(raw);
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void EscapeThenUnescape_OnNaughtyContent_ShouldReturnTheOriginal(string naughty)
+        => TranslationLineEscaper.Unescape(TranslationLineEscaper.Escape(naughty)).ShouldBe(naughty);
+
+    [Theory]
+    [InlineData("Line1\nLine2")]
+    [InlineData(@"C:\notes")]
+    [InlineData("mixed \\ and \r\n together")]
+    public void Escape_WithARealNewline_ShouldNeverEmitACharacterThatSplitsTheLine(string raw)
+    {
+        // Act
+        string escaped = TranslationLineEscaper.Escape(raw);
+
+        // Assert — the whole point of the escape: one row is one line.
+        escaped.ShouldNotContain("\r");
+        escaped.ShouldNotContain("\n");
+    }
+
+    [Fact]
+    public void Escape_WithNull_ShouldThrowInsteadOfReturningNull()
+        => Should.Throw<ArgumentNullException>(() => TranslationLineEscaper.Escape(null!));
+
+    [Fact]
+    public void Unescape_WithNull_ShouldThrowInsteadOfReturningNull()
+        => Should.Throw<ArgumentNullException>(() => TranslationLineEscaper.Unescape(null!));
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/CoreLoop/CoreLoopTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/CoreLoop/CoreLoopTests.cs
@@ -151,6 +151,60 @@ public sealed class CoreLoopTests : IAsyncLifetime
         secondFile.ShouldNotContain($"{FileId}||1||");
     }
 
+    [Fact]
+    public async Task CoreLoop_ContentCarryingNewlinesAndBackslashes_SurvivesImportApproveDownloadAndPatcherParse()
+    {
+        // #596 / ADR-0039 end to end. Two hazards in one flow: a Polish translation typed with real
+        // newlines in the editor's textarea (it used to split the row into two malformed lines and
+        // vanish from the file), and a literal backslash in front of 'n' (it used to unfold into a
+        // control character on the patcher's side).
+        const string multiLinePolish = "Polski jeden\nDruga linia";
+        const string backslashPolish = @"Sciezka C:\notes";
+        const string escapedMultiLinePolish = @"Polski jeden\nDruga linia";
+        const string escapedBackslashPolish = @"Sciezka C:\\notes";
+
+        using HttpClient admin = AdminClient();
+        using HttpClient translator = TranslatorClient();
+
+        // The English baseline itself arrives escaped from the patcher's exporter.
+        Guid versionId = await RegisterVersionAsync(admin, "48.0");
+        await ImportAsync(admin, versionId, Line(1, @"English one\nsecond line"), Line(2, "English two"));
+
+        // The import unfolds the escape, so the catalog holds the raw source the DAT contains.
+        TranslationDetailResponse first = await UpsertAsync(translator, gossipId: 1, polish: multiLinePolish);
+        first.SourceText.ShouldBe("English one\nsecond line");
+
+        TranslationDetailResponse second = await UpsertAsync(translator, gossipId: 2, polish: backslashPolish);
+        (await admin.PostAsync(ApproveRoute(first.Id.Value), null)).StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        (await admin.PostAsync(ApproveRoute(second.Id.Value), null)).StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        // Both rows reach the distributed file, each folded onto exactly one line.
+        (_, string file) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            FileRoute,
+            (candidate, content) => candidate.IsSuccessStatusCode
+                && content.Contains($"{FileId}||2||{escapedBackslashPolish}||NULL||NULL||1"));
+        file.ShouldContain($"{FileId}||1||{escapedMultiLinePolish}||NULL||NULL||1");
+        file.ShouldContain($"{FileId}||2||{escapedBackslashPolish}||NULL||NULL||1");
+
+        // And the patcher recovers the raw text it is about to write into the DAT.
+        string tempFile = Path.Combine(Path.GetTempPath(), $"polish_{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(tempFile, file);
+        try
+        {
+            IReadOnlyList<LotroKoniecDev.Domain.Models.Translation> parsed =
+                new TranslationFileParser().ParseFile(tempFile).Value;
+
+            parsed.Count.ShouldBe(2);
+            parsed[0].Content.ShouldBe(multiLinePolish);
+            parsed[1].Content.ShouldBe(backslashPolish);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
     private static string ApproveRoute(Guid translationId) => $"{TranslationsRoute}/{translationId}/approve";
 
     private static string Line(int gossipId, string text) => $"{FileId}||{gossipId}||{text}||NULL||NULL||1";

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/TestData/exported-sample.txt
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/TestData/exported-sample.txt
@@ -1,7 +1,10 @@
 # Golden fixture mirroring the patcher's || contract. Guards both contexts against format drift.
+# Rows 1006-1007 carry the ADR-0039 escape: \n / \r fold a real newline, \\ folds a real backslash.
 620756992||1001||Witaj w Srodziemiu!||NULL||NULL||1
 620756992||1002||Tekst z <--DO_NOT_TOUCH!--> argumentem||1||1||1
 620756992||1003||Line with || inside the content||NULL||NULL||1
 620756992||1004||Multi||arg||content||1-2||1-2||1
 
 620756992||1005||Trailing approved zero||NULL||NULL||0
+620756992||1006||Wiersz jeden\nWiersz dwa\r\nWiersz trzy||NULL||NULL||1
+620756992||1007||Sciezka C:\\notes i sekwencja \\n||NULL||NULL||1

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/ParserContractParityTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/ParserContractParityTests.cs
@@ -2,6 +2,8 @@ using System.Text;
 using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.Tests.Shared;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
+using PatcherEscaper = LotroKoniecDev.Application.Parsers.TranslationLineEscaper;
+using TmsEscaper = LotroKoniecDev.TranslationSystem.API.Parsing.TranslationLineEscaper;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
 
@@ -9,10 +11,9 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
 /// The two bounded contexts own independent parsers of the same <c>||</c> contract
 /// (CLAUDE.md: "share a data contract, not code"). This is the contract's drift guard: it pins that
 /// the patcher's <see cref="TranslationFileParser"/> and the TMS' <see cref="TranslationExportParser"/>
-/// carve an export line identically. They diverge only by design — the patcher unescapes content and
-/// converts the args columns to 0-indexed int arrays, the TMS keeps the verbatim exported
-/// representation — so parity is asserted at the contract-field level: file id, gossip id, the
-/// both-ends-anchored content, the args boundary, and the approved flag.
+/// carve an export line identically. Since ADR-0039 both unfold the content escape, so content is
+/// compared directly on every input; the one remaining representational difference is the args
+/// columns (the patcher converts them to 0-indexed int arrays), rebuilt here for comparison.
 /// </summary>
 public sealed class ParserContractParityTests
 {
@@ -32,9 +33,8 @@ public sealed class ParserContractParityTests
         ParsedExport tmsExport = await ParseAsync(line);
         ParsedExportRow tms = tmsExport.Rows.ShouldHaveSingleItem();
 
-        // Assert — these lines carry no escape sequences, so the patcher's unescape is a no-op and
-        // the anchored content compares directly; the args boundary is checked by rebuilding the
-        // verbatim args string from the patcher's int arrays.
+        // Assert — the args boundary is checked by rebuilding the verbatim args string from the
+        // patcher's int arrays; everything else compares directly.
         patcher.FileId.ShouldBe(tms.FileId);
         ((long)patcher.GossipId).ShouldBe(tms.GossipId);
         patcher.Content.ShouldBe(tms.Content);
@@ -48,9 +48,9 @@ public sealed class ParserContractParityTests
     public async Task BothParsers_OnNaughtyContent_ShouldCarveTheSameContractLineIdentically(string naughty)
     {
         // Arrange — hostile content is where two hand-written parsers of one format drift apart
-        // first (#569). No entry of the list carries a real newline or a literal backslash escape
-        // sequence, so the patcher's unescape stays a no-op here and the two contents compare
-        // directly; the escape asymmetry itself is pinned in the per-parser suites.
+        // first (#569). The corpus is injected RAW, so this asserts the two parsers agree on
+        // whatever they make of it, not that the line round-trips; fidelity is the job of the
+        // per-parser suites, which feed the corpus through the matching writer first.
         string line = $"620756992||1001||{naughty}||1-2||1-2||1";
 
         LotroKoniecDev.Domain.Models.Translation patcher = new TranslationFileParser().ParseLine(line).Value;
@@ -70,13 +70,15 @@ public sealed class ParserContractParityTests
     [Theory]
     [InlineData(@"Line1\nLine2", "Line1\u000ALine2")]
     [InlineData(@"Line1\rLine2", "Line1\u000DLine2")]
-    public async Task BothParsers_OnAnEscapeSequence_ShouldDivergeExactlyAsDesigned(string escapedContent, string unescapedContent)
+    [InlineData(@"C:\\notes", @"C:\notes")]
+    [InlineData(@"sekwencja \\n", @"sekwencja \n")]
+    [InlineData(@"nieznana \t sekwencja", @"nieznana \t sekwencja")]
+    public async Task BothParsers_OnAnEscapeSequence_ShouldUnfoldItIdentically(string escapedContent, string rawContent)
     {
-        // Arrange — the ONE deliberate difference between the two parsers, and the reason the theory
-        // above compares contents directly: the patcher unfolds the exporter's escape because it is
-        // about to write real characters into the DAT, while the TMS keeps the exported
-        // representation verbatim so the row round-trips byte-for-byte back out to the patcher.
-        // Nothing else pins this, and no naughty string reaches it (none carries such a sequence).
+        // Arrange — this used to be the ONE deliberate divergence: the patcher unfolded the escape
+        // while the TMS kept the file representation. ADR-0039 made the escape a property of the
+        // file rather than of one caller, so both readers now answer with the raw text. No naughty
+        // string carries such a sequence, so these cases are composed by hand.
         string line = $"620756992||1001||{escapedContent}||NULL||NULL||1";
 
         // Act
@@ -84,8 +86,80 @@ public sealed class ParserContractParityTests
         ParsedExportRow tms = (await ParseAsync(line)).Rows.ShouldHaveSingleItem();
 
         // Assert
-        patcher.Content.ShouldBe(unescapedContent);
-        tms.Content.ShouldBe(escapedContent);
+        patcher.Content.ShouldBe(rawContent);
+        tms.Content.ShouldBe(rawContent);
+    }
+
+    [Fact]
+    public async Task BothParsers_OnTheGoldenFixture_ShouldProduceTheSameContentForEveryRow()
+    {
+        // Arrange — the golden fixture IS the contract (CLAUDE.md), so it is driven through BOTH
+        // parsers rather than only the TMS one. The patcher parser is per-line, so comments and
+        // blank lines are filtered the way its own ParseFile does.
+        string path = Path.Combine(AppContext.BaseDirectory, "TestData", "exported-sample.txt");
+        string[] rowLines = (await File.ReadAllLinesAsync(path))
+            .Where(line => !string.IsNullOrWhiteSpace(line) && !line.TrimStart().StartsWith('#'))
+            .ToArray();
+
+        await using FileStream stream = File.OpenRead(path);
+        ParsedExport tmsExport = await new TranslationExportParser().ParseAsync(stream, CancellationToken.None);
+
+        // Act
+        TranslationFileParser patcher = new();
+        string[] patcherContents = rowLines.Select(line => patcher.ParseLine(line).Value.Content).ToArray();
+
+        // Assert
+        tmsExport.Errors.ShouldBeEmpty();
+        tmsExport.Rows.Select(row => row.Content).ShouldBe(patcherContents);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void BothEscapers_OnTheSameInput_ShouldProduceIdenticalBytes(string naughty)
+    {
+        // The two copies of the escape rule (ADR-0039) are duplicated by design — the contexts share
+        // the file, never code — so nothing but this test stops one of them from drifting. The twin
+        // per-context suites would both stay green through a one-sided change; this one would not.
+        PatcherEscaper.Escape(naughty).ShouldBe(TmsEscaper.Escape(naughty));
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public async Task PatcherExporterEscape_ThenTmsImportParse_ShouldRecoverTheOriginal(string naughty)
+    {
+        // Arrange — THE production direction: the patcher writes exported.txt, the TMS reads it.
+        // Every other suite covers one context's writer against its own reader, or the TMS writer
+        // against the patcher reader; this is the leg that carries every real import.
+        string escaped = PatcherEscaper.Escape(naughty);
+        string line = $"620756992||1001||{escaped}||NULL||NULL||1";
+
+        // Act
+        ParsedExport parsed = await ParseAsync(line);
+
+        // Assert
+        parsed.Errors.ShouldBeEmpty();
+        parsed.Rows.ShouldHaveSingleItem().Content.ShouldBe(naughty);
+    }
+
+    [Theory]
+    [InlineData("Line1\nLine2")]
+    [InlineData("Line1\r\nLine2")]
+    [InlineData(@"C:\notes")]
+    [InlineData(@"a||b\nc")]
+    [InlineData("")]
+    public async Task PatcherExporterEscape_ThenTmsImportParse_OnAHandComposedHazard_ShouldRecoverTheOriginal(string raw)
+    {
+        // Arrange — the naughty corpus carries no real newline, no escape sequence and no separator
+        // combined with one, so the hazards this format is weakest at are composed by hand.
+        string escaped = PatcherEscaper.Escape(raw);
+        string line = $"620756992||1001||{escaped}||NULL||NULL||1";
+
+        // Act
+        ParsedExport parsed = await ParseAsync(line);
+
+        // Assert
+        parsed.Errors.ShouldBeEmpty();
+        parsed.Rows.ShouldHaveSingleItem().Content.ShouldBe(raw);
     }
 
     private static async Task<ParsedExport> ParseAsync(string content)

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationExportParserTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationExportParserTests.cs
@@ -30,13 +30,27 @@ public sealed class TranslationExportParserTests
         // Act
         ParsedExport result = await ParseFixtureAsync("exported-sample.txt");
 
-        // Assert — the comment and the blank line are skipped, five rows remain.
+        // Assert — the comments and the blank line are skipped, seven rows remain.
         result.HasErrors.ShouldBeFalse();
-        result.Rows.Count.ShouldBe(5);
+        result.Rows.Count.ShouldBe(7);
         result.Rows[0].FileId.ShouldBe(620756992);
         result.Rows[0].GossipId.ShouldBe(1001);
         result.Rows[0].Content.ShouldBe("Witaj w Srodziemiu!");
         result.Rows[0].ArgsOrder.ShouldBe("NULL");
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithGoldenFixture_ShouldUnfoldTheEscapeIntoRawText()
+    {
+        // Act
+        ParsedExport result = await ParseFixtureAsync("exported-sample.txt");
+
+        // Assert — the catalog stores raw text, never the file representation (ADR-0039). The
+        // backslash row is what proves the transform is injective: it must NOT become a newline.
+        result.Rows.Single(row => row.GossipId == 1006).Content
+            .ShouldBe("Wiersz jeden\nWiersz dwa\r\nWiersz trzy");
+        result.Rows.Single(row => row.GossipId == 1007).Content
+            .ShouldBe(@"Sciezka C:\notes i sekwencja \n");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileNaughtyStringTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileNaughtyStringTests.cs
@@ -11,8 +11,8 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
 /// <c>exported.txt</c> back.
 /// </summary>
 /// <remarks>
-/// These tests pin CURRENT behavior. Changing the format itself still needs an ADR plus updated
-/// golden fixtures on both sides of the contract (CLAUDE.md).
+/// Changing the format itself needs an ADR plus updated golden fixtures on both sides of the
+/// contract (CLAUDE.md) — ADR-0039 is the last one.
 /// </remarks>
 public sealed class TranslationFileNaughtyStringTests
 {
@@ -93,23 +93,40 @@ public sealed class TranslationFileNaughtyStringTests
     [InlineData("Polish\ntext")]
     [InlineData("Polish\r\ntext")]
     [InlineData("Polish\rtext")]
-    public async Task SerializeThenParse_ContentCarryingARealNewline_ShouldLoseTheRow(string content)
+    [InlineData("Multi\nline\r\nPolish\rtext")]
+    public async Task SerializeThenParse_ContentCarryingARealNewline_ShouldRoundTripExactly(string content)
     {
-        // Arrange — DOCUMENTED CURRENT BEHAVIOR, not an endorsement. The serializer emits content
-        // verbatim because imported source text arrives already escaped from the patcher's exporter.
-        // Translator-submitted Polish never passes through that escape (the editor is a multi-line
-        // textarea and the upsert slice only checks NotEmpty), so a newline in a translation splits
-        // one row into two malformed lines and the fragment silently disappears from the distributed
-        // file. Tracked as #596; pinned here so fixing it is a deliberate, visible change to this
-        // assertion, never an accident.
+        // Arrange — translator-submitted Polish reaches the serializer raw (the editor is a
+        // multi-line textarea and the upsert slice only checks NotEmpty), so the WRITER escapes it
+        // (ADR-0039). Before that, a newline split one row into two malformed lines and the fragment
+        // silently disappeared from the distributed file (#596).
         string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, content, null, null)]);
 
         // Act
         ParsedExport parsed = await ParseAsync(file);
 
         // Assert
-        parsed.Rows.ShouldBeEmpty();
-        parsed.Errors.ShouldNotBeEmpty();
+        parsed.Errors.ShouldBeEmpty();
+        parsed.Rows.ShouldHaveSingleItem().Content.ShouldBe(content);
+    }
+
+    [Theory]
+    [InlineData(@"C:\notes")]
+    [InlineData(@"backslash \n here")]
+    [InlineData(@"\r")]
+    [InlineData(@"\\n")]
+    public async Task SerializeThenParse_ContentCarryingALiteralBackslashEscapeSequence_ShouldRoundTripExactly(string content)
+    {
+        // Arrange — the other half of #596: the escape escapes its own escape character, so a
+        // backslash in front of 'r'/'n' survives instead of unfolding into a control character.
+        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, content, null, null)]);
+
+        // Act
+        ParsedExport parsed = await ParseAsync(file);
+
+        // Assert
+        parsed.Errors.ShouldBeEmpty();
+        parsed.Rows.ShouldHaveSingleItem().Content.ShouldBe(content);
     }
 
     [Theory]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileSerializerParityTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileSerializerParityTests.cs
@@ -40,17 +40,27 @@ public sealed class TranslationFileSerializerParityTests
         }
     }
 
-    [Fact]
-    public void SerializedRow_WithEscapedNewline_ShouldBeUnescapedByThePatcher()
+    [Theory]
+    [InlineData("Line1\nLine2")]
+    [InlineData("Line1\r\nLine2")]
+    [InlineData("Line1\rLine2")]
+    [InlineData(@"C:\notes")]
+    [InlineData(@"backslash \n here")]
+    [InlineData(@"a||b" + "\n" + "c")]
+    [InlineData("Zażółć gęślą jaźń")]
+    public void SerializedRow_CarryingAnEscapableCharacter_ShouldReachThePatcherIntact(string content)
     {
-        // Arrange — content is stored escaped; the patcher unescapes on its way into the DAT.
-        string serialized = new TranslationFileSerializer().Serialize([new ArtifactRow(1, 2, @"Line1\nLine2", null, null)]);
+        // Arrange — the end-to-end statement of ADR-0039: the TMS stores raw text, escapes it on the
+        // way out, and the patcher unfolds it on the way into the DAT. This is #596's acceptance
+        // criterion expressed across both contexts.
+        string serialized = new TranslationFileSerializer().Serialize([new ArtifactRow(1, 2, content, null, null)]);
 
-        // Act
+        // Act — the escape guarantees exactly one line, so trimming the terminator is safe.
+        string[] lines = serialized.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
         LotroKoniecDev.Domain.Models.Translation parsed =
-            new TranslationFileParser().ParseLine(serialized.TrimEnd('\r', '\n')).Value;
+            new TranslationFileParser().ParseLine(lines.ShouldHaveSingleItem()).Value;
 
         // Assert
-        parsed.Content.ShouldBe("Line1\nLine2");
+        parsed.Content.ShouldBe(content);
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileSerializerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileSerializerTests.cs
@@ -22,9 +22,19 @@ public sealed class TranslationFileSerializerTests
             .ShouldBe("1||2||x||NULL||NULL||1\r\n");
 
     [Fact]
-    public void Serialize_WithEscapedNewlines_ShouldKeepThemVerbatim()
-        => Serialize(new ArtifactRow(1, 2, @"Line1\nLine2", null, null))
+    public void Serialize_WithARealNewline_ShouldFoldItOntoOneLine()
+        => Serialize(new ArtifactRow(1, 2, "Line1\nLine2", null, null))
             .ShouldBe(@"1||2||Line1\nLine2||NULL||NULL||1" + "\r\n");
+
+    [Fact]
+    public void Serialize_WithARealCarriageReturnLineFeed_ShouldFoldBothCharacters()
+        => Serialize(new ArtifactRow(1, 2, "Line1\r\nLine2", null, null))
+            .ShouldBe(@"1||2||Line1\r\nLine2||NULL||NULL||1" + "\r\n");
+
+    [Fact]
+    public void Serialize_WithALiteralBackslash_ShouldEscapeItSoTheParserCannotMistakeItForAnEscape()
+        => Serialize(new ArtifactRow(1, 2, @"Line1\nLine2", null, null))
+            .ShouldBe(@"1||2||Line1\\nLine2||NULL||NULL||1" + "\r\n");
 
     [Fact]
     public void Serialize_WithSeparatorInContent_ShouldEmitItVerbatim()

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationLineEscaperTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationLineEscaperTests.cs
@@ -1,0 +1,99 @@
+using LotroKoniecDev.Tests.Shared;
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
+
+/// <summary>
+/// The TMS' copy of the <c>||</c> file's content escape (ADR-0039, #596). The patcher owns an
+/// identical copy in its own assembly with a twin suite — the two contexts share the file, never
+/// code — and <see cref="ParserContractParityTests"/> asserts the two copies agree byte for byte.
+/// </summary>
+public sealed class TranslationLineEscaperTests
+{
+    [Theory]
+    [InlineData("plain text", "plain text")]
+    [InlineData("", "")]
+    [InlineData("a\rb", @"a\rb")]
+    [InlineData("a\nb", @"a\nb")]
+    [InlineData("a\r\nb", @"a\r\nb")]
+    [InlineData(@"C:\notes", @"C:\\notes")]
+    [InlineData(@"a\nb", @"a\\nb")]
+    [InlineData("\\", @"\\")]
+    public void Escape_WithAnEscapableCharacter_ShouldFoldIt(string raw, string expected)
+        => TranslationLineEscaper.Escape(raw).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("plain text", "plain text")]
+    [InlineData("", "")]
+    [InlineData(@"a\rb", "a\rb")]
+    [InlineData(@"a\nb", "a\nb")]
+    [InlineData(@"a\r\nb", "a\r\nb")]
+    [InlineData(@"C:\\notes", @"C:\notes")]
+    [InlineData(@"a\\nb", @"a\nb")]
+    public void Unescape_WithAnEscapeSequence_ShouldUnfoldIt(string escaped, string expected)
+        => TranslationLineEscaper.Unescape(escaped).ShouldBe(expected);
+
+    [Theory]
+    [InlineData(@"a\tb")]
+    [InlineData(@"a\qb")]
+    [InlineData(@"trailing\")]
+    [InlineData(@"\")]
+    public void Unescape_WithASequenceNoWriterCanProduce_ShouldKeepItVerbatim(string legacy)
+        => TranslationLineEscaper.Unescape(legacy).ShouldBe(legacy);
+
+    [Theory]
+    [InlineData(@"\\n", @"\n")]
+    [InlineData(@"path\\to", @"path\to")]
+    public void Unescape_OnAFileWrittenBeforeTheEscapeChange_ShouldDivergeFromTheOldReader(string legacy, string expected)
+    {
+        // ACCEPTED DIVERGENCE, pinned so a future change to it is deliberate. A pre-ADR-0039 writer
+        // never escaped the backslash, so a doubled backslash meant two characters; the old reader
+        // answered "\" + LF for the first case and left the second untouched. The new reader collapses
+        // the pair, which is the only reading a conforming writer can have meant. Re-export before
+        // re-importing a legacy file (ADR-0039, "The migration cost").
+        TranslationLineEscaper.Unescape(legacy).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("Line1\nLine2")]
+    [InlineData("Line1\r\nLine2")]
+    [InlineData("Line1\rLine2")]
+    [InlineData(@"C:\notes")]
+    [InlineData(@"\r")]
+    [InlineData(@"\n")]
+    [InlineData(@"\\n")]
+    [InlineData("\\")]
+    [InlineData("")]
+    [InlineData("Zażółć gęślą jaźń")]
+    [InlineData("Tekst z <--DO_NOT_TOUCH!--> argumentem")]
+    [InlineData(@"a||b" + "\n" + "c")]
+    public void EscapeThenUnescape_WithAHandComposedHazard_ShouldReturnTheOriginal(string raw)
+        => TranslationLineEscaper.Unescape(TranslationLineEscaper.Escape(raw)).ShouldBe(raw);
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
+    public void EscapeThenUnescape_OnNaughtyContent_ShouldReturnTheOriginal(string naughty)
+        => TranslationLineEscaper.Unescape(TranslationLineEscaper.Escape(naughty)).ShouldBe(naughty);
+
+    [Theory]
+    [InlineData("Line1\nLine2")]
+    [InlineData(@"C:\notes")]
+    [InlineData("mixed \\ and \r\n together")]
+    public void Escape_WithARealNewline_ShouldNeverEmitACharacterThatSplitsTheLine(string raw)
+    {
+        // Act
+        string escaped = TranslationLineEscaper.Escape(raw);
+
+        // Assert — the whole point of the escape: one row is one line.
+        escaped.ShouldNotContain("\r");
+        escaped.ShouldNotContain("\n");
+    }
+
+    [Fact]
+    public void Escape_WithNull_ShouldThrowInsteadOfReturningNull()
+        => Should.Throw<ArgumentNullException>(() => TranslationLineEscaper.Escape(null!));
+
+    [Fact]
+    public void Unescape_WithNull_ShouldThrowInsteadOfReturningNull()
+        => Should.Throw<ArgumentNullException>(() => TranslationLineEscaper.Unescape(null!));
+}


### PR DESCRIPTION
Closes #596

## What

The `||` file's escape was a property of **one caller** (the patcher's exporter) instead of a property of the file: applied at one of four ends, inverted at another, and it never escaped its own escape character. ADR-0039 makes it a property of the format.

| End | Before | Now |
|---|---|---|
| patcher `ExportTextsQueryHandler` (writes `exported.txt`) | escapes CR/LF | escapes `\`, CR, LF |
| TMS `TranslationExportParser` (reads it) | **nothing** | unescapes |
| TMS `TranslationFileSerializer` (writes `polish.txt`) | **nothing** | escapes |
| patcher `TranslationFileParser` (reads it) | unescapes CR/LF | unescapes `\\`, `\r`, `\n` |

The rule is `\`→`\\`, CR→`\r`, LF→`\n`, so `Unescape(Escape(x)) == x` for every string. The database now holds **raw** text — the escape exists only between `Serialize` and `Parse`. `TranslationLineEscaper` is duplicated once per bounded context on purpose (the contexts share the file, never code); the parity suite asserts the two copies agree byte for byte.

Also drops `Translation.GetUnescapedContent()` — a third copy of the old rule, unused by production since the parser unescapes on parse, and a double-unescape trap.

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| A translation containing `\n` / `\r\n` / `\r` survives approve → artifact rebuild → download → patcher parse | `CoreLoopTests.CoreLoop_ContentCarryingNewlinesAndBackslashes_…` — end to end against real PostgreSQL |
| A literal backslash before `r`/`n` round-trips byte-exact through both parsers | the two flipped pinning tests + `BothParsers_OnAnEscapeSequence_ShouldUnfoldItIdentically` |
| Source text from a patcher export is not double-escaped | the import parser unescapes; `ParseAsync_WithGoldenFixture_ShouldUnfoldTheEscapeIntoRawText` |
| Both unit suites and the parity guard green, zero warnings | see below |

## Migration — `TranslatedText` is backfilled, source text is not

Under the old pipeline the **only** way a translator could produce a line break was to type the two characters `\n` (the serializer emitted them verbatim, the patcher unescaped them unconditionally) — `translations/polish.txt` shows that convention in the wild. Escaping on write would turn every such row into a literal backslash-n **in game**, and a re-import rewrites source rows but never translated ones, so there would be no repair path at all. Hence a one-shot data migration applying the old reader's rule to the column: behavior-preserving, not a guess.

Verified against PostgreSQL 17 over a hazard matrix (`\\n`, `C:\notes`, a trailing lone backslash, rows already holding a real LF, `\q` markup, NULL): the `WHERE` selects exactly the rows the `SET` would change, results match the old C# reader on all of them, and a second run is `UPDATE 0`. `E''` literals are load-bearing — with `standard_conforming_strings` off a plain `'\r'` parses as a carriage return and the migration would silently do nothing.

Source columns are left alone: their stored form is genuinely ambiguous (that *is* defect 2), so any script would pick one reading and corrupt the other. **Operational step after deploy:** re-export with the new CLI and re-import. Rows whose English text contains a newline will report as source-changed and their approved Polish will be flagged `NeedsReview` — the honest outcome, because the stored source for those rows really was wrong. No translation text is lost.

## Deliberately not done

- **Line-ending normalization.** An HTML `<textarea>` submits CRLF, so a translator pressing Enter now stores `\r\n`. Not normalized: #596's AC requires `\n`, `\r\n` **and `\r`** to survive *intact*, and rewriting what a translator typed is a product decision, not a transport one. Recorded as ADR-0039 §6; worth its own ticket after someone checks how the DAT renders a CR.
- **A second golden fixture on the patcher side.** One shared fixture driven through *both* parsers is strictly stronger than two copies that can drift apart.

## Test summary

Build 0 warnings. Unit: `Tests.Unit` 3811, `TranslationSystem.API.Tests.Unit` 4273 (+1111 — the drift guard), Architecture 21, Domain 3511, SharedKernel 69, Frontend 442, AuthSystem 154, Logging 36. Integration: TMS 217 green against real PostgreSQL (which applies the new migration). Gates: migration-safety, SSR purity, Dockerfile restore graph, classify-changes — all pass.

Reviewed twice by the `code-reviewer` agent; every blocking finding is fixed (the `E''` literal was the last one).
