### PR TITLE
chore(claude): move the review, worker and audit roles from Fable 5 to Opus 5

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -3,7 +3,7 @@ name: code-reviewer
 description: Use this agent to review code changes against ticket acceptance criteria, find regressions, architecture violations, audit for unhandled edge cases (anti-happy-path gate), and verify test coverage. Invoke after implementing a feature or before creating a PR.
 tools: Read, Grep, Glob, Bash
 # model-policy: review
-model: claude-fable-5
+model: claude-opus-5
 effort: high
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ scripts/claude/backlog-loop.sh 123 130                 # exactly these tickets, 
 caffeinate -is scripts/claude/backlog-loop.sh          # overnight run on macOS (blocks sleep)
 scripts/claude/next-ticket.sh                          # print the next READY ticket (priority + deps)
 scripts/claude/work-ticket.sh 123                      # one ticket, one fresh headless session
-# defaults: fable (Fable 5) · effort high (reviews at high too) · permission-mode auto — override via LOOP_MODEL /
+# defaults: opus (Opus 5) · effort high (reviews at high too) · permission-mode auto — override via LOOP_MODEL /
 # LOOP_EFFORT / LOOP_PERMISSION_MODE / LOOP_UNSAFE=1 · full manual: docs/claude-loop.md
 
 # TMS — EF Core migrations (write context owns them; --connection makes it work without appsettings/live DB)
@@ -397,12 +397,12 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 - **Right-size the design — YAGNI by default.** Before proposing an abstraction, cache, config
   knob, queue, or new infra, check it solves a **real, present** need from the current
   spec/ticket — not a hypothetical future. Pick the simple path and note the trade-off in one line.
-- **Agent fan-out is budgeted; everything runs on Fable 5 at high effort** (2026-07-17: reviews
-  moved back to Fable 5 + high via the central model policy, matching loop workers — history:
-  Fable switch 2026-07-09→11, same-day Opus revert #497, Fable re-enable #503, Opus for reviews
-  2026-07-13). Hard cap:
+- **Agent fan-out is budgeted; everything runs on Opus 5 at high effort** (2026-08-05: reviews,
+  loop workers and audits all moved to Opus 5 via the central model policy — history: Fable
+  switch 2026-07-09→11, same-day Opus revert #497, Fable re-enable #503, Opus for reviews
+  2026-07-13, Fable again 2026-07-17). Hard cap:
   **max 4 subagents in parallel**, no chained waves by default; a small diff gets reviewed
-  **inline, zero agents**. The `code-reviewer` agent runs with **model Fable 5 + effort high**;
+  **inline, zero agents**. The `code-reviewer` agent runs with **model Opus 5 + effort high**;
   `/code-review` and `/security-review` follow the session model/effort; loop-mode worker
   sessions run at **effort high**
   (`LOOP_EFFORT` default) — unless the prompt for that run explicitly says otherwise. Applies to

--- a/docs/claude-loop.md
+++ b/docs/claude-loop.md
@@ -96,8 +96,8 @@ one ticket with `LOOP_TRUST_GATE=0`, or add the commenter to `LOOP_TRUSTED_LOGIN
 
 | Var | Default | Meaning |
 |---|---|---|
-| `LOOP_EFFORT` | `high` | claude effort per ticket (reviews inside the session run at `xhigh` via the `code-reviewer` agent definition) |
-| `LOOP_MODEL` | `fable` | Fable 5 (re-enabled 2026-07-13 after a same-day Opus revert; original switch 2026-07-09) |
+| `LOOP_EFFORT` | `high` | claude effort per ticket (reviews inside the session run at `high` via the `code-reviewer` agent definition) |
+| `LOOP_MODEL` | `opus` | Opus 5 (2026-08-05 — replaced Fable 5, which had run since 2026-07-17) |
 | `LOOP_PERMISSION_MODE` | `auto` | headless permission mode |
 | `LOOP_CONFIG_DIR` | `~/.claude-account1` | Claude config dir = which account runs the loop (exported as `CLAUDE_CONFIG_DIR`) |
 | `LOOP_ALLOWED_TOOLS` | git/gh/dotnet/scripts | loop-scoped Bash allowlist passed via `--allowedTools` |

--- a/scripts/claude/backlog-loop.sh
+++ b/scripts/claude/backlog-loop.sh
@@ -12,8 +12,8 @@
 #   caffeinate -is scripts/claude/backlog-loop.sh   # overnight on macOS (blocks sleep)
 #
 # Env (all forwarded to work-ticket.sh): LOOP_EFFORT and LOOP_MODEL (defaults come from the
-#   worker role in ~/.claude/model-policy.env when present, else high/fable; reviews run at
-#   xhigh via the code-reviewer agent definition),
+#   worker role in ~/.claude/model-policy.env when present, else high/opus; reviews run at
+#   high via the code-reviewer agent definition),
 #   LOOP_CONFIG_DIR (default ~/.claude-account1 — which account runs the loop),
 #   LOOP_PERMISSION_MODE (default auto), LOOP_UNSAFE, LOOP_MAX_BUDGET_USD,
 #   LOOP_TICKET_TIMEOUT_MIN, LOOP_CHECKS_TIMEOUT_MIN, LOOP_SKIP_LABELS,

--- a/scripts/claude/work-ticket.sh
+++ b/scripts/claude/work-ticket.sh
@@ -10,10 +10,10 @@
 # Env:
 #   LOOP_EFFORT             claude effort level (default: the worker effort from
 #                           ~/.claude/model-policy.env when present, else high — reviews inside
-#                           the session run at xhigh via the code-reviewer agent definition)
+#                           the session run at high via the code-reviewer agent definition)
 #   LOOP_MODEL              model (default: the worker model from ~/.claude/model-policy.env
-#                           when present, else fable — Fable 5; re-enabled 2026-07-13 after a
-#                           same-day Opus revert)
+#                           when present, else opus — Opus 5; switched back from Fable 5
+#                           on 2026-08-05)
 #   LOOP_CONFIG_DIR         Claude config dir = which account runs the loop
 #                           (default: ~/.claude-account1)
 #   LOOP_GH_USER            gh account whose token backs the loop's gh write calls — PR merge,
@@ -52,7 +52,7 @@ if [ -f "$HOME/.claude/model-policy.env" ]; then
     . "$HOME/.claude/model-policy.env"
 fi
 EFFORT="${LOOP_EFFORT:-${MODEL_POLICY_WORKER_EFFORT:-high}}"
-MODEL="${LOOP_MODEL:-${MODEL_POLICY_WORKER_MODEL:-fable}}"
+MODEL="${LOOP_MODEL:-${MODEL_POLICY_WORKER_MODEL:-opus}}"
 export CLAUDE_CONFIG_DIR="${LOOP_CONFIG_DIR:-$HOME/.claude-account1}"
 PERMISSION_MODE="${LOOP_PERMISSION_MODE:-auto}"
 TIMEOUT_MIN="${LOOP_TICKET_TIMEOUT_MIN:-90}"
@@ -111,7 +111,7 @@ salvage() {
         git add -A >/dev/null 2>&1 || true
         git commit --quiet --no-verify \
             -m "claude-loop: salvage uncommitted work for #$ISSUE" \
-            -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>" >/dev/null 2>&1 || true
+            -m "Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>" >/dev/null 2>&1 || true
         log "leftover changes committed on branch $salvage_branch"
     fi
     git checkout main --quiet 2>/dev/null || true


### PR DESCRIPTION
## What

All agent roles driven by the central `~/.claude/model-policy.env` move from Fable 5 to Opus 5:

| role | before | after |
|---|---|---|
| `review` (code-reviewer agent) | `claude-fable-5` / high | `claude-opus-5` / high |
| `worker` (backlog loop) | `fable` / high | `opus` / high |
| `audit` (audit.sh) | `claude-fable-5` / max | `claude-opus-5` / max |

Effort levels are unchanged.

## Why

Owner decision — reviews, loop workers and audits should run on Opus 5.

## What is in this PR

The policy file itself is machine-local (`~/.claude/model-policy.env`), so this PR carries only the parts that live in the repo:

- `.claude/agents/code-reviewer.md` — re-stamped by `apply-model-policy.sh` (the `# model-policy: review` marker drives it; the value is never hand-edited)
- `scripts/claude/work-ticket.sh` — committed `LOOP_MODEL` fallback + the salvage commit's `Co-Authored-By` trailer
- `scripts/claude/backlog-loop.sh`, `CLAUDE.md`, `docs/claude-loop.md` — prose and default tables

`scripts/claude/audit.sh` got the same fallback swap but is not tracked (`.git/info/exclude`).

Two stale "reviews run at xhigh" comments in the loop scripts are corrected to `high`, matching what the agent file has said since 2026-07-17.

## How it was tested

- `~/.claude/scripts/apply-model-policy.sh` re-run: 3 files stamped, 0 skipped
- `grep -ri fable` over the repo returns only historical prose in `CLAUDE.md` / `docs/claude-loop.md` (the model-change history line) — no live default left
- Docs/config only; no build or test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3R4Cew6w6tfHQ8GqnCoR