### PR TITLE
Bug: /ticket and /work-ticket read issues with `gh issue view --comments`, which hides the body and forces a probe hop

### DIFF
--- a/.claude/commands/ticket.md
+++ b/.claude/commands/ticket.md
@@ -22,9 +22,11 @@ This makes the post-merge loop self-contained: after merging the previous PR on 
 
 ## 1. Pull the ticket
 
-- `gh issue view <n> --comments` — read title (`M{milestone}-{nn}: Title`), labels, body
-  (Context / Depends on / Tasks / Acceptance criteria) and every comment (later comments override
-  the body).
+- `gh issue view <n> --json number,title,state,labels,body,comments` — one call that returns
+  everything: title (`M{milestone}-{nn}: Title`), labels, body (Context / Depends on / Tasks /
+  Acceptance criteria) and the `comments` array (later comments override the body). **Never use
+  `-c/--comments`** — it does not add comments to the default view, it *replaces* it with a
+  comments-only view, so on a comment-free issue it prints nothing and still exits 0.
 - For each `Depends on #X` / `Blocks #X`: `gh issue view X` enough to know whether the dependency
   is satisfied. If an open dependency genuinely blocks this ticket, **stop and say so** — don't
   build on missing foundations.

--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -21,12 +21,14 @@ push → `gh pr create` (the interactive "ask before pushing" rule is waived). Y
 
 ## The loop (do not skip steps)
 
-1. **Pull the ticket.** `gh issue view $ARGUMENTS --comments` — title, labels, body (Context /
-   Depends on / Tasks / Acceptance criteria), every comment (later comments override the body).
-   For each `Depends on #X`, verify it is satisfied; an open blocking dependency → `STATUS: BLOCKED`
-   (category: dependency). Issues predating the 2026-06 pivot may describe a dead world (MediatR,
-   one shared Application, auth in M5) — **CLAUDE.md wins**; note the conflict and build the
-   current world.
+1. **Pull the ticket.** `gh issue view $ARGUMENTS --json number,title,state,labels,body,comments`
+   — one call returning title, labels, body (Context / Depends on / Tasks / Acceptance criteria)
+   and the `comments` array (later comments override the body). **Never use `-c/--comments`** — it
+   replaces the default view with a comments-only one, so a comment-free issue prints nothing and
+   still exits 0. For each `Depends on #X`, verify it is satisfied; an open blocking dependency →
+   `STATUS: BLOCKED` (category: dependency). Issues predating the 2026-06 pivot may describe a dead
+   world (MediatR, one shared Application, auth in M5) — **CLAUDE.md wins**; note the conflict and
+   build the current world.
 2. **Ground it in the repo.** Read the areas the ticket touches; identify the nearest sibling
    slice to mirror (here, or TheKittySaver `AdoptionSystem.API/Features/…` + de-mediatorization).
    DAT/update work → `docs/knowledge-base/` FIRST (vnum, translation survival, launch flow are


### PR DESCRIPTION
Closes #612

## What

Both ticket-working commands read the issue with `gh issue view <n> --comments`. That flag does
**not** add comments to the default view — it *replaces* it with a comments-only view. On an issue
with zero comments (most of this backlog) the command prints nothing and exits 0.

Replaced in `.claude/commands/ticket.md` and `.claude/commands/work-ticket.md` with one
deterministic call, plus an explicit "never use `-c/--comments`" warning so the wrong flag does not
creep back:

```
gh issue view <n> --json number,title,state,labels,body,comments
```

## Why

The agent gets an empty tool result with a success exit code and cannot distinguish an empty view
from a missing issue or an auth problem, so it probes — re-runs with `| head`, then falls back to
`--json`. Two to three wasted round trips on every `/ticket` against a comment-free issue, and
silently in every headless `scripts/claude/work-ticket.sh` worker session where nobody sees it.

This PR reproduced the defect on itself: the first two `gh issue view 612 --comments` calls in the
session returned nothing, and #612 only became readable through the `--json` fallback.

## Test

Docs-only change to two prompt files — no C# touched, so no build or test run (`.claude/` is inert
for the .NET gate by `scripts/ci/classify-changes.sh`). Acceptance criteria verified directly:

| AC | Result |
|---|---|
| `grep -rn "issue view.*--comments" .claude/commands/` returns nothing | pass (only the new "never use" warnings remain, and they are not invocations) |
| Zero-comment issue read in **one** call, no retry | pass — #612: body 3596 chars + labels + state, exit 0 |
| Issue with comments still surfaces every comment | pass — #604: body 1191 chars **and** 1 comment (`koniecdev`, `OWNER`, 1344 chars) |
| TheKittySaver's two command files carry the same call | done locally on `fix/gh-issue-view-json-in-ticket-commands`, awaiting a separate PR in that repo |

## Not in scope

`scripts/claude/issue-trust.sh` and ADR-0026 keep using `gh api` — the issue-level
`authorAssociation` really is absent from `gh issue view --json`, so that gate is unchanged. The
dependency lookups (`gh issue view X`, `next-ticket.sh --json`) already behave and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3R4Cew6w6tfHQ8GqnCoR