### PR TITLE
Frontend: resolve every TMS entry point from discovery instead of hardcoded paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Pure-SSR guard
         run: ./scripts/check-ssr-purity.sh
 
+      # Same hypermedia gate as pr-verify — backstops direct pushes to main.
+      - name: Frontend hypermedia guard
+        run: ./scripts/check-frontend-hypermedia.sh
+
       # Same restore-graph gate as pr-verify — backstops direct pushes to main.
       - name: Docker restore-graph guard
         run: ./scripts/check-dockerfile-restore-graph.sh

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -99,6 +99,12 @@ jobs:
       - name: Pure-SSR guard
         run: ./scripts/check-ssr-purity.sh
 
+      # Same shape, the other Frontend invariant: no hardcoded API paths. There is no gateway
+      # (ADR-0041), so a client resolves every entry point by rel — a compiled-in "/api/v1/..."
+      # only fails at runtime, and this catches it in seconds.
+      - name: Frontend hypermedia guard
+        run: ./scripts/check-frontend-hypermedia.sh
+
       # Build-cache analog of the SSR gate: every Dockerfile must COPY the full transitive
       # .csproj closure it restores. `dotnet restore` SKIPS a missing project file and still
       # exits 0, so a stale COPY list degrades the restore layer silently and stays green.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,6 +425,16 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
   `@rendermode`, `StateHasChanged`, or `AddInteractive*`. `scripts/check-ssr-purity.sh` (with a
   `.ps1` twin for local Windows devs) gates this in **both** `pr-verify` and `ci`, before
   `setup-dotnet`. Genuinely need interactivity? That's an ADR-first architecture change.
+- **The Frontend hardcodes no API path — enforced, not just documented (#610).** There is no
+  gateway (ADR-0041), so every entry point is resolved by **rel name** through
+  `IDiscoveryCache.ResolveTranslationSystemHrefAsync(Rels.<Name>)` and every id-keyed action follows
+  the href the loaded resource advertises. A missing rel is a `ProblemDetails` failure — never a
+  locally composed path, because an absent rel means the server does not offer that affordance to
+  this caller. `scripts/check-frontend-hypermedia.sh` (with a `.ps1` twin) flags an API path in any
+  string literal under `src/Frontend/` and gates it in **both** `pr-verify` and `ci`, alongside the
+  SSR guard; prose mentions in comments stay allowed. The one bounded exception is the editor's
+  detail URI (`{discovered translations href}/{id}`) — the `/editor/{id}` route hands over an id,
+  not a link, and it is documented as such in `TranslationEditorLoader`.
 - **Docker restore layers are loud and gated (ADR-0028, amended).** Every Dockerfile that lists
   `.csproj` files must COPY the **full transitive closure** of the projects it restores.
   `dotnet restore` treats a missing project file as `Skipping project … because it was not found`

--- a/scripts/check-frontend-hypermedia.ps1
+++ b/scripts/check-frontend-hypermedia.ps1
@@ -1,0 +1,68 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Hypermedia guard for the Frontend (PowerShell twin of check-frontend-hypermedia.sh).
+
+.DESCRIPTION
+    There is no API gateway (ADR-0041): each API's discovery document IS the client contract
+    surface, so the Frontend resolves every entry point by REL NAME through IDiscoveryCache and
+    follows the href the server hands back. It must never carry an API path of its own - a
+    hardcoded "/api/v1/..." silently reintroduces the coupling #610 removed, and it fails at
+    runtime (404, or worse a call the caller was never authorized to make) instead of at build time.
+
+    CLAUDE.md and ADR-0041 state the rule in prose; this script enforces it. CI runs the .sh;
+    this .ps1 is the local twin for Windows devs - keep the two in sync.
+
+    What it flags: an API path inside a STRING LITERAL (the shape a hardcoded route actually
+    takes - a const, an interpolation base, a razor href). Prose mentions in comments and XML
+    docs are deliberately allowed: documenting which route a rel points at is useful, and
+    banning that only pushes people to weaken the guard.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot    = Split-Path -Parent $PSScriptRoot
+$frontendDir = Join-Path $repoRoot 'src/Frontend'
+
+if (-not (Test-Path $frontendDir)) {
+    Write-Error "Hypermedia guard: Frontend directory not found at $frontendDir"
+    exit 2
+}
+
+# obj/ and bin/ are build output, not source - never scan them (mirrors the .sh --exclude-dir).
+$files = Get-ChildItem -Path $frontendDir -Recurse -File -Include '*.razor', '*.cs' |
+    Where-Object { $_.FullName -notmatch '[\\/](obj|bin)[\\/]' }
+$script:fail = $false
+
+function Test-Hypermedia {
+    param(
+        [Parameter(Mandatory)][string] $Pattern,
+        [Parameter(Mandatory)][string] $Message
+    )
+
+    $hits = $files | Select-String -Pattern $Pattern -CaseSensitive
+    if ($hits) {
+        $script:fail = $true
+        Write-Host "X $Message"
+        foreach ($hit in $hits) {
+            Write-Host ("    {0}:{1}:{2}" -f $hit.Path, $hit.LineNumber, $hit.Line.Trim())
+        }
+        Write-Host ""
+    }
+}
+
+# A double-quoted literal containing a versioned API path. C# strings and razor attributes both
+# use double quotes, so one pattern covers every real occurrence; the version is matched loosely
+# so a future /api/v2 cannot slip through.
+Test-Hypermedia -Pattern '"[^"]*api/v[0-9]' `
+    -Message 'A TMS API path is hardcoded in a string literal. Resolve the entry point by rel instead: IDiscoveryCache.ResolveTranslationSystemHrefAsync(Rels.<Name>), or follow the href a loaded resource already advertises.'
+
+if ($script:fail) {
+    Write-Host "----------------------------------------------------------------------"
+    Write-Host "Hypermedia guard FAILED - the Frontend must not hardcode API paths."
+    Write-Host "See ADR-0041 and CLAUDE.md -> 'No API gateway'. A client takes one root URL"
+    Write-Host "per service as config and resolves everything else by rel name."
+    exit 1
+}
+
+Write-Host "OK Hypermedia guard passed - Frontend resolves its entry points by rel."

--- a/scripts/check-frontend-hypermedia.sh
+++ b/scripts/check-frontend-hypermedia.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Hypermedia guard for the Frontend.
+#
+# There is no API gateway (ADR-0041): each API's discovery document IS the client
+# contract surface, so the Frontend resolves every entry point by REL NAME through
+# IDiscoveryCache and follows the href the server hands back. It must never carry an
+# API path of its own — a hardcoded "/api/v1/..." silently reintroduces the coupling
+# #610 removed, and it fails at runtime (404, or worse a call the caller was never
+# authorized to make) instead of at build time.
+#
+# CLAUDE.md and ADR-0041 state this rule in prose; THIS script is the machine that
+# enforces it, so the rule can't rot. Run it before pushing; CI (pr-verify + ci) runs
+# it on every PR. Keep this in sync with its check-frontend-hypermedia.ps1 twin.
+#
+# What it flags: an API path inside a STRING LITERAL (the shape a hardcoded route
+# actually takes — a const, an interpolation base, a razor href). Prose mentions in
+# comments and XML docs are deliberately allowed: documenting which route a rel points
+# at is useful, and banning that only pushes people to weaken the guard.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FRONTEND_DIR="$REPO_ROOT/src/Frontend"
+
+if [ ! -d "$FRONTEND_DIR" ]; then
+    echo "Hypermedia guard: Frontend directory not found at $FRONTEND_DIR" >&2
+    exit 2
+fi
+
+fail=0
+
+check() {
+    # $1 = grep -E pattern to flag, $2 = plain explanation of what to do instead.
+    # obj/ and bin/ are build output, not source — never scan them (in CI this runs before
+    # restore/build, but a local run after a build would otherwise hit generated *.g.cs).
+    local matches
+    matches="$(grep -rnE "$1" --include='*.razor' --include='*.cs' --exclude-dir=obj --exclude-dir=bin "$FRONTEND_DIR" 2>/dev/null || true)"
+    if [ -n "$matches" ]; then
+        fail=1
+        printf '✗ %s\n' "$2"
+        echo "$matches" | sed 's/^/    /'
+        echo
+    fi
+}
+
+# A double-quoted literal containing a versioned API path. C# strings and razor attributes
+# both use double quotes, so one pattern covers every real occurrence; the version is matched
+# loosely so a future /api/v2 cannot slip through.
+check '"[^"]*api/v[0-9]' \
+    'A TMS API path is hardcoded in a string literal. Resolve the entry point by rel instead: IDiscoveryCache.ResolveTranslationSystemHrefAsync(Rels.<Name>), or follow the href a loaded resource already advertises.'
+
+if [ "$fail" -ne 0 ]; then
+    echo "──────────────────────────────────────────────────────────────────────"
+    echo "Hypermedia guard FAILED — the Frontend must not hardcode API paths."
+    echo "See ADR-0041 and CLAUDE.md → 'No API gateway'. A client takes one root URL"
+    echo "per service as config and resolves everything else by rel name."
+    exit 1
+fi
+
+echo "✓ Hypermedia guard passed — Frontend resolves its entry points by rel."

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -50,7 +50,7 @@ INERT='\.md$|^docs/|^LICENSE$|^\.gitignore$|^\.gitattributes$|\.sh$|\.ps1$|(^|/)
 # thing that checks it before it gets there (HETZ-04); the two scripts/ci/ halves of the N-1
 # promotion gate for the same reason — CD's prod leg runs them (#534) and their self-tests are the
 # only pre-deploy check they face.
-GUARD_INPUTS='^scripts/check-ssr-purity\.(sh|ps1)$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|^scripts/claude/(issue-trust|next-ticket|work-ticket)\.sh$|^scripts/tests/claude-loop-provenance\.tests\.sh$|^scripts/hetzner/deploy\.sh$|^scripts/tests/hetzner-deploy\.tests\.sh$|^scripts/ci/(resolve-prod-baseline|n1-promotion-gate)\.sh$|^scripts/tests/(resolve-prod-baseline|n1-promotion-gate)\.tests\.sh$|(^|/)Dockerfile[^/]*$|^\.github/workflows/(pr-verify|ci)\.yml$'
+GUARD_INPUTS='^scripts/check-ssr-purity\.(sh|ps1)$|^scripts/check-frontend-hypermedia\.(sh|ps1)$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|^scripts/claude/(issue-trust|next-ticket|work-ticket)\.sh$|^scripts/tests/claude-loop-provenance\.tests\.sh$|^scripts/hetzner/deploy\.sh$|^scripts/tests/hetzner-deploy\.tests\.sh$|^scripts/ci/(resolve-prod-baseline|n1-promotion-gate)\.sh$|^scripts/tests/(resolve-prod-baseline|n1-promotion-gate)\.tests\.sh$|(^|/)Dockerfile[^/]*$|^\.github/workflows/(pr-verify|ci)\.yml$'
 
 # Build-relevant despite matching INERT: the two workflows that DEFINE the .NET gate.
 CODE_INPUTS='^\.github/workflows/(pr-verify|ci)\.yml$'

--- a/scripts/tests/classify-changes.tests.sh
+++ b/scripts/tests/classify-changes.tests.sh
@@ -77,6 +77,8 @@ echo '── guards only: the bash gates re-run, the .NET gate does not ──�
 expect 'code=false guards=true images=false' 'a script the provenance self-test executes' 'scripts/claude/work-ticket.sh'
 expect 'code=false guards=true images=false' 'the provenance gate itself'                 'scripts/claude/issue-trust.sh'
 expect 'code=false guards=true images=false' 'the SSR-purity guard'                       'scripts/check-ssr-purity.sh'
+expect 'code=false guards=true images=false' 'the hypermedia guard'                       'scripts/check-frontend-hypermedia.sh'
+expect 'code=false guards=true images=false' 'the hypermedia guard PowerShell twin'       'scripts/check-frontend-hypermedia.ps1'
 expect 'code=false guards=true images=false' 'the migration-safety guard'                 'scripts/check-migration-safety.sh'
 expect 'code=false guards=true images=false' 'a guard self-test'                          'scripts/tests/check-migration-safety.tests.sh'
 expect 'code=false guards=true images=false' 'the script CD runs on a prod box'           'scripts/hetzner/deploy.sh'

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Hateoas/Rels.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Hateoas/Rels.cs
@@ -13,5 +13,13 @@ public static class Rels
     // Discovery
     public const string Register = "register";
     public const string ForgotPassword = "forgot-password";
+
+    /// <summary>
+    /// The caller's own account export. <b>Load-bearing beyond its endpoint:</b> the auth root advertises
+    /// it only to authenticated callers, so the frontend's <c>DiscoveryCache</c> treats its absence under
+    /// an authenticated cache key as proof the bearer never reached the API, and force-signs the session
+    /// out. Renaming this rel — or stopping its emission to any authenticated caller — signs every
+    /// logged-in user out on their next page load; change the frontend guard in the same commit.
+    /// </summary>
     public const string ExportAccountData = "export-account-data";
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
@@ -2,8 +2,10 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Translators;
 using Microsoft.AspNetCore.Mvc;
 
@@ -22,9 +24,6 @@ internal static class AccountEndpointsExtensions
 {
     /// <summary>The download URL — linked from the account page's export action.</summary>
     internal const string ExportDownloadPath = "/account/export";
-
-    /// <summary>The TMS leg — the caller's contribution export (self-only; LEGAL-07).</summary>
-    internal const string ContributionExportApiPath = "/api/v1/translators/me/data-export";
 
     private static readonly JsonSerializerOptions ExportSerializerOptions = new()
     {
@@ -52,6 +51,7 @@ internal static class AccountEndpointsExtensions
     /// </summary>
     internal static async Task<IResult> DownloadAccountExportAsync(
         AccountLoader loader,
+        IDiscoveryCache discoveryCache,
         ITranslationSystemClient translationSystemClient,
         CancellationToken cancellationToken)
     {
@@ -69,14 +69,24 @@ internal static class AccountEndpointsExtensions
         TranslatorDataExportResponse? translationData = null;
         try
         {
-            ApiResult<TranslatorDataExportResponse> contributionResult =
-                await translationSystemClient.GetApiResultAsync<TranslatorDataExportResponse>(
-                    ContributionExportApiPath,
-                    cancellationToken);
+            // The TMS leg is addressed by the 'contribution-data-export' rel (#610). An unresolvable
+            // rel degrades exactly like a failed call does — it never falls back to a guessed path,
+            // and it never fails the download (ADR-0032).
+            ApiResult<string> contributionHref = await discoveryCache.ResolveTranslationSystemHrefAsync(
+                Rels.ContributionDataExport,
+                cancellationToken);
 
-            if (contributionResult.IsSuccess)
+            if (contributionHref.IsSuccess)
             {
-                translationData = contributionResult.Value;
+                ApiResult<TranslatorDataExportResponse> contributionResult =
+                    await translationSystemClient.GetApiResultAsync<TranslatorDataExportResponse>(
+                        contributionHref.Value,
+                        cancellationToken);
+
+                if (contributionResult.IsSuccess)
+                {
+                    translationData = contributionResult.Value;
+                }
             }
         }
         catch (JsonException)

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/DashboardStatsLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/DashboardStatsLoader.cs
@@ -1,27 +1,39 @@
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 
 namespace LotroKoniecDev.Frontend.Components.Pages.Dashboard;
 
 /// <summary>
-/// Fetches the mini-dashboard's progress counters (M3-05) through the typed TMS client. Kept as a thin
-/// injectable seam so the page's data flow is unit-testable end-to-end over a stubbed HTTP handler (the
-/// Frontend has no bUnit for component-level rendering tests).
+/// Fetches the mini-dashboard's progress counters (M3-05) through the typed TMS client, resolving the
+/// entry point from the service document's <c>translation-stats</c> rel (#610) — a rel the API emits
+/// only for a translator, so an unauthorized session gets a clear failure instead of a guessed call.
+/// Kept as a thin injectable seam so the page's data flow is unit-testable end-to-end over a stubbed
+/// HTTP handler (the Frontend has no bUnit for component-level rendering tests).
 /// </summary>
 internal sealed class DashboardStatsLoader
 {
-    private const string StatsRelativeUri = "/api/v1/translations/stats";
-
+    private readonly IDiscoveryCache _discoveryCache;
     private readonly ITranslationSystemClient _client;
 
-    public DashboardStatsLoader(ITranslationSystemClient client)
+    public DashboardStatsLoader(IDiscoveryCache discoveryCache, ITranslationSystemClient client)
     {
+        _discoveryCache = discoveryCache;
         _client = client;
     }
 
-    public Task<ApiResult<TranslationStatsResponse>> LoadAsync(CancellationToken cancellationToken = default)
+    public async Task<ApiResult<TranslationStatsResponse>> LoadAsync(CancellationToken cancellationToken = default)
     {
-        return _client.GetApiResultAsync<TranslationStatsResponse>(StatsRelativeUri, cancellationToken);
+        ApiResult<string> href = await _discoveryCache.ResolveTranslationSystemHrefAsync(
+            Rels.TranslationStats,
+            cancellationToken);
+        if (href.IsFailure)
+        {
+            return ApiResult.Failure<TranslationStatsResponse>(href.ProblemDetails!);
+        }
+
+        return await _client.GetApiResultAsync<TranslationStatsResponse>(href.Value, cancellationToken);
     }
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
@@ -202,13 +202,6 @@
 
 @code
 {
-    /// <summary>
-    /// Recovery-only fallback for the upsert target: the upsert rel is row-independent (it always points
-    /// at the collection PUT), so when the row could not be reloaded on a resubmit we PUT here rather
-    /// than trust a client-submitted href. The happy path follows <c>_detail</c>'s advertised link.
-    /// </summary>
-    private const string CollectionUpsertPath = "/api/v1/translations";
-
     [Parameter]
     public Guid Id { get; set; }
 
@@ -260,9 +253,22 @@
         _draftText = DraftField ?? string.Empty;
 
         // Follow the row's server-advertised upsert href (never a client-submitted one — that would let a
-        // tampered post redirect the bearer-token request off-host); fall back to the collection PUT only
-        // when the row is unloadable on a recovery resubmit.
-        string upsertHref = _detail?.Links.FindLink(Rels.Upsert)?.Href ?? CollectionUpsertPath;
+        // tampered post redirect the bearer-token request off-host). The upsert rel is row-independent
+        // (it always points at the collection PUT), so whenever the row cannot supply it — unloadable on
+        // a recovery resubmit, or loaded but withholding the rel — we resolve the same rel from the
+        // service document instead of a compiled-in path (#610). The server still rules on the request.
+        string? upsertHref = _detail?.Links.FindLink(Rels.Upsert)?.Href;
+        if (upsertHref is null)
+        {
+            ApiResult<string> resolved = await Loader.ResolveCollectionUpsertHrefAsync(CancellationToken.None);
+            if (resolved.IsFailure)
+            {
+                _saveProblem = resolved.ProblemDetails;
+                return;
+            }
+
+            upsertHref = resolved.Value;
+        }
 
         UpsertTranslationRequest request = new(FileIdField, GossipIdField, _draftText);
         ApiResult<TranslationDetailResponse> result = await Loader.SaveAsync(upsertHref, request, CancellationToken.None);

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/TranslationEditorLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/TranslationEditorLoader.cs
@@ -1,41 +1,62 @@
 using System.Globalization;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 
 namespace LotroKoniecDev.Frontend.Components.Pages.Editor;
 
 /// <summary>
-/// Drives the side-by-side editor's three TMS calls through the typed client: load one translation
-/// (<c>GET /api/v1/translations/{id}</c>) is the FE-built entry point, while save and approve are
-/// link-driven (#158 / spec 0002) — they follow the <c>upsert</c> / <c>approve</c> hypermedia
-/// <c>href</c> the loaded row advertises rather than a hardcoded path, so the server alone decides the
-/// role + Draft/NeedsReview affordance. Kept as a thin injectable seam so the editor's load / save /
-/// approve behavior is unit-testable end-to-end over a stubbed HTTP handler, and so a bUnit render test
-/// can drive the editor through a substituted loader.
+/// Drives the side-by-side editor's TMS calls through the typed client. Loading one row is the entry
+/// point: the collection's address comes from the service document's <c>translations</c> rel (#610) and
+/// the row id is appended, because the editor is reached by its own <c>/editor/{id}</c> route and so
+/// holds an id rather than a link. Save and approve stay link-driven (#158 / spec 0002) — they follow
+/// the <c>upsert</c> / <c>approve</c> hypermedia <c>href</c> the loaded row advertises, so the server
+/// alone decides the role + Draft/NeedsReview affordance. Kept as a thin injectable seam so the
+/// editor's load / save / approve behavior is unit-testable end-to-end over a stubbed HTTP handler, and
+/// so a bUnit render test can drive the editor through a substituted loader.
 /// </summary>
 internal sealed class TranslationEditorLoader
 {
-    private const string TranslationsApiPath = "/api/v1/translations";
-
     /// <summary>The approve endpoint takes no body; an empty object keeps the typed POST helper happy.</summary>
     private static readonly object EmptyApprovePayload = new();
 
+    private readonly IDiscoveryCache _discoveryCache;
     private readonly ITranslationSystemClient _client;
 
-    public TranslationEditorLoader(ITranslationSystemClient client)
+    public TranslationEditorLoader(IDiscoveryCache discoveryCache, ITranslationSystemClient client)
     {
+        _discoveryCache = discoveryCache;
         _client = client;
     }
 
-    public Task<ApiResult<TranslationDetailResponse>> LoadAsync(
+    public async Task<ApiResult<TranslationDetailResponse>> LoadAsync(
         TranslationId id,
         CancellationToken cancellationToken = default)
     {
-        return _client.GetApiResultAsync<TranslationDetailResponse>(
-            DetailUri(id),
+        ApiResult<string> collectionHref = await _discoveryCache.ResolveTranslationSystemHrefAsync(
+            Rels.Translations,
             cancellationToken);
+        if (collectionHref.IsFailure)
+        {
+            return ApiResult.Failure<TranslationDetailResponse>(collectionHref.ProblemDetails!);
+        }
+
+        return await _client.GetApiResultAsync<TranslationDetailResponse>(
+            DetailUri(collectionHref.Value, id),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// The collection-level <c>upsert</c> entry point from the service document, for the one case that
+    /// has no row to advertise it: a resubmit whose row could not be reloaded. Resolving it here keeps
+    /// the recovery path server-addressed rather than falling back to a compiled-in path.
+    /// </summary>
+    public Task<ApiResult<string>> ResolveCollectionUpsertHrefAsync(CancellationToken cancellationToken = default)
+    {
+        return _discoveryCache.ResolveTranslationSystemHrefAsync(Rels.Upsert, cancellationToken);
     }
 
     /// <summary>
@@ -73,6 +94,14 @@ internal sealed class TranslationEditorLoader
             cancellationToken);
     }
 
-    private static string DetailUri(TranslationId id) =>
-        string.Create(CultureInfo.InvariantCulture, $"{TranslationsApiPath}/{id.Value}");
+    /// <summary>
+    /// The one place this frontend still assumes something about the API's URI space, and a deliberate,
+    /// bounded exception to ADR-0041: the editor is reached by its own <c>/editor/{id}</c> route, so it
+    /// holds an id rather than a link, and the service document carries no templated per-row rel to
+    /// resolve instead. The base is still server-supplied — only the id is appended. Retire this the day
+    /// the API advertises a templated <c>translation</c> rel (or the list row's <c>self</c> is carried
+    /// through); it would also break if the <c>translations</c> link ever gained a query string.
+    /// </summary>
+    private static string DetailUri(string collectionHref, TranslationId id) =>
+        string.Create(CultureInfo.InvariantCulture, $"{collectionHref.TrimEnd('/')}/{id.Value}");
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
@@ -54,7 +54,7 @@
     }
 
     @* The register affordance is the collection's admin-only `register` rel (#158) — not a local role check. *@
-    @if (_canRegister)
+    @if (_registerHref is not null)
     {
         <section class="panel">
             <header class="panel-head">
@@ -126,11 +126,12 @@
                                 </span>
                             </td>
                             <td class="col-actions">
-                                @* The `delete` rel is emitted only for an admin on an Unprocessed version (#158). *@
-                                @if (version.Links.HasLink(Rels.Delete))
+                                @* The `delete` rel is emitted only for an admin on an Unprocessed version (#158),
+                                   and it carries the URI to call — the page never composes one (#610). *@
+                                @if (version.Links.FindLink(Rels.Delete) is { } deleteLink)
                                 {
                                     <form method="post" @formname="@DeleteFormName(version.Id)"
-                                          @onsubmit="() => DeleteAsync(version.Id)">
+                                          @onsubmit="() => DeleteAsync(deleteLink.Href)">
                                         <AntiforgeryToken/>
                                         <button type="submit" class="btn btn-ghost btn-sm">Usuń</button>
                                     </form>
@@ -160,7 +161,12 @@
     private ProblemDetails? _versionsProblem;
     private ProblemDetails? _actionProblem;
     private string? _actionMessage;
-    private bool _canRegister;
+
+    /// <summary>
+    /// The collection's server-advertised <c>register</c> href — admin-only, so its presence is both the
+    /// affordance gate and the URI the form posts to (#610). Null means "not offered to this caller".
+    /// </summary>
+    private string? _registerHref;
 
     protected override async Task OnInitializedAsync()
     {
@@ -179,13 +185,13 @@
         if (result.IsSuccess)
         {
             _versions = [.. result.Value.Items];
-            _canRegister = result.Value.Links.HasLink(Rels.Register);
+            _registerHref = result.Value.Links.FindLink(Rels.Register)?.Href;
             _versionsProblem = null;
         }
         else
         {
             _versions = null;
-            _canRegister = false;
+            _registerHref = null;
             _versionsProblem = result.ProblemDetails;
         }
     }
@@ -195,7 +201,7 @@
         _actionProblem = null;
         _actionMessage = null;
 
-        if (!_canRegister)
+        if (_registerHref is not { } registerHref)
         {
             return;
         }
@@ -208,7 +214,8 @@
             return;
         }
 
-        ApiResult<GameVersionResponse> result = await Loader.RegisterGameVersionAsync(version, CancellationToken.None);
+        ApiResult<GameVersionResponse> result =
+            await Loader.RegisterGameVersionAsync(registerHref, version, CancellationToken.None);
         if (result.IsSuccess)
         {
             _actionMessage = $"Zarejestrowano wersję {result.Value.Version}.";
@@ -223,12 +230,12 @@
         await LoadVersionsAsync();
     }
 
-    private async Task DeleteAsync(GameVersionId id)
+    private async Task DeleteAsync(string deleteHref)
     {
         _actionProblem = null;
         _actionMessage = null;
 
-        ApiResult result = await Loader.DeleteGameVersionAsync(id, CancellationToken.None);
+        ApiResult result = await Loader.DeleteGameVersionAsync(deleteHref, CancellationToken.None);
         if (result.IsSuccess)
         {
             _actionMessage = "Usunięto wersję gry.";

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersionsLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersionsLoader.cs
@@ -1,56 +1,81 @@
-using System.Globalization;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
 using LotroKoniecDev.TranslationSystem.Contracts.Common;
 using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
-using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 
 namespace LotroKoniecDev.Frontend.Components.Pages.GameVersions;
 
 /// <summary>
-/// Drives the game-versions page's TMS calls through the typed client (#209): list every known
-/// version as the HATEOAS collection envelope — <b>keeping its <c>Links</c></b> so the page can gate
-/// the admin <c>register</c> / per-item <c>delete</c> affordances on the server-advertised rels (#158)
-/// rather than recomputing the role locally — register one manually (<c>POST /api/v1/game-versions</c>,
-/// #107) and delete a still-unprocessed mistaken entry (<c>DELETE /api/v1/game-versions/{id}</c>).
-/// Kept as a thin injectable seam so the page's data flow is unit-testable end-to-end over a stubbed
-/// HTTP handler and so a bUnit render test can drive the page through a substituted loader.
+/// Drives the game-versions page's TMS calls through the typed client (#209). The list is the one entry
+/// point, resolved from the service document's <c>game-versions</c> rel (#610); everything past it is
+/// link-driven — the collection envelope's <c>register</c> rel and each item's <c>delete</c> rel are
+/// both the affordance gate and the URI to call (#158), so the server alone decides who may do what and
+/// where. Kept as a thin injectable seam so the page's data flow is unit-testable end-to-end over a
+/// stubbed HTTP handler and so a bUnit render test can drive the page through a substituted loader.
 /// </summary>
 internal sealed class GameVersionsLoader
 {
-    private const string GameVersionsApiPath = "/api/v1/game-versions";
-
+    private readonly IDiscoveryCache _discoveryCache;
     private readonly ITranslationSystemClient _client;
 
-    public GameVersionsLoader(ITranslationSystemClient client)
+    public GameVersionsLoader(IDiscoveryCache discoveryCache, ITranslationSystemClient client)
     {
+        _discoveryCache = discoveryCache;
         _client = client;
     }
 
-    public Task<ApiResult<CollectionResponse<GameVersionResponse>>> ListGameVersionsAsync(
+    /// <summary>
+    /// Lists every known version as the HATEOAS collection envelope, <b>keeping its <c>Links</c></b> so
+    /// the page can gate — and address — the admin <c>register</c> / per-item <c>delete</c> actions from
+    /// the server-advertised rels rather than recomputing the role locally.
+    /// </summary>
+    public async Task<ApiResult<CollectionResponse<GameVersionResponse>>> ListGameVersionsAsync(
         CancellationToken cancellationToken = default)
     {
-        return _client.GetApiResultAsync<CollectionResponse<GameVersionResponse>>(
-            GameVersionsApiPath,
+        ApiResult<string> href = await _discoveryCache.ResolveTranslationSystemHrefAsync(
+            Rels.GameVersions,
+            cancellationToken);
+        if (href.IsFailure)
+        {
+            return ApiResult.Failure<CollectionResponse<GameVersionResponse>>(href.ProblemDetails!);
+        }
+
+        return await _client.GetApiResultAsync<CollectionResponse<GameVersionResponse>>(
+            href.Value,
             cancellationToken);
     }
 
+    /// <summary>
+    /// Registers a version manually (#107) by POSTing to the collection's <c>register</c> link.
+    /// <paramref name="registerHref"/> is the server-advertised URI — emitted admin-only, never a
+    /// FE-constructed path.
+    /// </summary>
     public Task<ApiResult<GameVersionResponse>> RegisterGameVersionAsync(
+        string registerHref,
         string version,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerHref);
+
         return _client.PostApiResultAsync<GameVersionResponse>(
-            GameVersionsApiPath,
+            registerHref,
             new RegisterGameVersionRequest(version),
             cancellationToken);
     }
 
+    /// <summary>
+    /// Deletes a mistaken, still-unprocessed entry by following its own <c>delete</c> link.
+    /// <paramref name="deleteHref"/> is the server-advertised URI — present only for an admin on an
+    /// <c>Unprocessed</c> row, which is the whole gate.
+    /// </summary>
     public Task<ApiResult> DeleteGameVersionAsync(
-        GameVersionId id,
+        string deleteHref,
         CancellationToken cancellationToken = default)
     {
-        return _client.DeleteApiResultAsync(
-            string.Create(CultureInfo.InvariantCulture, $"{GameVersionsApiPath}/{id.Value}"),
-            cancellationToken);
+        ArgumentException.ThrowIfNullOrWhiteSpace(deleteHref);
+
+        return _client.DeleteApiResultAsync(deleteHref, cancellationToken);
     }
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home/HomeProgressLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Home/HomeProgressLoader.cs
@@ -1,28 +1,38 @@
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Progress;
 
 namespace LotroKoniecDev.Frontend.Components.Pages.Home;
 
 /// <summary>
-/// Fetches the landing page's public progress snapshot (#309) through the typed TMS client — the
-/// anonymous <c>GET /api/v1/progress</c>, so the page works before any login exists. Kept as a thin
-/// injectable seam so the page's data flow is unit-testable end-to-end over a stubbed HTTP handler
-/// (mirrors <see cref="Dashboard.DashboardStatsLoader"/>).
+/// Fetches the landing page's public progress snapshot (#309) through the typed TMS client. The entry
+/// point comes from the service document's <c>progress</c> rel (#610) — that endpoint is anonymous, so
+/// the page works before any login exists. Kept as a thin injectable seam so the page's data flow is
+/// unit-testable end-to-end over a stubbed HTTP handler (mirrors <see cref="Dashboard.DashboardStatsLoader"/>).
 /// </summary>
 internal sealed class HomeProgressLoader
 {
-    private const string ProgressRelativeUri = "/api/v1/progress";
-
+    private readonly IDiscoveryCache _discoveryCache;
     private readonly ITranslationSystemClient _client;
 
-    public HomeProgressLoader(ITranslationSystemClient client)
+    public HomeProgressLoader(IDiscoveryCache discoveryCache, ITranslationSystemClient client)
     {
+        _discoveryCache = discoveryCache;
         _client = client;
     }
 
-    public Task<ApiResult<PublicProgressResponse>> LoadAsync(CancellationToken cancellationToken = default)
+    public async Task<ApiResult<PublicProgressResponse>> LoadAsync(CancellationToken cancellationToken = default)
     {
-        return _client.GetApiResultAsync<PublicProgressResponse>(ProgressRelativeUri, cancellationToken);
+        ApiResult<string> href = await _discoveryCache.ResolveTranslationSystemHrefAsync(
+            Rels.Progress,
+            cancellationToken);
+        if (href.IsFailure)
+        {
+            return ApiResult.Failure<PublicProgressResponse>(href.ProblemDetails!);
+        }
+
+        return await _client.GetApiResultAsync<PublicProgressResponse>(href.Value, cancellationToken);
     }
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
@@ -101,6 +101,16 @@
                         <p>Najpierw zarejestruj wersję gry, zanim zaimportujesz eksport.</p>
                     </div>
                 }
+                else if (_importableVersions is { Count: 0 })
+                {
+                    @* Versions exist, but the server advertises `import` on none of them — every one is
+                       Superseded. Say so here instead of offering a selector whose every option would be
+                       refused on submit (#610). *@
+                    <div class="empty">
+                        <h2>Brak wersji do importu</h2>
+                        <p>Żadna z zarejestrowanych wersji gry nie przyjmuje już importu. Zarejestruj nowszą wersję.</p>
+                    </div>
+                }
                 else if (_versions is not null)
                 {
                     @* EditForm in static SSR emits the antiforgery token itself; a manual <AntiforgeryToken/>
@@ -113,7 +123,7 @@
                                 <label for="game-version">Wersja gry</label>
                                 <div class="select-wrap">
                                     <select id="game-version" name="ImportInput.GameVersionId">
-                                        @foreach (GameVersionResponse version in _versions)
+                                        @foreach (GameVersionResponse version in _importableVersions)
                                         {
                                             <option value="@version.Id.Value" selected="@(version.Id.Value == ImportInput?.GameVersionId)">
                                                 @version.Version (@version.Status)
@@ -202,6 +212,13 @@
     private ImportFormModel? ImportInput { get; set; }
 
     private IReadOnlyList<GameVersionResponse>? _versions;
+
+    /// <summary>
+    /// The subset of <c>_versions</c> the server advertises an <c>import</c> rel for — the selector's
+    /// options and the only ids <see cref="ImportAsync"/> can resolve a target for (#610).
+    /// </summary>
+    private IReadOnlyList<GameVersionResponse> _importableVersions = [];
+
     private ProblemDetails? _versionsProblem;
     private ProblemDetails? _importProblem;
     private ImportSummary? _summary;
@@ -224,12 +241,15 @@
         if (result.IsSuccess)
         {
             _versions = [.. result.Value.Items];
+            _importableVersions = ImportTargets.Importable(_versions);
             _canImport = result.Value.Links.HasLink(Rels.Register);
             _versionsProblem = null;
         }
         else
         {
             _versions = null;
+            _importableVersions = [];
+            _canImport = false;
             _versionsProblem = result.ProblemDetails;
         }
     }
@@ -260,10 +280,24 @@
             return;
         }
 
+        // The upload target is the chosen version's own `import` rel (#610) — the API emits it for an
+        // admin on any version that is not Superseded, so a missing link means the server refuses this
+        // import. Never compose the path from the id.
+        if (ImportTargets.FindImportHref(_versions, input.GameVersionId) is not { } importHref)
+        {
+            _importProblem = new ProblemDetails
+            {
+                Title = "Nie można zaimportować do tej wersji gry.",
+                Detail = "Serwer nie udostępnia importu dla wybranej wersji. Odśwież stronę i wybierz inną wersję."
+            };
+            await LoadVersionsAsync();
+            return;
+        }
+
         await using Stream fileStream = input.File.OpenReadStream();
 
         ApiResult<ImportSummary> result = await Loader.ImportAsync(
-            GameVersionId.FromValue(input.GameVersionId),
+            importHref,
             fileStream,
             input.File.FileName,
             input.AllowMassRemoval,

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExportLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExportLoader.cs
@@ -1,65 +1,82 @@
-using System.Globalization;
 using System.Net.Http.Headers;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
 using LotroKoniecDev.TranslationSystem.Contracts.Common;
 using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Import;
-using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace LotroKoniecDev.Frontend.Components.Pages.ImportExport;
 
 /// <summary>
-/// Drives the import/export page's TMS calls through the typed client (M3-07): list game versions to
-/// pick the import target (<c>GET /api/v1/game-versions</c>, #103), upload a fresh <c>exported.txt</c>
-/// against a chosen version (<c>POST /api/v1/game-versions/{id}/import</c>, #97) and fetch the
-/// pre-built <c>polish.txt</c> artifact as raw text (<c>GET /api/v1/translation-files/pl</c>, #102).
-/// Kept as a thin injectable seam so the page's data flow is unit-testable end-to-end over a stubbed
-/// HTTP handler and so a bUnit render test can drive the page through a substituted loader.
+/// Drives the import/export page's TMS calls through the typed client (M3-07). Two entry points come
+/// from the service document (#610): the <c>game-versions</c> rel to pick the import target (#103) and
+/// the <c>translation-file</c> rel for the pre-built <c>polish.txt</c> artifact (#102, anonymous). The
+/// import itself (#97) is keyed by the version it lands against, so it follows the <c>import</c> rel the
+/// chosen version advertises — emitted admin-only, and never for a superseded version. Kept as a thin
+/// injectable seam so the page's data flow is unit-testable end-to-end over a stubbed HTTP handler and
+/// so a bUnit render test can drive the page through a substituted loader.
 /// </summary>
 internal sealed class ImportExportLoader
 {
-    private const string GameVersionsApiPath = "/api/v1/game-versions";
     private const string FileFieldName = "file";
+
+    /// <summary>The caller's per-upload override; the server cannot know it when it emits the link.</summary>
+    private const string AllowMassRemovalParameter = "allowMassRemoval";
 
     /// <summary>The export is the <c>||</c>-format plain-text file (mirrors the API's <c>IFormFile</c> import part).</summary>
     private const string UploadContentType = "text/plain";
 
-    /// <summary>The catalog is Polish-only today (mirrors the API's <c>SupportedLanguages.Polish</c>).</summary>
-    private const string Language = "pl";
-
-    private const string TranslationFileApiPath = $"/api/v1/translation-files/{Language}";
-
     /// <summary>The downloaded artifact's filename, as the patcher's <c>patch</c> command expects it.</summary>
     public const string DownloadFileName = "polish.txt";
 
+    private readonly IDiscoveryCache _discoveryCache;
     private readonly ITranslationSystemClient _client;
 
-    public ImportExportLoader(ITranslationSystemClient client)
+    public ImportExportLoader(IDiscoveryCache discoveryCache, ITranslationSystemClient client)
     {
+        _discoveryCache = discoveryCache;
         _client = client;
     }
 
     /// <summary>
     /// Lists the game versions as the HATEOAS collection envelope (M2-25), <b>keeping its
     /// <c>Links</c></b> (#158): the page reads the collection-level <c>register</c> rel — emitted
-    /// admin-only by the API — to gate the import affordance, instead of recomputing the role locally.
+    /// admin-only by the API — to gate the import panel, and each item's <c>import</c> rel to address
+    /// the upload, instead of recomputing the role locally.
     /// </summary>
-    public Task<ApiResult<CollectionResponse<GameVersionResponse>>> ListGameVersionsAsync(
+    public async Task<ApiResult<CollectionResponse<GameVersionResponse>>> ListGameVersionsAsync(
         CancellationToken cancellationToken = default)
     {
-        return _client.GetApiResultAsync<CollectionResponse<GameVersionResponse>>(
-            GameVersionsApiPath,
+        ApiResult<string> href = await _discoveryCache.ResolveTranslationSystemHrefAsync(
+            Rels.GameVersions,
+            cancellationToken);
+        if (href.IsFailure)
+        {
+            return ApiResult.Failure<CollectionResponse<GameVersionResponse>>(href.ProblemDetails!);
+        }
+
+        return await _client.GetApiResultAsync<CollectionResponse<GameVersionResponse>>(
+            href.Value,
             cancellationToken);
     }
 
+    /// <summary>
+    /// Uploads an <c>exported.txt</c> against the version whose <c>import</c> link is
+    /// <paramref name="importHref"/> — the server-advertised URI, which already carries the version id.
+    /// Only <c>allowMassRemoval</c> is appended, because it is the caller's choice for this one upload
+    /// and nothing the server could have known when it emitted the link.
+    /// </summary>
     public async Task<ApiResult<ImportSummary>> ImportAsync(
-        GameVersionId gameVersionId,
+        string importHref,
         Stream fileStream,
         string fileName,
         bool allowMassRemoval,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(importHref);
         ArgumentNullException.ThrowIfNull(fileStream);
 
         using MultipartFormDataContent content = new();
@@ -69,18 +86,21 @@ internal sealed class ImportExportLoader
 
         return await _client.SendMultipartApiResultAsync<ImportSummary>(
             HttpMethod.Post,
-            ImportUri(gameVersionId, allowMassRemoval),
+            QueryHelpers.AddQueryString(importHref, AllowMassRemovalParameter, allowMassRemoval ? "true" : "false"),
             content,
             cancellationToken);
     }
 
-    public Task<ApiResult<string>> DownloadTranslationFileAsync(CancellationToken cancellationToken = default)
+    public async Task<ApiResult<string>> DownloadTranslationFileAsync(CancellationToken cancellationToken = default)
     {
-        return _client.GetTextAsync(TranslationFileApiPath, cancellationToken);
-    }
+        ApiResult<string> href = await _discoveryCache.ResolveTranslationSystemHrefAsync(
+            Rels.TranslationFile,
+            cancellationToken);
+        if (href.IsFailure)
+        {
+            return ApiResult.Failure<string>(href.ProblemDetails!);
+        }
 
-    private static string ImportUri(GameVersionId gameVersionId, bool allowMassRemoval) =>
-        string.Create(
-            CultureInfo.InvariantCulture,
-            $"{GameVersionsApiPath}/{gameVersionId.Value}/import?allowMassRemoval={allowMassRemoval.ToString().ToLowerInvariant()}");
+        return await _client.GetTextAsync(href.Value, cancellationToken);
+    }
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportTargets.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportTargets.cs
@@ -1,0 +1,39 @@
+using LotroKoniecDev.Frontend.Infrastructure.Hateoas;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+
+namespace LotroKoniecDev.Frontend.Components.Pages.ImportExport;
+
+/// <summary>
+/// Which game versions an <c>exported.txt</c> may actually be imported into, and where to POST it —
+/// read purely from the per-item <c>import</c> rel the API emits (#610). The API withholds that rel for
+/// a non-admin and for a <c>Superseded</c> version, so this is the whole gate: no status enum is
+/// re-interpreted here and no URI is composed from an id.
+/// <para>
+/// Pure and isolated because the page's own form cannot be driven end-to-end in bUnit — Blazor's
+/// static-SSR form mapping does not serialize a programmatically set file input — so the selection rule
+/// would otherwise ship unverified (mirrors <see cref="Editor.PlaceholderAnalyzer"/>).
+/// </para>
+/// </summary>
+internal static class ImportTargets
+{
+    /// <summary>
+    /// The versions to offer in the selector: only those advertising <c>import</c>. Offering a version
+    /// the server would refuse is a lie the user only discovers on submit.
+    /// </summary>
+    internal static IReadOnlyList<GameVersionResponse> Importable(IReadOnlyList<GameVersionResponse>? versions) =>
+        versions is null
+            ? []
+            : [.. versions.Where(version => version.Links.HasLink(Rels.Import))];
+
+    /// <summary>
+    /// The <c>import</c> href advertised by the version <paramref name="gameVersionId"/> identifies, or
+    /// <see langword="null"/> when that version is unknown (the list moved under a stale form post) or
+    /// offers no import affordance. A <see langword="null"/> is a refusal to call, never a fallback.
+    /// </summary>
+    internal static string? FindImportHref(IReadOnlyList<GameVersionResponse>? versions, Guid gameVersionId) =>
+        versions
+            ?.FirstOrDefault(version => version.Id.Value == gameVersionId)
+            ?.Links.FindLink(Rels.Import)
+            ?.Href;
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListLoader.cs
@@ -1,33 +1,46 @@
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
 using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 
 namespace LotroKoniecDev.Frontend.Components.Pages.Translations;
 
 /// <summary>
 /// Fetches a page of translations for the list view through the typed TMS client, given the page's
-/// normalized <see cref="TranslationListQuery"/>. Kept as a thin injectable seam so the page's
-/// search / status-filter / pagination behavior is unit-testable end-to-end over a stubbed HTTP
-/// handler (the Frontend has no bUnit for component-level rendering tests).
+/// normalized <see cref="TranslationListQuery"/>. The collection's address comes from the service
+/// document's <c>translations</c> rel (#610) — anonymous, like the page itself. Kept as a thin
+/// injectable seam so the page's search / status-filter / pagination behavior is unit-testable
+/// end-to-end over a stubbed HTTP handler (the Frontend has no bUnit for component-level rendering tests).
 /// </summary>
 internal sealed class TranslationListLoader
 {
+    private readonly IDiscoveryCache _discoveryCache;
     private readonly ITranslationSystemClient _client;
 
-    public TranslationListLoader(ITranslationSystemClient client)
+    public TranslationListLoader(IDiscoveryCache discoveryCache, ITranslationSystemClient client)
     {
+        _discoveryCache = discoveryCache;
         _client = client;
     }
 
-    public Task<ApiResult<PaginationResponse<TranslationListItemResponse>>> LoadAsync(
+    public async Task<ApiResult<PaginationResponse<TranslationListItemResponse>>> LoadAsync(
         TranslationListQuery query,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        return _client.GetApiResultAsync<PaginationResponse<TranslationListItemResponse>>(
-            query.ToApiRelativeUri(),
+        ApiResult<string> href = await _discoveryCache.ResolveTranslationSystemHrefAsync(
+            Rels.Translations,
+            cancellationToken);
+        if (href.IsFailure)
+        {
+            return ApiResult.Failure<PaginationResponse<TranslationListItemResponse>>(href.ProblemDetails!);
+        }
+
+        return await _client.GetApiResultAsync<PaginationResponse<TranslationListItemResponse>>(
+            query.ToApiUri(href.Value),
             cancellationToken);
     }
 

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListQuery.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/TranslationListQuery.cs
@@ -6,9 +6,11 @@ namespace LotroKoniecDev.Frontend.Components.Pages.Translations;
 
 /// <summary>
 /// The normalized filter/paging state of the translation list page, and the single place that turns it
-/// into the relative URI the typed client calls (<c>GET /api/v1/translations</c>). Pure and isolated so
-/// the search / status-filter / pagination wiring is unit-testable without rendering the component (the
-/// Frontend has no bUnit) — the page reads it from the query string and hands it to the loader.
+/// into the URI the typed client calls. The collection's own address is <em>not</em> known here — it is
+/// the <c>translations</c> entry point resolved from the TMS service document (#610) and passed in — so
+/// this type only ever appends the filter/paging query string to it. Pure and isolated so the search /
+/// status-filter / pagination wiring is unit-testable without rendering the component (the Frontend has
+/// no bUnit) — the page reads it from the query string and hands it to the loader.
 /// </summary>
 internal sealed record TranslationListQuery
 {
@@ -25,7 +27,6 @@ internal sealed record TranslationListQuery
     /// </summary>
     internal static readonly IReadOnlyList<int> PageSizeOptions = [25, 50, 100];
 
-    private const string ApiPath = "/api/v1/translations";
     private const string PagePath = "/translations";
 
     private TranslationListQuery(string? search, TranslationStatus? status, int page, int pageSize)
@@ -56,11 +57,14 @@ internal sealed record TranslationListQuery
     }
 
     /// <summary>
-    /// The relative URI for the API call: always carries <c>lang</c>, <c>page</c> and <c>pageSize</c>;
-    /// adds <c>search</c> and <c>status</c> only when set, with values URL-encoded.
+    /// The API call's URI: the server-advertised <paramref name="collectionHref"/> plus this state's
+    /// query string — always <c>lang</c>, <c>page</c> and <c>pageSize</c>, adding <c>search</c> and
+    /// <c>status</c> only when set, with values URL-encoded.
     /// </summary>
-    public string ToApiRelativeUri()
+    public string ToApiUri(string collectionHref)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(collectionHref);
+
         Dictionary<string, string?> parameters = new()
         {
             ["lang"] = Language,
@@ -68,7 +72,7 @@ internal sealed record TranslationListQuery
         };
         AddPagingAndFilterParameters(parameters);
 
-        return QueryHelpers.AddQueryString(ApiPath, parameters);
+        return QueryHelpers.AddQueryString(collectionHref, parameters);
     }
 
     /// <summary>

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/DiscoveryCache.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/DiscoveryCache.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Caching.Hybrid;
 using AuthDiscoveryResponse = LotroKoniecDev.AuthSystem.Contracts.Discovery.DiscoveryResponse;
 using AuthRels = LotroKoniecDev.AuthSystem.Contracts.Hateoas.Rels;
 using TranslationDiscoveryResponse = LotroKoniecDev.TranslationSystem.Contracts.Discovery.DiscoveryResponse;
+using TranslationRels = LotroKoniecDev.TranslationSystem.Contracts.Hateoas.Rels;
 
 namespace LotroKoniecDev.Frontend.Infrastructure.Discovery;
 
@@ -62,15 +63,36 @@ internal sealed class DiscoveryCache : IDiscoveryCache
         {
             return ApiResult.Failure<TranslationDiscoveryResponse>(ex.ProblemDetails);
         }
+        catch (AuthenticatedLinksDegradedException)
+        {
+            // Same handling as the auth leg: the cookie reads authenticated but the API answered with
+            // the anonymous link set, so the bearer never reached it. Mark the session dead (the next
+            // OnValidatePrincipal signs the cookie out cleanly) and serve the anonymous links, so the
+            // public pages keep rendering instead of erroring on the way out.
+            await MarkSessionDeadAsync(cancellationToken);
+
+            try
+            {
+                TranslationDiscoveryResponse anonymous =
+                    await GetOrCreateTranslationAsync(AnonymousSuffix, cancellationToken);
+                return ApiResult.Success(anonymous);
+            }
+            catch (DiscoveryUnavailableException ex) when (ex.ProblemDetails is not null)
+            {
+                // The API died between the two calls — keep errors-as-values instead of letting the
+                // sentinel escape and 500 the page.
+                return ApiResult.Failure<TranslationDiscoveryResponse>(ex.ProblemDetails);
+            }
+        }
     }
 
     public async Task<ApiResult<AuthDiscoveryResponse>> GetAuthSystemDiscoveryAsync(
         CancellationToken cancellationToken = default)
     {
-        // Same poisoning guard idea as the TMS leg, but stricter: the auth root advertises the
-        // 'export-account-data' rel only to authenticated callers, so an authenticated key must never
-        // cache a response missing it (which would mean the bearer never reached the API) — that
-        // would break the whole account section for every signed-in user for a day.
+        // The same poisoning guard the TMS leg runs: the auth root advertises the 'export-account-data'
+        // rel only to authenticated callers, so an authenticated key must never cache a response
+        // missing it (which would mean the bearer never reached the API) — that would break the whole
+        // account section for every signed-in user for a day.
         string authSuffix = GetAuthSuffix();
 
         try
@@ -112,16 +134,28 @@ internal sealed class DiscoveryCache : IDiscoveryCache
         // Only successful, correctly-shaped payloads are cached. A ProblemDetails failure must never be
         // persisted under the 1-day TTL (it would keep the app broken for 24h after a transient outage):
         // the factory throws so HybridCache discards the entry and the next request retries the live
-        // endpoint.
+        // endpoint. The same rule covers a degraded link set — see the guard below.
         return await _hybridCache.GetOrCreateAsync(
             TranslationSystemDiscoveryCacheKeyPrefix + authSuffix,
-            _translationSystemClient,
-            static async (client, ct) =>
+            (Client: _translationSystemClient, RequiresAuthenticatedLinks: authSuffix is not AnonymousSuffix),
+            static async (state, ct) =>
             {
-                ApiResult<TranslationDiscoveryResponse> result = await client.GetDiscoveryAsync(ct);
+                ApiResult<TranslationDiscoveryResponse> result = await state.Client.GetDiscoveryAsync(ct);
                 if (result.IsFailure)
                 {
                     throw new DiscoveryUnavailableException(result.ProblemDetails);
+                }
+
+                // The TMS root is anonymous (#608) and tailors its links to the caller, so an
+                // authenticated key that comes back with only the anonymous set means the bearer never
+                // reached the API. Caching that would strip every signed-in user of the dashboard,
+                // editor and admin entry points for a day. 'contribution-data-export' is the sentinel:
+                // its endpoint requires nothing beyond authentication, so every authenticated caller
+                // gets it — exactly what 'export-account-data' is for the auth leg.
+                if (state.RequiresAuthenticatedLinks
+                    && !ContainsGetRel(result.Value.Links, TranslationRels.ContributionDataExport))
+                {
+                    throw new AuthenticatedLinksDegradedException();
                 }
 
                 return result.Value;

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/TranslationSystemEntryPointExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/TranslationSystemEntryPointExtensions.cs
@@ -1,0 +1,55 @@
+using LotroKoniecDev.Frontend.Infrastructure.Hateoas;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Hateoas.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+using TranslationDiscoveryResponse = LotroKoniecDev.TranslationSystem.Contracts.Discovery.DiscoveryResponse;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Discovery;
+
+/// <summary>
+/// The single seam through which a page gets its <em>first</em> TMS URL (#610 / ADR-0041): resolve the
+/// service document, then read the entry point by rel name. There is no API gateway and no shared path
+/// constant — the discovery document is the contract surface, so a rel the server does not advertise is
+/// an affordance this caller does not have, and the answer is a failure rather than a locally composed
+/// path. Mirrors <c>AccountLoader</c>'s auth-side resolution.
+/// </summary>
+internal static class TranslationSystemEntryPointExtensions
+{
+    extension(IDiscoveryCache discoveryCache)
+    {
+        /// <summary>
+        /// The href the TMS advertises for <paramref name="rel"/>, or a failure carrying the discovery
+        /// outage's own <see cref="ProblemDetails"/> (unreachable API) or a 403 (the caller is not
+        /// offered this affordance). Never falls back to a guessed path.
+        /// </summary>
+        public async Task<ApiResult<string>> ResolveTranslationSystemHrefAsync(
+            string rel,
+            CancellationToken cancellationToken = default)
+        {
+            ApiResult<TranslationDiscoveryResponse> discoveryResult =
+                await discoveryCache.GetTranslationSystemDiscoveryAsync(cancellationToken);
+            if (discoveryResult.IsFailure)
+            {
+                return ApiResult.Failure<string>(discoveryResult.ProblemDetails!);
+            }
+
+            LinkDto? link = discoveryResult.Value.Links.FindLink(rel);
+
+            return link is null
+                ? ApiResult.Failure<string>(MissingEntryPoint(rel))
+                : ApiResult.Success(link.Href);
+        }
+    }
+
+    /// <summary>
+    /// The failure for a rel the service document does not offer this caller. A 403 because the
+    /// affordance exists but is not this session's to use — the rel travels in <c>Detail</c> so a
+    /// support report names the missing entry point instead of "coś poszło nie tak".
+    /// </summary>
+    private static ProblemDetails MissingEntryPoint(string rel) => new()
+    {
+        Title = "Ta funkcja jest niedostępna",
+        Detail = $"Serwer nie udostępnia tej sesji zasobu „{rel}”. Zaloguj się ponownie lub spróbuj później.",
+        Status = StatusCodes.Status403Forbidden
+    };
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translators/ExportMyContributionData.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translators/ExportMyContributionData.cs
@@ -131,6 +131,10 @@ internal sealed partial class ExportMyContributionData : IEndpoint
             })
             .WithName(nameof(ExportMyContributionData))
             .WithTags("Translators")
+            // Authentication and nothing more, deliberately: because every authenticated caller is
+            // allowed here, the discovery document advertises this endpoint's rel to every authenticated
+            // caller, and the frontend's DiscoveryCache reads that as its "the bearer reached the API"
+            // sentinel. Tightening this policy force-signs every logged-in user out — see Rels.ContributionDataExport.
             .RequireAuthorization(AuthorizationPolicies.RequireAuthenticatedUser)
             .Produces<TranslatorDataExportResponse>(StatusCodes.Status200OK);
     }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Hateoas/Rels.cs
@@ -11,6 +11,14 @@ public static class Rels
     public const string Translations = "translations";
     public const string TranslationStats = "translation-stats";
     public const string GameVersions = "game-versions";
+
+    /// <summary>
+    /// The caller's own contribution export. <b>Load-bearing beyond its endpoint:</b> its target requires
+    /// nothing but authentication, so the frontend's <c>DiscoveryCache</c> treats its absence under an
+    /// authenticated cache key as proof the bearer never reached the API, and force-signs the session out.
+    /// Tightening that endpoint's policy — or renaming this rel — signs every logged-in user out on their
+    /// next page load; change the frontend guard in the same commit.
+    /// </summary>
     public const string ContributionDataExport = "contribution-data-export";
 
     // Translation aggregate actions

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
@@ -21,6 +21,8 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using AuthDiscoveryResponse = LotroKoniecDev.AuthSystem.Contracts.Discovery.DiscoveryResponse;
+using TranslationDiscoveryResponse = LotroKoniecDev.TranslationSystem.Contracts.Discovery.DiscoveryResponse;
+using TranslationRels = LotroKoniecDev.TranslationSystem.Contracts.Hateoas.Rels;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Account;
 
@@ -35,6 +37,7 @@ public sealed class AccountEndpointsExtensionsTests
     private const string BaseUrl = "https://localhost:5003/";
     private const string TmsBaseUrl = "https://localhost:5002/";
     private const string ExportHref = "auth/account/data-export";
+    private const string ContributionExportHref = "/advertised/my-contribution-export";
 
     private static readonly JsonSerializerOptions ApiJsonOptions = new(JsonSerializerDefaults.Web)
     {
@@ -49,7 +52,7 @@ public sealed class AccountEndpointsExtensionsTests
         AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         file.ContentType.ShouldBe("application/json");
@@ -63,7 +66,7 @@ public sealed class AccountEndpointsExtensionsTests
         AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -78,7 +81,7 @@ public sealed class AccountEndpointsExtensionsTests
         AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -97,7 +100,7 @@ public sealed class AccountEndpointsExtensionsTests
             """{ "title": "Usługa chwilowo niedostępna", "status": 503 }"""));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, tmsClient, CancellationToken.None);
+            loader, _discoveryCache, tmsClient, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -115,11 +118,52 @@ public sealed class AccountEndpointsExtensionsTests
             """{ "title": "Błąd serwera", "status": 500 }"""));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, tmsClient, CancellationToken.None);
+            loader, _discoveryCache, tmsClient, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         file.ContentType.ShouldBe("application/json");
         file.FileDownloadName!.ShouldStartWith("lotro-translator-moje-dane-");
+    }
+
+    [Fact]
+    public async Task DownloadAccountExportAsync_WhenTheContributionRelIsNotAdvertised_ServesTheFileWithIsCompleteFalse()
+    {
+        // An unresolvable rel degrades exactly like a failed TMS call (ADR-0032): the Art. 15 document
+        // still downloads, honestly flagged incomplete — it must never fall back to a guessed path, and
+        // must never fail the auth leg's download either.
+        AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
+        _discoveryCache.GetTranslationSystemDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(new TranslationDiscoveryResponse("LotroKoniecDev.TranslationSystem")));
+        StubHttpMessageHandler tmsHandler = StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(CreateContribution(), ApiJsonOptions));
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, _discoveryCache, CreateTmsClient(tmsHandler), CancellationToken.None);
+
+        FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
+        string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
+        json.ShouldContain("\"translationData\": null");
+        json.ShouldContain("\"isComplete\": false");
+        // No rel, no call — the contribution endpoint was never guessed at.
+        tmsHandler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task DownloadAccountExportAsync_WhenTmsDiscoveryIsUnavailable_ServesTheFileWithIsCompleteFalse()
+    {
+        // A TMS outage degrades the file rather than failing the download — only the auth leg can do that.
+        AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
+        _discoveryCache.GetTranslationSystemDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<TranslationDiscoveryResponse>(new ProblemDetails { Status = 503 }));
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
+
+        FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
+        string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
+        json.ShouldContain("\"translationData\": null");
+        json.ShouldContain("\"isComplete\": false");
     }
 
     [Fact]
@@ -130,7 +174,7 @@ public sealed class AccountEndpointsExtensionsTests
             StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "this is not json"));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, tmsClient, CancellationToken.None);
+            loader, _discoveryCache, tmsClient, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -146,7 +190,7 @@ public sealed class AccountEndpointsExtensionsTests
             StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, string.Empty));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, tmsClient, CancellationToken.None);
+            loader, _discoveryCache, tmsClient, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -165,7 +209,7 @@ public sealed class AccountEndpointsExtensionsTests
                 """{ "title": "Nie znaleziono użytkownika", "status": 404 }""")));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
 
         ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
         problem.ProblemDetails.Status.ShouldBe(404);
@@ -185,7 +229,7 @@ public sealed class AccountEndpointsExtensionsTests
             CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}")));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
 
         ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
         problem.ProblemDetails.Status.ShouldBe(503);
@@ -209,6 +253,14 @@ public sealed class AccountEndpointsExtensionsTests
         };
         _discoveryCache.GetAuthSystemDiscoveryAsync(Arg.Any<CancellationToken>())
             .Returns(ApiResult.Success(discovery));
+
+        // The TMS leg is addressed by its own rel (#610), so the same cache serves both legs here.
+        TranslationDiscoveryResponse translationDiscovery = new("LotroKoniecDev.TranslationSystem")
+        {
+            Links = [new LinkDto(ContributionExportHref, TranslationRels.ContributionDataExport, "GET")]
+        };
+        _discoveryCache.GetTranslationSystemDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(translationDiscovery));
     }
 
     private static AuthSystemClient CreateClient(StubHttpMessageHandler handler)

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Dashboard/DashboardStatsLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Dashboard/DashboardStatsLoaderTests.cs
@@ -2,9 +2,12 @@ using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.Frontend.Components.Pages.Dashboard;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Dashboard;
@@ -36,7 +39,7 @@ public sealed class DashboardStatsLoaderTests
     }
 
     [Fact]
-    public async Task LoadAsync_RequestsTheStatsEndpoint()
+    public async Task LoadAsync_WhenTheStatsRelIsAdvertised_GetsThatHref()
     {
         DashboardStatsLoader loader = CreateLoader(
             new TranslationStatsResponse(0, 0, 0, 0),
@@ -46,7 +49,36 @@ public sealed class DashboardStatsLoaderTests
 
         handler.LastRequest.ShouldNotBeNull();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
-        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/translations/stats");
+        handler.LastRequest.RequestUri!.ToString()
+            .ShouldBe(BaseUrl.TrimEnd('/') + StubDiscoveryCache.HrefFor(Rels.TranslationStats));
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenTheStatsRelIsNotAdvertised_FailsWithoutCallingTheApi()
+    {
+        // The rel is translator-only. An unauthorized session gets a clear failure — never a call to
+        // a locally guessed path (#610).
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        DashboardStatsLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Progress), CreateClient(handler));
+
+        ApiResult<TranslationStatsResponse> result = await loader.LoadAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(403);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenDiscoveryIsUnavailable_PassesThatProblemThrough()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        DashboardStatsLoader loader = new(StubDiscoveryCache.Unavailable(), CreateClient(handler));
+
+        ApiResult<TranslationStatsResponse> result = await loader.LoadAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+        handler.LastRequest.ShouldBeNull();
     }
 
     [Fact]
@@ -55,7 +87,7 @@ public sealed class DashboardStatsLoaderTests
         StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
             HttpStatusCode.InternalServerError,
             """{ "title": "Nie udało się wczytać statystyk.", "status": 500 }""");
-        DashboardStatsLoader loader = new(CreateClient(handler));
+        DashboardStatsLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.TranslationStats), CreateClient(handler));
 
         ApiResult<TranslationStatsResponse> result = await loader.LoadAsync();
 
@@ -71,7 +103,7 @@ public sealed class DashboardStatsLoaderTests
         handler = StubHttpMessageHandler.RespondWith(
             HttpStatusCode.OK,
             JsonSerializer.Serialize(stats, ApiJsonOptions));
-        return new DashboardStatsLoader(CreateClient(handler));
+        return new DashboardStatsLoader(StubDiscoveryCache.AdvertisingGet(Rels.TranslationStats), CreateClient(handler));
     }
 
     private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using EditorComponent = LotroKoniecDev.Frontend.Components.Pages.Editor.Editor;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Editor;
 
@@ -34,6 +35,7 @@ public sealed class EditorTests : BunitContext
     {
         Services.AddAntiforgery();
         Services.AddSingleton(_client);
+        Services.AddSingleton(StubDiscoveryCache.AdvertisingGet(Rels.Translations, Rels.Upsert));
         Services.AddScoped<TranslationEditorLoader>();
         AddAuthorization().SetAuthorized("Frodo");
     }
@@ -300,6 +302,72 @@ public sealed class EditorTests : BunitContext
         recoveryForm.QuerySelectorAll("textarea[name=DraftField]").Length.ShouldBe(1);
         recoveryForm.QuerySelector("button[type=submit]")!.TextContent.ShouldContain("Zapisz ponownie");
         component.FindAll(".editor-grid").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Save_FromTheRecoveryFormWithNoLoadedRow_PutsToTheUpsertHrefFromTheServiceDocument()
+    {
+        // With no row to advertise the upsert rel, the recovery resubmit resolves it from TMS discovery
+        // (#610) instead of a compiled-in collection path. Only a PUT to that exact advertised href is
+        // stubbed to succeed, so the redirect happens iff the discovered href was the one used.
+        Guid id = Guid.NewGuid();
+        _client
+            .GetApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                ApiResult.Success(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canEdit: true)),
+                ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Nie znaleziono." }));
+        _client
+            .PutApiResultAsync<TranslationDetailResponse>(SaveHref, Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Zapis odrzucony." }));
+        _client
+            .PutApiResultAsync<TranslationDetailResponse>(
+                StubDiscoveryCache.HrefFor(Rels.Upsert), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(BuildDetail("Hello.", "Cześć.", canEdit: true)));
+        BunitNavigationManager navigation = Navigation();
+        IRenderedComponent<EditorComponent> component = RenderEditor(id);
+
+        // First submit follows the loaded row's href and is rejected; the reload then fails, leaving the
+        // recovery form with no row — exactly the state a real SSR resubmit request lands in.
+        await component.Find("form").SubmitAsync();
+        component.Render();
+        await component.Find("form").SubmitAsync();
+
+        navigation.Uri.ShouldEndWith($"/editor/{id}?saved=true");
+    }
+
+    [Fact]
+    public async Task Save_FromTheRecoveryFormWhenTheUpsertRelIsNotAdvertised_ShowsTheErrorAndDoesNotPut()
+    {
+        // The other half of the recovery path: discovery answers, but withholds `upsert` (a reader, or a
+        // session whose bearer stopped being accepted). The page must surface that instead of PUTting to
+        // a guessed collection URL (#610).
+        BunitContext context = new();
+        context.Services.AddAntiforgery();
+        ITranslationSystemClient client = Substitute.For<ITranslationSystemClient>();
+        context.Services.AddSingleton(client);
+        context.Services.AddSingleton(StubDiscoveryCache.AdvertisingGet(Rels.Translations));
+        context.Services.AddScoped<TranslationEditorLoader>();
+        context.AddAuthorization().SetAuthorized("Frodo");
+        client
+            .GetApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                ApiResult.Success(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canEdit: true)),
+                ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Nie znaleziono." }));
+        client
+            .PutApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Zapis odrzucony." }));
+        IRenderedComponent<EditorComponent> component =
+            context.Render<EditorComponent>(parameters => parameters.Add(p => p.Id, Guid.NewGuid()));
+
+        await component.Find("form").SubmitAsync();
+        component.Render();
+        await component.Find("form").SubmitAsync();
+
+        // Exactly one PUT — the first submit's, which followed the loaded row's href. The recovery
+        // resubmit never reached the client because the rel could not be resolved.
+        await client.Received(1).PutApiResultAsync<TranslationDetailResponse>(
+            Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
+        component.Markup.ShouldContain("Ta funkcja jest niedostępna");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/TranslationEditorLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/TranslationEditorLoaderTests.cs
@@ -2,9 +2,12 @@ using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.Frontend.Components.Pages.Editor;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
@@ -22,6 +25,8 @@ public sealed class TranslationEditorLoaderTests
     private const string ApproveHref = "https://tms.example/hateoas/translations/abc/approve";
 
     private static readonly Guid TranslationGuid = Guid.Parse("0192a000-0000-7000-8000-000000000042");
+    private static readonly string ResolvedTranslationsUri =
+        BaseUrl.TrimEnd('/') + StubDiscoveryCache.HrefFor(Rels.Translations);
 
     // Mirrors the JSON options the Frontend's HTTP seam uses (HttpClientApiExtensions) so the stub
     // body deserializes through the exact same contract the loader relies on.
@@ -55,7 +60,7 @@ public sealed class TranslationEditorLoaderTests
     }
 
     [Fact]
-    public async Task LoadAsync_RequestsTheGetOneEndpointForTheGivenId()
+    public async Task LoadAsync_WhenTheTranslationsRelIsAdvertised_AppendsTheIdToThatHref()
     {
         TranslationEditorLoader loader = CreateLoader(
             HttpStatusCode.OK,
@@ -67,7 +72,7 @@ public sealed class TranslationEditorLoaderTests
         handler.LastRequest.ShouldNotBeNull();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
         handler.LastRequest.RequestUri!.ToString()
-            .ShouldBe($"{BaseUrl}api/v1/translations/{TranslationGuid}");
+            .ShouldBe($"{ResolvedTranslationsUri}/{TranslationGuid}");
     }
 
     [Fact]
@@ -184,13 +189,71 @@ public sealed class TranslationEditorLoaderTests
             CreatedAt: DateTimeOffset.UtcNow,
             UpdatedAt: DateTimeOffset.UtcNow);
 
+    [Fact]
+    public async Task LoadAsync_WhenTheTranslationsRelIsNotAdvertised_FailsWithoutCallingTheApi()
+    {
+        // `translations` is anonymous today, but the editor route is [Authorize] and the loader must not
+        // assume the rel is there — an absent rel is a refusal to call, not a path to compose (#610).
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        TranslationEditorLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Progress), CreateClient(handler));
+
+        ApiResult<TranslationDetailResponse> result = await loader.LoadAsync(TranslationId.Create(TranslationGuid));
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(403);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenDiscoveryIsUnavailable_PassesThatProblemThrough()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        TranslationEditorLoader loader = new(StubDiscoveryCache.Unavailable(), CreateClient(handler));
+
+        ApiResult<TranslationDetailResponse> result = await loader.LoadAsync(TranslationId.Create(TranslationGuid));
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ResolveCollectionUpsertHrefAsync_WhenTheUpsertRelIsAdvertised_ReturnsThatHref()
+    {
+        // The recovery path (a resubmit whose row could not be reloaded) has no row to read the upsert
+        // rel from, so it resolves the same rel from the service document — never a compiled-in path.
+        TranslationEditorLoader loader = CreateLoader(HttpStatusCode.OK, "{}", out _);
+
+        ApiResult<string> result = await loader.ResolveCollectionUpsertHrefAsync();
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe(StubDiscoveryCache.HrefFor(Rels.Upsert));
+    }
+
+    [Fact]
+    public async Task ResolveCollectionUpsertHrefAsync_WhenTheUpsertRelIsNotAdvertised_Fails()
+    {
+        // The API emits `upsert` only for a translator. A reader who somehow reaches the recovery path
+        // gets a failure the page can render — not a PUT to a guessed collection URL.
+        TranslationEditorLoader loader = new(
+            StubDiscoveryCache.AdvertisingGet(Rels.Translations),
+            CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}")));
+
+        ApiResult<string> result = await loader.ResolveCollectionUpsertHrefAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(403);
+    }
+
     private static TranslationEditorLoader CreateLoader(
         HttpStatusCode statusCode,
         string jsonBody,
         out StubHttpMessageHandler handler)
     {
         handler = StubHttpMessageHandler.RespondWith(statusCode, jsonBody);
-        return new TranslationEditorLoader(CreateClient(handler));
+        return new TranslationEditorLoader(
+            StubDiscoveryCache.AdvertisingGet(Rels.Translations, Rels.Upsert),
+            CreateClient(handler));
     }
 
     private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsLoaderTests.cs
@@ -2,8 +2,10 @@ using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.Frontend.Components.Pages.GameVersions;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
 using LotroKoniecDev.Hateoas.Abstractions;
 using LotroKoniecDev.TranslationSystem.Contracts.Common;
@@ -17,7 +19,15 @@ namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.GameVersions;
 public sealed class GameVersionsLoaderTests
 {
     private const string BaseUrl = "https://localhost:5002/";
+
+    /// <summary>The per-row / collection hrefs the API advertises — never composed by the loader (#610).</summary>
+    private const string AdvertisedRegisterHref = "/advertised/register-game-version";
+
+    private const string AdvertisedDeleteHref = "/advertised/delete-game-version/42";
+
     private static readonly Guid GameVersionGuid = Guid.Parse("0192a000-0000-7000-8000-0000000000aa");
+    private static readonly string ResolvedGameVersionsUri =
+        BaseUrl.TrimEnd('/') + StubDiscoveryCache.HrefFor(Rels.GameVersions);
 
     // Mirrors the JSON options the Frontend's HTTP seam uses (HttpClientApiExtensions) so the stub
     // body deserializes through the exact same contract the loader relies on.
@@ -27,7 +37,7 @@ public sealed class GameVersionsLoaderTests
     };
 
     [Fact]
-    public async Task ListGameVersionsAsync_RequestsTheGameVersionsCollectionEndpoint()
+    public async Task ListGameVersionsAsync_WhenTheGameVersionsRelIsAdvertised_GetsThatHref()
     {
         GameVersionsLoader loader = CreateLoader(
             HttpStatusCode.OK,
@@ -38,7 +48,7 @@ public sealed class GameVersionsLoaderTests
 
         handler.LastRequest.ShouldNotBeNull();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
-        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/game-versions");
+        handler.LastRequest.RequestUri!.ToString().ShouldBe(ResolvedGameVersionsUri);
     }
 
     [Fact]
@@ -75,18 +85,47 @@ public sealed class GameVersionsLoaderTests
     }
 
     [Fact]
-    public async Task RegisterGameVersionAsync_PostsTheVersionToTheCollectionEndpoint()
+    public async Task ListGameVersionsAsync_WhenTheGameVersionsRelIsNotAdvertised_FailsWithoutCallingTheApi()
+    {
+        // `game-versions` is RequireTranslatorRole while /game-versions is only [Authorize], so an
+        // authenticated non-translator reaches this on a normal navigation — it must be a clear failure,
+        // never a call to a guessed path (#610).
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        GameVersionsLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Progress), CreateClient(handler));
+
+        ApiResult<CollectionResponse<GameVersionResponse>> result = await loader.ListGameVersionsAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(403);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ListGameVersionsAsync_WhenDiscoveryIsUnavailable_PassesThatProblemThrough()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        GameVersionsLoader loader = new(StubDiscoveryCache.Unavailable(), CreateClient(handler));
+
+        ApiResult<CollectionResponse<GameVersionResponse>> result = await loader.ListGameVersionsAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RegisterGameVersionAsync_WhenGivenTheCollectionsRegisterHref_PostsTheVersionToIt()
     {
         GameVersionsLoader loader = CreateLoader(
             HttpStatusCode.Created,
             JsonSerializer.Serialize(VersionFixture(), ApiJsonOptions),
             out StubHttpMessageHandler handler);
 
-        ApiResult<GameVersionResponse> result = await loader.RegisterGameVersionAsync("48.0");
+        ApiResult<GameVersionResponse> result = await loader.RegisterGameVersionAsync(AdvertisedRegisterHref, "48.0");
 
         result.IsSuccess.ShouldBeTrue();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Post);
-        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/game-versions");
+        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}{AdvertisedRegisterHref.TrimStart('/')}");
         handler.LastRequestBody.ShouldNotBeNull();
         handler.LastRequestBody!.ShouldContain("48.0");
     }
@@ -99,22 +138,22 @@ public sealed class GameVersionsLoaderTests
             """{ "title": "Data Conflict", "status": 422 }""",
             out _);
 
-        ApiResult<GameVersionResponse> result = await loader.RegisterGameVersionAsync("48.0");
+        ApiResult<GameVersionResponse> result = await loader.RegisterGameVersionAsync(AdvertisedRegisterHref, "48.0");
 
         result.IsFailure.ShouldBeTrue();
         result.ProblemDetails!.Status.ShouldBe(422);
     }
 
     [Fact]
-    public async Task DeleteGameVersionAsync_SendsDeleteToTheVersionScopedEndpoint()
+    public async Task DeleteGameVersionAsync_WhenGivenTheRowsDeleteHref_SendsDeleteToIt()
     {
         GameVersionsLoader loader = CreateLoader(HttpStatusCode.NoContent, string.Empty, out StubHttpMessageHandler handler);
 
-        ApiResult result = await loader.DeleteGameVersionAsync(GameVersionId.Create(GameVersionGuid));
+        ApiResult result = await loader.DeleteGameVersionAsync(AdvertisedDeleteHref);
 
         result.IsSuccess.ShouldBeTrue();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Delete);
-        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/game-versions/{GameVersionGuid}");
+        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}{AdvertisedDeleteHref.TrimStart('/')}");
     }
 
     [Fact]
@@ -125,7 +164,7 @@ public sealed class GameVersionsLoaderTests
             """{ "title": "Data Conflict", "status": 422 }""",
             out _);
 
-        ApiResult result = await loader.DeleteGameVersionAsync(GameVersionId.Create(GameVersionGuid));
+        ApiResult result = await loader.DeleteGameVersionAsync(AdvertisedDeleteHref);
 
         result.IsFailure.ShouldBeTrue();
         result.ProblemDetails!.Status.ShouldBe(422);
@@ -137,7 +176,7 @@ public sealed class GameVersionsLoaderTests
     private static GameVersionsLoader CreateLoader(HttpStatusCode statusCode, string body, out StubHttpMessageHandler handler)
     {
         handler = StubHttpMessageHandler.RespondWith(statusCode, body);
-        return new GameVersionsLoader(CreateClient(handler));
+        return new GameVersionsLoader(StubDiscoveryCache.AdvertisingGet(Rels.GameVersions), CreateClient(handler));
     }
 
     private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
@@ -12,6 +12,7 @@ using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregat
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using GameVersionsComponent = LotroKoniecDev.Frontend.Components.Pages.GameVersions.GameVersions;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.GameVersions;
 
@@ -41,6 +42,7 @@ public sealed class GameVersionsTests : BunitContext
     {
         Services.AddAntiforgery();
         Services.AddSingleton(_client);
+        Services.AddSingleton(StubDiscoveryCache.AdvertisingGet(Rels.GameVersions));
         Services.AddScoped<GameVersionsLoader>();
     }
 

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Home/HomeProgressLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Home/HomeProgressLoaderTests.cs
@@ -2,9 +2,13 @@ using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.Frontend.Components.Pages.Home;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Progress;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Home;
@@ -49,7 +53,7 @@ public sealed class HomeProgressLoaderTests
     }
 
     [Fact]
-    public async Task LoadAsync_RequestsThePublicProgressEndpoint()
+    public async Task LoadAsync_WhenTheProgressRelIsAdvertised_GetsThatHref()
     {
         HomeProgressLoader loader = CreateLoader(
             new PublicProgressResponse(0, 0, 0, null),
@@ -59,7 +63,54 @@ public sealed class HomeProgressLoaderTests
 
         handler.LastRequest.ShouldNotBeNull();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
-        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/progress");
+        handler.LastRequest.RequestUri!.ToString()
+            .ShouldBe(BaseUrl.TrimEnd('/') + StubDiscoveryCache.HrefFor(Rels.Progress));
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenTheAdvertisedHrefIsAbsolute_CallsItInsteadOfTheClientsBaseAddress()
+    {
+        // The production shape: LinkGenerator emits absolute hrefs, so every real TMS call now travels
+        // to whatever origin discovery names — not to the typed client's configured base address. The
+        // other stubs here use relative hrefs, so without this the absolute path is never exercised.
+        const string AbsoluteHref = "https://tms.lotro.test/api/v1/progress";
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(new PublicProgressResponse(1, 1, 1, "48.1"), ApiJsonOptions));
+        HomeProgressLoader loader = new(
+            StubDiscoveryCache.Advertising(new LinkDto(AbsoluteHref, Rels.Progress, "GET")),
+            CreateClient(handler));
+
+        ApiResult<PublicProgressResponse> result = await loader.LoadAsync();
+
+        result.IsSuccess.ShouldBeTrue();
+        handler.LastRequest!.RequestUri!.ToString().ShouldBe(AbsoluteHref);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenTheProgressRelIsNotAdvertised_FailsWithoutCallingTheApi()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        HomeProgressLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Translations), CreateClient(handler));
+
+        ApiResult<PublicProgressResponse> result = await loader.LoadAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(403);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenDiscoveryIsUnavailable_PassesThatProblemThrough()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        HomeProgressLoader loader = new(StubDiscoveryCache.Unavailable(), CreateClient(handler));
+
+        ApiResult<PublicProgressResponse> result = await loader.LoadAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+        handler.LastRequest.ShouldBeNull();
     }
 
     [Fact]
@@ -68,7 +119,7 @@ public sealed class HomeProgressLoaderTests
         StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
             HttpStatusCode.InternalServerError,
             """{ "title": "Nie udało się wczytać postępu.", "status": 500 }""");
-        HomeProgressLoader loader = new(CreateClient(handler));
+        HomeProgressLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Progress), CreateClient(handler));
 
         ApiResult<PublicProgressResponse> result = await loader.LoadAsync();
 
@@ -84,7 +135,7 @@ public sealed class HomeProgressLoaderTests
         handler = StubHttpMessageHandler.RespondWith(
             HttpStatusCode.OK,
             JsonSerializer.Serialize(progress, ApiJsonOptions));
-        return new HomeProgressLoader(CreateClient(handler));
+        return new HomeProgressLoader(StubDiscoveryCache.AdvertisingGet(Rels.Progress), CreateClient(handler));
     }
 
     private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Home/HomeTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Home/HomeTests.cs
@@ -13,6 +13,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using HomeComponent = LotroKoniecDev.Frontend.Components.Pages.Home.Home;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Home;
 
@@ -28,6 +30,7 @@ public sealed class HomeTests : BunitContext
     public HomeTests()
     {
         Services.AddSingleton(_client);
+        Services.AddSingleton(StubDiscoveryCache.AdvertisingGet(Rels.Progress));
         Services.AddScoped<HomeProgressLoader>();
     }
 

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportEndpointsExtensionsTests.cs
@@ -2,7 +2,9 @@ using System.Net;
 using System.Text;
 using LotroKoniecDev.Frontend.Components.Pages.ImportExport;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
@@ -63,8 +65,9 @@ public sealed class ImportExportEndpointsExtensionsTests
     {
         // A transport failure yields a synthesized ProblemDetails (503) from the HTTP seam; the route
         // passes it through. The 502 fallback only fires for the (defensive) null-ProblemDetails case.
-        ImportExportLoader loader = new(CreateClient(
-            StubHttpMessageHandler.Throw(new HttpRequestException("connection refused"))));
+        ImportExportLoader loader = new(
+            StubDiscoveryCache.AdvertisingGet(Rels.TranslationFile),
+            CreateClient(StubHttpMessageHandler.Throw(new HttpRequestException("connection refused"))));
 
         IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, CancellationToken.None);
 
@@ -73,7 +76,9 @@ public sealed class ImportExportEndpointsExtensionsTests
     }
 
     private static ImportExportLoader CreateLoader(HttpStatusCode statusCode, string body) =>
-        new(CreateClient(StubHttpMessageHandler.RespondWith(statusCode, body)));
+        new(
+            StubDiscoveryCache.AdvertisingGet(Rels.TranslationFile),
+            CreateClient(StubHttpMessageHandler.RespondWith(statusCode, body)));
 
     private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)
     {

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportLoaderTests.cs
@@ -3,8 +3,10 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.Frontend.Components.Pages.ImportExport;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
 using LotroKoniecDev.Hateoas.Abstractions;
 using LotroKoniecDev.TranslationSystem.Contracts.Common;
@@ -19,7 +21,16 @@ namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.ImportExport;
 public sealed class ImportExportLoaderTests
 {
     private const string BaseUrl = "https://localhost:5002/";
+
+    /// <summary>
+    /// The per-version <c>import</c> href the API advertises. It looks nothing like the real route on
+    /// purpose: a passing assertion proves the loader followed the advertised link (#610).
+    /// </summary>
+    private const string AdvertisedImportHref = "/advertised/import-into/42";
+
     private static readonly Guid GameVersionGuid = Guid.Parse("0192a000-0000-7000-8000-000000000099");
+    private static readonly string ResolvedGameVersionsUri =
+        BaseUrl.TrimEnd('/') + StubDiscoveryCache.HrefFor(Rels.GameVersions);
 
     // Mirrors the JSON options the Frontend's HTTP seam uses (HttpClientApiExtensions) so the stub
     // body deserializes through the exact same contract the loader relies on.
@@ -29,7 +40,7 @@ public sealed class ImportExportLoaderTests
     };
 
     [Fact]
-    public async Task ListGameVersionsAsync_RequestsTheGameVersionsCollectionEndpoint()
+    public async Task ListGameVersionsAsync_WhenTheGameVersionsRelIsAdvertised_GetsThatHref()
     {
         ImportExportLoader loader = CreateLoader(
             HttpStatusCode.OK,
@@ -41,7 +52,7 @@ public sealed class ImportExportLoaderTests
 
         handler.LastRequest.ShouldNotBeNull();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
-        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/game-versions");
+        handler.LastRequest.RequestUri!.ToString().ShouldBe(ResolvedGameVersionsUri);
     }
 
     [Fact]
@@ -98,7 +109,61 @@ public sealed class ImportExportLoaderTests
     }
 
     [Fact]
-    public async Task ImportAsync_PostsMultipartToTheVersionScopedImportEndpoint()
+    public async Task ListGameVersionsAsync_WhenTheGameVersionsRelIsNotAdvertised_FailsWithoutCallingTheApi()
+    {
+        // `game-versions` is RequireTranslatorRole while /import-export is only [Authorize], so an
+        // authenticated non-translator lands here on a normal navigation (#610).
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        ImportExportLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Progress), CreateClient(handler));
+
+        ApiResult<CollectionResponse<GameVersionResponse>> result = await loader.ListGameVersionsAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(403);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ListGameVersionsAsync_WhenDiscoveryIsUnavailable_PassesThatProblemThrough()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        ImportExportLoader loader = new(StubDiscoveryCache.Unavailable(), CreateClient(handler));
+
+        ApiResult<CollectionResponse<GameVersionResponse>> result = await loader.ListGameVersionsAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task DownloadTranslationFileAsync_WhenTheTranslationFileRelIsNotAdvertised_FailsWithoutCallingTheApi()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "body");
+        ImportExportLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Progress), CreateClient(handler));
+
+        ApiResult<string> result = await loader.DownloadTranslationFileAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(403);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task DownloadTranslationFileAsync_WhenDiscoveryIsUnavailable_PassesThatProblemThrough()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "body");
+        ImportExportLoader loader = new(StubDiscoveryCache.Unavailable(), CreateClient(handler));
+
+        ApiResult<string> result = await loader.DownloadTranslationFileAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ImportAsync_WhenGivenTheVersionsImportHref_PostsMultipartToIt()
     {
         ImportExportLoader loader = CreateLoader(
             HttpStatusCode.OK,
@@ -106,12 +171,12 @@ public sealed class ImportExportLoaderTests
             out StubHttpMessageHandler handler);
         using MemoryStream file = new(Encoding.UTF8.GetBytes("620756992||1001||Witaj||NULL||NULL||1"));
 
-        await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
+        await loader.ImportAsync(AdvertisedImportHref, file, "exported.txt", allowMassRemoval: false);
 
         handler.LastRequest.ShouldNotBeNull();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Post);
         handler.LastRequest.RequestUri!.ToString()
-            .ShouldBe($"{BaseUrl}api/v1/game-versions/{GameVersionGuid}/import?allowMassRemoval=false");
+            .ShouldBe($"{BaseUrl}{AdvertisedImportHref.TrimStart('/')}?allowMassRemoval=false");
     }
 
     [Fact]
@@ -123,7 +188,7 @@ public sealed class ImportExportLoaderTests
             out StubHttpMessageHandler handler);
         using MemoryStream file = new(Encoding.UTF8.GetBytes("620756992||1001||Witaj||NULL||NULL||1"));
 
-        await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
+        await loader.ImportAsync(AdvertisedImportHref, file, "exported.txt", allowMassRemoval: false);
 
         handler.LastRequestBody.ShouldNotBeNull();
         handler.LastRequestBody!.ShouldContain("name=file");
@@ -142,7 +207,7 @@ public sealed class ImportExportLoaderTests
             out StubHttpMessageHandler handler);
         using MemoryStream file = new(Encoding.UTF8.GetBytes("x"));
 
-        await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: true);
+        await loader.ImportAsync(AdvertisedImportHref, file, "exported.txt", allowMassRemoval: true);
 
         handler.LastRequest!.RequestUri!.Query.ShouldBe("?allowMassRemoval=true");
     }
@@ -157,7 +222,7 @@ public sealed class ImportExportLoaderTests
         using MemoryStream file = new(Encoding.UTF8.GetBytes("x"));
 
         ApiResult<ImportSummary> result =
-            await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
+            await loader.ImportAsync(AdvertisedImportHref, file, "exported.txt", allowMassRemoval: false);
 
         result.IsSuccess.ShouldBeTrue();
         result.Value.Added.ShouldBe(3);
@@ -178,14 +243,14 @@ public sealed class ImportExportLoaderTests
         using MemoryStream file = new(Encoding.UTF8.GetBytes("x"));
 
         ApiResult<ImportSummary> result =
-            await loader.ImportAsync(GameVersionId.Create(GameVersionGuid), file, "exported.txt", allowMassRemoval: false);
+            await loader.ImportAsync(AdvertisedImportHref, file, "exported.txt", allowMassRemoval: false);
 
         result.IsFailure.ShouldBeTrue();
         result.ProblemDetails!.Status.ShouldBe(422);
     }
 
     [Fact]
-    public async Task DownloadTranslationFileAsync_RequestsThePolishTranslationFileEndpoint()
+    public async Task DownloadTranslationFileAsync_WhenTheTranslationFileRelIsAdvertised_GetsThatHref()
     {
         ImportExportLoader loader = CreateLoader(HttpStatusCode.OK, "file body", out StubHttpMessageHandler handler);
 
@@ -193,7 +258,8 @@ public sealed class ImportExportLoaderTests
 
         handler.LastRequest.ShouldNotBeNull();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
-        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}api/v1/translation-files/pl");
+        handler.LastRequest.RequestUri!.ToString()
+            .ShouldBe(BaseUrl.TrimEnd('/') + StubDiscoveryCache.HrefFor(Rels.TranslationFile));
     }
 
     [Fact]
@@ -234,7 +300,9 @@ public sealed class ImportExportLoaderTests
         out StubHttpMessageHandler handler)
     {
         handler = StubHttpMessageHandler.RespondWith(statusCode, body);
-        return new ImportExportLoader(CreateClient(handler));
+        return new ImportExportLoader(
+            StubDiscoveryCache.AdvertisingGet(Rels.GameVersions, Rels.TranslationFile),
+            CreateClient(handler));
     }
 
     private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportTests.cs
@@ -12,6 +12,7 @@ using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregat
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using ImportExportComponent = LotroKoniecDev.Frontend.Components.Pages.ImportExport.ImportExport;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.ImportExport;
 
@@ -33,6 +34,7 @@ public sealed class ImportExportTests : BunitContext
     {
         Services.AddAntiforgery();
         Services.AddSingleton(_client);
+        Services.AddSingleton(StubDiscoveryCache.AdvertisingGet(Rels.GameVersions, Rels.TranslationFile));
         Services.AddScoped<ImportExportLoader>();
     }
 
@@ -55,8 +57,7 @@ public sealed class ImportExportTests : BunitContext
         // A non-admin translator can list versions but the collection carries no `register` rel, so the
         // admin-only import panel stays hidden — driven by the server's affordance, not a local role check.
         AuthorizeAs("Frodo");
-        StubVersions(
-            new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed));
+        StubVersions(NonImportableVersion("48.0"));
 
         IRenderedComponent<ImportExportComponent> component = RenderPage();
 
@@ -68,9 +69,7 @@ public sealed class ImportExportTests : BunitContext
     public void Render_WhenCollectionHasTheRegisterRel_ShowsTheImportFormWithAVersionOptionPerListedVersion()
     {
         AuthorizeAs("Sam");
-        StubVersionsWithRegisterRel(
-            new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed),
-            new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "47.2", DateTimeOffset.UnixEpoch, GameVersionStatus.Processed));
+        StubVersionsWithRegisterRel(ImportableVersion("48.0"), ImportableVersion("47.2"));
 
         IRenderedComponent<ImportExportComponent> component = RenderPage();
 
@@ -84,7 +83,7 @@ public sealed class ImportExportTests : BunitContext
         // property of a [SupplyParameterFromForm] model, so the inputs MUST be named ImportInput.* —
         // a bare name (e.g. "UploadFile") binds null and the import can never run.
         AuthorizeAs("Sam");
-        StubVersionsWithRegisterRel(new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed));
+        StubVersionsWithRegisterRel(ImportableVersion("48.0"));
 
         IRenderedComponent<ImportExportComponent> component = RenderPage();
 
@@ -97,7 +96,7 @@ public sealed class ImportExportTests : BunitContext
     public async Task Submit_WhenNoFileChosen_ShowsTheChooseFileValidationAndDoesNotCallImport()
     {
         AuthorizeAs("Sam");
-        StubVersionsWithRegisterRel(new GameVersionResponse(GameVersionId.Create(Guid.NewGuid()), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed));
+        StubVersionsWithRegisterRel(ImportableVersion("48.0"));
         IRenderedComponent<ImportExportComponent> component = RenderPage();
 
         await component.Find("form").SubmitAsync();
@@ -123,6 +122,32 @@ public sealed class ImportExportTests : BunitContext
     }
 
     [Fact]
+    public void Render_WhenNoVersionAdvertisesTheImportRel_SaysSoInsteadOfOfferingAnUnusableSelector()
+    {
+        // An admin whose every registered version is Superseded: the API withholds `import` on all of
+        // them, so a selector would offer only options the server would refuse on submit (#610).
+        AuthorizeAs("Sam");
+        StubVersionsWithRegisterRel(NonImportableVersion("47.2"), NonImportableVersion("46.0"));
+
+        IRenderedComponent<ImportExportComponent> component = RenderPage();
+
+        component.Find(".empty").TextContent.ShouldContain("Brak wersji do importu");
+        component.FindAll("input[type=file]").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenOnlySomeVersionsAdvertiseTheImportRel_OffersOnlyThose()
+    {
+        AuthorizeAs("Sam");
+        StubVersionsWithRegisterRel(ImportableVersion("48.0"), NonImportableVersion("46.0"));
+
+        IRenderedComponent<ImportExportComponent> component = RenderPage();
+
+        IReadOnlyList<IElement> options = component.FindAll("select[name=\"ImportInput.GameVersionId\"] option");
+        options.ShouldHaveSingleItem().TextContent.ShouldContain("48.0");
+    }
+
+    [Fact]
     public void Render_WhenTheCollectionFailsToLoad_HidesTheImportPanelButSurfacesTheErrorAndKeepsTheDownload()
     {
         // The register rel can't be read from a failed fetch, so the import panel is hidden — but the
@@ -145,6 +170,17 @@ public sealed class ImportExportTests : BunitContext
 
     private void AuthorizeAs(string userName) =>
         AddAuthorization().SetAuthorized(userName);
+
+    /// <summary>A version the API offers an admin an <c>import</c> affordance for (not Superseded).</summary>
+    private static GameVersionResponse ImportableVersion(string version) =>
+        new(GameVersionId.Create(Guid.NewGuid()), version, DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed)
+        {
+            Links = [new LinkDto($"https://tms.example/hateoas/import/{version}", Rels.Import, "POST")]
+        };
+
+    /// <summary>A version carrying no <c>import</c> rel — what a non-admin sees, and what an admin sees on a Superseded row.</summary>
+    private static GameVersionResponse NonImportableVersion(string version) =>
+        new(GameVersionId.Create(Guid.NewGuid()), version, DateTimeOffset.UnixEpoch, GameVersionStatus.Superseded);
 
     /// <summary>Stubs the versions list as a plain translator sees it — no admin <c>register</c> rel.</summary>
     private void StubVersions(params GameVersionResponse[] versions) =>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportTargetsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportTargetsTests.cs
@@ -1,0 +1,97 @@
+using LotroKoniecDev.Frontend.Components.Pages.ImportExport;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.TranslationSystem.Contracts.GameVersions;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.ImportExport;
+
+/// <summary>
+/// The import page's target-selection rule, extracted so it can be verified at all: Blazor's static-SSR
+/// form mapping never serializes a programmatically set file input, so the page's own submit path stops
+/// at the "choose a file" guard in bUnit and this logic would otherwise ship untested.
+/// <para>
+/// The rule is entirely the server's <c>import</c> rel (#610) — the API withholds it for a non-admin and
+/// for a <c>Superseded</c> version. Status is deliberately NOT re-interpreted here: a
+/// <c>Superseded</c> row that somehow carried the rel would still be offered, because the server, not
+/// this page, decides.
+/// </para>
+/// </summary>
+public sealed class ImportTargetsTests
+{
+    private const string ImportHref = "/advertised/import-into/42";
+
+    [Fact]
+    public void Importable_WhenSomeVersionsAdvertiseTheRel_KeepsOnlyThose()
+    {
+        GameVersionResponse importable = Version("48.0", ImportHref);
+        GameVersionResponse superseded = Version("47.0", importHref: null);
+
+        IReadOnlyList<GameVersionResponse> result = ImportTargets.Importable([importable, superseded]);
+
+        result.ShouldHaveSingleItem().Version.ShouldBe("48.0");
+    }
+
+    [Fact]
+    public void Importable_WhenNoVersionAdvertisesTheRel_IsEmptySoThePageOffersNoSelector()
+    {
+        // What a non-admin sees, and what an admin sees once every version is Superseded — the page must
+        // say so instead of rendering a selector whose every option would be refused on submit.
+        IReadOnlyList<GameVersionResponse> result =
+            ImportTargets.Importable([Version("47.0", importHref: null), Version("46.0", importHref: null)]);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Importable_WhenTheListIsNull_IsEmpty()
+    {
+        ImportTargets.Importable(null).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindImportHref_WhenTheVersionAdvertisesTheRel_ReturnsThatHref()
+    {
+        GameVersionResponse version = Version("48.0", ImportHref);
+
+        string? href = ImportTargets.FindImportHref([version], version.Id.Value);
+
+        href.ShouldBe(ImportHref);
+    }
+
+    [Fact]
+    public void FindImportHref_WhenTheVersionWithholdsTheRel_IsNullSoTheUploadIsRefused()
+    {
+        // The reachable production case: an admin posting against a Superseded version. A null here is a
+        // refusal that surfaces as a message — never a path composed from the id.
+        GameVersionResponse version = Version("47.0", importHref: null);
+
+        ImportTargets.FindImportHref([version], version.Id.Value).ShouldBeNull();
+    }
+
+    [Fact]
+    public void FindImportHref_WhenTheIdIsNotInTheList_IsNull()
+    {
+        // A stale form post: the catalog moved between render and submit.
+        ImportTargets.FindImportHref([Version("48.0", ImportHref)], Guid.NewGuid()).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FindImportHref_WhenTheListIsNullOrEmpty_IsNull(bool useNull)
+    {
+        IReadOnlyList<GameVersionResponse>? versions = useNull ? null : [];
+
+        ImportTargets.FindImportHref(versions, Guid.NewGuid()).ShouldBeNull();
+    }
+
+    private static GameVersionResponse Version(string version, string? importHref) =>
+        new(GameVersionId.Create(), version, DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed)
+        {
+            Links = importHref is null
+                ? []
+                : [new LinkDto(importHref, Rels.Import, "POST")]
+        };
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListLoaderTests.cs
@@ -2,10 +2,13 @@ using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.Frontend.Components.Pages.Translations;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
 using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
@@ -16,6 +19,9 @@ namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Translations;
 public sealed class TranslationListLoaderTests
 {
     private const string BaseUrl = "https://localhost:5002/";
+
+    private static readonly string ResolvedTranslationsUri =
+        BaseUrl.TrimEnd('/') + StubDiscoveryCache.HrefFor(Rels.Translations);
 
     // Mirrors the JSON options the Frontend's HTTP seam uses (HttpClientApiExtensions) so the stub
     // body deserializes through the exact same contract the loader relies on.
@@ -52,7 +58,7 @@ public sealed class TranslationListLoaderTests
     }
 
     [Fact]
-    public async Task LoadAsync_WithNoFilters_RequestsTheTranslationsEndpointWithLangAndDefaultPaging()
+    public async Task LoadAsync_WithNoFilters_QueriesTheAdvertisedTranslationsHrefWithLangAndDefaultPaging()
     {
         TranslationListLoader loader = CreateLoader(EmptyPage(), out StubHttpMessageHandler handler);
 
@@ -61,7 +67,7 @@ public sealed class TranslationListLoaderTests
         handler.LastRequest.ShouldNotBeNull();
         handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
         string requestUri = handler.LastRequest.RequestUri!.ToString();
-        requestUri.ShouldStartWith($"{BaseUrl}api/v1/translations?");
+        requestUri.ShouldStartWith($"{ResolvedTranslationsUri}?");
         requestUri.ShouldContain("lang=pl");
         requestUri.ShouldContain("page=1");
         requestUri.ShouldContain($"pageSize={TranslationListQuery.DefaultPageSize}");
@@ -121,7 +127,7 @@ public sealed class TranslationListLoaderTests
         StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
             HttpStatusCode.BadRequest,
             """{ "title": "Nieobsługiwany język", "status": 400 }""");
-        TranslationListLoader loader = new(CreateClient(handler));
+        TranslationListLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Translations), CreateClient(handler));
 
         ApiResult<PaginationResponse<TranslationListItemResponse>> result =
             await loader.LoadAsync(TranslationListQuery.From(null, null, 1));
@@ -132,6 +138,34 @@ public sealed class TranslationListLoaderTests
     }
 
     [Fact]
+    public async Task LoadAsync_WhenTheTranslationsRelIsNotAdvertised_FailsWithoutCallingTheApi()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        TranslationListLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Progress), CreateClient(handler));
+
+        ApiResult<PaginationResponse<TranslationListItemResponse>> result =
+            await loader.LoadAsync(TranslationListQuery.From(null, null, 1));
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(403);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenDiscoveryIsUnavailable_PassesThatProblemThrough()
+    {
+        StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}");
+        TranslationListLoader loader = new(StubDiscoveryCache.Unavailable(), CreateClient(handler));
+
+        ApiResult<PaginationResponse<TranslationListItemResponse>> result =
+            await loader.LoadAsync(TranslationListQuery.From(null, null, 1));
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+        handler.LastRequest.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task BulkApproveAsync_PostsTheSelectedIdsToTheHref_AndReturnsTheSummary()
     {
         Guid first = Guid.NewGuid();
@@ -139,7 +173,7 @@ public sealed class TranslationListLoaderTests
         StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
             HttpStatusCode.OK,
             JsonSerializer.Serialize(new BulkApproveTranslationsResponse(2, 2, 0), ApiJsonOptions));
-        TranslationListLoader loader = new(CreateClient(handler));
+        TranslationListLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Translations), CreateClient(handler));
 
         ApiResult<BulkApproveTranslationsResponse> result =
             await loader.BulkApproveAsync("/api/v1/translations/approve", [first, second]);
@@ -159,7 +193,7 @@ public sealed class TranslationListLoaderTests
         StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(
             HttpStatusCode.BadRequest,
             """{ "title": "Za dużo pozycji", "status": 400 }""");
-        TranslationListLoader loader = new(CreateClient(handler));
+        TranslationListLoader loader = new(StubDiscoveryCache.AdvertisingGet(Rels.Translations), CreateClient(handler));
 
         ApiResult<BulkApproveTranslationsResponse> result =
             await loader.BulkApproveAsync("/api/v1/translations/approve", [Guid.NewGuid()]);
@@ -192,7 +226,7 @@ public sealed class TranslationListLoaderTests
         handler = StubHttpMessageHandler.RespondWith(
             HttpStatusCode.OK,
             JsonSerializer.Serialize(page, ApiJsonOptions));
-        return new TranslationListLoader(CreateClient(handler));
+        return new TranslationListLoader(StubDiscoveryCache.AdvertisingGet(Rels.Translations), CreateClient(handler));
     }
 
     private static ITranslationSystemClient CreateClient(StubHttpMessageHandler handler)

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListQueryTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationListQueryTests.cs
@@ -5,14 +5,21 @@ namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Translations;
 
 public sealed class TranslationListQueryTests
 {
+    /// <summary>
+    /// Stands in for the <c>translations</c> href the TMS service document advertises (#610). It looks
+    /// nothing like the real route on purpose — this type must only ever append a query string to
+    /// whatever the server handed it, never know an API path of its own.
+    /// </summary>
+    private const string CollectionHref = "/resolved-by-discovery/translations";
+
     [Fact]
     public void From_WithNoFilters_BuildsBaseUriWithLangAndDefaultPaging()
     {
         TranslationListQuery query = TranslationListQuery.From(search: null, status: null, page: 1);
 
-        string uri = query.ToApiRelativeUri();
+        string uri = query.ToApiUri(CollectionHref);
 
-        uri.ShouldStartWith("/api/v1/translations?");
+        uri.ShouldStartWith($"{CollectionHref}?");
         uri.ShouldContain("lang=pl");
         uri.ShouldContain("page=1");
         uri.ShouldContain($"pageSize={TranslationListQuery.DefaultPageSize}");
@@ -25,7 +32,7 @@ public sealed class TranslationListQueryTests
     {
         TranslationListQuery query = TranslationListQuery.From(search: "Witaj w Śródziemiu", status: null, page: 1);
 
-        query.ToApiRelativeUri().ShouldContain("search=Witaj%20w%20%C5%9Ar%C3%B3dziemiu");
+        query.ToApiUri(CollectionHref).ShouldContain("search=Witaj%20w%20%C5%9Ar%C3%B3dziemiu");
     }
 
     [Fact]
@@ -34,7 +41,7 @@ public sealed class TranslationListQueryTests
         TranslationListQuery query = TranslationListQuery.From(search: "100% & <tag>", status: null, page: 1);
 
         // The page only URL-encodes; the API escapes LIKE metacharacters server-side.
-        string uri = query.ToApiRelativeUri();
+        string uri = query.ToApiUri(CollectionHref);
         uri.ShouldContain("search=100%25%20%26%20%3Ctag%3E");
     }
 
@@ -43,7 +50,7 @@ public sealed class TranslationListQueryTests
     {
         TranslationListQuery query = TranslationListQuery.From(search: null, status: "NeedsReview", page: 1);
 
-        query.ToApiRelativeUri().ShouldContain("status=NeedsReview");
+        query.ToApiUri(CollectionHref).ShouldContain("status=NeedsReview");
         query.Status.ShouldBe(TranslationStatus.NeedsReview);
     }
 
@@ -69,7 +76,7 @@ public sealed class TranslationListQueryTests
         TranslationListQuery query = TranslationListQuery.From(search: null, status: status, page: 1);
 
         query.Status.ShouldBeNull();
-        query.ToApiRelativeUri().ShouldNotContain("status=");
+        query.ToApiUri(CollectionHref).ShouldNotContain("status=");
     }
 
     [Theory]
@@ -81,7 +88,7 @@ public sealed class TranslationListQueryTests
         TranslationListQuery query = TranslationListQuery.From(search: search, status: null, page: 1);
 
         query.Search.ShouldBeNull();
-        query.ToApiRelativeUri().ShouldNotContain("search=");
+        query.ToApiUri(CollectionHref).ShouldNotContain("search=");
     }
 
     [Fact]
@@ -102,17 +109,17 @@ public sealed class TranslationListQueryTests
         TranslationListQuery query = TranslationListQuery.From(search: null, status: null, page: requested);
 
         query.Page.ShouldBe(expected);
-        query.ToApiRelativeUri().ShouldContain($"page={expected}");
+        query.ToApiUri(CollectionHref).ShouldContain($"page={expected}");
     }
 
     [Fact]
-    public void ToApiRelativeUri_WithAllFilters_ComposesEveryParameter()
+    public void ToApiUri_WithAllFilters_ComposesEveryParameter()
     {
         TranslationListQuery query = TranslationListQuery.From(search: "Gandalf", status: "Approved", page: 2);
 
-        string uri = query.ToApiRelativeUri();
+        string uri = query.ToApiUri(CollectionHref);
 
-        uri.ShouldStartWith("/api/v1/translations?");
+        uri.ShouldStartWith($"{CollectionHref}?");
         uri.ShouldContain("lang=pl");
         uri.ShouldContain("page=2");
         uri.ShouldContain($"pageSize={TranslationListQuery.DefaultPageSize}");
@@ -199,7 +206,7 @@ public sealed class TranslationListQueryTests
         TranslationListQuery query = TranslationListQuery.From(search: null, status: null, page: 1, pageSize: pageSize);
 
         query.PageSize.ShouldBe(pageSize);
-        query.ToApiRelativeUri().ShouldContain($"pageSize={pageSize}");
+        query.ToApiUri(CollectionHref).ShouldContain($"pageSize={pageSize}");
     }
 
     [Theory]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using TranslationsComponent = LotroKoniecDev.Frontend.Components.Pages.Translations.Translations;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Translations;
 
@@ -32,6 +33,7 @@ public sealed class TranslationsTests : BunitContext
     {
         Services.AddAntiforgery();
         Services.AddSingleton(_client);
+        Services.AddSingleton(StubDiscoveryCache.AdvertisingGet(Rels.Translations));
         Services.AddScoped<TranslationListLoader>();
         AddAuthorization().SetAuthorized("Frodo");
     }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Discovery/DiscoveryCacheTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Discovery/DiscoveryCacheTests.cs
@@ -12,19 +12,23 @@ using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using AuthDiscoveryResponse = LotroKoniecDev.AuthSystem.Contracts.Discovery.DiscoveryResponse;
+using TranslationDiscoveryResponse = LotroKoniecDev.TranslationSystem.Contracts.Discovery.DiscoveryResponse;
+using TranslationRels = LotroKoniecDev.TranslationSystem.Contracts.Hateoas.Rels;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 
 /// <summary>
-/// The auth leg of the discovery cache over a real <see cref="HybridCache"/> and a substituted
-/// client: the poisoning guard must never cache an anonymous link set under an authenticated key
-/// (that would brick the whole account section for every signed-in user for a day), a degraded
-/// response must mark the session dead and fall back to the anonymous links, and a genuine outage
-/// stays a ProblemDetails failure — never cached, never reclassified as "session expired".
+/// Both legs of the discovery cache over a real <see cref="HybridCache"/> and substituted clients. Each
+/// leg runs the same poisoning guard: it must never cache an anonymous link set under an authenticated
+/// key (that would strip every signed-in user of the affordances their session actually has — for a
+/// full day), a degraded response must mark the session dead and fall back to the anonymous links, and
+/// a genuine outage stays a ProblemDetails failure — never cached, never reclassified as "session
+/// expired".
 /// </summary>
 public sealed class DiscoveryCacheTests
 {
     private const string ExportHref = "auth/account/data-export";
+    private const string ContributionExportHref = "api/v1/translators/me/data-export";
     private const string Subject = "user-sub-1";
 
     private readonly IAuthSystemClient _authClient = Substitute.For<IAuthSystemClient>();
@@ -136,6 +140,114 @@ public sealed class DiscoveryCacheTests
         result.ProblemDetails!.Status.ShouldBe(503);
     }
 
+    [Fact]
+    public async Task GetTranslationSystemDiscoveryAsync_WhenAuthenticatedAndRelPresent_CachesTheLinkSet()
+    {
+        _translationClient.GetDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                ApiResult.Success(AuthenticatedTranslationDiscovery()),
+                ApiResult.Failure<TranslationDiscoveryResponse>(Problem(503)));
+        DiscoveryCache cache = CreateCache(authenticated: true);
+
+        ApiResult<TranslationDiscoveryResponse> first = await cache.GetTranslationSystemDiscoveryAsync();
+        // The second call must be served from the cache — the client's queued failure never surfaces.
+        ApiResult<TranslationDiscoveryResponse> second = await cache.GetTranslationSystemDiscoveryAsync();
+
+        first.IsSuccess.ShouldBeTrue();
+        second.IsSuccess.ShouldBeTrue();
+        second.Value.Links.ShouldContain(link => link.Rel == TranslationRels.ContributionDataExport);
+    }
+
+    [Fact]
+    public async Task GetTranslationSystemDiscoveryAsync_WhenAuthenticatedGetsAnonymousLinks_DegradesAndMarksTheSessionDead()
+    {
+        _translationClient.GetDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(AnonymousTranslationDiscovery()));
+        DiscoveryCache cache = CreateCache(authenticated: true);
+
+        ApiResult<TranslationDiscoveryResponse> result = await cache.GetTranslationSystemDiscoveryAsync();
+
+        // Degrades to the anonymous link set — the public pages keep rendering on the way out…
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Links.ShouldNotContain(link => link.Rel == TranslationRels.ContributionDataExport);
+        result.Value.Links.ShouldContain(link => link.Rel == TranslationRels.Progress);
+        // …and the sign-out is invisible in the return value — the .Received() is the only proof.
+        await _deadSessionRegistry.Received(1).MarkDeadAsync(Subject, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetTranslationSystemDiscoveryAsync_NeverCachesAnonymousLinksUnderTheAuthenticatedKey()
+    {
+        // First call: the bearer never reached the API → anonymous set. Second call: the API answers
+        // correctly. If the degraded set had been cached under the "user" key, the second call would
+        // still be missing the authenticated entry points — for a full day.
+        _translationClient.GetDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                ApiResult.Success(AnonymousTranslationDiscovery()),
+                ApiResult.Success(AnonymousTranslationDiscovery()),
+                ApiResult.Success(AuthenticatedTranslationDiscovery()));
+        DiscoveryCache cache = CreateCache(authenticated: true);
+
+        ApiResult<TranslationDiscoveryResponse> degraded = await cache.GetTranslationSystemDiscoveryAsync();
+        ApiResult<TranslationDiscoveryResponse> recovered = await cache.GetTranslationSystemDiscoveryAsync();
+
+        degraded.Value.Links.ShouldNotContain(link => link.Rel == TranslationRels.ContributionDataExport);
+        recovered.Value.Links.ShouldContain(link => link.Rel == TranslationRels.ContributionDataExport);
+    }
+
+    [Fact]
+    public async Task GetTranslationSystemDiscoveryAsync_WhenAnonymous_DoesNotRequireTheAuthenticatedRels()
+    {
+        // The TMS root is anonymous by design (#608): a guest legitimately gets only the public entry
+        // points, so the guard must not read that as a broken bearer.
+        _translationClient.GetDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(AnonymousTranslationDiscovery()));
+        DiscoveryCache cache = CreateCache(authenticated: false);
+
+        ApiResult<TranslationDiscoveryResponse> result = await cache.GetTranslationSystemDiscoveryAsync();
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Links.ShouldContain(link => link.Rel == TranslationRels.Progress);
+        await _deadSessionRegistry.DidNotReceive().MarkDeadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetTranslationSystemDiscoveryAsync_WhenTheApiFails_ReturnsTheProblemAndDoesNotCacheIt()
+    {
+        _translationClient.GetDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                ApiResult.Failure<TranslationDiscoveryResponse>(Problem(503)),
+                ApiResult.Success(AuthenticatedTranslationDiscovery()));
+        DiscoveryCache cache = CreateCache(authenticated: true);
+
+        ApiResult<TranslationDiscoveryResponse> outage = await cache.GetTranslationSystemDiscoveryAsync();
+        ApiResult<TranslationDiscoveryResponse> recovered = await cache.GetTranslationSystemDiscoveryAsync();
+
+        // A genuine outage is a failure (never reclassified as "session expired")…
+        outage.IsFailure.ShouldBeTrue();
+        outage.ProblemDetails!.Status.ShouldBe(503);
+        await _deadSessionRegistry.DidNotReceive().MarkDeadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        // …and is never persisted under the 1-day TTL: the next call retries the live endpoint.
+        recovered.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetTranslationSystemDiscoveryAsync_WhenTheFallbackFetchAlsoFails_ReturnsTheProblem()
+    {
+        // Degraded set under the user key, then the API dies before the anonymous fallback fetch —
+        // the sentinel must not escape as an exception; errors stay values.
+        _translationClient.GetDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                ApiResult.Success(AnonymousTranslationDiscovery()),
+                ApiResult.Failure<TranslationDiscoveryResponse>(Problem(503)));
+        DiscoveryCache cache = CreateCache(authenticated: true);
+
+        ApiResult<TranslationDiscoveryResponse> result = await cache.GetTranslationSystemDiscoveryAsync();
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(503);
+    }
+
     private DiscoveryCache CreateCache(bool authenticated)
     {
         ServiceCollection services = new();
@@ -166,6 +278,32 @@ public sealed class DiscoveryCacheTests
         new("LotroKoniecDev.AuthSystem")
         {
             Links = [new LinkDto("auth/register", Rels.Register, "POST")]
+        };
+
+    /// <summary>
+    /// What the TMS root answers an authenticated caller: the public entry points plus at least
+    /// <c>contribution-data-export</c>, whose endpoint requires nothing beyond authentication — the
+    /// sentinel the guard reads.
+    /// </summary>
+    private static TranslationDiscoveryResponse AuthenticatedTranslationDiscovery() =>
+        new("LotroKoniecDev.TranslationSystem")
+        {
+            Links =
+            [
+                new LinkDto("api/v1/progress", TranslationRels.Progress, "GET"),
+                new LinkDto(ContributionExportHref, TranslationRels.ContributionDataExport, "GET")
+            ]
+        };
+
+    /// <summary>What the TMS root answers a guest — the three anonymous endpoints, and nothing more.</summary>
+    private static TranslationDiscoveryResponse AnonymousTranslationDiscovery() =>
+        new("LotroKoniecDev.TranslationSystem")
+        {
+            Links =
+            [
+                new LinkDto("api/v1/progress", TranslationRels.Progress, "GET"),
+                new LinkDto("api/v1/translations", TranslationRels.Translations, "GET")
+            ]
         };
 
     private static ProblemDetails Problem(int status) => new()

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Discovery/StubDiscoveryCache.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Discovery/StubDiscoveryCache.cs
@@ -1,0 +1,61 @@
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Hateoas.Abstractions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using TranslationDiscoveryResponse = LotroKoniecDev.TranslationSystem.Contracts.Discovery.DiscoveryResponse;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
+
+/// <summary>
+/// Builds an <see cref="IDiscoveryCache"/> whose TMS leg advertises a chosen link set, for the loader
+/// tests that now resolve their entry point by rel (#610).
+/// <para>
+/// The hrefs handed out here deliberately do <b>not</b> look like the API's real routes: a loader test
+/// that asserts the request landed on one of them is proving the loader followed the href the server
+/// advertised, and could not pass by accident if a hardcoded path crept back in.
+/// </para>
+/// </summary>
+internal static class StubDiscoveryCache
+{
+    /// <summary>The prefix every stub href carries — nothing the API would ever emit.</summary>
+    internal const string HrefPrefix = "/resolved-by-discovery/";
+
+    /// <summary>The href the stub advertises for <paramref name="rel"/>.</summary>
+    internal static string HrefFor(string rel) => HrefPrefix + rel;
+
+    /// <summary>
+    /// A cache whose TMS discovery advertises a <c>GET</c> link per rel in <paramref name="rels"/>,
+    /// each pointing at <see cref="HrefFor"/>. A rel not listed here is simply absent — which is how a
+    /// caller learns the server does not offer it.
+    /// </summary>
+    internal static IDiscoveryCache AdvertisingGet(params string[] rels) =>
+        Advertising([.. rels.Select(rel => new LinkDto(HrefFor(rel), rel, HttpMethods.Get))]);
+
+    /// <summary>A cache whose TMS discovery advertises exactly <paramref name="links"/>.</summary>
+    internal static IDiscoveryCache Advertising(params LinkDto[] links)
+    {
+        IDiscoveryCache cache = Substitute.For<IDiscoveryCache>();
+        cache.GetTranslationSystemDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(
+                new TranslationDiscoveryResponse("LotroKoniecDev.TranslationSystem") { Links = links }));
+        return cache;
+    }
+
+    /// <summary>
+    /// A cache whose TMS discovery is down. The loader must surface this problem verbatim rather than
+    /// guessing a URL — an unreachable service document means no entry point is known.
+    /// </summary>
+    internal static IDiscoveryCache Unavailable(int status = StatusCodes.Status503ServiceUnavailable)
+    {
+        IDiscoveryCache cache = Substitute.For<IDiscoveryCache>();
+        cache.GetTranslationSystemDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<TranslationDiscoveryResponse>(new ProblemDetails
+            {
+                Title = "Usługa chwilowo niedostępna",
+                Status = status
+            }));
+        return cache;
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Discovery/TranslationSystemEntryPointExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Discovery/TranslationSystemEntryPointExtensionsTests.cs
@@ -1,0 +1,81 @@
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+using Microsoft.AspNetCore.Http;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
+
+/// <summary>
+/// The seam every page now uses to get its first TMS URL (#610 / ADR-0041). Three outcomes and no
+/// fourth: the advertised href, the discovery outage passed through verbatim, or a 403 saying the
+/// server does not offer this caller that affordance. There is deliberately no path that composes a
+/// URL locally, so a rel the server withheld can never turn into a request.
+/// </summary>
+public sealed class TranslationSystemEntryPointExtensionsTests
+{
+    [Fact]
+    public async Task ResolveTranslationSystemHrefAsync_WhenAdvertised_ReturnsTheServersHref()
+    {
+        IDiscoveryCache cache = StubDiscoveryCache.AdvertisingGet(Rels.Progress, Rels.Translations);
+
+        ApiResult<string> result = await cache.ResolveTranslationSystemHrefAsync(Rels.Progress);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe(StubDiscoveryCache.HrefFor(Rels.Progress));
+    }
+
+    [Fact]
+    public async Task ResolveTranslationSystemHrefAsync_WhenTheRelIsAbsent_ReturnsForbidden()
+    {
+        // A rel the service document does not carry is an affordance this session does not have —
+        // the answer is a failure, never a locally built path.
+        IDiscoveryCache cache = StubDiscoveryCache.AdvertisingGet(Rels.Progress);
+
+        ApiResult<string> result = await cache.ResolveTranslationSystemHrefAsync(Rels.GameVersions);
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(StatusCodes.Status403Forbidden);
+        result.ProblemDetails.Detail.ShouldNotBeNull();
+        result.ProblemDetails.Detail!.ShouldContain(Rels.GameVersions);
+    }
+
+    [Fact]
+    public async Task ResolveTranslationSystemHrefAsync_WhenTheServiceDocumentIsEmpty_ReturnsForbidden()
+    {
+        IDiscoveryCache cache = StubDiscoveryCache.Advertising();
+
+        ApiResult<string> result = await cache.ResolveTranslationSystemHrefAsync(Rels.Translations);
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task ResolveTranslationSystemHrefAsync_WhenDiscoveryIsUnavailable_PassesThatProblemThrough()
+    {
+        // An outage is NOT a "you may not do this" — the caller must see the real cause, so a transient
+        // 503 never renders as a permissions message.
+        IDiscoveryCache cache = StubDiscoveryCache.Unavailable();
+
+        ApiResult<string> result = await cache.ResolveTranslationSystemHrefAsync(Rels.Progress);
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task ResolveTranslationSystemHrefAsync_WhenTheRelIsANonGetAffordance_StillResolvesIt()
+    {
+        // The document carries one link per entry point; the rel is the whole lookup key. A write
+        // affordance (PUT upsert) must resolve just as a GET does.
+        IDiscoveryCache cache = StubDiscoveryCache.Advertising(
+            new LinkDto("/advertised/translations", Rels.Translations, HttpMethods.Get),
+            new LinkDto("/advertised/upsert", Rels.Upsert, HttpMethods.Put));
+
+        ApiResult<string> result = await cache.ResolveTranslationSystemHrefAsync(Rels.Upsert);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe("/advertised/upsert");
+    }
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Snapshots/HomeMarkupSnapshotTests.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using HomeComponent = LotroKoniecDev.Frontend.Components.Pages.Home.Home;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Snapshots;
 
@@ -36,6 +38,7 @@ public sealed class HomeMarkupSnapshotTests : BunitContext
     public HomeMarkupSnapshotTests()
     {
         Services.AddSingleton(_client);
+        Services.AddSingleton(StubDiscoveryCache.AdvertisingGet(Rels.Progress));
         Services.AddScoped<HomeProgressLoader>();
     }
 


### PR DESCRIPTION
Closes #610

## What

The frontend did hypermedia correctly for transitions but hardcoded all eight entry points into the TMS API. Every one now resolves by **rel name** through the discovery document.

ADR-0041 says there is no API gateway: each API's discovery root owns semantics, and a client takes one root URL per service as config and resolves everything else by rel. This makes the frontend actually do that.

## Why it is more than a find-and-replace

- **A missing rel is a failure, not a fallback.** An absent rel means the server does not offer that affordance to this caller, so it surfaces as a `ProblemDetails` — there is deliberately no code path that composes a URL locally.
- **Two id-keyed actions had to move too.** Removing the path constants left nothing for game-version delete and import to compose from, so they now follow the rel the row itself advertises; register follows the collection rel the page already used as its gate.
- **That surfaced a real hole.** The import page gated its panel on the collection `register` rel while the API decides importability *per version*, so a `Superseded` version could be selected and would only fail on submit. The selector now offers exactly the versions advertising `import`, and says so when none do.
- **The discovery cache needed the auth leg's poisoning guard.** The TMS root is anonymous since #608 and tailors links per caller, so a rejected bearer returns a silent 200 with the public link set instead of a 401. Caching that under an authenticated key would strip every signed-in user of their entry points for a day.

## One bounded exception

`TranslationEditorLoader` appends the id to the discovered collection href: the `/editor/{id}` route hands over an id rather than a link, and the service document carries no templated per-row rel. Documented where it lives, with the condition that retires it.

## Regression gate

`scripts/check-frontend-hypermedia.sh` (+ `.ps1` twin) flags an API path in any string literal under `src/Frontend/`, wired into `pr-verify` and `ci` next to the SSR guard. Checked against the nine literals this branch removes — it catches every one. Comments and XML docs stay allowed.

## Acceptance criteria

| Criterion | Status |
|---|---|
| No `/api/v1/...` literal under `src/Frontend/` | `git ls-files src/Frontend \| xargs grep api/v1` → zero hits (stricter than the AC, which allowed comments) |
| Every page renders for its intended audience | home anonymous, translator + admin pages via their rels; bUnit render tests updated |
| No advertised link → clear failure, no guessed URL | 403 `ProblemDetails` at every call site, each covered |
| Cache never persists a degraded link set under an authenticated key | 6 new `DiscoveryCacheTests` on the TMS leg |
| Unit tests for the changed loaders over a stubbed handler | +24 frontend tests (460 → 484) |
| Green build, zero warnings, SSR purity green | all green |

## Test

- `dotnet build LotroKoniecDev.slnx` — zero warnings
- All 8 unit suites — **12,359 passed, 0 failed**
- TMS API integration, discovery filter — 14 passed (Docker)
- `check-ssr-purity.sh`, `check-frontend-hypermedia.sh`, `classify-changes.tests.sh` (40 cases) — green

Reviewed by the `code-reviewer` agent; its four "handled but untested" findings are fixed in this branch (missing-rel + outage coverage on the four role-gated loaders, the GDPR export degrade path, the editor recovery-resolve failure, and the import-target rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3R4Cew6w6tfHQ8GqnCoR