### PR TITLE
Patcher: seal Result<TValue> in LotroKoniecDev.Domain (house rule violation caught by the architecture tests)

### DIFF
--- a/src/Patcher/LotroKoniecDev.Domain/Core/Monads/Result.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Core/Monads/Result.cs
@@ -58,11 +58,11 @@ public class Result
 /// Represents a result of an operation with status information, a value, and possibly an error.
 /// </summary>
 /// <typeparam name="TValue">The type of the result value.</typeparam>
-public class Result<TValue> : Result
+public sealed class Result<TValue> : Result
 {
     private readonly TValue _value;
 
-    protected internal Result(TValue value, bool isSuccess, Error error)
+    internal Result(TValue value, bool isSuccess, Error error)
         : base(isSuccess, error)
     {
         _value = value;

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -239,7 +239,9 @@ namespaces on the assemblies below.
 
 `SealedConventionTests.KnownViolations` quarantines pre-existing violations, each keyed to its own
 ticket (#570 is a test-only change). The list is **self-cleaning** — a second test fails once an entry
-stops violating, so a fix cannot land without removing it.
+stops violating, so a fix cannot land without removing it. It is **empty since #599** sealed the last
+one (`Domain.Core.Monads.Result<TValue>`): a new violation now fails the gate outright, and adding an
+entry instead of sealing the type needs a ticket to point at.
 
 ## Infrastructure Tests (LotroKoniecDev.Tests.Infrastructure)
 

--- a/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/SealedConventionTests.cs
+++ b/tests/LotroKoniecDev.Architecture.Tests.Unit/Tests/SealedConventionTests.cs
@@ -24,12 +24,9 @@ public sealed class SealedConventionTests
 
     /// <summary>
     /// Real violations that predate this suite, each fixed under its own ticket — #570 is a test-only
-    /// change. Keyed by type full name, valued by the ticket that removes the entry.
+    /// change. Keyed by type full name, valued by the ticket that removes the entry. Empty since #599.
     /// </summary>
-    private static readonly Dictionary<string, string> KnownViolations = new(StringComparer.Ordinal)
-    {
-        ["LotroKoniecDev.Domain.Core.Monads.Result`1"] = "#599",
-    };
+    private static readonly Dictionary<string, string> KnownViolations = new(StringComparer.Ordinal);
 
     [Fact]
     public void ProductionClasses_WithoutAnExplicitSubclass_AreSealed()


### PR DESCRIPTION
Closes #599

## What

- `Domain.Core.Monads.Result<TValue>` is now `sealed`. Nothing in `src/` or `tests/` derives from it, and its SharedKernel twin has been sealed all along.
- Its value constructor moves from `protected internal` to `internal`.
- `SealedConventionTests.KnownViolations` loses its last entry, so the quarantine is empty.

## Why the constructor changed too

`protected` in a sealed type is CS0628, and `TreatWarningsAsErrors` turns that into a failing build — so sealing without touching the modifier does not compile. Both call sites are the `Result.Success<T>` / `Failure<T>` factories in the same assembly, and `internal` is exactly what the SharedKernel twin uses, so the two monads stay in the same shape.

## Tests

No assertions were touched (the patcher is stable, not frozen — ADR-0002 amendment). The self-cleaning half of the quarantine did its job: the suite went red on the stale entry until it was removed.

- `dotnet build LotroKoniecDev.slnx` — green, **0 warnings**
- `tests/LotroKoniecDev.Tests.Unit` — 3811 passed
- `tests/LotroKoniecDev.Architecture.Tests.Unit` — 21 passed
- Every other pure unit suite also run and green (SharedKernel, TranslationSystem.Domain / API, Frontend, AuthSystem.API, Logging) — 12359 total

`tests/CLAUDE.md` is updated so it no longer describes the quarantine as holding entries.