### PR TITLE
Bug: content ending in an odd number of pipes is silently truncated and corrupts the args column

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,14 +295,22 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
 ```
 
 - `<--DO_NOT_TOUCH!-->` = argument placeholder
-- `args_order`: `NULL` or `1-2-3` (1-indexed in file, 0-indexed internally)
+- `args_order` / `args_id`: `NULL` or `1-2-3` (1-indexed in file, 0-indexed internally). Anything
+  else **rejects the row and is reported** (ADR-0042) — the CLI prints it as a patch warning, the
+  import fails the whole upload. Whether the positions FIT the fragment is checked downstream in
+  `Fragment.TryReorderArgRefs`, the only place that knows how many argument references there are.
 - **Content escape (ADR-0039): `\`→`\\`, CR→`\r`, LF→`\n`.** It escapes its own escape character, so
   it is injective and `Unescape(Escape(x)) == x`. **Every writer escapes and every reader unescapes**
   — all four ends (patcher exporter + parser, TMS serializer + import parser), each via its context's
   own `TranslationLineEscaper`. Text held anywhere else — in the DAT, in `TranslationSource.Text`, in
   `TranslatedText` — is always the RAW form; the escape exists only between `Serialize` and `Parse`.
-  A sequence no writer can produce (`\t`, a trailing lone `\`) reads back verbatim. The `||`
-  separator is deliberately **not** escaped: both parsers anchor from both ends instead.
+  A sequence no writer can produce (`\t`, a trailing lone `\`) reads back verbatim.
+- **The `||` separator is deliberately NOT escaped — the line is CARVED, never `Split` (ADR-0042).**
+  Each context's `TranslationLineCarver` scans **forward** for the two id separators and **backward**
+  for the three trailing ones (slicing before each backward search), so content may contain `||` and
+  may end in any run of `|`. `string.Split` resolves every boundary greedily left to right, which
+  silently ate a trailing pipe into the args column (#597); never reintroduce it here. Nothing but
+  content can hold a `|`, so both boundaries are recoverable by construction — no escape needed.
 - Results sorted by FileId then GossipId for sequential DAT I/O
 - **Changing this format requires an ADR + updated golden fixtures in BOTH contexts** (patcher
   parser tests and TMS import/export tests).

--- a/docs/adr/0039-injective-backslash-escape-for-the-translation-file-format.md
+++ b/docs/adr/0039-injective-backslash-escape-for-the-translation-file-format.md
@@ -60,7 +60,8 @@ live inside content, `NULL` args, the comment marker and CRLF line endings are a
 particular **the separator is deliberately NOT escaped** — anchoring from both ends already
 recovers it, both parsers already agree on it, and escaping it would break every `exported.txt` and
 every `polish.txt` in existence for a problem that does not exist. (The one true delimiter defect,
-content ending in an odd run of `|`, is #597 and is out of scope here.)
+content ending in an odd run of `|`, is #597 and is out of scope here. **Settled by ADR-0042**,
+which kept the separator unescaped and fixed the carving instead.)
 
 ### 2. All four ends apply it
 

--- a/docs/adr/0042-both-ends-anchoring-carves-the-translation-line-instead-of-splitting-it.md
+++ b/docs/adr/0042-both-ends-anchoring-carves-the-translation-line-instead-of-splitting-it.md
@@ -1,0 +1,176 @@
+# ADR-0042: The `||` line is carved by both-ends anchoring, not by `Split` — and the separator stays unescaped
+
+**Status:** Accepted
+**Date:** 2026-08-06
+**Decision-makers:** Solo maintainer
+**Related:** #597 (the defect), #569 (the hostile-string coverage that found it), ADR-0039 (the content escape, which deferred this), CLAUDE.md "Translation file format — THE inter-context contract", `TranslationFileParser`, `TranslationExportParser`
+
+## Context
+
+The `||` file is the only contract between the two bounded contexts:
+
+```
+file_id||gossip_id||content||args_order||args_id||approved
+```
+
+Content may legally contain `||`, so neither parser can simply take the third field. Both were
+written to "anchor from both ends": the first two fields lead, the last three trail, and everything
+between is re-joined as content. Both implement it the same way — `line.Split("||")`, then index
+`parts[2..^3]`.
+
+That is not both-ends anchoring. `Split` resolves **every** boundary greedily left to right
+*before* the anchoring happens, so a boundary inside a pipe run is already decided by the time the
+indexes are applied. Content ending in an odd run of `|` therefore merges with the separator that
+follows it and the content boundary lands one character too early.
+
+Content `abc|` is written as `620756992||1001||abc|||NULL||NULL||1` and splits into:
+
+```
+["620756992", "1001", "abc", "|NULL", "NULL", "1"]
+```
+
+Measured, before this ADR — leading and interior pipes were already fine, only an odd **trailing**
+run broke:
+
+| content written | content read back | args_order read back |
+|---|---|---|
+| `abc\|` | `abc` | `\|NULL` |
+| `abc\|\|\|` | `abc\|\|` | `\|NULL` |
+| `\|` | (empty) | `\|NULL` |
+| `\|abc` | `\|abc` | `NULL` |
+| `abc\|\|` | `abc\|\|` | `NULL` |
+| `a\|b` | `a\|b` | `NULL` |
+
+Both parsers did it identically, which is why `ParserContractParityTests` — the drift guard — could
+not see it: the two contexts agreed on the wrong answer.
+
+The corrupted args column then diverged between the contexts, which is worse than a plain
+truncation. The patcher's `ParseArgsArray` reached `int.Parse` inside a bare `catch { return null; }`
+and dropped the arguments silently, so a fragment that had reordered arguments lost that ordering.
+The TMS stored `"|NULL"` verbatim as `ArgsOrder` — neither `null` nor a valid `1-2-3` column — and
+because `TranslationSource` equality covers the args columns (spec 0001), that value also
+participated in the import diff.
+
+Reachable end to end: a translator types a trailing `|` in the editor, the artifact is written, the
+CLI downloads it, and the wrong text is patched into the DAT with no warning to anyone.
+
+ADR-0039 settled the *content* escape (`\`→`\\`, CR→`\r`, LF→`\n`) and deliberately left the
+separator unescaped, naming this defect as out of scope. This ADR closes that item.
+
+## Decision
+
+### 1. The separator stays unescaped — the information was never lost
+
+The format is **not** ambiguous, and it never was. The five non-content fields cannot contain a
+`|`: the two id columns are ASCII decimal integers, the two args columns are `NULL` or a
+`-`-separated integer list, and the approved column is `0` or `1`. So at a field boundary next to
+content, a run of `n` pipes is always `content_pipes + 2`, and the separator is:
+
+- the **first two** characters of the run at the leading boundary, and
+- the **last two** characters of the run at the trailing boundary.
+
+Both are recoverable by construction. The bytes on disk always carried the right answer; the
+parsers threw it away.
+
+Escaping the separator was rejected. It is a format change: it would break every `exported.txt` and
+every `polish.txt` in existence, force a version gate between the CLI and the TMS, and rewrite the
+golden fixtures — all to encode information the line already carries. ADR-0039 declined it for the
+same reason and nothing here changes that.
+
+### 2. Both parsers carve the line by scanning, not by splitting
+
+The two leading separators are found by a **forward** search from the start of the line; the three
+trailing separators by a **backward** search, each over the slice that ends where the previously
+found separator begins. Content is the substring between the second leading separator and the
+third-from-last one.
+
+Slicing before searching is what makes the backward pass exact. A match must fit entirely inside
+the remaining slice, so when an args column is empty the separator pair that straddles the slice
+boundary cannot be mistaken for the next separator.
+
+That one detail is load-bearing and invisible in the common case: with `NULL` args the columns are
+padded apart and a bound that allowed a straddling match still carves correctly. It only breaks on
+an **empty** args column next to content ending in a pipe. Both `TranslationLineCarverTests` suites
+and the `BothCarvers_OnALineWithEmptyArgsColumns_…` parity theory exist specifically to reach it —
+verified by mutation: widening either bound by one turns 335 tests red, and left every suite green
+before they were added.
+
+A line is malformed when the two passes cross — the content start would sit past the content end.
+That is the same rejection the old "fewer than 6 fields" check produced, restated for a scan.
+
+For content with no pipe run at a boundary the new carving and the old `Split` agree on every
+field, so this is a strictly widening fix: nothing that parsed correctly before parses differently
+now.
+
+The rule is stated once per context, next to that context's escaper — the contexts share the file,
+never code (CLAUDE.md), and `ParserContractParityTests` keeps the two copies honest.
+
+### 3. A malformed args column rejects its row and is reported
+
+The bare `catch { return null; }` is gone. Both parsers now validate the args columns
+**syntactically**: absent (`NULL`, empty, whitespace) or a non-empty `-`-separated list of ASCII
+decimal integers, nothing else. A column that fails is a malformed row:
+
+- **Patcher** — `ParseLine` answers with `Result.Failure`, and `ParseFile` now **returns** the
+  per-line warnings it already collected instead of dropping them on the floor. They flow into
+  `PatchSummaryResponse.Warnings`, which `PatchCommand` already prints.
+- **TMS** — the line yields an `ExportParseError`, which the import already collects and fails the
+  whole upload on.
+
+**Range and arity stay downstream**, where they can actually be checked: `Fragment.TryReorderArgRefs`
+knows how many argument references the fragment has and already warns when the order does not fit.
+The parser cannot know that, so it does not guess.
+
+Rejecting the row was chosen over the softer "keep the text, drop the args with a warning". Applying
+Polish text with the wrong argument order renders placeholders in the wrong positions — a silent
+in-game defect — whereas a rejected row simply leaves the English text in place and says so. The
+file is machine-generated; a malformed args column means the file is corrupt or hand-edited, and the
+TMS import already fails closed on a bad `file_id` for the same reason.
+
+Returning the parser's warnings is part of the fix, not scope creep. Without it, replacing a silent
+null with a rejected line would only move the loss: the whole translation would disappear instead of
+just its argument order, and still without telling anyone.
+
+Two consequences of that channel, both deliberate:
+
+- **A file whose every line is rejected fails with the reason attached.** The CLI prints the warning
+  list only on a *successful* patch, so on the `NoTranslations` failure path the diagnosis has to
+  ride inside the `Error` itself (`NoTranslationsEveryLineRejected`). Otherwise the one case where
+  the file is most broken would be the one case that stays silent. An empty or comments-only file is
+  not a corruption and still reports the plain `NoTranslations`.
+- **The warning list is capped at 100, mirroring the import's `MaxCollectedParseErrors`** (spec
+  0006). Every warning quotes a whole line and a real `polish.txt` is ~790k rows, so an uncapped
+  list would bury the console. `TranslationParseResult.RejectedLineCount` stays uncapped, so the
+  reported scale is always the true one and the list ends with an explicit "… and N more".
+
+## Consequences
+
+### Good
+
+- Content ending in any number of `|` round-trips byte-exact through both parsers, in both
+  directions.
+- The args columns can no longer be polluted by content, in either context.
+- A malformed args column reaches a human: the CLI prints it, the import rejects the upload and
+  names the line.
+- No format change. Every existing `exported.txt` and `polish.txt` keeps parsing — and starts
+  parsing *better*, with no re-export, no migration and no CLI/TMS version skew. ADR-0039 had to
+  accept two skew edges; this has none.
+- The two pinning tests from #597 flip to exact round trips, and the golden fixture gains a
+  trailing-pipe row so the parity suite drives the case through both parsers.
+
+### Neutral
+
+- `ITranslationParser.ParseFile` now returns `TranslationParseResult` (translations + warnings +
+  the uncapped rejected-line count) rather than a bare list. The seam is patcher-internal — three
+  call sites — and the warnings channel it feeds already existed.
+- Carving costs two forward and three backward `IndexOf`/`LastIndexOf` scans per line instead of
+  one `Split`, and allocates no intermediate array. Not measurable next to the per-row work on
+  either side.
+
+### The limit of this fix
+
+A **non-conforming** writer can still produce a line no reader can resolve — put a raw `|` into an
+args column and the trailing anchor lands in the wrong place. That is out of reach of any parser
+that does not escape the separator, and it is not a case the pipeline produces: both writers emit
+the args columns from validated data. The syntactic args check in §3 is what turns such a line into
+a reported error rather than a silent mis-parse.

--- a/src/Patcher/LotroKoniecDev.Application/Abstractions/ITranslationParser.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Abstractions/ITranslationParser.cs
@@ -8,11 +8,11 @@ namespace LotroKoniecDev.Application.Abstractions;
 public interface ITranslationParser
 {
     /// <summary>
-    /// Parses a translation file and returns all valid translations.
+    /// Parses a translation file into its valid translations plus a warning per rejected line.
     /// </summary>
     /// <param name="filePath">Path to the translation file.</param>
-    /// <returns>Result containing the list of translations or an error.</returns>
-    Result<IReadOnlyList<Translation>> ParseFile(string filePath);
+    /// <returns>Result containing the parsed translations and warnings, or an error.</returns>
+    Result<TranslationParseResult> ParseFile(string filePath);
 
     /// <summary>
     /// Parses a single translation line.

--- a/src/Patcher/LotroKoniecDev.Application/Abstractions/TranslationParseResult.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Abstractions/TranslationParseResult.cs
@@ -1,0 +1,22 @@
+using LotroKoniecDev.Domain.Models;
+
+namespace LotroKoniecDev.Application.Abstractions;
+
+/// <summary>
+/// The outcome of reading a translation file: the rows that parsed, plus one warning per line that
+/// did not. A rejected line is never silently dropped (ADR-0042) — the warnings travel up into
+/// <c>PatchSummaryResponse.Warnings</c>, which the CLI prints after a patch run.
+/// </summary>
+/// <param name="Translations">The rows that parsed, sorted by file id then gossip id.</param>
+/// <param name="Warnings">
+/// One entry per rejected line, capped so a wholly corrupt file cannot flood the console, plus a
+/// trailing "… and N more" entry once the cap is hit.
+/// </param>
+/// <param name="RejectedLineCount">
+/// How many lines were actually rejected — uncapped, unlike <paramref name="Warnings"/>, so a caller
+/// can report the true scale of the damage.
+/// </param>
+public sealed record TranslationParseResult(
+    IReadOnlyList<Translation> Translations,
+    IReadOnlyList<string> Warnings,
+    int RejectedLineCount);

--- a/src/Patcher/LotroKoniecDev.Application/EventIds.cs
+++ b/src/Patcher/LotroKoniecDev.Application/EventIds.cs
@@ -36,4 +36,5 @@ internal static class EventIds
     public const int LaunchGameLaunchFailed = 5122;
     public const int LaunchLauncherStarted = 5123;
     public const int LaunchEnded = 5124;
+    public const int LaunchPatchWarning = 5125;
 }

--- a/src/Patcher/LotroKoniecDev.Application/Features/GameLaunching/SimplifiedGameLaunchingStrategy.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/GameLaunching/SimplifiedGameLaunchingStrategy.cs
@@ -112,6 +112,13 @@ internal sealed partial class SimplifiedGameLaunchingStrategy : IGameLaunchingSt
 
             PatchSummaryResponse patchSummary = patchResult.Value;
 
+            // The launch path runs the same parser as `patch`, so a rejected line must reach a human
+            // here too (ADR-0042). `patch` prints the summary; launch has only the log.
+            foreach (string warning in patchSummary.Warnings)
+            {
+                LogPatchWarning(_logger, warning);
+            }
+
             translationsApplied = true;
             appliedCount = patchSummary.AppliedTranslations;
             skippedCount = patchSummary.SkippedTranslations;
@@ -219,6 +226,9 @@ internal sealed partial class SimplifiedGameLaunchingStrategy : IGameLaunchingSt
 
     [LoggerMessage(EventId = EventIds.LaunchTranslationsPatched, Level = LogLevel.Information, Message = "Patched translations: {Applied} applied, {Skipped} skipped")]
     private static partial void LogTranslationsPatched(ILogger logger, int applied, int skipped);
+
+    [LoggerMessage(EventId = EventIds.LaunchPatchWarning, Level = LogLevel.Warning, Message = "Patch warning: {Warning}")]
+    private static partial void LogPatchWarning(ILogger logger, string warning);
 
     [LoggerMessage(EventId = EventIds.LaunchReadingDatVnum, Level = LogLevel.Information, Message = "Reading DAT vnum to save alongside hash...")]
     private static partial void LogReadingDatVnum(ILogger logger);

--- a/src/Patcher/LotroKoniecDev.Application/Features/Patching/PatchingService.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/Patching/PatchingService.cs
@@ -27,7 +27,7 @@ internal sealed class PatchingService : IPatchingService
         string datFilePath,
         IProgress<OperationProgress>? progress = null)
     {
-        Result<IReadOnlyList<Translation>> translationParseResult =
+        Result<TranslationParseResult> translationParseResult =
             _translationParser.ParseFile(translationsPath);
 
         if (translationParseResult.IsFailure)
@@ -35,11 +35,23 @@ internal sealed class PatchingService : IPatchingService
             return Result.Failure<PatchSummaryResponse>(translationParseResult.Error);
         }
 
-        IReadOnlyList<Translation> translations = translationParseResult.Value;
+        IReadOnlyList<Translation> translations = translationParseResult.Value.Translations;
+
+        // A line the parser rejected is reported, never swallowed (ADR-0042): its warning rides
+        // along with the per-fragment ones into the summary the CLI prints.
+        IReadOnlyList<string> parseWarnings = translationParseResult.Value.Warnings;
 
         if (translations.Count == 0)
         {
-            return Result.Failure<PatchSummaryResponse>(DomainErrors.Translation.NoTranslations);
+            // A file whose every line was rejected must say WHY. The warning list is only printed on
+            // a successful patch, so on this path the diagnosis has to ride in the error itself —
+            // otherwise the fix of ADR-0042 would stop exactly where it matters most.
+            return Result.Failure<PatchSummaryResponse>(
+                translationParseResult.Value.RejectedLineCount > 0
+                    ? DomainErrors.Translation.NoTranslationsEveryLineRejected(
+                        translationParseResult.Value.RejectedLineCount,
+                        parseWarnings[0])
+                    : DomainErrors.Translation.NoTranslations);
         }
 
         Result<int> datFileOpenResult = _datFileHandler.Open(datFilePath, DatFileAccess.ReadWrite);
@@ -55,7 +67,7 @@ internal sealed class PatchingService : IPatchingService
         {
             Dictionary<int, (int Size, int Iteration)> fileSizes = _datFileHandler.GetAllSubfileSizes(datFileHandle);
 
-            List<string> warnings = [];
+            List<string> warnings = [.. parseWarnings];
             int appliedCount = 0;
             int skippedCount = 0;
 

--- a/src/Patcher/LotroKoniecDev.Application/Parsers/TranslationFileParser.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Parsers/TranslationFileParser.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using LotroKoniecDev.Application.Abstractions;
 using LotroKoniecDev.Domain.Core.Errors;
 using LotroKoniecDev.Domain.Models;
@@ -10,26 +11,38 @@ namespace LotroKoniecDev.Application.Parsers;
 /// <remarks>
 /// File format: file_id||gossip_id||content||args_order||args_id||approved
 /// Lines starting with # are comments, empty lines are ignored.
+/// Fields are carved by <see cref="TranslationLineCarver"/>, which anchors from both ends
+/// (ADR-0042), so content may contain the separator and may end in any run of <c>|</c>.
 /// Content arrives escaped (ADR-0039) and is unfolded by <see cref="TranslationLineEscaper"/>, so
 /// <see cref="Translation.Content"/> always carries the raw text about to be written into the DAT.
 /// </remarks>
 public sealed class TranslationFileParser : ITranslationParser
 {
     private const string FieldSeparator = "||";
-    private const int MinimumFieldCount = 6;
+    private const int SeparatorCount = 5;
+    private const string AbsentArgs = "NULL";
+    private const char ArgsPositionSeparator = '-';
 
-    public Result<IReadOnlyList<Translation>> ParseFile(string filePath)
+    /// <summary>
+    /// Mirrors the TMS import's own cap (spec 0006): a wholly corrupt file is rejected either way,
+    /// and the cap only bounds how many lines are quoted back. Without it a 790k-row file gone bad
+    /// would print one full-line warning per row to the console.
+    /// </summary>
+    private const int MaxCollectedWarnings = 100;
+
+    public Result<TranslationParseResult> ParseFile(string filePath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
 
         if (!File.Exists(filePath))
         {
-            return Result.Failure<IReadOnlyList<Translation>>(
+            return Result.Failure<TranslationParseResult>(
                 DomainErrors.Translation.FileNotFound(filePath));
         }
 
         List<Translation> translations = [];
         List<string> warnings = [];
+        int rejectedLineCount = 0;
 
         foreach (string line in File.ReadLines(filePath))
         {
@@ -43,11 +56,21 @@ public sealed class TranslationFileParser : ITranslationParser
             if (parseResult.IsSuccess)
             {
                 translations.Add(parseResult.Value);
+                continue;
             }
-            else
+
+            rejectedLineCount++;
+
+            if (warnings.Count < MaxCollectedWarnings)
             {
                 warnings.Add(parseResult.Error.Message);
             }
+        }
+
+        int quotedWarnings = warnings.Count;
+        if (rejectedLineCount > quotedWarnings)
+        {
+            warnings.Add($"... and {rejectedLineCount - quotedWarnings} more rejected lines (only the first {MaxCollectedWarnings} are listed).");
         }
 
         // Sort by FileId then GossipId for optimal I/O during patching
@@ -56,7 +79,7 @@ public sealed class TranslationFileParser : ITranslationParser
             .ThenBy(t => t.GossipId)
             .ToList();
 
-        return Result.Success<IReadOnlyList<Translation>>(sortedTranslations);
+        return Result.Success(new TranslationParseResult(sortedTranslations, warnings, rejectedLineCount));
     }
 
     public Result<Translation> ParseLine(string line)
@@ -67,38 +90,48 @@ public sealed class TranslationFileParser : ITranslationParser
                 DomainErrors.Translation.InvalidFormat("Empty line"));
         }
 
-        string[] parts = line.Split([FieldSeparator], StringSplitOptions.None);
-
-        if (parts.Length < MinimumFieldCount)
+        if (!TranslationLineCarver.TryCarve(line, out CarvedTranslationLine? carved))
         {
             return Result.Failure<Translation>(
                 DomainErrors.Translation.InvalidFormat(
-                    $"Expected at least {MinimumFieldCount} fields, got {parts.Length}"));
+                    $"expected {SeparatorCount} '{FieldSeparator}' separators outside the content, in line '{line}'"));
         }
 
-        try
-        {
-            // Anchor from both ends: file_id, gossip_id lead; args_order, args_id, approved trail.
-            // Everything between is content re-joined with the separator, so content may contain "||".
-            string content = string.Join(FieldSeparator, parts[2..^3]);
-
-            Translation translation = new()
-            {
-                FileId = int.Parse(parts[0]),
-                GossipId = ulong.Parse(parts[1]),
-                Content = TranslationLineEscaper.Unescape(content),
-                ArgsOrder = ParseArgsArray(parts[^3]),
-                ArgsId = ParseArgsArray(parts[^2]),
-                IsApproved = parts[^1] == "1"
-            };
-
-            return Result.Success(translation);
-        }
-        catch (Exception ex) when (ex is FormatException or OverflowException)
+        if (!int.TryParse(carved.FileId, NumberStyles.Integer, CultureInfo.InvariantCulture, out int fileId))
         {
             return Result.Failure<Translation>(
-                DomainErrors.Translation.ParseError(line, ex.Message));
+                DomainErrors.Translation.ParseError(line, $"File id '{carved.FileId}' is not a valid integer."));
         }
+
+        if (!ulong.TryParse(carved.GossipId, NumberStyles.Integer, CultureInfo.InvariantCulture, out ulong gossipId))
+        {
+            return Result.Failure<Translation>(
+                DomainErrors.Translation.ParseError(line, $"Gossip id '{carved.GossipId}' is not a valid integer."));
+        }
+
+        if (!TryParseArgsArray(carved.ArgsOrder, out int[]? argsOrder))
+        {
+            return Result.Failure<Translation>(
+                DomainErrors.Translation.ParseError(line, DescribeMalformedArgs("args_order", carved.ArgsOrder)));
+        }
+
+        if (!TryParseArgsArray(carved.ArgsId, out int[]? argsId))
+        {
+            return Result.Failure<Translation>(
+                DomainErrors.Translation.ParseError(line, DescribeMalformedArgs("args_id", carved.ArgsId)));
+        }
+
+        Translation translation = new()
+        {
+            FileId = fileId,
+            GossipId = gossipId,
+            Content = TranslationLineEscaper.Unescape(carved.Content),
+            ArgsOrder = argsOrder,
+            ArgsId = argsId,
+            IsApproved = carved.Approved == "1"
+        };
+
+        return Result.Success(translation);
     }
 
     /// <summary>
@@ -108,29 +141,42 @@ public sealed class TranslationFileParser : ITranslationParser
         string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#');
 
     /// <summary>
-    /// Parses an argument array in format "1-2-3" to 0-indexed integers.
+    /// Parses an argument column in format "1-2-3" to 0-indexed integers. An absent column
+    /// (<c>NULL</c>, empty or blank) yields <see langword="null"/> arguments and succeeds; anything
+    /// else that is not a <c>-</c>-separated list of ASCII decimal integers fails, so the caller
+    /// rejects and reports the row rather than silently patching it without its argument order
+    /// (ADR-0042). Whether the positions FIT the fragment is checked downstream by
+    /// <c>Fragment.TryReorderArgRefs</c>, which is the only place that knows how many there are.
     /// </summary>
-    /// <param name="value">The string value to parse.</param>
-    /// <returns>Array of 0-indexed integers, or null if value is NULL or empty.</returns>
-    private static int[]? ParseArgsArray(string value)
+    private static bool TryParseArgsArray(string value, out int[]? args)
     {
+        args = null;
+
         if (string.IsNullOrWhiteSpace(value) ||
-            value.Equals("NULL", StringComparison.OrdinalIgnoreCase))
+            value.Equals(AbsentArgs, StringComparison.OrdinalIgnoreCase))
         {
-            return null;
+            return true;
         }
 
-        try
+        string[] positions = value.Split(ArgsPositionSeparator);
+        int[] parsed = new int[positions.Length];
+
+        for (int index = 0; index < positions.Length; index++)
         {
-            // Format: "1-2-3" -> [0, 1, 2] (convert from 1-indexed to 0-indexed)
-            return value
-                .Split('-')
-                .Select(s => int.Parse(s) - 1)
-                .ToArray();
+            // NumberStyles.None on purpose: no sign (the '-' is the separator), no surrounding
+            // whitespace, ASCII digits only. An overflowing position fails here too.
+            if (!int.TryParse(positions[index], NumberStyles.None, CultureInfo.InvariantCulture, out int position))
+            {
+                return false;
+            }
+
+            parsed[index] = position - 1;
         }
-        catch
-        {
-            return null;
-        }
+
+        args = parsed;
+        return true;
     }
+
+    private static string DescribeMalformedArgs(string column, string value)
+        => $"The {column} column '{value}' is neither NULL nor a '-' separated list of integers.";
 }

--- a/src/Patcher/LotroKoniecDev.Application/Parsers/TranslationLineCarver.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Parsers/TranslationLineCarver.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace LotroKoniecDev.Application.Parsers;
+
+/// <summary>
+/// One carved <c>||</c> line, fields verbatim — no escape unfolded, no number parsed. Content may
+/// legally contain the separator and may end in any number of <c>|</c>.
+/// </summary>
+internal sealed record CarvedTranslationLine(
+    string FileId,
+    string GossipId,
+    string Content,
+    string ArgsOrder,
+    string ArgsId,
+    string Approved);
+
+/// <summary>
+/// Splits a <c>||</c> line into its six fields by anchoring from both ends (ADR-0042): the two id
+/// columns are found by scanning forward from the start, the three trailing columns by scanning
+/// backward from the end, and content is whatever lies between. Content may therefore contain the
+/// separator itself and may end in an odd run of <c>|</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Scanning is what makes this exact — <c>string.Split</c> resolves every boundary greedily left to
+/// right, so a trailing pipe in the content merges with the separator that follows it and the
+/// boundary lands one character early (#597). Nothing but content can contain a <c>|</c>, so at a
+/// boundary a run of pipes is always <c>content_pipes + 2</c> and the separator is the run's first
+/// two characters going forward, its last two going backward.
+/// </para>
+/// <para>
+/// The TMS owns an identical copy in its own <c>Parsing</c> namespace — the two bounded contexts
+/// share the file, never code (CLAUDE.md). The parity suites are what keep the copies honest.
+/// </para>
+/// </remarks>
+internal static class TranslationLineCarver
+{
+    private const string FieldSeparator = "||";
+
+    /// <summary>
+    /// Carves <paramref name="line"/> into its six fields, or answers <see langword="false"/> when
+    /// the line does not carry five separators that leave room for a content field.
+    /// </summary>
+    public static bool TryCarve(string line, [NotNullWhen(true)] out CarvedTranslationLine? carved)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+
+        carved = null;
+
+        int fileIdEnd = line.IndexOf(FieldSeparator, StringComparison.Ordinal);
+        if (fileIdEnd < 0)
+        {
+            return false;
+        }
+
+        int gossipIdStart = fileIdEnd + FieldSeparator.Length;
+
+        int gossipIdEnd = line.IndexOf(FieldSeparator, gossipIdStart, StringComparison.Ordinal);
+        if (gossipIdEnd < 0)
+        {
+            return false;
+        }
+
+        int contentStart = gossipIdEnd + FieldSeparator.Length;
+
+        // Each backward step searches the slice that ENDS where the separator it already found
+        // begins, so a match always fits entirely inside the remaining region. That is what stops
+        // the pair straddling an empty args column from being mistaken for the next separator.
+        int beforeApproved = line.AsSpan().LastIndexOf(FieldSeparator);
+        if (beforeApproved < contentStart)
+        {
+            return false;
+        }
+
+        int beforeArgsId = line.AsSpan(0, beforeApproved).LastIndexOf(FieldSeparator);
+        if (beforeArgsId < contentStart)
+        {
+            return false;
+        }
+
+        int contentEnd = line.AsSpan(0, beforeArgsId).LastIndexOf(FieldSeparator);
+        if (contentEnd < contentStart)
+        {
+            return false;
+        }
+
+        carved = new CarvedTranslationLine(
+            FileId: line[..fileIdEnd],
+            GossipId: line[gossipIdStart..gossipIdEnd],
+            Content: line[contentStart..contentEnd],
+            ArgsOrder: line[(contentEnd + FieldSeparator.Length)..beforeArgsId],
+            ArgsId: line[(beforeArgsId + FieldSeparator.Length)..beforeApproved],
+            Approved: line[(beforeApproved + FieldSeparator.Length)..]);
+
+        return true;
+    }
+}

--- a/src/Patcher/LotroKoniecDev.Domain/Core/Errors/TranslationDomainErrors.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Core/Errors/TranslationDomainErrors.cs
@@ -17,6 +17,17 @@ public static partial class DomainErrors
 
         public static Error NoTranslations =>
             Error.Validation("Translation.NoTranslations", "No translations to apply.");
+
+        /// <summary>
+        /// The file held candidate rows but the parser rejected every one of them. Carries the first
+        /// rejection, because this is a failure path — the CLI prints the warning list only on a
+        /// successful patch, so an error that just said "no translations" would be the exact silence
+        /// ADR-0042 set out to remove.
+        /// </summary>
+        public static Error NoTranslationsEveryLineRejected(int rejectedLineCount, string firstWarning) =>
+            Error.Validation(
+                "Translation.NoTranslations",
+                $"No translations to apply: all {rejectedLineCount} candidate lines were rejected. First: {firstWarning}");
     }
 
     public static class Export

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationExportParser.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationExportParser.cs
@@ -6,14 +6,17 @@ namespace LotroKoniecDev.TranslationSystem.API.Parsing;
 
 /// <summary>
 /// Parses an uploaded <c>exported.txt</c> in the LOTRO <c>||</c> contract
-/// (<c>file_id||gossip_id||content||args_order||args_id||approved</c>), unfolding the content escape
-/// (ADR-0039) so the catalog stores the raw source text rather than its file representation. The TMS
-/// owns its own parser; golden fixtures + round-trip tests guard it against drift from the patcher's.
+/// (<c>file_id||gossip_id||content||args_order||args_id||approved</c>), carving fields by anchoring
+/// from both ends (ADR-0042) and unfolding the content escape (ADR-0039) so the catalog stores the
+/// raw source text rather than its file representation. The TMS owns its own parser; golden fixtures
+/// + round-trip tests guard it against drift from the patcher's.
 /// </summary>
 internal sealed class TranslationExportParser : ITranslationExportParser
 {
     private const string FieldSeparator = "||";
-    private const int MinimumFieldCount = 6;
+    private const int SeparatorCount = 5;
+    private const string AbsentArgs = "NULL";
+    private const char ArgsPositionSeparator = '-';
 
     /// <summary>
     /// The patcher writes <c>exported.txt</c> as UTF-8; decode it strictly. A wrong-charset or
@@ -96,43 +99,77 @@ internal sealed class TranslationExportParser : ITranslationExportParser
     {
         row = null;
 
-        string[] parts = line.Split(FieldSeparator, StringSplitOptions.None);
-
-        if (parts.Length < MinimumFieldCount)
-        {
-            error = $"Expected at least {MinimumFieldCount} fields, got {parts.Length}.";
-            return false;
-        }
-
-        if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out int fileId))
-        {
-            error = $"File id '{parts[0]}' is not a valid integer.";
-            return false;
-        }
-
-        if (!long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out long gossipId))
-        {
-            error = $"Gossip id '{parts[1]}' is not a valid integer.";
-            return false;
-        }
-
         // Anchor from both ends (matches the patcher, #29/#106): file_id, gossip_id lead;
-        // args_order, args_id, approved trail; everything between is content re-joined with the
-        // separator, so content may legally contain "||". The escape is unfolded last (ADR-0039),
-        // so the row hands out the raw source text the DAT actually holds.
-        string content = TranslationLineEscaper.Unescape(string.Join(FieldSeparator, parts[2..^3]));
+        // args_order, args_id, approved trail; everything between is content, so it may legally
+        // contain "||" and may end in any run of '|' (ADR-0042).
+        if (!TranslationLineCarver.TryCarve(line, out CarvedTranslationLine? carved))
+        {
+            error = $"Expected {SeparatorCount} '{FieldSeparator}' separators outside the content.";
+            return false;
+        }
+
+        if (!int.TryParse(carved.FileId, NumberStyles.Integer, CultureInfo.InvariantCulture, out int fileId))
+        {
+            error = $"File id '{carved.FileId}' is not a valid integer.";
+            return false;
+        }
+
+        if (!long.TryParse(carved.GossipId, NumberStyles.Integer, CultureInfo.InvariantCulture, out long gossipId))
+        {
+            error = $"Gossip id '{carved.GossipId}' is not a valid integer.";
+            return false;
+        }
+
+        if (!IsWellFormedArgs(carved.ArgsOrder))
+        {
+            error = DescribeMalformedArgs("args_order", carved.ArgsOrder);
+            return false;
+        }
+
+        if (!IsWellFormedArgs(carved.ArgsId))
+        {
+            error = DescribeMalformedArgs("args_id", carved.ArgsId);
+            return false;
+        }
 
         row = new ParsedExportRow(
             FileId: fileId,
             GossipId: gossipId,
-            Content: content,
-            ArgsOrder: parts[^3],
-            ArgsId: parts[^2],
-            Approved: parts[^1].Trim() == "1");
+            // The escape is unfolded last (ADR-0039), so the row hands out the raw source text the
+            // DAT actually holds.
+            Content: TranslationLineEscaper.Unescape(carved.Content),
+            ArgsOrder: carved.ArgsOrder,
+            ArgsId: carved.ArgsId,
+            Approved: carved.Approved.Trim() == "1");
 
         error = null;
         return true;
     }
+
+    /// <summary>
+    /// An args column is either absent (<c>NULL</c>, empty or blank) or a <c>-</c>-separated list of
+    /// ASCII decimal integers. Anything else rejects the row (ADR-0042) rather than being stored
+    /// verbatim, where it would be neither <see langword="null"/> nor a usable order and would still
+    /// take part in the import diff (spec 0001). Whether the positions fit the fragment is the
+    /// patcher's call, not the catalog's — the TMS never sees the argument references.
+    /// </summary>
+    private static bool IsWellFormedArgs(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) ||
+            value.Equals(AbsentArgs, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // NumberStyles.None on purpose: no sign (the '-' is the separator), no surrounding
+        // whitespace, ASCII digits only. An overflowing position fails here too.
+        return value
+            .Split(ArgsPositionSeparator)
+            .All(position => int.TryParse(position, NumberStyles.None, CultureInfo.InvariantCulture, out _));
+    }
+
+    private static string DescribeMalformedArgs(string column, string value)
+        => $"The {column} column '{value}' is neither NULL nor a '-' separated list of integers.";
 
     private static bool ShouldSkipLine(string line)
         => string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#');

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationLineCarver.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Parsing/TranslationLineCarver.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace LotroKoniecDev.TranslationSystem.API.Parsing;
+
+/// <summary>
+/// One carved <c>||</c> line, fields verbatim — no escape unfolded, no number parsed. Content may
+/// legally contain the separator and may end in any number of <c>|</c>.
+/// </summary>
+internal sealed record CarvedTranslationLine(
+    string FileId,
+    string GossipId,
+    string Content,
+    string ArgsOrder,
+    string ArgsId,
+    string Approved);
+
+/// <summary>
+/// Splits a <c>||</c> line into its six fields by anchoring from both ends (ADR-0042): the two id
+/// columns are found by scanning forward from the start, the three trailing columns by scanning
+/// backward from the end, and content is whatever lies between. Content may therefore contain the
+/// separator itself and may end in an odd run of <c>|</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Scanning is what makes this exact — <c>string.Split</c> resolves every boundary greedily left to
+/// right, so a trailing pipe in the content merges with the separator that follows it and the
+/// boundary lands one character early (#597). Nothing but content can contain a <c>|</c>, so at a
+/// boundary a run of pipes is always <c>content_pipes + 2</c> and the separator is the run's first
+/// two characters going forward, its last two going backward.
+/// </para>
+/// <para>
+/// The patcher owns an identical copy in its own <c>Parsers</c> namespace — the two bounded contexts
+/// share the file, never code (CLAUDE.md). The parity suites are what keep the copies honest.
+/// </para>
+/// </remarks>
+internal static class TranslationLineCarver
+{
+    private const string FieldSeparator = "||";
+
+    /// <summary>
+    /// Carves <paramref name="line"/> into its six fields, or answers <see langword="false"/> when
+    /// the line does not carry five separators that leave room for a content field.
+    /// </summary>
+    public static bool TryCarve(string line, [NotNullWhen(true)] out CarvedTranslationLine? carved)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+
+        carved = null;
+
+        int fileIdEnd = line.IndexOf(FieldSeparator, StringComparison.Ordinal);
+        if (fileIdEnd < 0)
+        {
+            return false;
+        }
+
+        int gossipIdStart = fileIdEnd + FieldSeparator.Length;
+
+        int gossipIdEnd = line.IndexOf(FieldSeparator, gossipIdStart, StringComparison.Ordinal);
+        if (gossipIdEnd < 0)
+        {
+            return false;
+        }
+
+        int contentStart = gossipIdEnd + FieldSeparator.Length;
+
+        // Each backward step searches the slice that ENDS where the separator it already found
+        // begins, so a match always fits entirely inside the remaining region. That is what stops
+        // the pair straddling an empty args column from being mistaken for the next separator.
+        int beforeApproved = line.AsSpan().LastIndexOf(FieldSeparator);
+        if (beforeApproved < contentStart)
+        {
+            return false;
+        }
+
+        int beforeArgsId = line.AsSpan(0, beforeApproved).LastIndexOf(FieldSeparator);
+        if (beforeArgsId < contentStart)
+        {
+            return false;
+        }
+
+        int contentEnd = line.AsSpan(0, beforeArgsId).LastIndexOf(FieldSeparator);
+        if (contentEnd < contentStart)
+        {
+            return false;
+        }
+
+        carved = new CarvedTranslationLine(
+            FileId: line[..fileIdEnd],
+            GossipId: line[gossipIdStart..gossipIdEnd],
+            Content: line[contentStart..contentEnd],
+            ArgsOrder: line[(contentEnd + FieldSeparator.Length)..beforeArgsId],
+            ArgsId: line[(beforeArgsId + FieldSeparator.Length)..beforeApproved],
+            Approved: line[(beforeApproved + FieldSeparator.Length)..]);
+
+        return true;
+    }
+}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -78,11 +78,13 @@ suite rather than copy-pasting lists; add a category source there rather than in
 
 Sources: `All` (everything), `UnicodeHazards` (UTF-16 length hazards), `DelimiterHazards` (collides
 with a delimited text format), `NonAsciiDigits` (id columns), `SubmittableText` / `BlankText` (what
-the API's `NotEmpty()` does and does not let through as translated text), plus `AllValues` — the raw
-list, for a suite that must filter the corpus down to what its seam accepts **before** building a
-`TheoryData`, so its assertion stays unconditional instead of hiding in an `if`. Entries are
-de-duplicated: the upstream list repeats two, and a duplicate logs a "Skipping test case with
-duplicate ID" line on every run.
+the API's `NotEmpty()` does and does not let through as translated text), `PipeRuns` (**not** from
+the corpus — every string over `{'a','|'}` up to six characters, 127 entries, so both `||` parsers
+are pinned exhaustively against the delimiter collision of #597 rather than at six sampled points),
+plus `AllValues` — the raw list, for a suite that must filter the corpus down to what its seam
+accepts **before** building a `TheoryData`, so its assertion stays unconditional instead of hiding
+in an `if`. Entries are de-duplicated: the upstream list repeats two, and a duplicate logs a
+"Skipping test case with duplicate ID" line on every run.
 
 Both sides of the `||` contract carry hostile round-trip coverage:
 `TranslationFileParserNaughtyStringTests` + `FragmentNaughtyStringTests` (patcher — parser and the
@@ -94,17 +96,24 @@ exception).
 **The corpus does not reach every interesting case.** It carries no empty string, no real newline,
 no literal `\r`/`\n` escape sequence and no entry ending in an odd run of `|` — exactly the
 delimiter collisions this format is weakest at. Those are composed by hand as explicit
-`[InlineData]` theories next to the corpus-driven ones; when you add a seam, check whether its
-hazard is actually present in the data before trusting a `MemberData` theory to cover it.
+`[InlineData]` theories next to the corpus-driven ones (and, for the pipe runs, by the generated
+`PipeRuns` source above); when you add a seam, check whether its hazard is actually present in the
+data before trusting a `MemberData` theory to cover it.
 
 Several tests pin **known-lossy** behavior on purpose, say so in-place, and name the defect ticket
-they document (#597 odd trailing pipe, #598 over-long piece). Do not "fix" such a test — fix the
-defect, then change the assertion deliberately. That is what #596 did: the escape asymmetry it
-pinned is gone (ADR-0039), so both its tests now assert exact round trips, and
-`TranslationLineEscaperTests` exists **twice** — one suite per bounded context, over that context's
-own copy of the rule. The two copies are duplicated by design (the contexts share the file, never
-code), so the twin suites plus `ParserContractParityTests` are the only thing keeping them in step:
-change one escaper, change the other in the same commit.
+they document (today: #598 over-long piece). Do not "fix" such a test — fix the defect, then change
+the assertion deliberately. That is what #596 and #597 did: the escape asymmetry (ADR-0039) and the
+swallowed trailing pipe (ADR-0042) are both gone, so all four of their tests now assert exact round
+trips.
+
+The `||` rule now lives in **two duplicated-by-design types per context** — `TranslationLineEscaper`
+(the content escape) and `TranslationLineCarver` (the field boundaries) — each with its own twin
+unit suite, plus `BothEscapers_…` / `BothCarvers_…` in `ParserContractParityTests`. The contexts
+share the file, never code, so those parity tests are the only thing keeping the copies in step:
+**change one copy, change the other in the same commit.** The twin per-context suites would both
+stay green through a one-sided change; the parity suite would not. #597 is the cautionary tale for
+why parity alone is not enough — both parsers carved the line identically *wrongly*, so the drift
+guard saw nothing. Round-trip fidelity through each context's own writer is what caught it.
 
 ## Snapshot tests (Verify — #571)
 

--- a/tests/LotroKoniecDev.Tests.E2E/Tests/ExportE2ETests.cs
+++ b/tests/LotroKoniecDev.Tests.E2E/Tests/ExportE2ETests.cs
@@ -1,3 +1,4 @@
+using LotroKoniecDev.Application.Abstractions;
 using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Domain.Models;
@@ -77,11 +78,12 @@ public sealed class ExportE2ETests
         Skip.If(!_fixture.IsDatFileAvailable, "DAT file not found in TestData/");
 
         TranslationFileParser parser = new();
-        Result<IReadOnlyList<Translation>> result = parser.ParseFile(_fixture.CachedExportPath);
+        Result<TranslationParseResult> result = parser.ParseFile(_fixture.CachedExportPath);
 
         result.IsSuccess.ShouldBeTrue(
             $"Parser should succeed. Error: {(result.IsFailure ? result.Error.Message : "")}");
-        result.Value.ShouldNotBeEmpty("Parsed translations should not be empty");
+        result.Value.Translations.ShouldNotBeEmpty("Parsed translations should not be empty");
+        result.Value.Warnings.ShouldBeEmpty("A real export must not contain a line the parser rejects");
     }
 
     [SkippableFact]

--- a/tests/LotroKoniecDev.Tests.E2E/Tests/RoundtripE2ETests.cs
+++ b/tests/LotroKoniecDev.Tests.E2E/Tests/RoundtripE2ETests.cs
@@ -1,3 +1,4 @@
+using LotroKoniecDev.Application.Abstractions;
 using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Domain.Models;
@@ -21,10 +22,10 @@ public sealed class RoundtripE2ETests
 
         //Arrange — parse polish.txt to get target IDs and expected content
         TranslationFileParser parser = new();
-        Result<IReadOnlyList<Translation>> polishResult = parser.ParseFile(_fixture.TranslationsPolishPath);
+        Result<TranslationParseResult> polishResult = parser.ParseFile(_fixture.TranslationsPolishPath);
         polishResult.IsSuccess.ShouldBeTrue(
             $"polish.txt should parse. Error: {(polishResult.IsFailure ? polishResult.Error.Message : "")}");
-        polishResult.Value.ShouldNotBeEmpty("polish.txt should contain translations");
+        polishResult.Value.Translations.ShouldNotBeEmpty("polish.txt should contain translations");
 
         //Arrange — use cached export as "before" (original English DAT)
         _fixture.CachedExportResult!.ExitCode.ShouldBe((int)CliExitCode.Success,
@@ -50,7 +51,7 @@ public sealed class RoundtripE2ETests
         Dictionary<string, string> beforeIndex = BuildLineIndex(_fixture.CachedExportPath);
         Dictionary<string, string> afterIndex = BuildLineIndex(afterPath);
 
-        foreach (Translation expected in polishResult.Value)
+        foreach (Translation expected in polishResult.Value.Translations)
         {
             string linePrefix = $"{expected.FileId}||{expected.GossipId}||";
 
@@ -79,11 +80,11 @@ public sealed class RoundtripE2ETests
 
         //Arrange — get set of translated IDs to exclude
         TranslationFileParser parser = new();
-        Result<IReadOnlyList<Translation>> polishResult = parser.ParseFile(_fixture.TranslationsPolishPath);
+        Result<TranslationParseResult> polishResult = parser.ParseFile(_fixture.TranslationsPolishPath);
         polishResult.IsSuccess.ShouldBeTrue(
             $"polish.txt should parse. Error: {(polishResult.IsFailure ? polishResult.Error.Message : "")}");
 
-        HashSet<string> translatedKeys = polishResult.Value
+        HashSet<string> translatedKeys = polishResult.Value.Translations
             .Select(t => $"{t.FileId}||{t.GossipId}||")
             .ToHashSet();
 

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Features/PatchingServiceTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Features/PatchingServiceTests.cs
@@ -44,8 +44,13 @@ public sealed class PatchingServiceTests
 
     private void SetupTranslations(params Translation[] translations)
     {
+        SetupParsedFile(translations, []);
+    }
+
+    private void SetupParsedFile(IReadOnlyList<Translation> translations, IReadOnlyList<string> warnings)
+    {
         _translationParser.ParseFile(Arg.Any<string>())
-            .Returns(Result.Success<IReadOnlyList<Translation>>(translations.ToList()));
+            .Returns(Result.Success(new TranslationParseResult(translations, warnings, warnings.Count)));
     }
 
     private static Translation CreateTranslation(
@@ -88,7 +93,7 @@ public sealed class PatchingServiceTests
         SetupAllPassingDefaults();
         Error parseError = new("Translation.ParseError", "Bad format", ErrorType.Validation);
         _translationParser.ParseFile(Arg.Any<string>())
-            .Returns(Result.Failure<IReadOnlyList<Translation>>(parseError));
+            .Returns(Result.Failure<TranslationParseResult>(parseError));
 
         // Act
         Result<PatchSummaryResponse> result = _sut.ApplyTranslations("/translations/polish.txt", "/game/client_local_English.dat");
@@ -96,6 +101,57 @@ public sealed class PatchingServiceTests
         // Assert
         result.IsFailure.ShouldBeTrue();
         result.Error.Code.ShouldBe("Translation.ParseError");
+    }
+
+    [Fact]
+    public void ApplyTranslations_WhenTheParserRejectedALine_ShouldSurfaceItsWarningInTheSummary()
+    {
+        // Arrange — a rejected line used to vanish inside the parser (ADR-0042). The summary is the
+        // only channel the CLI prints, so a warning that does not reach it is still swallowed.
+        SetupAllPassingDefaults();
+        SetupParsedFile([CreateTranslation()], ["Line 7: the args_order column '1-x' is malformed."]);
+
+        // Act
+        Result<PatchSummaryResponse> result = _sut.ApplyTranslations("/translations/polish.txt", "/game/client_local_English.dat");
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Warnings.ShouldContain("Line 7: the args_order column '1-x' is malformed.");
+    }
+
+    [Fact]
+    public void ApplyTranslations_WhenEveryLineWasRejected_ShouldSayWhyInsteadOfJustNoTranslations()
+    {
+        // Arrange — the failure path drops the warning list (the CLI prints it only on success), so
+        // without the reason in the Error itself a wholly corrupt polish.txt would report a bare
+        // "No translations to apply" — the exact silence ADR-0042 exists to remove.
+        SetupAllPassingDefaults();
+        SetupParsedFile([], ["Error parsing line '1||2||c||1-x||NULL||1': the args_order column is malformed."]);
+
+        // Act
+        Result<PatchSummaryResponse> result = _sut.ApplyTranslations("/translations/polish.txt", "/game/client_local_English.dat");
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translation.NoTranslations");
+        result.Error.Message.ShouldContain("args_order");
+    }
+
+    [Fact]
+    public void ApplyTranslations_WhenTheFileHeldNoRowsAtAll_ShouldReportPlainNoTranslations()
+    {
+        // Arrange — an empty or comments-only file is not a corruption, so it must not be dressed up
+        // as one; nothing was rejected and there is no reason to give.
+        SetupAllPassingDefaults();
+        SetupParsedFile([], []);
+
+        // Act
+        Result<PatchSummaryResponse> result = _sut.ApplyTranslations("/translations/polish.txt", "/game/client_local_English.dat");
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translation.NoTranslations");
+        result.Error.Message.ShouldBe("No translations to apply.");
     }
 
     [Fact]
@@ -437,7 +493,7 @@ public sealed class PatchingServiceTests
             .Returns(_ =>
             {
                 callOrder.Add("parse");
-                return Result.Success<IReadOnlyList<Translation>>(new List<Translation> { CreateTranslation() });
+                return Result.Success(new TranslationParseResult([CreateTranslation()], [], 0));
             });
 
         _datFileHandler.Open(Arg.Any<string>(), DatFileAccess.ReadWrite)

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserNaughtyStringTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserNaughtyStringTests.cs
@@ -129,27 +129,48 @@ public sealed class TranslationFileParserNaughtyStringTests
     }
 
     [Theory]
-    [InlineData("abc|", "abc")]
-    [InlineData("abc|||", "abc||")]
-    [InlineData("|", "")]
-    [InlineData("|||", "||")]
-    public void ParseLine_ContentEndingInAnOddNumberOfPipes_ShouldLoseTheLastPipe(string content, string expectedLossyContent)
+    [InlineData("abc|")]
+    [InlineData("abc||")]
+    [InlineData("abc|||")]
+    [InlineData("|")]
+    [InlineData("||")]
+    [InlineData("|||")]
+    public void ParseLine_ContentEndingInAnOddNumberOfPipes_ShouldRoundTripExactly(string content)
     {
-        // Arrange — DOCUMENTED CURRENT BEHAVIOR, not an endorsement. Split is greedy left to right,
-        // so a trailing pipe merges with the separator that follows it and the content boundary
-        // lands one character early: the pipe is swallowed and reappears glued to the args column.
-        // No entry of the naughty list ends in an odd pipe run, so this collision has to be composed
-        // by hand. Tracked as #597; pinned here so fixing it is a deliberate, visible change to this
-        // assertion, never an accident.
-        string line = $"620756992||1001||{content}||NULL||NULL||1";
+        // Arrange — the trailing boundary is found by scanning BACKWARD (ADR-0042), so the last two
+        // pipes of a run are the separator and every earlier one stays content. Split resolved the
+        // boundary greedily left to right, which landed it one character early: the pipe was
+        // swallowed and reappeared glued to the args column (#597). No entry of the naughty list
+        // ends in an odd pipe run, so this collision has to be composed by hand.
+        string line = $"620756992||1001||{EscapeAsExporter(content)}||NULL||NULL||1";
 
         // Act
         Result<Translation> result = _parser.ParseLine(line);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.Content.ShouldBe(expectedLossyContent);
-        result.Value.ArgsOrder.ShouldBeNull(); // "|NULL" is swallowed by ParseArgsArray's bare catch
+        result.Value.Content.ShouldBe(content);
+        result.Value.ArgsOrder.ShouldBeNull();
+        result.Value.ArgsId.ShouldBeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.PipeRuns), MemberType = typeof(NaughtyStringCases))]
+    public void ParseLine_EveryPipeRunUpToSixCharacters_ShouldRoundTripAndLeaveTheArgsColumnsClean(string content)
+    {
+        // Arrange — exhaustive over the alphabet this format is weakest at, in BOTH parities: the
+        // run can sit at the leading boundary, the trailing one, or both at once. The hand-picked
+        // cases above only sample it.
+        string line = $"620756992||1001||{EscapeAsExporter(content)}||1-2||3-4||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(content);
+        result.Value.ArgsOrder.ShouldBe([0, 1]);
+        result.Value.ArgsId.ShouldBe([2, 3]);
     }
 
     [Theory]

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationFileParserTests.cs
@@ -1,3 +1,4 @@
+using LotroKoniecDev.Application.Abstractions;
 using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Domain.Models;
@@ -28,7 +29,7 @@ public sealed class TranslationFileParserTests : IDisposable
     public void ParseFile_NullPath_ShouldThrowArgumentException()
     {
         // Act
-        Func<Result<IReadOnlyList<Translation>>> action = () => _parser.ParseFile(null!);
+        Func<Result<TranslationParseResult>> action = () => _parser.ParseFile(null!);
 
         // Assert
         action.ShouldThrow<ArgumentException>();
@@ -38,7 +39,7 @@ public sealed class TranslationFileParserTests : IDisposable
     public void ParseFile_EmptyPath_ShouldThrowArgumentException()
     {
         // Act
-        Func<Result<IReadOnlyList<Translation>>> action = () => _parser.ParseFile("   ");
+        Func<Result<TranslationParseResult>> action = () => _parser.ParseFile("   ");
 
         // Assert
         action.ShouldThrow<ArgumentException>();
@@ -51,7 +52,7 @@ public sealed class TranslationFileParserTests : IDisposable
         string nonExistentPath = Path.Combine(_tempDirectory, "nonexistent.txt");
 
         // Act
-        Result<IReadOnlyList<Translation>> result = _parser.ParseFile(nonExistentPath);
+        Result<TranslationParseResult> result = _parser.ParseFile(nonExistentPath);
 
         // Assert
         result.IsFailure.ShouldBeTrue();
@@ -66,11 +67,11 @@ public sealed class TranslationFileParserTests : IDisposable
         File.WriteAllText(filePath, "");
 
         // Act
-        Result<IReadOnlyList<Translation>> result = _parser.ParseFile(filePath);
+        Result<TranslationParseResult> result = _parser.ParseFile(filePath);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.ShouldBeEmpty();
+        result.Value.Translations.ShouldBeEmpty();
     }
 
     [Fact]
@@ -87,11 +88,11 @@ public sealed class TranslationFileParserTests : IDisposable
         File.WriteAllText(filePath, content);
 
         // Act
-        Result<IReadOnlyList<Translation>> result = _parser.ParseFile(filePath);
+        Result<TranslationParseResult> result = _parser.ParseFile(filePath);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.Count.ShouldBe(1);
+        result.Value.Translations.Count.ShouldBe(1);
     }
 
     [Fact]
@@ -103,16 +104,16 @@ public sealed class TranslationFileParserTests : IDisposable
         File.WriteAllText(filePath, content);
 
         // Act
-        Result<IReadOnlyList<Translation>> result = _parser.ParseFile(filePath);
+        Result<TranslationParseResult> result = _parser.ParseFile(filePath);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.Count.ShouldBe(1);
-        result.Value[0].FileId.ShouldBe(12345);
-        result.Value[0].GossipId.ShouldBe(67890UL);
-        result.Value[0].Content.ShouldBe("Hello World");
-        result.Value[0].ArgsOrder.ShouldBeNull();
-        result.Value[0].ArgsId.ShouldBeNull();
+        result.Value.Translations.Count.ShouldBe(1);
+        result.Value.Translations[0].FileId.ShouldBe(12345);
+        result.Value.Translations[0].GossipId.ShouldBe(67890UL);
+        result.Value.Translations[0].Content.ShouldBe("Hello World");
+        result.Value.Translations[0].ArgsOrder.ShouldBeNull();
+        result.Value.Translations[0].ArgsId.ShouldBeNull();
     }
 
     [Fact]
@@ -124,12 +125,12 @@ public sealed class TranslationFileParserTests : IDisposable
         File.WriteAllText(filePath, content);
 
         // Act
-        Result<IReadOnlyList<Translation>> result = _parser.ParseFile(filePath);
+        Result<TranslationParseResult> result = _parser.ParseFile(filePath);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value[0].ArgsOrder.ShouldBe(new[] { 0, 1, 2 }); // 1-indexed to 0-indexed
-        result.Value[0].ArgsId.ShouldBe(new[] { 3, 4, 5 });
+        result.Value.Translations[0].ArgsOrder.ShouldBe(new[] { 0, 1, 2 }); // 1-indexed to 0-indexed
+        result.Value.Translations[0].ArgsId.ShouldBe(new[] { 3, 4, 5 });
     }
 
     [Fact]
@@ -141,11 +142,11 @@ public sealed class TranslationFileParserTests : IDisposable
         File.WriteAllText(filePath, content);
 
         // Act
-        Result<IReadOnlyList<Translation>> result = _parser.ParseFile(filePath);
+        Result<TranslationParseResult> result = _parser.ParseFile(filePath);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value[0].Content.ShouldBe("Line1\nLine2\rLine3");
+        result.Value.Translations[0].Content.ShouldBe("Line1\nLine2\rLine3");
     }
 
     [Fact]
@@ -161,17 +162,17 @@ public sealed class TranslationFileParserTests : IDisposable
         File.WriteAllText(filePath, content);
 
         // Act
-        Result<IReadOnlyList<Translation>> result = _parser.ParseFile(filePath);
+        Result<TranslationParseResult> result = _parser.ParseFile(filePath);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.Count.ShouldBe(3);
-        result.Value[0].FileId.ShouldBe(100);
-        result.Value[0].GossipId.ShouldBe(200UL);
-        result.Value[1].FileId.ShouldBe(100);
-        result.Value[1].GossipId.ShouldBe(300UL);
-        result.Value[2].FileId.ShouldBe(200);
-        result.Value[2].GossipId.ShouldBe(300UL);
+        result.Value.Translations.Count.ShouldBe(3);
+        result.Value.Translations[0].FileId.ShouldBe(100);
+        result.Value.Translations[0].GossipId.ShouldBe(200UL);
+        result.Value.Translations[1].FileId.ShouldBe(100);
+        result.Value.Translations[1].GossipId.ShouldBe(300UL);
+        result.Value.Translations[2].FileId.ShouldBe(200);
+        result.Value.Translations[2].GossipId.ShouldBe(300UL);
     }
 
     [Fact]
@@ -359,7 +360,7 @@ public sealed class TranslationFileParserTests : IDisposable
     }
 
     [Fact]
-    public void ParseFile_WithInvalidLines_ShouldSkipAndContinue()
+    public void ParseFile_WithInvalidLines_ShouldSkipContinueAndReportTheRejectedLine()
     {
         // Arrange
         string filePath = Path.Combine(_tempDirectory, "mixed.txt");
@@ -371,10 +372,94 @@ public sealed class TranslationFileParserTests : IDisposable
         File.WriteAllText(filePath, content);
 
         // Act
-        Result<IReadOnlyList<Translation>> result = _parser.ParseFile(filePath);
+        Result<TranslationParseResult> result = _parser.ParseFile(filePath);
+
+        // Assert — a rejected line is reported, never silently dropped (ADR-0042); the warning
+        // travels into PatchSummaryResponse.Warnings, which the CLI prints.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Translations.Count.ShouldBe(2);
+        result.Value.Warnings.ShouldHaveSingleItem();
+        result.Value.RejectedLineCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ParseFile_WithMoreRejectedLinesThanTheWarningCap_ShouldQuoteTheCapAndCountTheRest()
+    {
+        // Arrange — 150 malformed rows. Every warning quotes a whole line, and a real polish.txt is
+        // ~790k rows, so an uncapped list would bury the console (the TMS import caps for the same
+        // reason, spec 0006). The COUNT must stay exact even though the list is truncated.
+        string filePath = Path.Combine(_tempDirectory, "all-bad.txt");
+        File.WriteAllLines(filePath, Enumerable.Range(0, 150).Select(index => $"100||{index}||Content||1-x||NULL||1"));
+
+        // Act
+        Result<TranslationParseResult> result = _parser.ParseFile(filePath);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.Count.ShouldBe(2);
+        result.Value.Translations.ShouldBeEmpty();
+        result.Value.RejectedLineCount.ShouldBe(150);
+        result.Value.Warnings.Count.ShouldBe(101);
+        result.Value.Warnings[^1].ShouldContain("and 50 more rejected lines");
+    }
+
+    [Theory]
+    [InlineData("100||200||Content||1-x||NULL||1", "args_order")]
+    [InlineData("100||200||Content||NULL||1-x||1", "args_id")]
+    [InlineData("100||200||Content||1--2||NULL||1", "args_order")]
+    [InlineData("100||200||Content||ONE||NULL||1", "args_order")]
+    [InlineData("100||200||Content|| 1-2||NULL||1", "args_order")]
+    [InlineData("100||200||Content||99999999999||NULL||1", "args_order")]
+    public void ParseLine_MalformedArgsColumn_ShouldFailInsteadOfSwallowingIt(string line, string column)
+    {
+        // Act — a bare catch used to turn an unparsable args column into null, so a fragment with
+        // reordered arguments was patched without its ordering and nobody was told (#597).
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translation.ParseError");
+        result.Error.Message.ShouldContain(column);
+    }
+
+    [Theory]
+    [InlineData("NULL")]
+    [InlineData("null")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseLine_AbsentArgsColumn_ShouldParseAsNoArguments(string absent)
+    {
+        // Act — every spelling of "this row carries no argument order" stays a success.
+        Result<Translation> result = _parser.ParseLine($"100||200||Content||{absent}||{absent}||1");
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ArgsOrder.ShouldBeNull();
+        result.Value.ArgsId.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("abc|")]
+    [InlineData("abc||")]
+    [InlineData("abc|||")]
+    [InlineData("|")]
+    [InlineData("||")]
+    [InlineData("|||")]
+    [InlineData("|abc|")]
+    [InlineData("a|b|")]
+    public void ParseLine_ContentEndingInPipes_ShouldKeepEveryPipeAndLeaveTheArgsColumnsClean(string content)
+    {
+        // Arrange — the boundary is found by scanning backward (ADR-0042), so the last two pipes of
+        // a run are the separator and everything before them stays content. Split resolved this
+        // greedily left to right and lost the last pipe into the args column (#597).
+        string line = $"620756992||1001||{content}||1-2||3-4||1";
+
+        // Act
+        Result<Translation> result = _parser.ParseLine(line);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Content.ShouldBe(content);
+        result.Value.ArgsOrder.ShouldBe(new[] { 0, 1 });
+        result.Value.ArgsId.ShouldBe(new[] { 2, 3 });
     }
 }

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationLineCarverTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Parsers/TranslationLineCarverTests.cs
@@ -1,0 +1,90 @@
+using LotroKoniecDev.Application.Parsers;
+
+namespace LotroKoniecDev.Tests.Unit.Tests.Parsers;
+
+/// <summary>
+/// The patcher's copy of the field-boundary rule (ADR-0042). Its twin lives in the TMS suite over
+/// the TMS' own copy, and <c>ParserContractParityTests</c> pins the two against each other — the
+/// contexts share the file, never code, so nothing else stops one copy from drifting.
+/// </summary>
+public sealed class TranslationLineCarverTests
+{
+    [Theory]
+    [InlineData("abc|")]
+    [InlineData("abc||")]
+    [InlineData("abc|||")]
+    [InlineData("|")]
+    [InlineData("||")]
+    [InlineData("|||")]
+    [InlineData("|abc|")]
+    [InlineData("")]
+    public void TryCarve_ContentEndingInPipesWithEmptyArgsColumns_ShouldStillEndContentAtTheRightPipe(string content)
+    {
+        // Arrange — THE case the backward pass slices for. With empty args columns the separator
+        // pairs sit adjacent, so a search bound that let a match straddle the slice edge would take
+        // the wrong pair and drag pipes out of the content. Every other test uses NULL args, which
+        // pads the columns apart and hides the bug entirely.
+        string line = $"620756992||1001||{content}||||||1";
+
+        // Act
+        bool carved = TranslationLineCarver.TryCarve(line, out CarvedTranslationLine? fields);
+
+        // Assert
+        carved.ShouldBeTrue();
+        fields!.Content.ShouldBe(content);
+        fields.ArgsOrder.ShouldBe(string.Empty);
+        fields.ArgsId.ShouldBe(string.Empty);
+        fields.Approved.ShouldBe("1");
+    }
+
+    [Theory]
+    [InlineData("620756992||1001||Witaj||NULL||NULL||1", "620756992", "1001", "Witaj", "NULL", "NULL", "1")]
+    [InlineData("1||2||||NULL||NULL||1", "1", "2", "", "NULL", "NULL", "1")]
+    [InlineData("1||2||a||b||1-2||3-4||0", "1", "2", "a||b", "1-2", "3-4", "0")]
+    [InlineData("1||2|||leading||NULL||NULL||1", "1", "2", "|leading", "NULL", "NULL", "1")]
+    [InlineData("1||2||trailing|||NULL||NULL||1", "1", "2", "trailing|", "NULL", "NULL", "1")]
+    [InlineData("1||2|||||NULL||NULL||1", "1", "2", "|", "NULL", "NULL", "1")]
+    public void TryCarve_WellFormedLine_ShouldCarveEveryFieldVerbatim(
+        string line, string fileId, string gossipId, string content, string argsOrder, string argsId, string approved)
+    {
+        // Act — the carver parses nothing and unescapes nothing; it only finds boundaries.
+        bool carved = TranslationLineCarver.TryCarve(line, out CarvedTranslationLine? fields);
+
+        // Assert
+        carved.ShouldBeTrue();
+        fields!.FileId.ShouldBe(fileId);
+        fields.GossipId.ShouldBe(gossipId);
+        fields.Content.ShouldBe(content);
+        fields.ArgsOrder.ShouldBe(argsOrder);
+        fields.ArgsId.ShouldBe(argsId);
+        fields.Approved.ShouldBe(approved);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("garbage")]
+    [InlineData("100")]
+    [InlineData("100||200")]
+    [InlineData("100||200||content")]
+    [InlineData("100||200||content||NULL")]
+    [InlineData("100||200||content||NULL||NULL")]
+    [InlineData("|||||||||")]
+    public void TryCarve_LineWithoutFiveSeparatorsOutsideTheContent_ShouldRefuseToCarve(string line)
+    {
+        // Act — the two passes must not cross. A run of nine pipes carries four separators, one
+        // short, and the backward pass would otherwise reach behind the gossip id separator.
+        bool carved = TranslationLineCarver.TryCarve(line, out CarvedTranslationLine? fields);
+
+        // Assert
+        carved.ShouldBeFalse();
+        fields.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCarve_NullLine_ShouldThrow()
+    {
+        // Act & Assert — a null line is a programmer error, not a malformed file (house rule:
+        // guards are for programmer errors, Results are for business failures).
+        Should.Throw<ArgumentNullException>(() => TranslationLineCarver.TryCarve(null!, out _));
+    }
+}

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/CoreLoop/CoreLoopTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/CoreLoop/CoreLoopTests.cs
@@ -87,7 +87,7 @@ public sealed class CoreLoopTests : IAsyncLifetime
         try
         {
             IReadOnlyList<LotroKoniecDev.Domain.Models.Translation> parsed =
-                new TranslationFileParser().ParseFile(tempFile).Value;
+                new TranslationFileParser().ParseFile(tempFile).Value.Translations;
 
             LotroKoniecDev.Domain.Models.Translation only = parsed.ShouldHaveSingleItem();
             only.FileId.ShouldBe(FileId);
@@ -193,7 +193,7 @@ public sealed class CoreLoopTests : IAsyncLifetime
         try
         {
             IReadOnlyList<LotroKoniecDev.Domain.Models.Translation> parsed =
-                new TranslationFileParser().ParseFile(tempFile).Value;
+                new TranslationFileParser().ParseFile(tempFile).Value.Translations;
 
             parsed.Count.ShouldBe(2);
             parsed[0].Content.ShouldBe(multiLinePolish);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/TranslationFiles/GetTranslationFileTests.cs
@@ -286,7 +286,7 @@ public sealed class GetTranslationFileTests : IAsyncLifetime
         try
         {
             IReadOnlyList<LotroKoniecDev.Domain.Models.Translation> parsed =
-                new TranslationFileParser().ParseFile(tempFile).Value;
+                new TranslationFileParser().ParseFile(tempFile).Value.Translations;
 
             // Assert — both rows round-trip: args preserved, || anchoring preserved, all approved.
             parsed.Count.ShouldBe(2);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/TestData/exported-sample.txt
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/TestData/exported-sample.txt
@@ -1,5 +1,7 @@
 # Golden fixture mirroring the patcher's || contract. Guards both contexts against format drift.
 # Rows 1006-1007 carry the ADR-0039 escape: \n / \r fold a real newline, \\ folds a real backslash.
+# Rows 1008-1009 end in an odd run of | — the separator is NOT escaped, the boundary is found by
+# scanning backward, so the last two pipes of the run are the separator (ADR-0042).
 620756992||1001||Witaj w Srodziemiu!||NULL||NULL||1
 620756992||1002||Tekst z <--DO_NOT_TOUCH!--> argumentem||1||1||1
 620756992||1003||Line with || inside the content||NULL||NULL||1
@@ -8,3 +10,5 @@
 620756992||1005||Trailing approved zero||NULL||NULL||0
 620756992||1006||Wiersz jeden\nWiersz dwa\r\nWiersz trzy||NULL||NULL||1
 620756992||1007||Sciezka C:\\notes i sekwencja \\n||NULL||NULL||1
+620756992||1008||Koniec rury|||NULL||NULL||1
+620756992||1009||Trzy rury|||||1-2||3-4||1

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/ParserContractParityTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/ParserContractParityTests.cs
@@ -2,7 +2,11 @@ using System.Text;
 using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.Tests.Shared;
 using LotroKoniecDev.TranslationSystem.API.Parsing;
+using PatcherCarvedLine = LotroKoniecDev.Application.Parsers.CarvedTranslationLine;
+using PatcherCarver = LotroKoniecDev.Application.Parsers.TranslationLineCarver;
 using PatcherEscaper = LotroKoniecDev.Application.Parsers.TranslationLineEscaper;
+using TmsCarvedLine = LotroKoniecDev.TranslationSystem.API.Parsing.CarvedTranslationLine;
+using TmsCarver = LotroKoniecDev.TranslationSystem.API.Parsing.TranslationLineCarver;
 using TmsEscaper = LotroKoniecDev.TranslationSystem.API.Parsing.TranslationLineEscaper;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
@@ -17,6 +21,8 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
 /// </summary>
 public sealed class ParserContractParityTests
 {
+    private const string AbsentArgs = "NULL";
+
     [Theory]
     [InlineData("620756992||1001||Witaj w Srodziemiu!||NULL||NULL||1")]
     [InlineData("620756992||1002||Tekst z <--DO_NOT_TOUCH!--> argumentem||1||1||1")]
@@ -25,6 +31,11 @@ public sealed class ParserContractParityTests
     [InlineData("620756992||1005||Trailing approved zero||NULL||NULL||0")]
     [InlineData("100||200||leading||||NULL||NULL||1")]
     [InlineData("100||200||||trailing||NULL||NULL||1")]
+    [InlineData("100||200||trailing pipe|||NULL||NULL||1")]
+    [InlineData("100||200||three trailing pipes|||||1-2||3-4||1")]
+    [InlineData("100||200|||||NULL||NULL||1")]
+    [InlineData("100||200||trailing pipe|||||||1")]
+    [InlineData("100||200||||||||1")]
     public async Task BothParsers_OnTheSameContractLine_ShouldAgreeOnEveryField(string line)
     {
         // Arrange — the patcher parser is per-line; the TMS parser is per-stream.
@@ -39,8 +50,8 @@ public sealed class ParserContractParityTests
         ((long)patcher.GossipId).ShouldBe(tms.GossipId);
         patcher.Content.ShouldBe(tms.Content);
         patcher.IsApproved.ShouldBe(tms.Approved);
-        ReconstructArgs(patcher.ArgsOrder).ShouldBe(tms.ArgsOrder);
-        ReconstructArgs(patcher.ArgsId).ShouldBe(tms.ArgsId);
+        ReconstructArgs(patcher.ArgsOrder).ShouldBe(NormalizeArgs(tms.ArgsOrder));
+        ReconstructArgs(patcher.ArgsId).ShouldBe(NormalizeArgs(tms.ArgsId));
     }
 
     [Theory]
@@ -63,8 +74,8 @@ public sealed class ParserContractParityTests
         ((long)patcher.GossipId).ShouldBe(tms.GossipId);
         patcher.Content.ShouldBe(tms.Content);
         patcher.IsApproved.ShouldBe(tms.Approved);
-        ReconstructArgs(patcher.ArgsOrder).ShouldBe(tms.ArgsOrder);
-        ReconstructArgs(patcher.ArgsId).ShouldBe(tms.ArgsId);
+        ReconstructArgs(patcher.ArgsOrder).ShouldBe(NormalizeArgs(tms.ArgsOrder));
+        ReconstructArgs(patcher.ArgsId).ShouldBe(NormalizeArgs(tms.ArgsId));
     }
 
     [Theory]
@@ -124,6 +135,66 @@ public sealed class ParserContractParityTests
     }
 
     [Theory]
+    [MemberData(nameof(NaughtyStringCases.DelimiterHazards), MemberType = typeof(NaughtyStringCases))]
+    public void BothCarvers_OnTheSameLine_ShouldFindIdenticalFieldBoundaries(string naughty)
+    {
+        // Arrange — the second duplicated-by-design rule (ADR-0042), guarded the same way the escape
+        // is: the content is followed by a raw trailing pipe, the exact collision #597 was about.
+        string line = $"620756992||1001||{naughty}|||1-2||3-4||1";
+
+        // Act
+        PatcherCarver.TryCarve(line, out PatcherCarvedLine? patcher).ShouldBeTrue();
+        TmsCarver.TryCarve(line, out TmsCarvedLine? tms).ShouldBeTrue();
+
+        // Assert
+        patcher!.FileId.ShouldBe(tms!.FileId);
+        patcher.GossipId.ShouldBe(tms.GossipId);
+        patcher.Content.ShouldBe(tms.Content);
+        patcher.ArgsOrder.ShouldBe(tms.ArgsOrder);
+        patcher.ArgsId.ShouldBe(tms.ArgsId);
+        patcher.Approved.ShouldBe(tms.Approved);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.DelimiterHazards), MemberType = typeof(NaughtyStringCases))]
+    public void BothCarvers_OnALineWithEmptyArgsColumns_ShouldFindIdenticalFieldBoundaries(string naughty)
+    {
+        // Arrange — the harder half: EMPTY args columns put the separator pairs next to each other,
+        // so a copy whose backward search let a match straddle its slice edge would take the wrong
+        // pair. With NULL args that mistake is invisible, which is why it needs its own theory.
+        string line = $"620756992||1001||{naughty}||||||1";
+
+        // Act
+        PatcherCarver.TryCarve(line, out PatcherCarvedLine? patcher).ShouldBeTrue();
+        TmsCarver.TryCarve(line, out TmsCarvedLine? tms).ShouldBeTrue();
+
+        // Assert
+        patcher!.FileId.ShouldBe(tms!.FileId);
+        patcher.GossipId.ShouldBe(tms.GossipId);
+        patcher.Content.ShouldBe(tms.Content);
+        patcher.ArgsOrder.ShouldBe(tms.ArgsOrder);
+        patcher.ArgsId.ShouldBe(tms.ArgsId);
+        patcher.Approved.ShouldBe(tms.Approved);
+    }
+
+    [Theory]
+    [InlineData("620756992||1001||Content||1-x||NULL||1")]
+    [InlineData("620756992||1001||Content||NULL||1-x||1")]
+    [InlineData("620756992||1001||Content||1--2||NULL||1")]
+    [InlineData("620756992||1001||Content||ONE||NULL||1")]
+    public async Task BothParsers_OnAMalformedArgsColumn_ShouldRejectTheLine(string line)
+    {
+        // A column that is neither NULL nor "1-2-3" is a malformed row on BOTH sides (ADR-0042).
+        // One side swallowing it while the other stores it verbatim is exactly the divergence #597
+        // produced once content leaked into the args boundary.
+        new TranslationFileParser().ParseLine(line).IsFailure.ShouldBeTrue();
+
+        ParsedExport tmsExport = await ParseAsync(line);
+        tmsExport.Rows.ShouldBeEmpty();
+        tmsExport.Errors.ShouldHaveSingleItem();
+    }
+
+    [Theory]
     [MemberData(nameof(NaughtyStringCases.All), MemberType = typeof(NaughtyStringCases))]
     public async Task PatcherExporterEscape_ThenTmsImportParse_ShouldRecoverTheOriginal(string naughty)
     {
@@ -170,5 +241,16 @@ public sealed class ParserContractParityTests
 
     /// <summary>Rebuilds the verbatim args string the TMS keeps from the patcher's 0-indexed int array.</summary>
     private static string ReconstructArgs(int[]? args)
-        => args is null ? "NULL" : string.Join('-', args.Select(value => value + 1));
+        => args is null ? AbsentArgs : string.Join('-', args.Select(value => value + 1));
+
+    /// <summary>
+    /// The patcher collapses every spelling of "no arguments" to a null array, while the TMS keeps
+    /// the column's file form. Comparing the raw strings would therefore make an EMPTY args column
+    /// permanently inexpressible here — and an empty column next to a trailing pipe is exactly the
+    /// boundary the backward pass slices for (ADR-0042), so the guard has to reach it.
+    /// </summary>
+    private static string NormalizeArgs(string args)
+        => string.IsNullOrWhiteSpace(args) || args.Equals(AbsentArgs, StringComparison.OrdinalIgnoreCase)
+            ? AbsentArgs
+            : args;
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationExportParserTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationExportParserTests.cs
@@ -30,9 +30,9 @@ public sealed class TranslationExportParserTests
         // Act
         ParsedExport result = await ParseFixtureAsync("exported-sample.txt");
 
-        // Assert — the comments and the blank line are skipped, seven rows remain.
+        // Assert — the comments and the blank line are skipped, nine rows remain.
         result.HasErrors.ShouldBeFalse();
-        result.Rows.Count.ShouldBe(7);
+        result.Rows.Count.ShouldBe(9);
         result.Rows[0].FileId.ShouldBe(620756992);
         result.Rows[0].GossipId.ShouldBe(1001);
         result.Rows[0].Content.ShouldBe("Witaj w Srodziemiu!");
@@ -51,6 +51,24 @@ public sealed class TranslationExportParserTests
             .ShouldBe("Wiersz jeden\nWiersz dwa\r\nWiersz trzy");
         result.Rows.Single(row => row.GossipId == 1007).Content
             .ShouldBe(@"Sciezka C:\notes i sekwencja \n");
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithGoldenFixture_ShouldKeepTrailingPipesOutOfTheArgsColumns()
+    {
+        // Act
+        ParsedExport result = await ParseFixtureAsync("exported-sample.txt");
+
+        // Assert — the separator is not escaped; the boundary is recovered by scanning backward, so
+        // the run's last two pipes are the separator and every earlier one is content (ADR-0042).
+        ParsedExportRow singlePipe = result.Rows.Single(row => row.GossipId == 1008);
+        singlePipe.Content.ShouldBe("Koniec rury|");
+        singlePipe.ArgsOrder.ShouldBe("NULL");
+
+        ParsedExportRow triplePipe = result.Rows.Single(row => row.GossipId == 1009);
+        triplePipe.Content.ShouldBe("Trzy rury|||");
+        triplePipe.ArgsOrder.ShouldBe("1-2");
+        triplePipe.ArgsId.ShouldBe("3-4");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileNaughtyStringTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationFileNaughtyStringTests.cs
@@ -130,26 +130,67 @@ public sealed class TranslationFileNaughtyStringTests
     }
 
     [Theory]
-    [InlineData("abc|", "abc")]
-    [InlineData("abc|||", "abc||")]
-    [InlineData("|", "")]
-    [InlineData("|||", "||")]
-    public async Task SerializeThenParse_ContentEndingInAnOddNumberOfPipes_ShouldLoseTheLastPipe(string content, string expectedLossyContent)
+    [InlineData("abc|")]
+    [InlineData("abc||")]
+    [InlineData("abc|||")]
+    [InlineData("|")]
+    [InlineData("||")]
+    [InlineData("|||")]
+    public async Task SerializeThenParse_ContentEndingInAnOddNumberOfPipes_ShouldRoundTripExactly(string content)
     {
-        // Arrange — DOCUMENTED CURRENT BEHAVIOR, not an endorsement, and identical to the patcher's
-        // (the two parsers agree here, which is exactly why the parity guard cannot see it). Split
-        // is greedy left to right, so a trailing pipe merges with the separator that follows it: the
-        // pipe is swallowed and reappears glued to the args column. No entry of the naughty list
-        // ends in an odd pipe run, so this collision has to be composed by hand. Tracked as #597.
-        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, content, null, null)]);
+        // Arrange — the trailing boundary is found by scanning BACKWARD (ADR-0042), so the last two
+        // pipes of a run are the separator and every earlier one stays content. Split resolved the
+        // boundary greedily left to right, so the last pipe was swallowed and reappeared glued to
+        // the args column — identically in both parsers, which is exactly why the parity guard could
+        // not see it (#597). No entry of the naughty list ends in an odd pipe run, so this collision
+        // has to be composed by hand.
+        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, content, "1-2", "3-4")]);
 
         // Act
         ParsedExport parsed = await ParseAsync(file);
 
         // Assert
+        parsed.Errors.ShouldBeEmpty();
         ParsedExportRow row = parsed.Rows.ShouldHaveSingleItem();
-        row.Content.ShouldBe(expectedLossyContent);
-        row.ArgsOrder.ShouldBe("|NULL"); // the swallowed pipe, now polluting the args column
+        row.Content.ShouldBe(content);
+        row.ArgsOrder.ShouldBe("1-2");
+        row.ArgsId.ShouldBe("3-4");
+    }
+
+    [Theory]
+    [InlineData("620756992||1001||Content||1-x||NULL||1", "args_order")]
+    [InlineData("620756992||1001||Content||NULL||1-x||1", "args_id")]
+    [InlineData("620756992||1001||Content||1--2||NULL||1", "args_order")]
+    [InlineData("620756992||1001||Content||ONE||NULL||1", "args_order")]
+    public async Task ParseAsync_MalformedArgsColumn_ShouldRejectTheRowInsteadOfStoringItVerbatim(string line, string column)
+    {
+        // Act — a value that is neither NULL nor "1-2-3" used to be stored as-is, where it was
+        // unusable as an order and still took part in the import diff (#597, spec 0001).
+        ParsedExport parsed = await ParseAsync($"{line}\r\n");
+
+        // Assert
+        parsed.Rows.ShouldBeEmpty();
+        parsed.Errors.ShouldHaveSingleItem().Message.ShouldContain(column);
+    }
+
+    [Theory]
+    [MemberData(nameof(NaughtyStringCases.PipeRuns), MemberType = typeof(NaughtyStringCases))]
+    public async Task SerializeThenParse_EveryPipeRunUpToSixCharacters_ShouldRoundTripExactly(string content)
+    {
+        // Arrange — exhaustive over the alphabet this format is weakest at, in BOTH parities: the
+        // run can sit at the leading boundary, the trailing one, or both at once. The hand-picked
+        // cases above only sample it.
+        string file = _serializer.Serialize([new ArtifactRow(620756992, 1001, content, "1-2", "3-4")]);
+
+        // Act
+        ParsedExport parsed = await ParseAsync(file);
+
+        // Assert
+        parsed.Errors.ShouldBeEmpty();
+        ParsedExportRow row = parsed.Rows.ShouldHaveSingleItem();
+        row.Content.ShouldBe(content);
+        row.ArgsOrder.ShouldBe("1-2");
+        row.ArgsId.ShouldBe("3-4");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationLineCarverTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Parsing/TranslationLineCarverTests.cs
@@ -1,0 +1,90 @@
+using LotroKoniecDev.TranslationSystem.API.Parsing;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Parsing;
+
+/// <summary>
+/// The TMS' copy of the field-boundary rule (ADR-0042). Its twin lives in the patcher suite over the
+/// patcher's own copy, and <c>ParserContractParityTests</c> pins the two against each other — the
+/// contexts share the file, never code, so nothing else stops one copy from drifting.
+/// </summary>
+public sealed class TranslationLineCarverTests
+{
+    [Theory]
+    [InlineData("abc|")]
+    [InlineData("abc||")]
+    [InlineData("abc|||")]
+    [InlineData("|")]
+    [InlineData("||")]
+    [InlineData("|||")]
+    [InlineData("|abc|")]
+    [InlineData("")]
+    public void TryCarve_ContentEndingInPipesWithEmptyArgsColumns_ShouldStillEndContentAtTheRightPipe(string content)
+    {
+        // Arrange — THE case the backward pass slices for. With empty args columns the separator
+        // pairs sit adjacent, so a search bound that let a match straddle the slice edge would take
+        // the wrong pair and drag pipes out of the content. Every other test uses NULL args, which
+        // pads the columns apart and hides the bug entirely.
+        string line = $"620756992||1001||{content}||||||1";
+
+        // Act
+        bool carved = TranslationLineCarver.TryCarve(line, out CarvedTranslationLine? fields);
+
+        // Assert
+        carved.ShouldBeTrue();
+        fields!.Content.ShouldBe(content);
+        fields.ArgsOrder.ShouldBe(string.Empty);
+        fields.ArgsId.ShouldBe(string.Empty);
+        fields.Approved.ShouldBe("1");
+    }
+
+    [Theory]
+    [InlineData("620756992||1001||Witaj||NULL||NULL||1", "620756992", "1001", "Witaj", "NULL", "NULL", "1")]
+    [InlineData("1||2||||NULL||NULL||1", "1", "2", "", "NULL", "NULL", "1")]
+    [InlineData("1||2||a||b||1-2||3-4||0", "1", "2", "a||b", "1-2", "3-4", "0")]
+    [InlineData("1||2|||leading||NULL||NULL||1", "1", "2", "|leading", "NULL", "NULL", "1")]
+    [InlineData("1||2||trailing|||NULL||NULL||1", "1", "2", "trailing|", "NULL", "NULL", "1")]
+    [InlineData("1||2|||||NULL||NULL||1", "1", "2", "|", "NULL", "NULL", "1")]
+    public void TryCarve_WellFormedLine_ShouldCarveEveryFieldVerbatim(
+        string line, string fileId, string gossipId, string content, string argsOrder, string argsId, string approved)
+    {
+        // Act — the carver parses nothing and unescapes nothing; it only finds boundaries.
+        bool carved = TranslationLineCarver.TryCarve(line, out CarvedTranslationLine? fields);
+
+        // Assert
+        carved.ShouldBeTrue();
+        fields!.FileId.ShouldBe(fileId);
+        fields.GossipId.ShouldBe(gossipId);
+        fields.Content.ShouldBe(content);
+        fields.ArgsOrder.ShouldBe(argsOrder);
+        fields.ArgsId.ShouldBe(argsId);
+        fields.Approved.ShouldBe(approved);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("garbage")]
+    [InlineData("100")]
+    [InlineData("100||200")]
+    [InlineData("100||200||content")]
+    [InlineData("100||200||content||NULL")]
+    [InlineData("100||200||content||NULL||NULL")]
+    [InlineData("|||||||||")]
+    public void TryCarve_LineWithoutFiveSeparatorsOutsideTheContent_ShouldRefuseToCarve(string line)
+    {
+        // Act — the two passes must not cross. A run of nine pipes carries four separators, one
+        // short, and the backward pass would otherwise reach behind the gossip id separator.
+        bool carved = TranslationLineCarver.TryCarve(line, out CarvedTranslationLine? fields);
+
+        // Assert
+        carved.ShouldBeFalse();
+        fields.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCarve_NullLine_ShouldThrow()
+    {
+        // Act & Assert — a null line is a programmer error, not a malformed file (house rule:
+        // guards are for programmer errors, Results are for business failures).
+        Should.Throw<ArgumentNullException>(() => TranslationLineCarver.TryCarve(null!, out _));
+    }
+}

--- a/tests/Shared/NaughtyStringCases.cs
+++ b/tests/Shared/NaughtyStringCases.cs
@@ -77,6 +77,39 @@ internal static class NaughtyStringCases
     ]);
 
     /// <summary>
+    /// Every string over the alphabet <c>{'a', '|'}</c> up to six characters — 127 entries covering
+    /// every pipe run the <c>||</c> contract can meet at either content boundary, in both parities,
+    /// including the empty string. The naughty corpus deliberately carries none of these (no entry
+    /// ends in an odd run of <c>|</c>), and hand-picked cases only sample the hazard: an odd
+    /// trailing run silently lost its last pipe into the args column for the life of the format
+    /// (#597, fixed by ADR-0042). Exhaustive is cheap here and pins the carving against a future
+    /// "simplification" back to <c>string.Split</c>.
+    /// </summary>
+    public static TheoryData<string> PipeRuns => ToTheoryData(BuildPipeRuns(maxLength: 6));
+
+    private static IEnumerable<string> BuildPipeRuns(int maxLength)
+    {
+        List<string> combinations = [string.Empty];
+        List<string> previousLength = [string.Empty];
+
+        for (int length = 1; length <= maxLength; length++)
+        {
+            List<string> currentLength = new(previousLength.Count * 2);
+
+            foreach (string prefix in previousLength)
+            {
+                currentLength.Add(prefix + 'a');
+                currentLength.Add(prefix + '|');
+            }
+
+            combinations.AddRange(currentLength);
+            previousLength = currentLength;
+        }
+
+        return combinations;
+    }
+
+    /// <summary>
     /// Digits a human reads as a number but <see cref="int.TryParse(string, out int)"/> does not —
     /// fullwidth, Arabic-Indic and other non-ASCII numerals. Aimed at the two id columns of the
     /// <c>||</c> contract, which must reject them rather than mis-parse them into a wrong fragment.


### PR DESCRIPTION
Closes #597

## What was wrong

Both parsers of the `||` contract claimed to "anchor from both ends", but did it with
`line.Split("||")` and then `parts[2..^3]`. `Split` resolves **every** boundary greedily left to
right, *before* the anchoring, so a trailing `|` in content merged with the separator that follows
it and the content boundary landed one character early. `abc|` was written as
`620756992||1001||abc|||NULL||NULL||1` and read back as content `abc` with `args_order = "|NULL"`.

The corrupted args column then diverged between the contexts: the patcher's
`catch { return null; }` dropped the argument ordering silently, while the TMS stored `"|NULL"`
verbatim — neither `null` nor a valid column, and part of the import diff (spec 0001).

Reachable end to end: a translator types a trailing pipe → the artifact is written → the CLI
downloads it → the wrong text is patched into the DAT, with nobody warned. Both parsers were wrong
*identically*, which is exactly why `ParserContractParityTests` could not see it.

## The fix — ADR-0042

**The separator stays unescaped.** Only content can contain a `|` (ids are integers, args are
`NULL`/`1-2-3`, approved is `0`/`1`), so at a boundary a run of pipes is always `content_pipes + 2`
and the separator is the run's first two characters going forward, its last two going backward.
Both boundaries are recoverable by construction — the bytes always carried the answer, the parsers
threw it away. Escaping it (the other option in the ticket) would break every existing
`exported.txt` and `polish.txt` and force a CLI/TMS version gate, to encode information the line
already holds; ADR-0039 declined it for the same reason and deferred this defect explicitly.

Each context now carves the line with its own `TranslationLineCarver` — forward `IndexOf` for the
two id separators, backward `LastIndexOf` over a **bounded slice** for the three trailing ones.
Slicing before searching is what makes the backward pass exact.

**A malformed args column rejects its row and is reported.** Applying Polish text with the wrong
argument order renders placeholders in the wrong slots — a silent in-game defect — while a rejected
row leaves English in place and says so. Range and arity stay downstream in
`Fragment.TryReorderArgRefs`, the only place that knows how many argument references exist.

**`ParseFile` returns its warnings.** Without this the fix would only *move* the silence: the whole
translation would vanish instead of just its args. They now reach `PatchSummaryResponse.Warnings`
(printed by `patch`), the launch strategy's log, and — when every line was rejected — the
`NoTranslations` error itself, since the CLI prints the warning list only on success. The list is
capped at 100 like the import's; the rejected count stays exact.

## Why this is safe

No format change, so no migration, no re-export, no CLI/TMS version skew — ADR-0039 had to accept
two skew edges, this has none. Existing files keep parsing, and start parsing *better*. Already
corrupted TMS rows (`ArgsOrder = "|NULL"`) self-heal on the next serialize→parse, because the
corruption was purely positional.

Verified empirically rather than by inspection:

- exhaustive round trip over every content in `{a,'|'}^≤9` × args/approved combinations — **0
  mis-carves**
- strictly-widening check over 300k structured lines — **0 cases where the old `Split` was right
  and the new carving is wrong**
- exception fuzz over 2M random strings incl. lone surrogates — **0 throws**
- real data (`data/exported.txt`, 792,501 rows; `translations/polish.txt`; the knowledge-base
  captures) — **0 rows newly rejected, 0 carve/split disagreements**

## Tests

The two pinning tests flip to exact round trips. New coverage:

- **`PipeRuns`**, a shared theory source — every string over `{'a','|'}` up to six characters (127,
  including empty), driven through both contexts' writer/reader pairs. The naughty corpus carries
  none of these on purpose.
- **`TranslationLineCarverTests`**, one per context (mirroring the twin escaper suites), covering
  the reject branches and — the point — content ending in a pipe next to **empty** args columns.
  That is the only shape where the slice bound matters; with `NULL` args the columns are padded
  apart and a wrong bound still carves correctly. Confirmed by mutation: widening either bound by
  one now turns **335 tests red**, and left every suite green before this PR.
- The parity guard could not express an empty args column at all (the patcher collapses "absent" to
  null, the TMS keeps the file form); normalizing the comparison lets it reach that boundary.
- Golden fixture gains rows 1008/1009, driven through both parsers by the parity suite.

Green: build 0 warnings · patcher unit 3985 · TMS unit 5087 · domain 3511 · architecture 21 ·
frontend 484 · auth 154 · sharedkernel 69 · logging 36 · TMS integration (real PostgreSQL) 231 ·
all four CI guard scripts.

## Known follow-up, deliberately not in this PR

Two **pre-existing** divergences between the parsers, surfaced by review and out of #597's scope
(fixing them means choosing which side wins, which is its own decision):

- gossip id is `ulong` in the patcher, `long` in the TMS — a negative id is accepted by exactly one
  side
- the approved column is `== "1"` in the patcher, `.Trim() == "1"` in the TMS — a trailing space
  un-approves a row on one side and approves it on the other

Happy to file these as a ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3R4Cew6w6tfHQ8GqnCoR
