### PR TITLE
Bug: unbounded TranslatedText can crash the patcher mid-write and leave a partially patched DAT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,13 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
   own `TranslationLineEscaper`. Text held anywhere else — in the DAT, in `TranslationSource.Text`, in
   `TranslatedText` — is always the RAW form; the escape exists only between `Serialize` and `Parse`.
   A sequence no writer can produce (`\t`, a trailing lone `\`) reads back verbatim.
+- **Content is bounded by the DAT, not by the file (ADR-0043).** A text piece is written behind a
+  2-byte VarLen prefix, so it cannot exceed **32767 UTF-16 code units**. The TMS refuses a longer
+  `TranslatedText` at the API (`UpsertTranslation.Validator` + a `CHECK` constraint — never a
+  `varchar(n)` narrowing, which would rewrite the ~780k-row table under `ACCESS EXCLUSIVE`); the
+  patcher warn-skips such a row **before** it loads or mutates a subfile
+  (`Fragment.IsWritablePiece`). `Fragment.Write` still throws — deliberately, as the last resort —
+  and `PatchingService` never catches mid-write.
 - **The `||` separator is deliberately NOT escaped — the line is CARVED, never `Split` (ADR-0042).**
   Each context's `TranslationLineCarver` scans **forward** for the two id separators and **backward**
   for the three trailing ones (slicing before each backward search), so content may contain `||` and

--- a/docs/adr/0043-over-long-content-is-refused-at-the-boundaries-not-caught-mid-write.md
+++ b/docs/adr/0043-over-long-content-is-refused-at-the-boundaries-not-caught-mid-write.md
@@ -1,0 +1,160 @@
+# ADR-0043: Over-long content is refused at both boundaries, never caught mid-write
+
+**Status:** Accepted
+**Date:** 2026-08-06
+**Decision-makers:** Solo maintainer
+**Related:** #598 (the defect), #569 (the hostile-string coverage that found it), ADR-0023 (forward-only, N-1-compatible migrations), ADR-0042 (the sibling parser defect), CLAUDE.md "Translation file format — THE inter-context contract", `PatchingService`, `Fragment`, `UpsertTranslation`
+
+## Context
+
+A fragment's text pieces are written into the DAT behind a variable-length length prefix whose
+two-byte form tops out at `0x7FFF` — 32767 UTF-16 code units. `VarLenEncoder.Write` guards that:
+
+```csharp
+ArgumentOutOfRangeException.ThrowIfGreaterThan(value, MaxTwoByteValue);
+```
+
+Throwing is right. A truncated prefix would desynchronise the reader for **every following fragment
+in the subfile**, so a writer that cannot express the length has no correct output to produce.
+
+Nothing upstream stopped an over-long value from getting there. `UpsertTranslation.Validator` checked
+only `NotEmpty()`, `Translation.ProvideTranslation` stored verbatim, and the column was unbounded
+`text` — so a 40000-character translation was accepted, approved, published into the artifact, and
+became a crash on someone else's machine hours later. `PatchingService.ApplyTranslations` is
+`try { … } finally { Flush; Close }` with no `catch`, and `ApplyPatchCommandHandler` has none either.
+
+Two claims in the defect report needed checking against the code, and one of them was wrong:
+
+- **`patch` does not leave a partially patched DAT.** `PatchCommand` takes a backup before patching
+  and its `catch (Exception)` restores it, returning exit code 3. The DAT is repaired; what the user
+  gets is a stack trace instead of an error message.
+- **`launch` does.** `LaunchCommand` has the same `catch` but **no backup and no restore**, and
+  `SimplifiedGameLaunchingStrategy` calls the same `ApplyTranslations`. Because `PutSubfileData` is
+  called per subfile as the loop advances, every subfile processed before the throw is already
+  committed, and `finally` flushes. That is the path that actually corrupts, and it is the default
+  one users run.
+
+The exposure is real but narrow: the artifact is machine-generated from validated rows, so an
+over-long piece can only arrive through a hand-edited or hostile `polish.txt` — or through the TMS,
+once the missing cap let one in.
+
+## Decision
+
+### 1. The TMS refuses over-long text at the API, and again at the column
+
+`UpsertTranslation.Validator` gains `MaximumLength(DatFormatConstants.MaxTranslatedTextLength)`, so
+the translator gets a 400 while editing instead of the patcher getting an exception. The constant
+lives in `TranslationSystem.Primitives/Constants/`, mirroring where the patcher keeps
+`DatFileConstants` — the two contexts share a data contract, not code, so each states the format
+fact in its own layer.
+
+The TMS caps the **whole text**; the DAT caps a **piece**. That is deliberate. The patcher cuts
+pieces on `<--DO_NOT_TOUCH!-->`, and teaching the TMS that rule would duplicate patcher logic across
+the context boundary for no gain. A whole-text cap is the strictest bound expressible without it and
+can never be wrong in the unsafe direction — a text within 32767 cannot produce a piece above it.
+It is theoretically over-strict for a multi-piece text summing past the limit. Measured on the
+shipped corpus (`data/exported.txt`, 792,500 rows): the longest English source is **5,959**
+characters, the average is **66**, and **zero** rows are above 32767 — so nothing real is within
+5.5× of the cap and the extra strictness costs nothing.
+
+`Translation.ProvideTranslation` gains a matching guard. Like the `ThrowIfNullOrWhiteSpace` beside
+it, this is a **programmer-error assertion, not a per-row validation failure**: the boundary that
+turns it into a message is the validator, and the domain merely refuses to hold a value it knows is
+unusable.
+
+The editor's textareas carry a matching `maxlength` so a translator is stopped while typing rather
+than on submit. It is a nicety, not enforcement — and it is deliberately *not* exact: HTML form
+submission normalizes textarea newlines to CRLF, so a draft of exactly 32767 characters containing
+line breaks arrives one byte longer per break and still earns its 400. That only bites within a
+handful of characters of a cap nothing real comes within 5.5× of, so tightening the client bound to
+compensate would trade a real invariant for a hypothetical one.
+
+### 2. The database backstop is a CHECK constraint, not `varchar(n)`
+
+`HasMaxLength(32767)` was the obvious move and is the wrong one. Narrowing `text` → `varchar(32767)`
+rewrites the whole table and rebuilds its trigram GIN index while holding `ACCESS EXCLUSIVE`.
+`Translations` carries the ~780k-row corpus (spec 0001), and under ADR-0023 the previous revision
+keeps serving throughout every migration — so that lock is exactly the deploy-window outage the ADR
+exists to prevent.
+
+The same guarantee ships as `ADD CONSTRAINT … NOT VALID` followed by a separate `VALIDATE
+CONSTRAINT`: the first takes `ACCESS EXCLUSIVE` only for the catalog write — it reads no rows — and
+the second takes `SHARE UPDATE EXCLUSIVE`, which lets reads and writes through for the scan. No
+rewrite, no index rebuild.
+
+**The two statements must live in two migrations, and that is the whole point.** PostgreSQL holds
+every lock until its transaction commits, and EF applies each migration in one transaction, so
+putting both statements in one file would hold the `ACCESS EXCLUSIVE` from the `ADD` across the
+`VALIDATE` scan — reproducing exactly the lock profile this form exists to avoid. Two migrations are
+two transactions: the lock is released after the declare and reacquired at the weaker level for the
+validate. It also makes the failure mode safe — the NOT VALID constraint is already committed, so it
+binds every new write even if the scan then fails on legacy data, and a re-run retries only the
+validate. (In one migration, a failed `VALIDATE` would roll the `ADD` back with it and leave nothing
+behind.) The scan itself is sub-second at this table size; the split is cheap insurance and, more
+importantly, the only version of this design whose stated properties are actually true.
+
+The bound is PostgreSQL `length()` — code points — while the DAT counts UTF-16 code units, so a text
+made entirely of astral-plane characters could pass the constraint and still be refused above it.
+Accepted: the exact measure belongs in C#, where `string.Length` already *is* that unit, and a
+backstop that over-rejected legitimate Polish would be the worse error.
+
+### 3. The patcher screens each row before it can touch a subfile
+
+`Fragment.IsWritablePiece` states `Write`'s precondition as a predicate. `PatchingService` evaluates
+it per row alongside the existing `not found in DAT` / `not a text file` checks — **before** a
+subfile is loaded, and well before one is mutated — and turns a failure into a warning plus a skip,
+the same shape every other unapplicable row already gets.
+
+Placement is the whole point. Screening before mutation means a bad row costs exactly one row: the
+run continues, the remaining rows apply, and nothing is committed on its account.
+
+### 4. `PatchingService` does not catch, and does not stage the file
+
+The defect report asked whether the service should catch, or stage every modified subfile and commit
+at the end. Both are rejected.
+
+**No catch.** With §3 in place, `Serialize()` is total over anything the parser can produce: pieces
+come either from the DAT — writable by construction, since they were read from a length prefix that
+could express them — or from a screened translation. Argument strings and group counts round-trip
+from the DAT untouched and are bounded the same way. A blanket `catch` would therefore catch nothing
+real, while converting genuine programmer errors into user-facing failures and hiding them from the
+tests. Errors are values here, not exceptions (CLAUDE.md); the invariant is enforced at the one
+mutation point rather than mopped up afterwards.
+
+**No staging.** Buffering every modified subfile to commit at the end would hold a large fraction of
+the game's text corpus in memory to protect against a failure mode §3 removes, and the native DAT
+API offers no transaction to commit into anyway — `PutSubfileData` is the commit. It also would not
+achieve atomicity, only move the partial-write window from "some subfiles" to "the flush".
+
+What remains worth fixing is separate and out of scope here: **`launch` patches without a backup**,
+so any future unhandled failure on that path still leaves a half-patched DAT where `patch` would
+self-repair. A partially patched DAT is recoverable — it is a valid DAT, and a re-patch applies the
+rest (`docs/knowledge-base/`) — but the asymmetry between the two commands is not deliberate.
+
+## Consequences
+
+### Good
+
+- An over-long translation is refused where a human is looking at it, with a validation message,
+  instead of becoming an exception on a player's machine after the artifact ships.
+- One unwritable row in a hand-edited `polish.txt` costs one warning, not the patch run — and the
+  `launch` path can no longer be aborted mid-write by content.
+- Three independent layers (validator, domain guard, CHECK constraint), each meaningful on its own,
+  and none of them a `catch`.
+- The database gains the constraint without a table rewrite, so the migration is N-1 safe under
+  ADR-0023 rather than an outage.
+
+### Neutral
+
+- `Fragment.Write` still throws for an over-long piece. It is now a deliberate last resort behind a
+  public predicate rather than a reachable failure mode, and `FragmentNaughtyStringTests` pins both
+  halves — that the predicate refuses the piece, and that `Write` never degrades to truncation.
+- `PatchingService` computes `GetPieces()` once per row and reuses it at the assignment, so the
+  screen costs no extra split.
+
+### The limit of this fix
+
+The cap is on what the TMS and the patcher will *accept*, not on what the DAT can hold — a fragment
+whose original English already exceeds the ceiling would be unpatchable in Polish too. No such
+fragment exists in the corpus, and one appearing would be a game-side change worth a knowledge-base
+entry rather than a code path.

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
@@ -10,6 +10,7 @@
 @using LotroKoniecDev.TranslationSystem.Contracts.Hateoas
 @using LotroKoniecDev.TranslationSystem.Contracts.Translations
 @using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate
+@using LotroKoniecDev.TranslationSystem.Primitives.Constants
 @inject TranslationEditorLoader Loader
 @inject NavigationManager Navigation
 
@@ -59,6 +60,7 @@
                         <input type="hidden" name="GossipIdField" value="@GossipIdField"/>
                         <label class="visually-hidden" for="translated-recovery">Tłumaczenie polskie</label>
                         <textarea id="translated-recovery" name="DraftField" class="editor-textarea mono" rows="8"
+                                  maxlength="@DatFormatConstants.MaxTranslatedTextLength"
                                   placeholder="Wpisz tłumaczenie…">@_draftText</textarea>
                         <div class="editor-actions" style="margin-top: 12px;">
                             <button type="submit" class="btn btn-primary">Zapisz ponownie</button>
@@ -176,6 +178,7 @@
                             <input type="hidden" name="GossipIdField" value="@detail.GossipId"/>
                             <label class="visually-hidden" for="translated">Tłumaczenie polskie</label>
                             <textarea id="translated" name="DraftField" class="editor-textarea mono" rows="8"
+                                      maxlength="@DatFormatConstants.MaxTranslatedTextLength"
                                       placeholder="Wpisz tłumaczenie…">@(_draftText ?? detail.TranslatedText)</textarea>
                             <div class="editor-actions" style="margin-top: 12px;">
                                 <button type="submit" class="btn btn-primary">Zapisz</button>

--- a/src/Patcher/LotroKoniecDev.Application/Features/Patching/PatchingService.cs
+++ b/src/Patcher/LotroKoniecDev.Application/Features/Patching/PatchingService.cs
@@ -3,6 +3,7 @@ using LotroKoniecDev.Application.Abstractions.DatFilesServices;
 using LotroKoniecDev.Application.Extensions;
 using LotroKoniecDev.Domain.Core.Errors;
 using LotroKoniecDev.Domain.Models;
+using LotroKoniecDev.Primitives.Constants;
 using LotroKoniecDev.Primitives.Enums;
 
 namespace LotroKoniecDev.Application.Features.Patching;
@@ -96,6 +97,21 @@ internal sealed class PatchingService : IPatchingService
                     continue;
                 }
 
+                // Screened here — before a subfile is loaded, and well before one is mutated — because
+                // this is the last point at which an unwritable row is still just a row (#598, ADR-0043).
+                // A hand-edited or hostile file is the only source: the TMS caps the text at the API.
+                string[] pieces = translation.GetPieces();
+
+                if (!pieces.All(Fragment.IsWritablePiece))
+                {
+                    warnings.Add(
+                        $"Fragment {translation.GossipId} in file {translation.FileId} has a text piece of "
+                        + $"{pieces.Max(piece => piece.Length)} characters, above the "
+                        + $"{DatFileConstants.MaxTextPieceLength} the DAT format allows");
+                    skippedCount++;
+                    continue;
+                }
+
                 if (translation.FileId != currentFileId)
                 {
                     if (currentSubFile is not null && currentFileId != -1)
@@ -142,7 +158,7 @@ internal sealed class PatchingService : IPatchingService
                 if (currentSubFile.TryGetFragment(translation.FragmentId, out Fragment? fragment)
                     && fragment is not null)
                 {
-                    fragment.Pieces = translation.GetPieces().ToList();
+                    fragment.Pieces = [.. pieces];
 
                     if (translation.ArgsOrder is not null && fragment.HasArguments)
                     {

--- a/src/Patcher/LotroKoniecDev.Domain/Core/Utilities/VarLenEncoder.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Core/Utilities/VarLenEncoder.cs
@@ -1,3 +1,5 @@
+using LotroKoniecDev.Primitives.Constants;
+
 namespace LotroKoniecDev.Domain.Core.Utilities;
 
 /// <summary>
@@ -9,7 +11,10 @@ public static class VarLenEncoder
     private const int HighBitMask = 0x80;
     private const int LowByteMask = 0xFF;
     private const int MaxSingleByteValue = 0x7F;
-    private const int MaxTwoByteValue = 0x7FFF;
+
+    // One constant with Fragment.IsWritablePiece — a screen that disagreed with the guard it screens
+    // for would re-open #598 by letting an unwritable piece through, or by refusing a writable one.
+    private const int MaxTwoByteValue = DatFileConstants.MaxVarLenValue;
 
     /// <summary>
     /// Reads a variable-length encoded integer from a BinaryReader.

--- a/src/Patcher/LotroKoniecDev.Domain/Models/Fragment.cs
+++ b/src/Patcher/LotroKoniecDev.Domain/Models/Fragment.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using LotroKoniecDev.Domain.Core.Utilities;
+using LotroKoniecDev.Primitives.Constants;
 
 namespace LotroKoniecDev.Domain.Models;
 
@@ -77,9 +78,27 @@ public sealed class Fragment
     }
 
     /// <summary>
+    /// Indicates whether a text piece can be written into the DAT — <see cref="Write"/>'s
+    /// precondition, exposed so callers can screen replacement content instead of discovering the
+    /// limit as an exception halfway through a subfile (#598). Pieces read out of the DAT satisfy
+    /// it by construction; only translated content can violate it.
+    /// </summary>
+    /// <param name="piece">The candidate text piece.</param>
+    public static bool IsWritablePiece(string piece)
+    {
+        ArgumentNullException.ThrowIfNull(piece);
+
+        return piece.Length <= DatFileConstants.MaxTextPieceLength;
+    }
+
+    /// <summary>
     /// Writes the fragment to binary format.
     /// </summary>
     /// <param name="writer">The binary writer to write to.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// When a piece fails <see cref="IsWritablePiece"/>. Deliberate: the variable-length prefix
+    /// cannot express the length, and writing a truncated one would corrupt the whole subfile.
+    /// </exception>
     public void Write(BinaryWriter writer)
     {
         ArgumentNullException.ThrowIfNull(writer);

--- a/src/Patcher/LotroKoniecDev.Primitives/Constants/DatFileConstants.cs
+++ b/src/Patcher/LotroKoniecDev.Primitives/Constants/DatFileConstants.cs
@@ -16,4 +16,18 @@ public static class DatFileConstants
     /// This marker indicates positions where game variables are inserted.
     /// </summary>
     public const string PieceSeparator = "<--DO_NOT_TOUCH!-->";
+
+    /// <summary>
+    /// Largest value the DAT's variable-length integer encoding can express: its two-byte form
+    /// spends one bit on the continuation flag, leaving 15.
+    /// </summary>
+    public const int MaxVarLenValue = 0x7FFF;
+
+    /// <summary>
+    /// Maximum length, in UTF-16 code units, of a single text piece written into the DAT.
+    /// A piece is length-prefixed with <see cref="MaxVarLenValue"/>'s encoding, so it inherits that
+    /// ceiling exactly — and a truncated prefix would desynchronise every following fragment in the
+    /// subfile, so an over-long piece can only ever be refused.
+    /// </summary>
+    public const int MaxTextPieceLength = MaxVarLenValue;
 }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/UpsertTranslation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Translations/UpsertTranslation.cs
@@ -18,6 +18,7 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.ReadDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Constants;
 using Microsoft.EntityFrameworkCore;
 
 namespace LotroKoniecDev.TranslationSystem.API.Features.Translations;
@@ -48,8 +49,12 @@ internal sealed class UpsertTranslation : IEndpoint
             RuleFor(command => command.GossipId)
                 .GreaterThanOrEqualTo(0);
 
+            // The upper bound is a DAT-format fact, not a UX preference: past it the patcher cannot
+            // write the row at all (#598). Rejecting here turns a mid-patch failure on someone
+            // else's machine into a validation error the translator sees while editing.
             RuleFor(command => command.TranslatedText)
-                .NotEmpty();
+                .NotEmpty()
+                .MaximumLength(DatFormatConstants.MaxTranslatedTextLength);
         }
     }
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Entities/Translation.cs
@@ -7,6 +7,7 @@ using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregat
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Constants;
 
 namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Entities;
 
@@ -114,10 +115,15 @@ public sealed class Translation : AggregateRoot<TranslationId>
     /// re-translating an invalidated row keeps the superseded English for side-by-side context until
     /// approve clears it. The text is stored verbatim, preserving its <c>&lt;--DO_NOT_TOUCH!--&gt;</c>
     /// placeholders; the placeholder-count-mismatch warning UX lives in M3.
+    /// Text the DAT cannot hold is refused (#598): like the blank-text guard beside it this is a
+    /// programmer-error assertion, not a per-row validation failure — the boundary that turns it
+    /// into a message for the translator is <c>UpsertTranslation.Validator</c>.
     /// </summary>
     public void ProvideTranslation(string translatedText, TranslatorId submittedBy, DateTimeOffset now)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(translatedText);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            translatedText.Length, DatFormatConstants.MaxTranslatedTextLength, nameof(translatedText));
         Ensure.NotEmpty(submittedBy);
 
         TranslatedText = translatedText;

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Configurations/TranslationConfiguration.cs
@@ -3,6 +3,7 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.En
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.ValueObjects;
 using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslatorAggregate.Entities;
 using LotroKoniecDev.TranslationSystem.Persistence.Consts;
+using LotroKoniecDev.TranslationSystem.Primitives.Constants;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -12,10 +13,22 @@ internal sealed class TranslationConfiguration : IEntityTypeConfiguration<Transl
 {
     private const string ConcurrencyTokenColumn = "xmin";
     private const string ConcurrencyTokenType = "xid";
+    private const string TranslatedTextLengthConstraint = "CK_Translations_TranslatedText_MaxLength";
 
     public void Configure(EntityTypeBuilder<Translation> builder)
     {
-        builder.ToTable("Translations");
+        // The database backstop behind UpsertTranslation.Validator and the ProvideTranslation guard:
+        // past this length the patcher cannot write the row into the DAT at all (#598, ADR-0043).
+        // A CHECK, not the varchar(n) that HasMaxLength would emit: narrowing text -> varchar rewrites
+        // the ~780k-row table and rebuilds its trigram index under ACCESS EXCLUSIVE, which is the
+        // deploy-window outage ADR-0023 exists to prevent. PostgreSQL's length() counts code points
+        // where the DAT counts UTF-16 code units, so this catches gross violations while the exact
+        // measure stays in the C# boundary; SourceText needs no cap at all — it comes out of the DAT
+        // and is within range by construction.
+        builder.ToTable("Translations", table => table.HasCheckConstraint(
+            TranslatedTextLengthConstraint,
+            $"\"{nameof(Translation.TranslatedText)}\" IS NULL "
+            + $"OR length(\"{nameof(Translation.TranslatedText)}\") <= {DatFormatConstants.MaxTranslatedTextLength}"));
 
         // PostgreSQL's xmin system column is a free optimistic-concurrency token (AUDIT-EF-01),
         // mapped as a shadow property exactly as TheKittySaver's AuditableEntityConfiguration does:

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260806081618_CapTranslatedTextToTheDatPieceLimit.Designer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260806081618_CapTranslatedTextToTheDatPieceLimit.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationWriteDbContext))]
-    partial class ApplicationWriteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260806081618_CapTranslatedTextToTheDatPieceLimit")]
+    partial class CapTranslatedTextToTheDatPieceLimit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260806081618_CapTranslatedTextToTheDatPieceLimit.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260806081618_CapTranslatedTextToTheDatPieceLimit.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
+{
+    /// <summary>
+    /// Database backstop for #598 / ADR-0043, step 1 of 2: declares the constraint without scanning.
+    /// <see cref="ValidateTranslatedTextLengthCap"/> validates it in a separate transaction.
+    /// </summary>
+    /// <remarks>
+    /// MIGRATION-SAFETY: acknowledged — this tightens a constraint over existing data, so it ships as
+    /// the two-step PostgreSQL form rather than the DDL EF scaffolds, split across two migrations.
+    ///
+    /// Why not HasMaxLength: varchar(32767) would narrow the column type, and narrowing text ->
+    /// varchar rewrites the whole table and rebuilds its trigram GIN index while holding ACCESS
+    /// EXCLUSIVE. Translations carries the full ~792.5k-row corpus, so that lock is a real
+    /// deploy-window outage — precisely what ADR-0023 forbids, since the previous revision keeps
+    /// serving throughout. ADD CONSTRAINT ... NOT VALID declares the rule without reading a single
+    /// row, so this migration's ACCESS EXCLUSIVE lasts only for the catalog write.
+    ///
+    /// Why the split: PostgreSQL holds every lock until its transaction commits, and EF applies each
+    /// migration in one transaction. Putting the VALIDATE in the same file would therefore hold this
+    /// ACCESS EXCLUSIVE for the whole scan — the exact lock profile the two-step form exists to
+    /// avoid. Two migrations are two transactions, so the lock is released here and reacquired at
+    /// the weaker SHARE UPDATE EXCLUSIVE level by the next one.
+    ///
+    /// N-1 (ADR-0023): the previous revision has no length rule of its own, but the only write it
+    /// loses is one that the current revision would already reject and that the patcher could not
+    /// apply. Measured on the shipped corpus (792,500 rows): longest English source 5,959 characters,
+    /// average 66, zero rows above 32767.
+    /// </remarks>
+    public partial class CapTranslatedTextToTheDatPieceLimit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE translation."Translations"
+                ADD CONSTRAINT "CK_Translations_TranslatedText_MaxLength"
+                CHECK ("TranslatedText" IS NULL OR length("TranslatedText") <= 32767) NOT VALID;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Translations_TranslatedText_MaxLength",
+                schema: "translation",
+                table: "Translations");
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260806084143_ValidateTranslatedTextLengthCap.Designer.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260806084143_ValidateTranslatedTextLengthCap.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationWriteDbContext))]
-    partial class ApplicationWriteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260806084143_ValidateTranslatedTextLengthCap")]
+    partial class ValidateTranslatedTextLengthCap
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260806084143_ValidateTranslatedTextLengthCap.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/Migrations/20260806084143_ValidateTranslatedTextLengthCap.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.TranslationSystem.Persistence.Migrations
+{
+    /// <summary>
+    /// Database backstop for #598 / ADR-0043, step 2 of 2: validates the constraint
+    /// <see cref="CapTranslatedTextToTheDatPieceLimit"/> declared NOT VALID, in its own transaction.
+    /// </summary>
+    /// <remarks>
+    /// MIGRATION-SAFETY: acknowledged — deliberate contract step; the declaring step shipped in the
+    /// migration immediately before this one, in the same release.
+    ///
+    /// VALIDATE CONSTRAINT takes SHARE UPDATE EXCLUSIVE, which lets reads and writes through for the
+    /// scan — the whole reason this is a separate migration rather than a second statement in the
+    /// previous one (see its remarks). No table rewrite and no index rebuild either way.
+    ///
+    /// Failure is safe by construction: the NOT VALID constraint is already committed by the previous
+    /// migration, so it keeps binding every new write even if this scan fails on legacy data, and
+    /// re-running the migrator retries only this step. Offending rows, if any, are found with
+    ///     SELECT "Id" FROM translation."Translations" WHERE length("TranslatedText") > 32767;
+    /// Measured on the shipped corpus (792,500 rows) there are none: longest English source is 5,959
+    /// characters and the average is 66.
+    ///
+    /// The bound is length() — code points — while the DAT counts UTF-16 code units, so a text made
+    /// entirely of astral-plane characters could pass here and still be refused at the API boundary.
+    /// Deliberate: the exact measure belongs in C#, where string.Length already is that unit, and a
+    /// backstop that over-rejected legitimate Polish would be the worse error.
+    /// </remarks>
+    public partial class ValidateTranslatedTextLengthCap : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE translation."Translations"
+                VALIDATE CONSTRAINT "CK_Translations_TranslatedText_MaxLength";
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Deliberately empty: migrations are forward-only (ADR-0023), and PostgreSQL offers no
+            // "invalidate constraint". Dropping the constraint outright belongs to the declaring
+            // migration's Down(), not here.
+        }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Constants/DatFormatConstants.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Primitives/Constants/DatFormatConstants.cs
@@ -1,0 +1,25 @@
+namespace LotroKoniecDev.TranslationSystem.Primitives.Constants;
+
+/// <summary>
+/// Facts about the game's DAT binary format that the TMS must respect even though it never touches
+/// the DAT: it produces the <c>||</c> file the patcher writes back from, so content the DAT cannot
+/// hold must be refused here, where a translator can still be told about it.
+/// The patcher keeps its own copy in <c>LotroKoniecDev.Primitives.Constants.DatFileConstants</c> —
+/// the two contexts share a data contract, not code.
+/// </summary>
+public static class DatFormatConstants
+{
+    /// <summary>
+    /// Maximum length, in UTF-16 code units, of the Polish text of one row.
+    /// The patcher splits that text on its <c>&lt;--DO_NOT_TOUCH!--&gt;</c> markers and writes each
+    /// piece into the DAT behind a two-byte variable-length prefix, which cannot express more than
+    /// 32767. Capping the whole text — rather than the per-piece limit the DAT actually enforces —
+    /// is the strictest bound expressible without teaching the TMS how the patcher cuts pieces, and
+    /// it can never be wrong in the unsafe direction: a text within it cannot produce an over-long
+    /// piece. Measured on the shipped corpus (792,500 rows): longest English source 5,959 characters,
+    /// average 66, zero rows above the cap — so the extra strictness costs nothing in practice.
+    /// Escaping (ADR-0039) happens after this point and is undone before the DAT write, so the raw
+    /// length measured here is the length the DAT sees.
+    /// </summary>
+    public const int MaxTranslatedTextLength = 32767;
+}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -101,10 +101,12 @@ delimiter collisions this format is weakest at. Those are composed by hand as ex
 data before trusting a `MemberData` theory to cover it.
 
 Several tests pin **known-lossy** behavior on purpose, say so in-place, and name the defect ticket
-they document (today: #598 over-long piece). Do not "fix" such a test — fix the defect, then change
-the assertion deliberately. That is what #596 and #597 did: the escape asymmetry (ADR-0039) and the
-swallowed trailing pipe (ADR-0042) are both gone, so all four of their tests now assert exact round
-trips.
+they document. Do not "fix" such a test — fix the defect, then change the assertion deliberately.
+That is what #596, #597 and #598 did: the escape asymmetry (ADR-0039), the swallowed trailing pipe
+(ADR-0042) and the over-long piece (ADR-0043) are all gone, so their tests now assert exact round
+trips — and `Write_PieceLongerThanTheVarLenCeiling_ShouldThrow` stays, restated as the deliberate
+last resort behind `Fragment.IsWritablePiece` rather than a reachable crash. **There is no
+known-lossy pin left today**; the next one to be added should name its ticket here.
 
 The `||` rule now lives in **two duplicated-by-design types per context** — `TranslationLineEscaper`
 (the content escape) and `TranslationLineCarver` (the field boundaries) — each with its own twin

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AngleSharp.Dom;
 using Bunit.TestDoubles;
 using LotroKoniecDev.Frontend.Components.Pages.Editor;
@@ -8,6 +9,7 @@ using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using LotroKoniecDev.TranslationSystem.Contracts.Translations;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Constants;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -140,6 +142,19 @@ public sealed class EditorTests : BunitContext
         IRenderedComponent<EditorComponent> component = RenderEditor();
 
         component.FindAll("textarea#translated").Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Render_SaveForm_CapsTheTextareaAtTheDatPieceLimit()
+    {
+        // The API rejects a longer text outright (#598); the browser cap keeps a translator from
+        // discovering that only after typing past it. Enforcement stays server-side.
+        StubLoad(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canEdit: true));
+
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        component.Find("textarea#translated").GetAttribute("maxlength")
+            .ShouldBe(DatFormatConstants.MaxTranslatedTextLength.ToString(CultureInfo.InvariantCulture));
     }
 
     [Fact]
@@ -302,6 +317,29 @@ public sealed class EditorTests : BunitContext
         recoveryForm.QuerySelectorAll("textarea[name=DraftField]").Length.ShouldBe(1);
         recoveryForm.QuerySelector("button[type=submit]")!.TextContent.ShouldContain("Zapisz ponownie");
         component.FindAll(".editor-grid").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Save_RecoveryForm_CapsItsTextareaAtTheDatPieceLimitToo()
+    {
+        // The recovery textarea is a second, independently written control (Editor.razor renders it in
+        // its own branch), so the cap it carries has to be pinned separately from the main one — the
+        // draft it holds is resubmitted to the same API rule (#598).
+        _client
+            .GetApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                ApiResult.Success(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canEdit: true)),
+                ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Nie znaleziono." }));
+        _client
+            .PutApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<TranslationDetailResponse>(new() { Title = "Zapis odrzucony." }));
+        IRenderedComponent<EditorComponent> component = RenderEditor();
+
+        await component.Find("form").SubmitAsync();
+        component.Render();
+
+        component.Find("textarea#translated-recovery").GetAttribute("maxlength")
+            .ShouldBe(DatFormatConstants.MaxTranslatedTextLength.ToString(CultureInfo.InvariantCulture));
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Features/PatchingServiceTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Features/PatchingServiceTests.cs
@@ -4,6 +4,7 @@ using LotroKoniecDev.Application.Features.Patching;
 using LotroKoniecDev.Domain.Core.BuildingBlocks;
 using LotroKoniecDev.Domain.Core.Monads;
 using LotroKoniecDev.Domain.Models;
+using LotroKoniecDev.Primitives.Constants;
 using LotroKoniecDev.Primitives.Enums;
 using LotroKoniecDev.Tests.Unit.Shared;
 
@@ -229,6 +230,72 @@ public sealed class PatchingServiceTests
         result.IsSuccess.ShouldBeTrue();
         result.Value.SkippedTranslations.ShouldBe(1);
         result.Value.Warnings.ShouldContain(w => w.Contains("not a text file"));
+    }
+
+    [Fact]
+    public void ApplyTranslations_PieceLongerThanTheDatAllows_ShouldSkipAndWarnWithoutWritingTheSubFile()
+    {
+        // Arrange — the TMS caps the text at its API, so this row can only come from a hand-edited or
+        // hostile polish.txt. It used to reach VarLenEncoder.Write and throw mid-loop (#598).
+        SetupAllPassingDefaults();
+        SetupTranslations(CreateTranslation(content: new string('ż', DatFileConstants.MaxTextPieceLength + 1)));
+
+        // Act
+        Result<PatchSummaryResponse> result = _sut.ApplyTranslations("/translations/polish.txt", "/game/client_local_English.dat");
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.AppliedTranslations.ShouldBe(0);
+        result.Value.SkippedTranslations.ShouldBe(1);
+        result.Value.Warnings.ShouldContain(w => w.Contains("32768 characters"));
+
+        // The row is screened before any subfile is loaded, so nothing is committed on its account —
+        // this is what keeps a bad row from leaving a half-patched DAT behind.
+        _datFileHandler.DidNotReceive().PutSubfileData(
+            Arg.Any<int>(), Arg.Any<int>(), Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<int>());
+    }
+
+    [Fact]
+    public void ApplyTranslations_PieceLongerThanTheDatAllows_ShouldStillApplyEveryOtherRow()
+    {
+        // Arrange — one poisoned row must cost exactly one row, not the whole patch run. Both rows
+        // target the same fragment because the fixture subfile holds exactly one; what is under test
+        // is that the loop survives the first row, not which fragment the second one lands on.
+        SetupAllPassingDefaults();
+        SetupTranslations(
+            CreateTranslation(gossipId: FragmentId1, content: new string('ż', DatFileConstants.MaxTextPieceLength + 1)),
+            CreateTranslation(gossipId: FragmentId1, content: "Zdrowy tekst"));
+
+        // Act
+        Result<PatchSummaryResponse> result = _sut.ApplyTranslations("/translations/polish.txt", "/game/client_local_English.dat");
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.AppliedTranslations.ShouldBe(1);
+        result.Value.SkippedTranslations.ShouldBe(1);
+
+        // The counters alone would also be satisfied by a run that applied the healthy row in memory
+        // and never committed it. The commit is invisible in the Result, so assert it here.
+        _datFileHandler.Received(1).PutSubfileData(
+            DatHandle, TextFileId, Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<int>());
+    }
+
+    [Fact]
+    public void ApplyTranslations_ContentSplittingIntoPiecesThatEachFit_ShouldApply()
+    {
+        // Arrange — the DAT caps each PIECE, not the whole row, and the patcher cuts pieces on the
+        // placeholder. Content twice the ceiling is therefore legal as long as no piece exceeds it.
+        SetupAllPassingDefaults();
+        string half = new('ż', DatFileConstants.MaxTextPieceLength);
+        SetupTranslations(CreateTranslation(content: $"{half}{DatFileConstants.PieceSeparator}{half}"));
+
+        // Act
+        Result<PatchSummaryResponse> result = _sut.ApplyTranslations("/translations/polish.txt", "/game/client_local_English.dat");
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.AppliedTranslations.ShouldBe(1);
+        result.Value.SkippedTranslations.ShouldBe(0);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.Tests.Unit/Tests/Models/FragmentNaughtyStringTests.cs
+++ b/tests/LotroKoniecDev.Tests.Unit/Tests/Models/FragmentNaughtyStringTests.cs
@@ -126,15 +126,42 @@ public sealed class FragmentNaughtyStringTests
         parsed.Pieces.ShouldBe([longPiece]);
     }
 
+    [Theory]
+    [InlineData(VarLenSingleByteCeiling)]
+    [InlineData(VarLenTwoByteCeiling)]
+    public void IsWritablePiece_PieceUpToTheVarLenCeiling_ShouldBeTrue(int length)
+    {
+        // Arrange
+        string piece = new('ż', length);
+
+        // Act
+        bool writable = Fragment.IsWritablePiece(piece);
+
+        // Assert
+        writable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsWritablePiece_PieceLongerThanTheVarLenCeiling_ShouldBeFalse()
+    {
+        // Arrange — the screen PatchingService runs before it mutates a loaded subfile (#598), so an
+        // over-long row costs one warning instead of a mid-loop throw over an already-written DAT.
+        string piece = new('ż', VarLenTwoByteCeiling + 1);
+
+        // Act
+        bool writable = Fragment.IsWritablePiece(piece);
+
+        // Assert
+        writable.ShouldBeFalse();
+    }
+
     [Fact]
     public void Write_PieceLongerThanTheVarLenCeiling_ShouldThrow()
     {
-        // Arrange — DOCUMENTED CURRENT BEHAVIOR. Refusing to write is right in itself: VarLen cannot
-        // express a length above 32767, and a truncated prefix would silently corrupt the subfile.
-        // What is NOT right is where the throw lands — nothing caps TranslatedText, and neither
-        // PatchingService nor its handler catches, so an over-long translation escapes as an
-        // unhandled exception mid-loop, after earlier subfiles were already written. Tracked as
-        // #598; pinned here so fixing it is a deliberate, visible change to this assertion.
+        // Arrange — the deliberate last resort behind IsWritablePiece, not a reachable failure mode:
+        // VarLen cannot express a length above 32767 and a truncated prefix would silently corrupt
+        // every following fragment, so writing one anyway is a programmer error. Callers screen the
+        // content first (#598, ADR-0043); this pins that Write itself never degrades to truncation.
         Fragment fragment = new() { Pieces = [new string('ż', VarLenTwoByteCeiling + 1)] };
         using MemoryStream stream = new();
         using BinaryWriter writer = new(stream, Encoding.Unicode, leaveOpen: true);

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/UpsertTranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Translations/UpsertTranslationTests.cs
@@ -16,7 +16,10 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.WriteDbContexts;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Constants;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Translations;
 
@@ -155,6 +158,64 @@ public sealed class UpsertTranslationTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Upsert_WithTextLongerThanTheDatAllows_ShouldReturn400()
+    {
+        // Arrange — over the DAT's per-piece ceiling the patcher cannot write the row at all, so the
+        // API must refuse it rather than let it reach the artifact and fail on a player's machine (#598).
+        await SeedAsync(gossipId: 1, source: "One", SeedStatus.Untranslated);
+        using HttpClient client = TranslatorClient(Guid.NewGuid());
+
+        // Act
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            Route,
+            new UpsertTranslationRequest(FileId, 1, new string('ż', DatFormatConstants.MaxTranslatedTextLength + 1)));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Upsert_WithTextExactlyAtTheDatLimit_ShouldPersistTheWholeText()
+    {
+        // Arrange — the boundary is legal, and the check constraint added alongside the validator must
+        // accept it too: a cap that silently truncated the last character would corrupt the artifact.
+        await SeedAsync(gossipId: 1, source: "One", SeedStatus.Untranslated);
+        using HttpClient client = TranslatorClient(Guid.NewGuid());
+        string atLimit = new('ż', DatFormatConstants.MaxTranslatedTextLength);
+
+        // Act
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            Route, new UpsertTranslationRequest(FileId, 1, atLimit));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        TranslationDetailResponse? detail = await response.Content.ReadFromJsonAsync<TranslationDetailResponse>(JsonOptions);
+        detail!.TranslatedText.ShouldBe(atLimit);
+    }
+
+    [Fact]
+    public async Task TranslatedTextCheckConstraint_ShouldRejectAnOverLongWriteThatBypassesTheApi()
+    {
+        // Arrange — the backstop of #598 sits below both the validator and the domain guard, so the
+        // only way to exercise it is to write past them. Pinned because a check constraint dropped by
+        // a later model change would leave no other trace.
+        await SeedAsync(gossipId: 1, source: "One", SeedStatus.Untranslated);
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationWriteDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationWriteDbContext>();
+
+        // Act
+        Func<Task> write = () => dbContext.Database.ExecuteSqlRawAsync(
+            "UPDATE translation.\"Translations\" SET \"TranslatedText\" = repeat('a', {0});",
+            DatFormatConstants.MaxTranslatedTextLength + 1);
+
+        // Assert
+        PostgresException violation = await write.ShouldThrowAsync<PostgresException>();
+        violation.ConstraintName.ShouldBe("CK_Translations_TranslatedText_MaxLength");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/UpsertTranslationHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Translations/UpsertTranslationHandlerTests.cs
@@ -15,6 +15,7 @@ using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregat
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Constants;
 using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslationAggregate;
 using LotroKoniecDev.TranslationSystem.ReadModels.Aggregates.TranslatorAggregate;
 using NSubstitute;
@@ -107,6 +108,40 @@ public sealed class UpsertTranslationHandlerTests
         result.IsFailure.ShouldBeTrue();
         result.Error.Code.ShouldBe("Translations.Validation");
         await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenTranslatedTextLongerThanTheDatAllows_ShouldReturnValidationError()
+    {
+        // Arrange — the patcher cannot write this row into the DAT at all, so it must be refused
+        // here rather than accepted, approved and published into the artifact (#598).
+        GivenStoredRow(Untranslated());
+        string tooLong = new('ż', DatFormatConstants.MaxTranslatedTextLength + 1);
+
+        // Act
+        Result<TranslationDetailResponse> result = await CreateHandler().Handle(Command(1, tooLong), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Translations.Validation");
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenTranslatedTextExactlyAtTheDatLimit_ShouldPersist()
+    {
+        // Arrange — the boundary itself is legal; the cap must not cost a translator the last character.
+        Translation row = Untranslated();
+        GivenStoredRow(row);
+        string atLimit = new('ż', DatFormatConstants.MaxTranslatedTextLength);
+        GivenReadBack(row, atLimit);
+
+        // Act
+        Result<TranslationDetailResponse> result = await CreateHandler().Handle(Command(1, atLimit), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        row.TranslatedText.ShouldBe(atLimit);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationTests.cs
@@ -4,6 +4,7 @@ using LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregate.Va
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Constants;
 
 namespace LotroKoniecDev.TranslationSystem.Domain.Tests.Unit.Tests.Aggregates.TranslationAggregate;
 
@@ -177,6 +178,39 @@ public sealed class TranslationTests
         translation.TranslatedText.ShouldBe("Witaj");
         translation.SubmittedById.ShouldBe(Submitter);
         translation.UpdatedAt.ShouldBe(Changed);
+    }
+
+    [Fact]
+    public void ProvideTranslation_TextAtTheDatLimit_ShouldAttachDraft()
+    {
+        // Arrange
+        Translation translation = CreateUntranslated();
+        string atLimit = new('ż', DatFormatConstants.MaxTranslatedTextLength);
+
+        // Act
+        translation.ProvideTranslation(atLimit, Submitter, Changed);
+
+        // Assert
+        translation.TranslatedText.ShouldBe(atLimit);
+    }
+
+    [Fact]
+    public void ProvideTranslation_TextLongerThanTheDatAllows_ShouldThrowAndLeaveTheRowUntouched()
+    {
+        // Arrange — a programmer-error guard like the blank-text one beside it: UpsertTranslation's
+        // validator is what turns this into a message for the translator (#598). What matters here is
+        // that a rejected text cannot half-apply — no Polish, no submitter, no status change.
+        Translation translation = CreateUntranslated();
+        string tooLong = new('ż', DatFormatConstants.MaxTranslatedTextLength + 1);
+
+        // Act
+        Action provide = () => translation.ProvideTranslation(tooLong, Submitter, Changed);
+
+        // Assert
+        provide.ShouldThrow<ArgumentOutOfRangeException>();
+        translation.TranslatedText.ShouldBeNull();
+        translation.SubmittedById.ShouldBeNull();
+        translation.Status.ShouldBe(TranslationStatus.Untranslated);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #598

## What

A text piece is written into the DAT behind a 2-byte VarLen length prefix, so it cannot exceed **32767 UTF-16 code units**. Nothing bounded `TranslatedText` anywhere between the translator's textarea and `VarLenEncoder.Write`, so an over-long translation was accepted, approved, published into the artifact, and became an exception on a player's machine — thrown out of the patch loop after earlier subfiles had already been committed.

Fixed in three independent layers, with no mid-write `catch`:

- **Patcher** — `Fragment.IsWritablePiece` states `Write`'s precondition as a predicate; `PatchingService` screens each row alongside the existing `not found in DAT` / `not a text file` checks, **before** a subfile is loaded and well before one is mutated, and warn-skips it. A bad row costs exactly one row.
- **TMS** — `MaximumLength` on `UpsertTranslation.Validator`, a matching guard in `ProvideTranslation`, and a database `CHECK` constraint.
- **Frontend** — `maxlength` on both editor textareas (a nicety; the API stays authoritative).

`VarLenEncoder` and `IsWritablePiece` now share one constant: a screen that disagreed with the guard it screens for would reopen the bug from either side.

## Why these choices

Both settled in **ADR-0043**:

- **No `catch`, no staging.** With the screen in place, `Serialize()` is total over anything the parser can produce, so a blanket `catch` would catch nothing real while hiding genuine programmer errors. Staging the file to commit at the end would hold a large part of the corpus in memory to protect against a failure mode the screen removes — and the native DAT API has no transaction to commit into anyway.
- **A `CHECK` constraint, not `HasMaxLength`.** Narrowing `text -> varchar(32767)` rewrites the whole `Translations` table and rebuilds its trigram GIN index under `ACCESS EXCLUSIVE`. On the ~792.5k-row corpus that is the deploy-window outage ADR-0023 exists to prevent. It ships as `ADD CONSTRAINT ... NOT VALID` + `VALIDATE` in **two migrations**, because PostgreSQL holds locks until commit and EF applies each migration in one transaction — in a single file the declare's `ACCESS EXCLUSIVE` would span the validate's scan, which is exactly the profile the two-step form exists to avoid.
- **The TMS caps the whole text where the DAT caps a piece.** Teaching the TMS how the patcher cuts pieces would duplicate patcher logic across the context boundary, and a whole-text cap can never be wrong in the unsafe direction. Measured on `data/exported.txt` (792,500 rows): longest source **5,959** chars, average **66**, **zero** rows above the cap.

## One correction to the ticket

The report says the CLI "leaves a partially patched DAT". For `patch` that is not true — `PatchCommand` takes a backup and its `catch` restores it. It is **`launch`** that has the same `catch` but **no backup**, so that was the path that actually corrupted. Recorded in the ADR; the missing backup on `launch` is named there as a remaining gap and is out of scope here.

## Acceptance criteria

| AC | How it is met |
|---|---|
| Over-long text rejected at the API, not published | `UpsertTranslation.Validator` -> 400; unit + integration tests |
| Over-long row warn-skipped, remaining rows still apply, no partial patch | `PatchingService` screen before load/mutate; 3 unit tests, incl. asserting the healthy row's subfile *was* committed and the bad row's was not |
| No unhandled `ArgumentOutOfRangeException` at the CLI | Unreachable from the patch path; `Write` throws only as a deliberate last resort |
| Unit coverage for rejection and warn-skip, suites green, zero warnings | See below |
| `Write_PieceLongerThanTheVarLenCeiling_ShouldThrow` updated | Kept, restated as the last resort behind `IsWritablePiece`, plus new predicate tests |

## Testing

- Build: **0 warnings, 0 errors**.
- All 8 unit suites green (13,359 tests); both integration suites green against real PostgreSQL (TMS 234, Auth 341) — the latter apply both new migrations via `MigrateAsync`.
- All 4 CI guard scripts pass; `dotnet ef migrations has-pending-model-changes` reports no drift.
- **The new tests were verified load-bearing**: with the screen disabled, the exact `ArgumentOutOfRangeException` from the ticket escapes `ApplyTranslations`.
- Boundary cases pinned on both sides: exactly 32767 accepted, 32768 rejected, and a multi-piece text summing above the ceiling still applied (the DAT caps the piece, not the row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3R4Cew6w6tfHQ8GqnCoR