### PR TITLE
TMS discovery: claims-aware link set and anonymous root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,15 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
   upsert (added in M2-11; persisted via the `IdentityId` converter in `TranslationSystem.Persistence`),
   and `ApprovedById` lands with the approve slice (#101 / M2-12). No auth-less interim state to
   retrofit later.
+- **Hypermedia links are authorization-aware, not role-branched (ADR-0040).** `ILinkFactory` replays
+  the *target* endpoint's own policy (`IAllowAnonymous` → `AuthorizationPolicy.CombineAsync` incl.
+  the fallback → `IAuthorizationService`) before emitting a link, so a rel is never advertised to a
+  caller who would get 401/403 following it. Never restate a role rule inside a link factory — a
+  link factory encodes *state* rules only (removed, `Draft`/`NeedsReview`, `Unprocessed`). The TMS
+  service document (`GET /`) is the one deliberate `AllowAnonymous` hole in authorized-by-default:
+  it advertises only what the caller may already reach, and it is what lets the CLI (and M4) boot
+  without hardcoded paths. Only parameterless entry points belong in it; id-keyed affordances
+  (`approve`, `delete`, `import`) live on the representation carrying the id.
 - **Validation:** FluentValidation **for commands only** — the command handler injects
   `IValidator<TCommand>` and maps failures to `Result` (never throws). Queries validate inline
   in their handler. Every validator must be registered in DI.

--- a/docs/adr/0040-authorization-aware-hateoas-links-and-an-anonymous-tms-root.md
+++ b/docs/adr/0040-authorization-aware-hateoas-links-and-an-anonymous-tms-root.md
@@ -1,0 +1,175 @@
+# ADR-0040: Authorization-aware HATEOAS link emission, and an anonymous TMS service document
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Solo maintainer
+**Related:** #608 (the ticket), #309 (anonymous translation browsing), #153 (link-driven frontend affordances), ADR-0031 (deletion grace window — the auth link set this must not disturb), `LinkFactory`, `DiscoveryLinkFactory` (both systems), `DiscoveryCache` (frontend)
+
+## Context
+
+The TMS advertised one link — `self` — from a root that required a bearer token. Two consequences,
+both load-bearing:
+
+1. **Nothing was discoverable.** `TranslationSystem.Contracts/Hateoas/Rels.cs` carried actions
+   (`upsert`, `approve`, `register`, `delete`) and pagination, but no vocabulary for entry points. So
+   every client hardcodes paths: the frontend six of them, the CLI
+   `api/v1/translation-files/pl` in `TranslationFileDownloader`.
+2. **The one client that most needs discovery could not reach it.** Three TMS endpoints are
+   deliberately anonymous — `GetTranslationFile` (the CLI's download, #309-era decision),
+   `GetPublicProgress` (the public home page) and `ListTranslations`. An unauthenticated client had
+   no way to learn about any of them.
+
+The frontend was already written against the fixed shape: `DiscoveryCache` keys its TMS entry by auth
+state precisely because "the API tailors its HATEOAS link set per role". The API never delivered that
+tailoring.
+
+The obvious fix — branch on roles inside `DiscoveryLinkFactory` — restates each endpoint's
+authorization rules in a second place. Those two places then drift, and a HATEOAS link that lies is
+worse than no link: the client renders an affordance and the server answers 403.
+
+The complication is blast radius. `LinkFactory` lives in the shared `Utilities/LotroKoniecDev.Hateoas`
+project and serves **both** APIs. Auth discovery works correctly today and the frontend depends on it
+hard: `DiscoveryCache` throws `AuthenticatedLinksDegradedException` and force-signs-out the session
+when an authenticated caller does not get `export-account-data` back. A regression there silently
+breaks the whole account section.
+
+## Decision
+
+### 1. A link is emitted only when the caller would be allowed to follow it
+
+`ILinkFactory.CreateAsync` resolves the target endpoint's URI as before, then replays ASP.NET's own
+authorization decision for that endpoint against the current request's caller. The endpoint's policy
+stays the single source of truth; no link factory restates a role rule.
+
+The evaluation mirrors `AuthorizationMiddleware` step for step:
+
+1. Find the target `Endpoint` via `IEndpointAddressScheme<string>` — the same address scheme
+   `LinkGenerator.GetUriByName` just used, so it is a dictionary lookup on the very endpoint whose
+   URI was generated, not a second and possibly divergent match.
+2. `IAllowAnonymous` metadata short-circuits to allowed, exactly as the middleware does. **The order
+   matters and is not cosmetic:** `AllowAnonymousAttribute` does not implement `IAuthorizeData`, so
+   under an authorized-by-default app an anonymous endpoint *still* combines to the fallback policy
+   (verified against .NET 10 — a `MapGet(...).AllowAnonymous()` yields
+   `DenyAnonymousAuthorizationRequirement` from `CombineAsync`). Evaluate the policy first and every
+   public endpoint's link disappears for the guests it exists for.
+3. `AuthorizationPolicy.CombineAsync(provider, authorizeData, policies)` folds the endpoint's
+   `IAuthorizeData` with the application's **fallback** policy — verified: an endpoint with no
+   authorization metadata at all combines to the fallback, not to `null`. This is what makes an
+   authorized-by-default API (the TMS sets a `RequireAuthenticatedUser` fallback) fail closed for an
+   endpoint that carries no metadata of its own.
+4. A null policy means allowed. Otherwise `IAuthorizationService.AuthorizeAsync(user, null,
+   policy.Requirements)` decides.
+
+**Rejected: hand-rolled role checks in each discovery factory.** Simpler, and wrong for exactly the
+case the tests now pin — a correctly-signed token whose role is neither `Admin` nor `Translator`
+clears `RequireAuthenticatedUser` but not the role policies. A hand-written `isAuthenticated` branch
+would have advertised the translator surface to it.
+
+**Consequence accepted: the whole link-building chain became async.** `IAuthorizationService` is
+asynchronous and blocking on it is not an option, so `Create` → `CreateAsync`, every aggregate/
+pagination/discovery factory method gained an `Async` suffix, and `HateoasResults.Ok`'s attacher went
+from `Action<T>` to `Func<T, ValueTask>`. Seven endpoint call sites across both APIs. The delegate is
+still only invoked when the client asked for the HATEOAS media type, so plain-JSON callers pay
+nothing.
+
+**Consequence accepted: `ILinkFactory` is now scoped, not singleton** — it depends on the scoped
+`IAuthorizationService`. DI validation (`ValidateScopes` + `ValidateOnBuild`, #572) would have caught
+the captive dependency at startup; the registration was changed deliberately instead.
+
+No per-request caching of the resolved policy. `CombineAsync` builds a small object and the
+requirements in play are role/claim checks that complete synchronously; a discovery document is ten
+links. Caching is available later (`IAuthorizationPolicyProvider.AllowsCachingPolicies` is the same
+guard the framework uses) if a profile ever justifies it.
+
+### 2. The TMS root is anonymous; its contents are claims-aware
+
+`Discovery` gets `.AllowAnonymous()`. This is the one deliberate hole in the authorized-by-default
+house rule, and it is safe for a specific reason: **the endpoints advertised to an anonymous caller
+are themselves anonymous**, so the document leaks nothing the caller could not already reach. This is
+how OIDC discovery and service documents work everywhere, and it is what lets the CLI — and the M4
+Avalonia app — bootstrap without credentials. The admin surface stays hidden through claims-aware
+link emission, not by walling off the root.
+
+The endpoint is mapped through `MapEndpoints(endpointsGroup)` like every other `IEndpoint`, so it
+stays inside the rate-limited group; the anonymous root is not a free unauthenticated hit in
+production.
+
+A bearer the API refuses (expired, unknown key) is simply not a caller identity on an anonymous
+endpoint: the request succeeds and returns the guest link set rather than 401. Token rejection is
+still enforced on every protected route.
+
+### 3. Discovery advertises entry points; id-keyed affordances live on the resource that carries the id
+
+Only parameterless routes belong in the service document. `import`
+(`POST /api/v1/game-versions/{id}/import`), `delete` and `approve` need an id, and
+`LinkGenerator.GetUriByName` cannot resolve a route whose required values are missing — it would
+return null and log a warning on every request.
+
+So the ticket's "admin sees register/delete/import" is satisfied across two representations, not one:
+`register` is an entry point and ships in the document; `delete` was already on the game-version item
+and `import` joins it there. That is also the correct hypermedia shape — a client learns an id by
+following `game-versions`, and the affordances for that id arrive with it.
+
+`import` is advertised to an admin on any version that is **not** `Superseded`: re-importing into an
+already-processed version is legal (`MarkAsProcessed` refuses only the superseded state), so unlike
+`delete` the affordance survives processing.
+
+The alternative — templated links (`{id}` in the href plus a `templated` flag on `LinkDto`) — would
+change the link contract in both bounded contexts to buy a client one round trip. Not now.
+
+### 4. The rel vocabulary
+
+Kebab-case, matching the existing style. These names are a frozen public contract:
+
+| Rel | Target | Visible to |
+|---|---|---|
+| `self` | `GET /` | everyone |
+| `translation-file` | `GET /api/v1/translation-files/pl` | everyone |
+| `progress` | `GET /api/v1/progress` | everyone |
+| `translations` | `GET /api/v1/translations` | everyone |
+| `upsert` | `PUT /api/v1/translations` | translator+ |
+| `translation-stats` | `GET /api/v1/translations/stats` | translator+ |
+| `game-versions` | `GET /api/v1/game-versions` | translator+ |
+| `contribution-data-export` | `GET /api/v1/translators/me/data-export` | any authenticated caller |
+| `bulk-approve` | `POST /api/v1/translations/approve` | admin |
+| `register` | `POST /api/v1/game-versions` | admin |
+
+`translation-file` resolves with `lang = SupportedLanguages.Polish`. Polish is the only language the
+platform serves, and the constant already exists; a second language means a second rel or a templated
+link, decided then.
+
+## Consequences
+
+### Good
+
+- A client can bootstrap from `GET /` with no credentials and no hardcoded paths. The CLI's
+  `api/v1/translation-files/pl` and the frontend's six constants become removable in follow-ups.
+- Role rules exist once, at the endpoint. A policy change on an endpoint changes its links
+  automatically — the drift that made the alternative unattractive cannot happen.
+- The redundant role predicates left in `TranslationAggregateLinkFactory` /
+  `GameVersionAggregateLinkFactory` are now a second gate over the same truth, not the only gate.
+  They stay because they also carry the **state** rules (`isRemoved`, `Draft`/`NeedsReview`,
+  `Unprocessed`, `Superseded`), which authorization knows nothing about.
+- Auth API output is provably unchanged: its endpoints already carry explicit `AllowAnonymous` /
+  `RequireAuthorization()` metadata that matches the hand-written `isAuthenticated` branch exactly,
+  and the full auth integration suite (341 tests, including `DiscoveryHateoasTests` and
+  `AccountAggregateHateoasTests`) passes untouched.
+
+### Watch
+
+- **The frontend's TMS discovery cache has no degradation guard yet.** Its auth leg throws
+  `AuthenticatedLinksDegradedException` when an authenticated caller does not get
+  `export-account-data` back; the TMS leg has no equivalent, because until now a dead bearer produced
+  a 401 there. With an anonymous root a dead bearer instead yields the guest link set, which the
+  1-day `HybridCache` entry would freeze under the authenticated key. It is **unreachable today** —
+  `GetTranslationSystemDiscoveryAsync` has no production caller; only the auth leg is consumed
+  (`AccountLoader`). The follow-up that makes frontend pages read TMS discovery must add the mirror
+  guard, keyed on `contribution-data-export` (the rel every authenticated caller has).
+- Every link now costs one policy evaluation. Trivial at today's link counts; revisit if a
+  collection ever emits links per row at a scale where it shows.
+
+### Neutral
+
+- Link factories read `await _linkFactory.CreateAsync(...)` inside `AddIfPresent`. The
+  `AddIfPresent` collection idiom and the null-on-unresolvable behavior are unchanged.
+- The link factory **fails closed**: an endpoint name that cannot be located advertises nothing.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ExportAccountData.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ExportAccountData.cs
@@ -94,9 +94,9 @@ internal sealed partial class ExportAccountData : IApiEndpoint
                     return Results.Problem(queryResult.Error.ToProblemDetails());
                 }
 
-                return HateoasResults.Ok(queryResult.Value, r =>
+                return HateoasResults.Ok(queryResult.Value, async r =>
                 {
-                    r.Links = accountAggregateLinkFactory.CreateAccountLinks(
+                    r.Links = await accountAggregateLinkFactory.CreateAccountLinksAsync(
                         isEmailConfirmed: r.AuthData.EmailConfirmed,
                         isDeletionScheduled: r.AuthData.DeletionScheduledAt is not null);
                 });

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Discovery/Discovery.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Discovery/Discovery.cs
@@ -16,8 +16,8 @@ internal sealed class Discovery : IApiEndpoint
             {
                 DiscoveryResponse response = new("LotroKoniecDev.AuthSystem");
 
-                return HateoasResults.Ok(response, r =>
-                    r.Links = discoveryLinkFactory.CreateDiscoveryLinks(
+                return HateoasResults.Ok(response, async r =>
+                    r.Links = await discoveryLinkFactory.CreateDiscoveryLinksAsync(
                         user.Identity?.IsAuthenticated is true));
             })
             .AllowAnonymous()

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/AccountAggregateLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/AccountAggregateLinkFactory.cs
@@ -14,12 +14,12 @@ internal sealed class AccountAggregateLinkFactory : IAccountAggregateLinkFactory
         _linkFactory = linkFactory;
     }
 
-    public List<LinkDto> CreateAccountLinks(bool isEmailConfirmed, bool isDeletionScheduled)
+    public async ValueTask<List<LinkDto>> CreateAccountLinksAsync(bool isEmailConfirmed, bool isDeletionScheduled)
     {
         List<LinkDto> links = [];
 
         // Self — GET the account data export (the resource itself)
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(ExportAccountData),
             rel: Rels.Self,
             method: HttpMethods.Get));
@@ -29,7 +29,7 @@ internal sealed class AccountAggregateLinkFactory : IAccountAggregateLinkFactory
         // so the normal account rels are suppressed as dead ends.
         if (isDeletionScheduled)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(CancelAccountDeletion),
                 rel: Rels.CancelDeletion,
                 method: HttpMethods.Post));
@@ -38,12 +38,12 @@ internal sealed class AccountAggregateLinkFactory : IAccountAggregateLinkFactory
         }
 
         // Always-available state transitions for an authenticated, active account
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(ChangePassword),
             rel: Rels.ChangePassword,
             method: HttpMethods.Post));
 
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(DeleteAccount),
             rel: Rels.DeleteAccount,
             method: HttpMethods.Post));
@@ -53,7 +53,7 @@ internal sealed class AccountAggregateLinkFactory : IAccountAggregateLinkFactory
         // disappears so clients do not advertise a dead transition.
         if (!isEmailConfirmed)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(ResendEmailConfirmation),
                 rel: Rels.ResendEmailConfirmation,
                 method: HttpMethods.Post));

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/IAccountAggregateLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/IAccountAggregateLinkFactory.cs
@@ -21,5 +21,5 @@ internal interface IAccountAggregateLinkFactory
     /// Whether GDPR deletion is scheduled for the account. While scheduled,
     /// the only advertised transition is <c>cancel-deletion</c> (ADR-0031).
     /// </param>
-    List<LinkDto> CreateAccountLinks(bool isEmailConfirmed, bool isDeletionScheduled);
+    ValueTask<List<LinkDto>> CreateAccountLinksAsync(bool isEmailConfirmed, bool isDeletionScheduled);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/DiscoveryFactories/DiscoveryLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/DiscoveryFactories/DiscoveryLinkFactory.cs
@@ -15,30 +15,30 @@ internal sealed class DiscoveryLinkFactory : IDiscoveryLinkFactory
         _linkFactory = linkFactory;
     }
 
-    public List<LinkDto> CreateDiscoveryLinks(bool isAuthenticated)
+    public async ValueTask<List<LinkDto>> CreateDiscoveryLinksAsync(bool isAuthenticated)
     {
         List<LinkDto> links = [];
 
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(Discovery),
             rel: Rels.Self,
             method: HttpMethods.Get));
 
         if (isAuthenticated)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(ExportAccountData),
                 rel: Rels.ExportAccountData,
                 method: HttpMethods.Get));
         }
         else
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(RegisterUser),
                 rel: Rels.Register,
                 method: HttpMethods.Post));
 
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(ForgotPassword),
                 rel: Rels.ForgotPassword,
                 method: HttpMethods.Post));

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/DiscoveryFactories/IDiscoveryLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/DiscoveryFactories/IDiscoveryLinkFactory.cs
@@ -4,5 +4,5 @@ namespace LotroKoniecDev.AuthSystem.API.Hateoas.DiscoveryFactories;
 
 internal interface IDiscoveryLinkFactory
 {
-    List<LinkDto> CreateDiscoveryLinks(bool isAuthenticated);
+    ValueTask<List<LinkDto>> CreateDiscoveryLinksAsync(bool isAuthenticated);
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Discovery/Discovery.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Discovery/Discovery.cs
@@ -9,15 +9,20 @@ internal sealed class Discovery : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
     {
-        // No explicit authorization metadata — the fallback policy applies, which makes this
-        // the canonical authorized-by-default endpoint (anonymous requests get 401).
+        // The root is anonymous on purpose (#608): the endpoints it advertises to an anonymous
+        // caller are themselves anonymous, so nothing leaks that the caller could not already
+        // reach, and an unauthenticated client (the CLI, later the Avalonia app) has no other way
+        // to bootstrap. The admin surface stays hidden through claims-aware link emission — the
+        // link factory replays each target endpoint's own policy — not by walling the root off.
+        // It still sits inside the rate-limited endpoint group mapped in Program.cs.
         endpointRouteBuilder.MapGet("", (IDiscoveryLinkFactory discoveryLinkFactory) =>
             {
                 DiscoveryResponse response = new("LotroKoniecDev.TranslationSystem");
 
-                return HateoasResults.Ok(response, r =>
-                    r.Links = discoveryLinkFactory.CreateDiscoveryLinks());
+                return HateoasResults.Ok(response, async r =>
+                    r.Links = await discoveryLinkFactory.CreateDiscoveryLinksAsync());
             })
+            .AllowAnonymous()
             .WithName(nameof(Discovery))
             .WithTags("Discovery")
             .Produces<DiscoveryResponse>(StatusCodes.Status200OK);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/GetGameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/GetGameVersion.cs
@@ -74,8 +74,8 @@ internal sealed class GetGameVersion : IEndpoint
 
                 bool callerIsAdmin = user.IsInRole(AuthConstants.Roles.Admin);
 
-                return HateoasResults.Ok(result.Value, r =>
-                    r.Links = gameVersionLinkFactory.CreateGameVersionLinks(r.Id, r.Status, callerIsAdmin));
+                return HateoasResults.Ok(result.Value, async r =>
+                    r.Links = await gameVersionLinkFactory.CreateGameVersionLinksAsync(r.Id, r.Status, callerIsAdmin));
             })
             .WithName(nameof(GetGameVersion))
             .WithTags("GameVersions")

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/ListGameVersions.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/ListGameVersions.cs
@@ -93,14 +93,15 @@ internal sealed class ListGameVersions : IEndpoint
                 CollectionResponse<GameVersionResponse> response = new() { Items = result.Value };
                 bool callerIsAdmin = user.IsInRole(AuthConstants.Roles.Admin);
 
-                return HateoasResults.Ok(response, collection =>
+                return HateoasResults.Ok(response, async collection =>
                 {
                     foreach (GameVersionResponse item in collection.Items)
                     {
-                        item.Links = gameVersionLinkFactory.CreateGameVersionLinks(item.Id, item.Status, callerIsAdmin);
+                        item.Links = await gameVersionLinkFactory.CreateGameVersionLinksAsync(
+                            item.Id, item.Status, callerIsAdmin);
                     }
 
-                    collection.Links = gameVersionLinkFactory.CreateCollectionLinks(callerIsAdmin);
+                    collection.Links = await gameVersionLinkFactory.CreateCollectionLinksAsync(callerIsAdmin);
                 });
             })
             .WithName(nameof(ListGameVersions))

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/GetTranslation.cs
@@ -97,8 +97,8 @@ internal sealed class GetTranslation : IEndpoint
                 bool callerIsAdmin = user.IsInRole(AuthConstants.Roles.Admin);
                 bool callerIsTranslator = callerIsAdmin || user.IsInRole(AuthConstants.Roles.Translator);
 
-                return HateoasResults.Ok(queryResult.Response, r =>
-                    r.Links = translationLinkFactory.CreateTranslationLinks(
+                return HateoasResults.Ok(queryResult.Response, async r =>
+                    r.Links = await translationLinkFactory.CreateTranslationLinksAsync(
                         r.Id, r.Status, queryResult.IsRemoved, callerIsTranslator, callerIsAdmin));
             })
             .WithName(nameof(GetTranslation))

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/ListTranslations.cs
@@ -172,19 +172,19 @@ internal sealed class ListTranslations : IEndpoint
                 bool callerIsAdmin = user.IsInRole(AuthConstants.Roles.Admin);
                 bool callerIsTranslator = callerIsAdmin || user.IsInRole(AuthConstants.Roles.Translator);
 
-                return HateoasResults.Ok(response, paged =>
+                return HateoasResults.Ok(response, async paged =>
                 {
                     foreach (TranslationListItemResponse item in paged.Items)
                     {
-                        item.Links = translationLinkFactory.CreateTranslationLinks(
+                        item.Links = await translationLinkFactory.CreateTranslationLinksAsync(
                             item.Id, item.Status, isRemoved: false, callerIsTranslator, callerIsAdmin);
                     }
 
                     paged.Links =
                     [
-                        .. paginationLinkFactory.CreatePaginationLinks(
+                        .. await paginationLinkFactory.CreatePaginationLinksAsync(
                             nameof(ListTranslations), paged, new { lang, search, status, sort }),
-                        .. translationLinkFactory.CreateCollectionLinks(callerIsAdmin)
+                        .. await translationLinkFactory.CreateCollectionLinksAsync(callerIsAdmin)
                     ];
                 });
             })

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/DiscoveryFactories/DiscoveryLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/DiscoveryFactories/DiscoveryLinkFactory.cs
@@ -1,9 +1,26 @@
 using LotroKoniecDev.Hateoas.Abstractions;
 using LotroKoniecDev.Hateoas.LinkFactories;
+using LotroKoniecDev.TranslationSystem.API.Common;
+using LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
+using LotroKoniecDev.TranslationSystem.API.Features.Progress;
+using LotroKoniecDev.TranslationSystem.API.Features.TranslationFiles;
+using LotroKoniecDev.TranslationSystem.API.Features.Translations;
+using LotroKoniecDev.TranslationSystem.API.Features.Translators;
 using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 
 namespace LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
 
+/// <summary>
+/// Builds the API's service document: every entry point a client may need, with no role branching of
+/// its own. <see cref="ILinkFactory"/> drops the links whose target endpoint would answer 401/403 for
+/// the current caller, so an anonymous caller is handed the anonymous surface, a translator theirs and
+/// an admin theirs — from one list, kept honest by the endpoints' own policies.
+/// </summary>
+/// <remarks>
+/// Only parameterless entry points belong here. Affordances keyed by an id — approve, delete, import —
+/// are emitted on the representation that carries that id, which is where a client learns the id in
+/// the first place.
+/// </remarks>
 internal sealed class DiscoveryLinkFactory : IDiscoveryLinkFactory
 {
     private readonly ILinkFactory _linkFactory;
@@ -13,13 +30,61 @@ internal sealed class DiscoveryLinkFactory : IDiscoveryLinkFactory
         _linkFactory = linkFactory;
     }
 
-    public List<LinkDto> CreateDiscoveryLinks()
+    public async ValueTask<List<LinkDto>> CreateDiscoveryLinksAsync()
     {
         List<LinkDto> links = [];
 
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(Features.Discovery.Discovery),
             rel: Rels.Self,
+            method: HttpMethods.Get));
+
+        // The distributed artifact the CLI and the Avalonia app download without credentials. The
+        // route is language-scoped, and Polish is the only language the platform serves.
+        links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(GetTranslationFile),
+            rel: Rels.TranslationFile,
+            method: HttpMethods.Get,
+            values: new { lang = SupportedLanguages.Polish }));
+
+        links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(GetPublicProgress),
+            rel: Rels.Progress,
+            method: HttpMethods.Get));
+
+        links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(ListTranslations),
+            rel: Rels.Translations,
+            method: HttpMethods.Get));
+
+        links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(UpsertTranslation),
+            rel: Rels.Upsert,
+            method: HttpMethods.Put));
+
+        links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(GetTranslationStats),
+            rel: Rels.TranslationStats,
+            method: HttpMethods.Get));
+
+        links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(BulkApproveTranslations),
+            rel: Rels.BulkApprove,
+            method: HttpMethods.Post));
+
+        links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(ListGameVersions),
+            rel: Rels.GameVersions,
+            method: HttpMethods.Get));
+
+        links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(RegisterGameVersion),
+            rel: Rels.Register,
+            method: HttpMethods.Post));
+
+        links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(ExportMyContributionData),
+            rel: Rels.ContributionDataExport,
             method: HttpMethods.Get));
 
         return links;

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/DiscoveryFactories/IDiscoveryLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/DiscoveryFactories/IDiscoveryLinkFactory.cs
@@ -4,5 +4,5 @@ namespace LotroKoniecDev.TranslationSystem.API.Hateoas.DiscoveryFactories;
 
 internal interface IDiscoveryLinkFactory
 {
-    List<LinkDto> CreateDiscoveryLinks();
+    ValueTask<List<LinkDto>> CreateDiscoveryLinksAsync();
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/GameVersionAggregateLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/GameVersionAggregateLinkFactory.cs
@@ -1,6 +1,7 @@
 using LotroKoniecDev.Hateoas.Abstractions;
 using LotroKoniecDev.Hateoas.LinkFactories;
 using LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
+using LotroKoniecDev.TranslationSystem.API.Features.Import;
 using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
@@ -16,11 +17,14 @@ internal sealed class GameVersionAggregateLinkFactory : IGameVersionAggregateLin
         _linkFactory = linkFactory;
     }
 
-    public List<LinkDto> CreateGameVersionLinks(GameVersionId id, GameVersionStatus status, bool callerIsAdmin)
+    public async ValueTask<List<LinkDto>> CreateGameVersionLinksAsync(
+        GameVersionId id,
+        GameVersionStatus status,
+        bool callerIsAdmin)
     {
         List<LinkDto> links = [];
 
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(GetGameVersion),
             rel: Rels.Self,
             method: HttpMethods.Get,
@@ -30,21 +34,33 @@ internal sealed class GameVersionAggregateLinkFactory : IGameVersionAggregateLin
         // may be removed (a processed/superseded one is referenced by translations — spec 0001).
         if (callerIsAdmin && status is GameVersionStatus.Unprocessed)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(DeleteGameVersion),
                 rel: Rels.Delete,
                 method: HttpMethods.Delete,
                 values: new { id = id.Value }));
         }
 
+        // Importing an exported.txt is keyed by the version it lands against, so the affordance lives
+        // on the item that carries the id, not on the service document (#608). A superseded version is
+        // the one state MarkAsProcessed refuses, so importing into it is a dead transition.
+        if (callerIsAdmin && status is not GameVersionStatus.Superseded)
+        {
+            links.AddIfPresent(await _linkFactory.CreateAsync(
+                endpoint: nameof(ImportExportedTexts),
+                rel: Rels.Import,
+                method: HttpMethods.Post,
+                values: new { id = id.Value }));
+        }
+
         return links;
     }
 
-    public List<LinkDto> CreateCollectionLinks(bool callerIsAdmin)
+    public async ValueTask<List<LinkDto>> CreateCollectionLinksAsync(bool callerIsAdmin)
     {
         List<LinkDto> links = [];
 
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(ListGameVersions),
             rel: Rels.Self,
             method: HttpMethods.Get));
@@ -52,7 +68,7 @@ internal sealed class GameVersionAggregateLinkFactory : IGameVersionAggregateLin
         // Manually registering a version is the reviewer/admin fallback when the forum scrape breaks.
         if (callerIsAdmin)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(RegisterGameVersion),
                 rel: Rels.Register,
                 method: HttpMethods.Post));

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/IGameVersionAggregateLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/IGameVersionAggregateLinkFactory.cs
@@ -13,13 +13,14 @@ internal interface IGameVersionAggregateLinkFactory
     /// <summary>
     /// Per-item links for one game version: <c>self</c>, plus <c>delete</c> when the caller holds the
     /// Admin role and the version is still <see cref="GameVersionStatus.Unprocessed"/> — a processed or
-    /// superseded version is woven into the update lifecycle and cannot be removed.
+    /// superseded version is woven into the update lifecycle and cannot be removed — plus <c>import</c>
+    /// for an admin on any version that is not <see cref="GameVersionStatus.Superseded"/>.
     /// </summary>
-    List<LinkDto> CreateGameVersionLinks(GameVersionId id, GameVersionStatus status, bool callerIsAdmin);
+    ValueTask<List<LinkDto>> CreateGameVersionLinksAsync(GameVersionId id, GameVersionStatus status, bool callerIsAdmin);
 
     /// <summary>
     /// Collection-level links for the game-version list: <c>self</c>, plus <c>register</c> when the
     /// caller holds the reviewer (Admin) role — the manual fallback used when the forum scrape breaks.
     /// </summary>
-    List<LinkDto> CreateCollectionLinks(bool callerIsAdmin);
+    ValueTask<List<LinkDto>> CreateCollectionLinksAsync(bool callerIsAdmin);
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/PaginationLinkFactories/IPaginationLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/PaginationLinkFactories/IPaginationLinkFactory.cs
@@ -10,7 +10,7 @@ namespace LotroKoniecDev.TranslationSystem.API.Hateoas.PaginationLinkFactories;
 /// </summary>
 internal interface IPaginationLinkFactory
 {
-    IReadOnlyList<LinkDto> CreatePaginationLinks<T>(
+    ValueTask<IReadOnlyList<LinkDto>> CreatePaginationLinksAsync<T>(
         string endpointName,
         PaginationResponse<T> paginationResponse,
         object? additionalRouteValues = null);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/PaginationLinkFactories/PaginationLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/PaginationLinkFactories/PaginationLinkFactory.cs
@@ -14,14 +14,14 @@ internal sealed class PaginationLinkFactory : IPaginationLinkFactory
         _linkFactory = linkFactory;
     }
 
-    public IReadOnlyList<LinkDto> CreatePaginationLinks<T>(
+    public async ValueTask<IReadOnlyList<LinkDto>> CreatePaginationLinksAsync<T>(
         string endpointName,
         PaginationResponse<T> paginationResponse,
         object? additionalRouteValues = null)
     {
         List<LinkDto> links = [];
 
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: endpointName,
             rel: Rels.Self,
             method: HttpMethods.Get,
@@ -29,13 +29,13 @@ internal sealed class PaginationLinkFactory : IPaginationLinkFactory
 
         if (paginationResponse.TotalPages > 0)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: endpointName,
                 rel: Rels.FirstPage,
                 method: HttpMethods.Get,
                 values: BuildRouteValues(1, paginationResponse.PageSize, additionalRouteValues)));
 
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: endpointName,
                 rel: Rels.LastPage,
                 method: HttpMethods.Get,
@@ -44,7 +44,7 @@ internal sealed class PaginationLinkFactory : IPaginationLinkFactory
 
         if (paginationResponse.Page > 1)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: endpointName,
                 rel: Rels.PreviousPage,
                 method: HttpMethods.Get,
@@ -53,7 +53,7 @@ internal sealed class PaginationLinkFactory : IPaginationLinkFactory
 
         if (paginationResponse.Page < paginationResponse.TotalPages)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: endpointName,
                 rel: Rels.NextPage,
                 method: HttpMethods.Get,

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/TranslationAggregateFactories/ITranslationAggregateLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/TranslationAggregateFactories/ITranslationAggregateLinkFactory.cs
@@ -19,7 +19,7 @@ internal interface ITranslationAggregateLinkFactory
     /// <param name="isRemoved">Whether the row is soft-removed (a removed row exposes <c>self</c> only).</param>
     /// <param name="callerIsTranslator">Whether the caller holds the Translator (or Admin) role — anonymous readers get no links.</param>
     /// <param name="callerIsAdmin">Whether the caller holds the reviewer (Admin) role (gates <c>approve</c>).</param>
-    List<LinkDto> CreateTranslationLinks(
+    ValueTask<List<LinkDto>> CreateTranslationLinksAsync(
         TranslationId id,
         TranslationStatus status,
         bool isRemoved,
@@ -31,5 +31,5 @@ internal interface ITranslationAggregateLinkFactory
     /// <c>bulk-approve</c> action (#322), so a non-admin caller gets an empty list.
     /// </summary>
     /// <param name="callerIsAdmin">Whether the caller holds the reviewer (Admin) role (gates <c>bulk-approve</c>).</param>
-    List<LinkDto> CreateCollectionLinks(bool callerIsAdmin);
+    ValueTask<List<LinkDto>> CreateCollectionLinksAsync(bool callerIsAdmin);
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/TranslationAggregateFactories/TranslationAggregateLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/TranslationAggregateFactories/TranslationAggregateLinkFactory.cs
@@ -16,7 +16,7 @@ internal sealed class TranslationAggregateLinkFactory : ITranslationAggregateLin
         _linkFactory = linkFactory;
     }
 
-    public List<LinkDto> CreateTranslationLinks(
+    public async ValueTask<List<LinkDto>> CreateTranslationLinksAsync(
         TranslationId id,
         TranslationStatus status,
         bool isRemoved,
@@ -26,13 +26,15 @@ internal sealed class TranslationAggregateLinkFactory : ITranslationAggregateLin
         List<LinkDto> links = [];
 
         // Anonymous read-only browsing (#309): every transition — including self, whose target GET
-        // is translator-only — needs authentication, so a non-translator caller gets no links.
+        // is translator-only — needs authentication, so a non-translator caller gets no links. The
+        // link factory replays each target endpoint's policy anyway (#608); these role predicates
+        // stay because they also carry the state rules below, and skip work that would be dropped.
         if (!callerIsTranslator)
         {
             return links;
         }
 
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(GetTranslation),
             rel: Rels.Self,
             method: HttpMethods.Get,
@@ -47,7 +49,7 @@ internal sealed class TranslationAggregateLinkFactory : ITranslationAggregateLin
 
         // Upsert is keyed by (FileId, GossipId) in the request body, so the rel targets the
         // collection PUT rather than an item URL.
-        links.AddIfPresent(_linkFactory.Create(
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(UpsertTranslation),
             rel: Rels.Upsert,
             method: HttpMethods.Put));
@@ -56,7 +58,7 @@ internal sealed class TranslationAggregateLinkFactory : ITranslationAggregateLin
         // untranslated row (nothing to approve) nor an already-approved one (idempotent dead end).
         if (callerIsAdmin && status is TranslationStatus.Draft or TranslationStatus.NeedsReview)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(ApproveTranslation),
                 rel: Rels.Approve,
                 method: HttpMethods.Post,
@@ -66,7 +68,7 @@ internal sealed class TranslationAggregateLinkFactory : ITranslationAggregateLin
         return links;
     }
 
-    public List<LinkDto> CreateCollectionLinks(bool callerIsAdmin)
+    public async ValueTask<List<LinkDto>> CreateCollectionLinksAsync(bool callerIsAdmin)
     {
         List<LinkDto> links = [];
 
@@ -74,7 +76,7 @@ internal sealed class TranslationAggregateLinkFactory : ITranslationAggregateLin
         // sees the collection affordance, mirroring the per-item approve gate.
         if (callerIsAdmin)
         {
-            links.AddIfPresent(_linkFactory.Create(
+            links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(BulkApproveTranslations),
                 rel: Rels.BulkApprove,
                 method: HttpMethods.Post));

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
@@ -4,6 +4,15 @@ public static class Rels
 {
     public const string Self = "self";
 
+    // Entry points — the vocabulary the discovery document advertises so a client never has to
+    // hardcode a path. These names are a public contract: rename one and every client breaks.
+    public const string TranslationFile = "translation-file";
+    public const string Progress = "progress";
+    public const string Translations = "translations";
+    public const string TranslationStats = "translation-stats";
+    public const string GameVersions = "game-versions";
+    public const string ContributionDataExport = "contribution-data-export";
+
     // Translation aggregate actions
     public const string Upsert = "upsert";
     public const string Approve = "approve";
@@ -14,6 +23,7 @@ public static class Rels
     // GameVersion aggregate actions
     public const string Register = "register";
     public const string Delete = "delete";
+    public const string Import = "import";
 
     // Collection / pagination navigation
     public const string FirstPage = "first-page";

--- a/src/Utilities/LotroKoniecDev.Hateoas/ContentNegotiation/HateoasNegotiatedResult.cs
+++ b/src/Utilities/LotroKoniecDev.Hateoas/ContentNegotiation/HateoasNegotiatedResult.cs
@@ -27,10 +27,10 @@ internal sealed class HateoasNegotiatedResult<T> : IResult
     where T : class
 {
     private readonly T _response;
-    private readonly Action<T>? _linkAttacher;
+    private readonly Func<T, ValueTask>? _linkAttacher;
     private readonly int _statusCode;
 
-    public HateoasNegotiatedResult(T response, Action<T>? linkAttacher, int statusCode)
+    public HateoasNegotiatedResult(T response, Func<T, ValueTask>? linkAttacher, int statusCode)
     {
         ArgumentNullException.ThrowIfNull(response);
         _response = response;
@@ -47,7 +47,7 @@ internal sealed class HateoasNegotiatedResult<T> : IResult
 
         if (includeHateoas)
         {
-            _linkAttacher!(_response);
+            await _linkAttacher!(_response);
         }
 
         // Append (never overwrite) so Vary tokens set by upstream middleware

--- a/src/Utilities/LotroKoniecDev.Hateoas/ContentNegotiation/HateoasResults.cs
+++ b/src/Utilities/LotroKoniecDev.Hateoas/ContentNegotiation/HateoasResults.cs
@@ -15,7 +15,7 @@ public static class HateoasResults
     /// vendor media type, <paramref name="attachLinks"/> is executed to
     /// populate the response's hypermedia links before serialization.
     /// </summary>
-    public static IResult Ok<T>(T response, Action<T>? attachLinks = null)
+    public static IResult Ok<T>(T response, Func<T, ValueTask>? attachLinks = null)
         where T : class
         => new HateoasNegotiatedResult<T>(response, attachLinks, StatusCodes.Status200OK);
 }

--- a/src/Utilities/LotroKoniecDev.Hateoas/DependencyInjection.cs
+++ b/src/Utilities/LotroKoniecDev.Hateoas/DependencyInjection.cs
@@ -14,7 +14,8 @@ public static class DependencyInjection
         /// <summary>
         /// Registers the cross-cutting HATEOAS infrastructure:
         /// <list type="bullet">
-        ///   <item><see cref="ILinkFactory"/> backed by ASP.NET's <c>LinkGenerator</c>.</item>
+        ///   <item><see cref="ILinkFactory"/> backed by ASP.NET's <c>LinkGenerator</c> and the
+        ///   target endpoint's own authorization metadata.</item>
         ///   <item><see cref="IHttpContextAccessor"/> — required by the link factory for absolute URIs.</item>
         ///   <item>A fallback <see cref="IProblemDetailsWriter"/> that serves RFC 7807 for the HATEOAS vendor media type.</item>
         ///   <item>A <see cref="JsonTypeInfo"/> modifier that suppresses empty <c>links</c> arrays from plain-JSON responses.</item>
@@ -33,7 +34,10 @@ public static class DependencyInjection
         public IServiceCollection AddHateoasInfrastructure()
         {
             services.AddHttpContextAccessor();
-            services.AddSingleton<ILinkFactory, LinkFactory>();
+
+            // Scoped, not singleton: the link factory evaluates the target endpoint's authorization
+            // through the scoped IAuthorizationService before emitting a link.
+            services.AddScoped<ILinkFactory, LinkFactory>();
             services.AddSingleton<IProblemDetailsWriter, FallbackProblemDetailsWriter>();
 
             services.ConfigureHttpJsonOptions(jsonOptions =>

--- a/src/Utilities/LotroKoniecDev.Hateoas/LinkFactories/ILinkFactory.cs
+++ b/src/Utilities/LotroKoniecDev.Hateoas/LinkFactories/ILinkFactory.cs
@@ -4,5 +4,9 @@ namespace LotroKoniecDev.Hateoas.LinkFactories;
 
 public interface ILinkFactory
 {
-    LinkDto? Create(string endpoint, string rel, string method, object? values = null);
+    /// <summary>
+    /// Builds the link for a named endpoint, or <see langword="null"/> when the endpoint cannot be
+    /// resolved or the current caller would be rejected by that endpoint's own authorization.
+    /// </summary>
+    ValueTask<LinkDto?> CreateAsync(string endpoint, string rel, string method, object? values = null);
 }

--- a/src/Utilities/LotroKoniecDev.Hateoas/LinkFactories/LinkFactory.cs
+++ b/src/Utilities/LotroKoniecDev.Hateoas/LinkFactories/LinkFactory.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
@@ -7,45 +8,112 @@ namespace LotroKoniecDev.Hateoas.LinkFactories;
 
 /// <summary>
 /// Resolves named endpoints to absolute URIs via ASP.NET's
-/// <see cref="LinkGenerator"/>. Returns <see langword="null"/> when the
+/// <see cref="LinkGenerator"/>, then emits the link only when the current caller
+/// would actually be allowed to follow it. Returns <see langword="null"/> when the
 /// endpoint cannot be resolved (e.g. typo in the endpoint name or missing
-/// <c>WithName(...)</c> on the route); callers collect non-null links via
+/// <c>WithName(...)</c> on the route) or when the target endpoint's own
+/// authorization would answer 401/403; callers collect non-null links via
 /// <see cref="LinkListExtensions.AddIfPresent"/>.
+/// <para>
+/// The authorization decision reads the <em>target</em> endpoint's metadata rather
+/// than re-stating role rules in each link factory, so an endpoint's policy stays
+/// the single source of truth and a link can never drift from what following it
+/// would really do.
+/// </para>
 /// </summary>
 internal sealed partial class LinkFactory : ILinkFactory
 {
     private readonly LinkGenerator _linkGenerator;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IEndpointAddressScheme<string> _endpointAddressScheme;
+    private readonly IAuthorizationPolicyProvider _authorizationPolicyProvider;
+    private readonly IAuthorizationService _authorizationService;
     private readonly ILogger<LinkFactory> _logger;
 
     public LinkFactory(
         LinkGenerator linkGenerator,
         IHttpContextAccessor httpContextAccessor,
+        IEndpointAddressScheme<string> endpointAddressScheme,
+        IAuthorizationPolicyProvider authorizationPolicyProvider,
+        IAuthorizationService authorizationService,
         ILogger<LinkFactory> logger)
     {
         _linkGenerator = linkGenerator;
         _httpContextAccessor = httpContextAccessor;
+        _endpointAddressScheme = endpointAddressScheme;
+        _authorizationPolicyProvider = authorizationPolicyProvider;
+        _authorizationService = authorizationService;
         _logger = logger;
     }
 
-    public LinkDto? Create(string endpoint, string rel, string method, object? values = null)
+    public async ValueTask<LinkDto?> CreateAsync(string endpoint, string rel, string method, object? values = null)
     {
-        ArgumentNullException.ThrowIfNull(_httpContextAccessor.HttpContext);
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        ArgumentNullException.ThrowIfNull(httpContext);
 
-        string? href = _linkGenerator.GetUriByName(
-            _httpContextAccessor.HttpContext,
-            endpoint,
-            values
-        );
+        string? href = _linkGenerator.GetUriByName(httpContext, endpoint, values);
 
-        if (href is not null)
+        if (href is null)
         {
-            return new LinkDto(Href: href, Rel: rel, Method: method);
+            LogHateoasLinksGenerationFailure(_logger, endpoint, rel, method, values);
+
+            return null;
         }
 
-        LogHateoasLinksGenerationFailure(_logger, endpoint, rel, method, values);
+        if (!await IsCallerAuthorizedAsync(httpContext, endpoint))
+        {
+            return null;
+        }
 
-        return null;
+        return new LinkDto(Href: href, Rel: rel, Method: method);
+    }
+
+    /// <summary>
+    /// Replays ASP.NET's own authorization decision for the target endpoint against the caller of
+    /// the current request. Fails closed: an endpoint that cannot be located advertises nothing.
+    /// </summary>
+    private async ValueTask<bool> IsCallerAuthorizedAsync(HttpContext httpContext, string endpointName)
+    {
+        // The same address scheme LinkGenerator.GetUriByName just used, so this is a dictionary
+        // lookup on the very endpoint whose URI was generated — never a second, divergent match.
+        Endpoint? endpoint = _endpointAddressScheme.FindEndpoints(endpointName).FirstOrDefault();
+
+        if (endpoint is null)
+        {
+            return false;
+        }
+
+        // Mirrors AuthorizationMiddleware: AllowAnonymous beats every policy, the fallback included.
+        // This check MUST come before CombineAsync: AllowAnonymousAttribute is not IAuthorizeData, so
+        // an anonymous endpoint under an authorized-by-default app still combines to the fallback
+        // policy. Evaluate that first and every public endpoint's link vanishes for guests.
+        if (endpoint.Metadata.GetMetadata<IAllowAnonymous>() is not null)
+        {
+            return true;
+        }
+
+        // CombineAsync folds in the application's fallback policy when the endpoint carries no
+        // authorize metadata of its own, so an authorized-by-default API is evaluated exactly as
+        // the middleware would evaluate it.
+        AuthorizationPolicy? policy = await AuthorizationPolicy.CombineAsync(
+            _authorizationPolicyProvider,
+            endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>(),
+            endpoint.Metadata.GetOrderedMetadata<AuthorizationPolicy>());
+
+        if (policy is null)
+        {
+            return true;
+        }
+
+        // No policy in either API names an authentication scheme, so the principal ASP.NET already
+        // authenticated for THIS request is the one the target endpoint would see; only the policy's
+        // requirements are left to evaluate.
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeAsync(
+            httpContext.User,
+            resource: null,
+            policy.Requirements);
+
+        return authorizationResult.Succeeded;
     }
 
     [LoggerMessage(

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Auth/AuthorizationDefaultsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Auth/AuthorizationDefaultsTests.cs
@@ -14,16 +14,19 @@ public sealed class AuthorizationDefaultsTests
     }
 
     [Fact]
-    public async Task GetDiscovery_WithoutToken_ShouldReturn401()
+    public async Task GetDiscovery_WithoutToken_ShouldReturn200()
     {
-        // Arrange
+        // Arrange — the service document is the one deliberate hole in authorized-by-default (#608):
+        // it advertises only endpoints the caller may already reach, and an unauthenticated client
+        // has no other way to bootstrap. What it hands back per caller is
+        // DiscoveryHateoasTests' subject; here the point is only that the root is not walled off.
         using HttpClient client = _factory.CreateClient();
 
         // Act
         HttpResponseMessage response = await client.GetAsync("/");
 
         // Assert
-        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -42,36 +45,6 @@ public sealed class AuthorizationDefaultsTests
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         body.ShouldNotBeNull();
         body.Name.ShouldBe("LotroKoniecDev.TranslationSystem");
-    }
-
-    [Fact]
-    public async Task GetDiscovery_WithTokenSignedByUnknownKey_ShouldReturn401()
-    {
-        // Arrange
-        using HttpClient client = _factory.CreateClient();
-        client.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", TranslationSystemApiFactory.CreateTokenSignedWithUnknownKey());
-
-        // Act
-        HttpResponseMessage response = await client.GetAsync("/");
-
-        // Assert
-        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
-    }
-
-    [Fact]
-    public async Task GetDiscovery_WithExpiredToken_ShouldReturn401()
-    {
-        // Arrange
-        using HttpClient client = _factory.CreateClient();
-        client.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", TranslationSystemApiFactory.CreateExpiredAccessToken());
-
-        // Act
-        HttpResponseMessage response = await client.GetAsync("/");
-
-        // Assert
-        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/DiscoveryHateoasTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/DiscoveryHateoasTests.cs
@@ -1,0 +1,230 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.SharedKernel.Authorization;
+using LotroKoniecDev.TranslationSystem.Contracts.Discovery;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Hateoas;
+
+/// <summary>
+/// Pins the service document's per-caller link set (#608). The root is anonymous so an
+/// unauthenticated client — the CLI today, the Avalonia app later — can bootstrap without hardcoding
+/// paths, and every rel is emitted only after the target endpoint's own authorization policy has said
+/// yes for this caller. The three caller shapes are asserted whole (exact sets, not "contains"), so a
+/// rel leaking to a caller who would be refused when following it fails the build.
+/// </summary>
+[Collection("TranslationApi")]
+public sealed class DiscoveryHateoasTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <summary>Every endpoint an anonymous caller may actually reach, plus the document itself.</summary>
+    private static readonly string[] AnonymousRels =
+    [
+        Rels.Self,
+        Rels.TranslationFile,
+        Rels.Progress,
+        Rels.Translations
+    ];
+
+    /// <summary>What the translator role adds on top of the anonymous set.</summary>
+    private static readonly string[] TranslatorOnlyRels =
+    [
+        Rels.Upsert,
+        Rels.TranslationStats,
+        Rels.GameVersions,
+        Rels.ContributionDataExport
+    ];
+
+    /// <summary>What the admin role adds on top of the translator set.</summary>
+    private static readonly string[] AdminOnlyRels =
+    [
+        Rels.BulkApprove,
+        Rels.Register
+    ];
+
+    private readonly TranslationSystemApiFactory _factory;
+
+    public DiscoveryHateoasTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Discovery_WithoutToken_ShouldAdvertiseOnlyTheAnonymousEntryPoints()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        DiscoveryResponse response = await GetDiscoveryAsync(client);
+
+        // Assert
+        response.Name.ShouldBe("LotroKoniecDev.TranslationSystem");
+        response.Links.Select(link => link.Rel).OrderBy(rel => rel)
+            .ShouldBe(AnonymousRels.Order());
+    }
+
+    [Fact]
+    public async Task Discovery_AsTranslator_ShouldAddTheTranslatorRelsAndNoAdminRel()
+    {
+        // Arrange
+        using HttpClient client = ClientForRole(AuthConstants.Roles.Translator);
+
+        // Act
+        DiscoveryResponse response = await GetDiscoveryAsync(client);
+
+        // Assert
+        response.Links.Select(link => link.Rel).OrderBy(rel => rel)
+            .ShouldBe(AnonymousRels.Concat(TranslatorOnlyRels).Order());
+    }
+
+    [Fact]
+    public async Task Discovery_AsAdmin_ShouldAddTheAdminRelsOnTopOfTheTranslatorSet()
+    {
+        // Arrange
+        using HttpClient client = ClientForRole(AuthConstants.Roles.Admin);
+
+        // Act
+        DiscoveryResponse response = await GetDiscoveryAsync(client);
+
+        // Assert
+        response.Links.Select(link => link.Rel).OrderBy(rel => rel)
+            .ShouldBe(AnonymousRels.Concat(TranslatorOnlyRels).Concat(AdminOnlyRels).Order());
+    }
+
+    [Fact]
+    public async Task Discovery_WithAnUnrecognizedRole_ShouldSeeOnlyWhatAnAuthenticatedCallerMayReach()
+    {
+        // Arrange — a correctly-signed token whose role is neither Admin nor Translator. It clears
+        // RequireAuthenticatedUser but not the role policies, which is the case a hand-written role
+        // check in the discovery factory would get wrong.
+        using HttpClient client = ClientForRole("Reviewer");
+
+        // Act
+        DiscoveryResponse response = await GetDiscoveryAsync(client);
+
+        // Assert
+        response.Links.Select(link => link.Rel).OrderBy(rel => rel)
+            .ShouldBe(AnonymousRels.Append(Rels.ContributionDataExport).Order());
+    }
+
+    [Theory]
+    [InlineData("expired")]
+    [InlineData("unknown-key")]
+    public async Task Discovery_WithARejectedToken_ShouldDegradeToTheAnonymousSetInsteadOf401(string tokenKind)
+    {
+        // Arrange — the root allows anonymous, so a bearer the API refuses is simply not a caller
+        // identity: the request succeeds and advertises exactly what a guest may reach. Rejection of
+        // such tokens is still enforced on every protected route (AuthorizationDefaultsTests).
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            tokenKind is "expired"
+                ? TranslationSystemApiFactory.CreateExpiredAccessToken()
+                : TranslationSystemApiFactory.CreateTokenSignedWithUnknownKey());
+
+        // Act
+        DiscoveryResponse response = await GetDiscoveryAsync(client);
+
+        // Assert
+        response.Links.Select(link => link.Rel).OrderBy(rel => rel)
+            .ShouldBe(AnonymousRels.Order());
+    }
+
+    [Fact]
+    public async Task Discovery_ShouldResolveTheTranslationFileRelToThePolishArtifact()
+    {
+        // Arrange — the rel exists so the CLI stops hardcoding /api/v1/translation-files/pl.
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        DiscoveryResponse response = await GetDiscoveryAsync(client);
+
+        // Assert
+        LinkDto translationFile = response.Links
+            .Where(link => link.Rel == Rels.TranslationFile)
+            .ShouldHaveSingleItem();
+        translationFile.Method.ShouldBe("GET");
+        translationFile.Href.ShouldEndWith("/api/v1/translation-files/pl");
+    }
+
+    [Fact]
+    public async Task Discovery_AsAdmin_ShouldCarryTheCorrectMethodOnEveryWriteRel()
+    {
+        // Arrange — a client follows Method blindly; a GET on an upsert rel is a broken affordance.
+        using HttpClient client = ClientForRole(AuthConstants.Roles.Admin);
+
+        // Act
+        DiscoveryResponse response = await GetDiscoveryAsync(client);
+
+        // Assert
+        response.Links.ShouldContain(link => link.Rel == Rels.Upsert && link.Method == "PUT");
+        response.Links.ShouldContain(link => link.Rel == Rels.BulkApprove && link.Method == "POST");
+        response.Links.ShouldContain(link => link.Rel == Rels.Register && link.Method == "POST");
+    }
+
+    [Fact]
+    public async Task Discovery_AllLinks_ShouldHaveAbsoluteHrefs()
+    {
+        // Arrange
+        using HttpClient client = ClientForRole(AuthConstants.Roles.Admin);
+
+        // Act
+        DiscoveryResponse response = await GetDiscoveryAsync(client);
+
+        // Assert
+        response.Links.ShouldNotBeEmpty();
+        foreach (LinkDto link in response.Links)
+        {
+            Uri.TryCreate(link.Href, UriKind.Absolute, out Uri? uri).ShouldBeTrue(
+                $"HATEOAS href for rel='{link.Rel}' must be absolute; got '{link.Href}'");
+            uri!.Scheme.ShouldMatch("https?");
+        }
+    }
+
+    [Fact]
+    public async Task Discovery_WhenPlainJsonRequested_ShouldOmitTheLinks()
+    {
+        // Arrange
+        using HttpClient client = ClientForRole(AuthConstants.Roles.Admin);
+        using HttpRequestMessage request = DiscoveryRequest(MediaTypes.Json);
+
+        // Act
+        using HttpResponseMessage httpResponse = await client.SendAsync(request);
+        DiscoveryResponse response =
+            (await httpResponse.Content.ReadFromJsonAsync<DiscoveryResponse>(JsonOptions))!;
+
+        // Assert
+        httpResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Links.Count.ShouldBe(0, "plain JSON responses must not carry hypermedia links");
+    }
+
+    private static HttpRequestMessage DiscoveryRequest(string accept)
+    {
+        HttpRequestMessage request = new(HttpMethod.Get, "/");
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+        return request;
+    }
+
+    private static async Task<DiscoveryResponse> GetDiscoveryAsync(HttpClient client)
+    {
+        using HttpRequestMessage request = DiscoveryRequest(MediaTypes.HateoasJson);
+        using HttpResponseMessage httpResponse = await client.SendAsync(request);
+
+        httpResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        httpResponse.Content.Headers.ContentType?.MediaType.ShouldBe(MediaTypes.HateoasJson);
+
+        return (await httpResponse.Content.ReadFromJsonAsync<DiscoveryResponse>(JsonOptions))!;
+    }
+
+    private HttpClient ClientForRole(string role)
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(role));
+        return client;
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/GameVersionAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/GameVersionAggregateHateoasTests.cs
@@ -16,8 +16,9 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Hateoas;
 
 /// <summary>
 /// Verifies the game-version aggregate's HATEOAS links: per-item <c>self</c> (resolving to the new
-/// item endpoint) plus the role-gated <c>delete</c> action (admins only, on unprocessed versions), the
-/// collection <c>self</c>, and the role-gated <c>register</c> action (admins only). Plain
+/// item endpoint) plus the role-gated <c>delete</c> action (admins only, on unprocessed versions) and
+/// <c>import</c> action (admins only, on anything not superseded — #608), the collection <c>self</c>,
+/// and the role-gated <c>register</c> action (admins only). Plain
 /// <c>application/json</c> requests must carry no links and still deserialize.
 /// </summary>
 [Collection("TranslationApi")]
@@ -170,6 +171,70 @@ public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetGameVersion_AsAdmin_WhenUnprocessed_AdvertisesImportAgainstTheVersion()
+    {
+        // Arrange — import is keyed by the version it lands against, so the affordance lives on the
+        // item that carries the id rather than on the service document (#608).
+        GameVersionId id = await SeedAsync("48.0");
+
+        // Act
+        GameVersionResponse response = await GetHateoasAsync<GameVersionResponse>(
+            AdminClient(), $"{Route}/{id.Value}");
+
+        // Assert
+        LinkDto import = response.Links.Where(l => l.Rel == Rels.Import).ShouldHaveSingleItem();
+        import.Method.ShouldBe("POST");
+        import.Href.ShouldEndWith($"{Route}/{id.Value}/import");
+    }
+
+    [Fact]
+    public async Task GetGameVersion_AsAdmin_WhenProcessed_StillAdvertisesImport()
+    {
+        // Arrange — re-importing into an already processed version is legal (MarkAsProcessed refuses
+        // only a superseded one), so the affordance survives processing even though delete does not.
+        GameVersionId id = await SeedProcessedAsync("48.0");
+
+        // Act
+        GameVersionResponse response = await GetHateoasAsync<GameVersionResponse>(
+            AdminClient(), $"{Route}/{id.Value}");
+
+        // Assert
+        response.Links.ShouldContain(l => l.Rel == Rels.Import);
+        response.Links.ShouldNotContain(l => l.Rel == Rels.Delete);
+    }
+
+    [Fact]
+    public async Task GetGameVersion_AsAdmin_WhenSuperseded_DoesNotAdvertiseImport()
+    {
+        // Arrange — a superseded version is the one state MarkAsProcessed refuses, so importing into
+        // it is a dead transition and must not be advertised.
+        GameVersionId id = await SeedSupersededAsync("47.0");
+
+        // Act
+        GameVersionResponse response = await GetHateoasAsync<GameVersionResponse>(
+            AdminClient(), $"{Route}/{id.Value}");
+
+        // Assert
+        response.Links.ShouldContain(l => l.Rel == Rels.Self);
+        response.Links.ShouldNotContain(l => l.Rel == Rels.Import);
+    }
+
+    [Fact]
+    public async Task GetGameVersion_AsTranslator_DoesNotAdvertiseImport()
+    {
+        // Arrange — import is admin-only; the endpoint's own policy is what drops the rel.
+        GameVersionId id = await SeedAsync("48.0");
+
+        // Act
+        GameVersionResponse response = await GetHateoasAsync<GameVersionResponse>(
+            TranslatorClient(), $"{Route}/{id.Value}");
+
+        // Assert
+        response.Links.ShouldContain(l => l.Rel == Rels.Self);
+        response.Links.ShouldNotContain(l => l.Rel == Rels.Import);
+    }
+
+    [Fact]
     public async Task ListGameVersions_PlainJson_OmitsLinks()
     {
         // Arrange
@@ -232,6 +297,19 @@ public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
 
         GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, Now).Value;
         gameVersion.MarkAsProcessed();
+        dbContext.GameVersions.Add(gameVersion);
+        await dbContext.SaveChangesAsync();
+
+        return gameVersion.Id;
+    }
+
+    private async Task<GameVersionId> SeedSupersededAsync(string version)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        GameVersion gameVersion = GameVersion.Create(LotroNotationVersion.Create(version).Value, Now).Value;
+        gameVersion.MarkSuperseded();
         dbContext.GameVersions.Add(gameVersion);
         await dbContext.SaveChangesAsync();
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/DiscoveryContractSnapshotTests.Discovery_Anonymously_MatchesThePublicHateoasContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/DiscoveryContractSnapshotTests.Discovery_Anonymously_MatchesThePublicHateoasContract.verified.json
@@ -1,0 +1,25 @@
+﻿{
+  "name": "LotroKoniecDev.TranslationSystem",
+  "links": [
+    {
+      "href": "http://localhost/",
+      "rel": "self",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translation-files/pl",
+      "rel": "translation-file",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/progress",
+      "rel": "progress",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations",
+      "rel": "translations",
+      "method": "GET"
+    }
+  ]
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/DiscoveryContractSnapshotTests.Discovery_AsAdmin_MatchesTheFullHateoasContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/DiscoveryContractSnapshotTests.Discovery_AsAdmin_MatchesTheFullHateoasContract.verified.json
@@ -1,0 +1,55 @@
+﻿{
+  "name": "LotroKoniecDev.TranslationSystem",
+  "links": [
+    {
+      "href": "http://localhost/",
+      "rel": "self",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translation-files/pl",
+      "rel": "translation-file",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/progress",
+      "rel": "progress",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations",
+      "rel": "translations",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations",
+      "rel": "upsert",
+      "method": "PUT"
+    },
+    {
+      "href": "http://localhost/api/v1/translations/stats",
+      "rel": "translation-stats",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/translations/approve",
+      "rel": "bulk-approve",
+      "method": "POST"
+    },
+    {
+      "href": "http://localhost/api/v1/game-versions",
+      "rel": "game-versions",
+      "method": "GET"
+    },
+    {
+      "href": "http://localhost/api/v1/game-versions",
+      "rel": "register",
+      "method": "POST"
+    },
+    {
+      "href": "http://localhost/api/v1/translators/me/data-export",
+      "rel": "contribution-data-export",
+      "method": "GET"
+    }
+  ]
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/DiscoveryContractSnapshotTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/DiscoveryContractSnapshotTests.cs
@@ -1,0 +1,56 @@
+using System.Net.Http.Headers;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.SharedKernel.Authorization;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Snapshots;
+
+/// <summary>
+/// Pins the service document whole, for the two callers that bound the surface: the anonymous root
+/// (#608) and an admin. The anonymous snapshot is the security-relevant one — the root is reachable
+/// without credentials, so a rel leaking into it is a leaked affordance, and this file is what forces
+/// that into a reviewable diff. The admin snapshot pins the complete rel vocabulary, so a rel silently
+/// moving between tiers shows up as two diffs instead of none.
+/// </summary>
+/// <remarks>
+/// <c>DiscoveryHateoasTests</c> still owns the behavior — which caller shape may see which rel is a
+/// statement about many inputs, and it asserts the sets exactly. These snapshots answer the other
+/// question: did anything at all about the document change (an href shape, a method, a property name).
+/// The API is stateless here, so no seed is needed and the payload is byte-stable per caller.
+/// </remarks>
+[Collection("TranslationApi")]
+public sealed class DiscoveryContractSnapshotTests
+{
+    private readonly TranslationSystemApiFactory _factory;
+
+    public DiscoveryContractSnapshotTests(TranslationSystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Discovery_Anonymously_MatchesThePublicHateoasContract()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        using HttpResponseMessage response = await ApiSnapshot.GetHateoasAsync(client, "/");
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await Verifier.Verify(body, "json");
+    }
+
+    [Fact]
+    public async Task Discovery_AsAdmin_MatchesTheFullHateoasContract()
+    {
+        using HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer", TranslationSystemApiFactory.CreateAccessToken(AuthConstants.Roles.Admin));
+
+        using HttpResponseMessage response = await ApiSnapshot.GetHateoasAsync(client, "/");
+        string body = await ApiSnapshot.IndentAsync(response);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe(MediaTypes.HateoasJson);
+        await Verifier.Verify(body, "json");
+    }
+}


### PR DESCRIPTION
Closes #608

## What

The TMS service document advertised one link (`self`) from behind the auth wall, so no client could
discover anything and every client hardcoded paths. Now `GET /` is anonymous and returns the entry
points the caller may actually reach.

**A link is emitted only when the caller would be allowed to follow it.** `ILinkFactory.CreateAsync`
replays the *target* endpoint's own authorization — `IAllowAnonymous` short-circuit, then
`AuthorizationPolicy.CombineAsync` (which folds in the app's fallback policy), then
`IAuthorizationService`. No link factory restates a role rule, so the endpoint's policy stays the
single source of truth and a link cannot drift from what following it would do. The factory fails
closed: an endpoint it cannot locate advertises nothing.

The `AllowAnonymous` check has to come first — `AllowAnonymousAttribute` is not `IAuthorizeData`, so
under an authorized-by-default app an anonymous endpoint still combines to the fallback policy.
Verified against .NET 10; recorded in ADR-0040 and in the code, because getting the order wrong
silently hides every public endpoint from guests.

**Why anonymous is safe here:** everything the document shows a guest is itself anonymous
(`GetTranslationFile`, `GetPublicProgress`, `ListTranslations`), so nothing leaks that the caller
could not already reach. The root stays inside the rate-limited endpoint group, which partitions by
client IP, and an anonymous request skips translator provisioning entirely — no DB hit.

**`import` and `delete` are not in the document.** Both are keyed by a game version id, which
`LinkGenerator` cannot resolve without one. They live on the game-version item, which is where a
client learns the id — the correct hypermedia shape, and the ticket's "admin sees register/delete/
import" is met across the two representations. `import` is new; unlike `delete` it survives
processing, since `MarkAsProcessed` refuses only a superseded version.

`IAuthorizationService` is async, so the link-building chain became async (`Create` → `CreateAsync`,
`HateoasResults.Ok` takes `Func<T, ValueTask>`) and `ILinkFactory` dropped from singleton to scoped.

## Acceptance criteria

| Criterion | How |
|---|---|
| Anonymous `GET /` → 200, exactly the three anonymous endpoints + `self` | `DiscoveryHateoasTests` asserts the set **exactly**; `DiscoveryContractSnapshotTests` pins the body |
| Translator sees their extra rels | exact-set assertion (`upsert`, `translation-stats`, `game-versions`, `contribution-data-export`) |
| Admin sees the admin rels | exact-set assertion (+ `bulk-approve`, `register`); `delete`/`import` on the game-version item |
| No rel emitted to a caller who would get 401/403 | enforced by construction; covered by the exact sets plus a signed token whose role is neither Admin nor Translator |
| Auth API discovery unchanged, proven by test | full auth integration suite green, 341/341, untouched |
| Integration tests, three caller shapes, real PostgreSQL | `DiscoveryHateoasTests` (Testcontainers) |
| Verify snapshot pins the anonymous document | `Discovery_Anonymously_MatchesThePublicHateoasContract` + an admin snapshot so a rel moving tiers shows twice |
| Discovery stays rate-limited | mapped via `MapEndpoints(endpointsGroup)` as before; no separate `app.MapGet` added |
| Green build, zero warnings | yes |

## Tests

- Build green, zero warnings; 8 unit suites green.
- TMS integration **231/231**; Auth integration **341/341**.
- New: `DiscoveryHateoasTests` (9 cases incl. the unrecognized-role case and a rejected bearer
  degrading to the guest set instead of 401), `DiscoveryContractSnapshotTests` (2 snapshots),
  4 new `import` cases on the game-version item.
- `AuthorizationDefaultsTests` now states the root is open; the token-rejection proof it used to
  carry on `/` already existed on the protected routes.

## Follow-up noted, not done here

The frontend's TMS discovery cache has no degradation guard (its auth leg has one keyed on
`export-account-data`). With an anonymous root, a dead bearer yields the guest set, which a 1-day
`HybridCache` entry would freeze under the authenticated key. **Unreachable today** —
`GetTranslationSystemDiscoveryAsync` has no production caller yet. The ticket that makes frontend
pages read TMS discovery must add the mirror guard, keyed on `contribution-data-export`. Recorded in
ADR-0040 § Watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NMWgZnBUmBV7hYXzuXmHf