### PR TITLE
FE: English API validation messages are surfaced verbatim in the Polish UI (editor save, game-version register)

### DIFF
--- a/docs/adr/0044-the-frontend-owns-polish-copy-and-translates-api-failures-by-default.md
+++ b/docs/adr/0044-the-frontend-owns-polish-copy-and-translates-api-failures-by-default.md
@@ -1,0 +1,170 @@
+# ADR-0044: The Frontend owns the Polish copy for API failures, and translates by default
+
+**Status:** Accepted
+**Date:** 2026-08-06
+**Decision-makers:** Solo maintainer
+**Related:** #548 (the defect), #268 / #272 (the QA reports that found it), ADR-0041 (no gateway — the API is a shared contract surface), ADR-0040 (rel names are a frozen public contract), `ApiProblemCopy`, `HttpClientApiExtensions`
+
+## Context
+
+The Frontend is Polish-only. Every API failure it renders is English.
+
+The pages already do the right *shape* — they carry the API's `ProblemDetails` on an `ApiResult`
+and render it instead of throwing — but what they render is whatever the API wrote:
+
+```razor
+<p>@(_actionProblem.Detail ?? _actionProblem.Title ?? "Operacja nie powiodła się.")</p>
+```
+
+`Detail` is the domain error message (`"The lotronotationversion value '48.0' is already taken."`),
+`Title` is the error-type name (`"Validation Error"`, `"Internal Server Error"`). The Polish string
+is the **third** branch — reached only when the API says nothing at all, which is the rare case. So
+a translator saving an empty translation gets a red box reading `Validation Error`, and an admin
+registering a malformed game version gets the FluentValidation default `'Version' must not be empty.`
+
+Fourteen render sites across eight pages had the same shape. Two variants existed and both are
+wrong in the same way: action failures render `Detail ?? Title`, load failures render `Title` alone
+— which is worse, because `Title` is *always* one of the six English type names.
+
+Widening the fallbacks does not fix it. The fallback is not the problem; the branch before it is.
+
+## Decision
+
+### 1. The Polish copy lives in the Frontend, keyed by `errorCode` — the API stays English
+
+The API already emits a machine-readable key on every failure it authors. Both
+`ErrorExtensions.ToProblemDetails()` implementations stamp `Extensions["errorCode"] = error.Code`,
+and all five exception handlers per API stamp a fixed code (`Validation.FluentValidation`,
+`Http.PayloadTooLarge`, `Db.ConcurrencyConflict`, `Http.InvalidArgument`,
+`Internal.UnhandledException`). Nothing had to change server-side to make this work; the key was
+already on the wire, unused.
+
+`ApiProblemCopy` maps that code to Polish. The alternative — localizing in the API and keeping the
+Frontend a dumb renderer — was rejected:
+
+- There is no gateway (ADR-0041). The TMS API is reached directly by the **CLI** (`export`/`patch`/
+  `launch` auto-download, M2-20) and will be reached by the Avalonia app (M4). Its `ProblemDetails`
+  is a shared contract, not one client's UI copy.
+- The API has no notion of a caller language. Adding one means content negotiation, a resource
+  pipeline and a per-locale message catalog server-side — infrastructure for a product that is
+  Polish-only and has one UI.
+- The existing house pattern already puts Polish in the Frontend: `HttpClientApiExtensions` writes
+  its transport-failure copy inline, and every page's fallback string is Polish.
+
+So `errorCode` becomes what a rel name is for links (ADR-0040): **a frozen contract token**.
+Additions are cheap; renaming a code silently degrades that failure to the generic message. The map
+covers every code both APIs can produce today.
+
+### 2. Translation is the default; only an explicitly marked Frontend problem passes through
+
+The Frontend authors `ProblemDetails` of its own — Polly transport failures
+(`"Usługa chwilowo niedostępna"`), missing-rel 403s, inline form guards (`"Podaj wersję gry."`).
+Those are already Polish and must pass through untouched. Something has to tell them apart from the
+API's.
+
+**"No `errorCode` ⇒ the Frontend wrote it" is the obvious discriminator and it is wrong.** Both APIs
+run `AddProblemDetails()` + `UseStatusCodePages()`, and for every status that middleware synthesizes
+— 401, 403, 404, 405, 415, 429 — the body is a bare English reason phrase with **no** `errorCode`.
+The repo's own committed contract says so:
+
+```json
+{ "type": "…rfc9110#section-15.5.2", "title": "Unauthorized", "status": 401, "traceId": "…" }
+```
+
+(`ProblemDetailsSnapshotTests.ProtectedEndpoint_WithoutToken_…verified.json`, and the `"Forbidden"`
+twin next to it.) Those are the *most common* failures in the app — an expired token on any page, a
+non-translator opening `/game-versions` — so keying off the code's absence would have painted the
+literal word `Unauthorized` into the Polish page: exactly the defect this ADR exists to remove, on
+the highest-traffic path.
+
+So the marker runs the other way, and the safe case is the default:
+
+- **Marked `frontendAuthored`** ⇒ ours ⇒ already Polish ⇒ render `Title` + `Detail`.
+- **Everything else** ⇒ translate: mapped code → status copy → call-site fallback.
+
+Only `ApiProblemCopy.FrontendAuthored(...)` stamps the marker, and `ParseProblemDetails` strips it
+from anything read off the wire, so a response body carrying that member cannot smuggle English
+past the lookup.
+
+The asymmetry is the point. Forgetting the marker on a new Frontend-authored problem shows a
+slightly generic Polish sentence; forgetting to anticipate an API surface shows English. One is a
+blemish, the other is the bug. The default has to fall on the blemish side.
+
+### 3. An unmapped code degrades to Polish by HTTP status — never to English
+
+Precedence for an API-authored problem: mapped code → status-code copy (400/401/403/404/409/413/
+422/429/5xx) → a generic Polish sentence. English can never reach the screen, including when the
+API ships an error the Frontend has not seen yet.
+
+The gap is not silent: `ApiProblemAlert` logs a warning naming the unmapped code and the endpoint's
+status the moment it renders one. The component is the right place for that log — it fires exactly
+when a user is actually looking at a degraded message, which is the condition worth reporting, and
+unlike the parsing seam it is DI-constructed and has an `ILogger`.
+
+The status map deliberately outranks the call site's own fallback string. `"Nie udało się wczytać
+statystyk."` says only that something failed; `"Nie masz uprawnień do wykonania tej operacji."` says
+what to do about it. The call-site fallback stays for the one case nothing else covers — no problem
+object at all.
+
+### 4. The original English survives as collapsible technical detail
+
+Some API messages carry numbers a static Polish string cannot reproduce: `Import.ParseFailed` names
+the first bad line, `Import.MassRemovalBlocked` names how many rows of how many would be removed.
+Those are the numbers an admin needs to decide what to do, and they are exactly what a code→copy
+map throws away.
+
+So `ApiProblemAlert` renders a Polish headline plus a collapsed `<details>` block carrying the code
+and the API's own `Detail`. The page is Polish; the diagnostics are one click away and can be pasted
+into a bug report. `<details>` is plain HTML — no interactivity, no SSR-purity cost.
+
+The alternative of adding structured extensions to the API's import errors (`lineNumber`,
+`removedCount`, …) so the Polish string could interpolate them was rejected as scope: it changes the
+API for one page's copy, and the nested parser messages inside `Import.ParseFailed` would stay
+English regardless.
+
+### 5. One component, both existing shells
+
+`ApiProblemAlert` renders the *body* — headline and `<details>` — not the box. The two established
+shells stay exactly as they are: the rich `error-message` box with its icon for load failures, and
+`status-message status-error` for action failures. A `HeadlineClass` parameter carries the `t` class
+the rich box's CSS expects.
+
+That keeps the visual diff at zero while making the copy lookup impossible to bypass: a page cannot
+render a `ProblemDetails` without going through the component.
+
+The two file-download routes (`polish.txt`, the GDPR account export) are the one surface with no
+component to render through — they answer with `Results.Problem(...)`, and the browser shows that
+body verbatim. They call `ApiProblemCopy.Localize` instead, which runs the same lookup and returns a
+Polish-titled problem, parking the API's wording under a `technicalDetail` extension. Same rule, same
+map, different transport.
+
+## Consequences
+
+### Good
+
+- No English reaches a Polish page, for any error either API can produce — including unmapped and
+  future ones.
+- `Title` stops being rendered anywhere. The six English type names (`"Validation Error"`,
+  `"Not Found"`, …) were never user-facing copy and are now confined to logs.
+- The copy is in one file. Rewording an error is a one-line change reviewed as copy, not spread
+  across eight pages.
+- The API keeps serving the CLI, the M4 app and any future client with the same English contract.
+- Load failures improve the most: they rendered `Title` alone, so they showed the *worst* English.
+
+### Neutral
+
+- `errorCode` joins rel names as a contract token: renaming one degrades the message to the status
+  fallback rather than breaking anything. The degradation is logged.
+- The map is maintained by hand. A new API error without copy is a visible generic message plus a
+  logged warning — not a silent regression, and not a build break either.
+- A new Frontend-authored problem must go through `ApiProblemCopy.FrontendAuthored`. Forgetting it
+  costs specificity (the status sentence instead of the page's own wording), never correctness —
+  and no raw `new ProblemDetails` is left in the Frontend for the next author to copy.
+
+### The limit of this fix
+
+`ValidationProblemDetails.errors` — FluentValidation's per-field English messages — still travels in
+the body. Nothing renders it, and the handler's `Validation.FluentValidation` code is mapped, so it
+is dead weight on the wire rather than a user-visible defect. Localizing per-field messages would
+need a field-level code vocabulary the API does not have; if forms ever need inline per-field
+errors, that is a separate decision.

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/Account.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/Account.razor
@@ -40,11 +40,9 @@
                 </svg>
             </span>
             <div class="em-body">
-                <span class="t">@(_result.ProblemDetails?.Title ?? "Nie udało się wczytać danych konta.")</span>
-                @if (!string.IsNullOrWhiteSpace(_result.ProblemDetails?.Detail))
-                {
-                    <span class="s">@_result.ProblemDetails!.Detail</span>
-                }
+                <ApiProblemAlert Problem="@_result.ProblemDetails"
+                                 Fallback="Nie udało się wczytać danych konta."
+                                 HeadlineClass="t"/>
             </div>
         </div>
     }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.Frontend.Infrastructure.Discovery;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
 using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
@@ -53,17 +54,18 @@ internal static class AccountEndpointsExtensions
         AccountLoader loader,
         IDiscoveryCache discoveryCache,
         ITranslationSystemClient translationSystemClient,
+        ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
         ApiResult<AccountDataExportResponse> result = await loader.LoadExportAsync(cancellationToken);
 
         if (result.IsFailure)
         {
-            return Results.Problem(result.ProblemDetails ?? new ProblemDetails
-            {
-                Title = "Nie udało się pobrać danych konta.",
-                Status = StatusCodes.Status502BadGateway
-            });
+            return Results.Problem(ApiProblemCopy.Localize(
+                loggerFactory,
+                result.ProblemDetails,
+                "Nie udało się pobrać danych konta.",
+                StatusCodes.Status502BadGateway));
         }
 
         TranslatorDataExportResponse? translationData = null;

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountLoader.cs
@@ -2,6 +2,7 @@ using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Password;
 using LotroKoniecDev.AuthSystem.Contracts.Hateoas;
 using LotroKoniecDev.Frontend.Infrastructure.Discovery;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.Hateoas;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.AuthSystemHttpClients;
@@ -49,12 +50,10 @@ internal sealed class AccountLoader
         LinkDto? exportLink = discoveryResult.Value.Links.FindLink(Rels.ExportAccountData);
         if (exportLink is null)
         {
-            return ApiResult.Failure<AccountDataExportResponse>(new ProblemDetails
-            {
-                Title = "Sekcja konta jest niedostępna",
-                Detail = "Serwer nie udostępnia danych konta dla tej sesji. Zaloguj się ponownie.",
-                Status = StatusCodes.Status403Forbidden
-            });
+            return ApiResult.Failure<AccountDataExportResponse>(ApiProblemCopy.FrontendAuthored(
+                "Sekcja konta jest niedostępna",
+                "Serwer nie udostępnia danych konta dla tej sesji. Zaloguj się ponownie.",
+                StatusCodes.Status403Forbidden));
         }
 
         return await _client.GetApiResultAsync<AccountDataExportResponse>(

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/ChangePassword.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/ChangePassword.razor
@@ -7,6 +7,7 @@
 @using LotroKoniecDev.Frontend.Infrastructure.Hateoas
 @using LotroKoniecDev.Frontend.Infrastructure.HttpClients
 @using LotroKoniecDev.Hateoas.Abstractions
+@using LotroKoniecDev.Frontend.Infrastructure.Errors
 @inject AccountLoader Loader
 
 <PageTitle>Zmień hasło — lotro-translator.pl</PageTitle>
@@ -46,7 +47,9 @@
                 </svg>
             </span>
             <div class="em-body">
-                <span class="t">@(_loadResult.ProblemDetails?.Title ?? "Nie udało się wczytać danych konta.")</span>
+                <ApiProblemAlert Problem="@_loadResult.ProblemDetails"
+                                 Fallback="Nie udało się wczytać danych konta."
+                                 HeadlineClass="t"/>
             </div>
         </div>
     }
@@ -75,11 +78,9 @@
                             </svg>
                         </span>
                         <div class="em-body">
-                            <span class="t">@_submitProblem.Title</span>
-                            @if (!string.IsNullOrWhiteSpace(_submitProblem.Detail))
-                            {
-                                <span class="s">@_submitProblem.Detail</span>
-                            }
+                            <ApiProblemAlert Problem="@_submitProblem"
+                                             Fallback="Nie udało się zmienić hasła."
+                                             HeadlineClass="t"/>
                         </div>
                     </div>
                 }
@@ -159,21 +160,17 @@
         if (string.IsNullOrWhiteSpace(PasswordInput?.CurrentPassword)
             || string.IsNullOrWhiteSpace(PasswordInput.NewPassword))
         {
-            _submitProblem = new Microsoft.AspNetCore.Mvc.ProblemDetails
-            {
-                Title = "Wypełnij wszystkie pola",
-                Detail = "Obecne i nowe hasło są wymagane."
-            };
+            _submitProblem = ApiProblemCopy.FrontendAuthored(
+                "Wypełnij wszystkie pola",
+                "Obecne i nowe hasło są wymagane.");
             return;
         }
 
         if (!string.Equals(PasswordInput.NewPassword, PasswordInput.RepeatPassword, StringComparison.Ordinal))
         {
-            _submitProblem = new Microsoft.AspNetCore.Mvc.ProblemDetails
-            {
-                Title = "Hasła nie są zgodne",
-                Detail = "Nowe hasło i jego powtórzenie muszą być identyczne."
-            };
+            _submitProblem = ApiProblemCopy.FrontendAuthored(
+                "Hasła nie są zgodne",
+                "Nowe hasło i jego powtórzenie muszą być identyczne.");
             return;
         }
 
@@ -191,18 +188,14 @@
 
         if (result.IsUnauthorized)
         {
-            _submitProblem = new Microsoft.AspNetCore.Mvc.ProblemDetails
-            {
-                Title = "Sesja wygasła",
-                Detail = "Zaloguj się ponownie, aby zmienić hasło."
-            };
+            _submitProblem = ApiProblemCopy.FrontendAuthored(
+                "Sesja wygasła",
+                "Zaloguj się ponownie, aby zmienić hasło.");
             return;
         }
 
-        _submitProblem = result.ProblemDetails ?? new Microsoft.AspNetCore.Mvc.ProblemDetails
-        {
-            Title = "Nie udało się zmienić hasła."
-        };
+        _submitProblem = result.ProblemDetails
+                         ?? ApiProblemCopy.FrontendAuthored("Nie udało się zmienić hasła.");
     }
 
     public sealed class ChangePasswordFormModel

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/DeleteAccount.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/DeleteAccount.razor
@@ -8,6 +8,7 @@
 @using LotroKoniecDev.Frontend.Infrastructure.Hateoas
 @using LotroKoniecDev.Frontend.Infrastructure.HttpClients
 @using LotroKoniecDev.Hateoas.Abstractions
+@using LotroKoniecDev.Frontend.Infrastructure.Errors
 @inject AccountLoader Loader
 
 <PageTitle>Usuń konto — lotro-translator.pl</PageTitle>
@@ -57,7 +58,9 @@
                 </svg>
             </span>
             <div class="em-body">
-                <span class="t">@(_loadResult.ProblemDetails?.Title ?? "Nie udało się wczytać danych konta.")</span>
+                <ApiProblemAlert Problem="@_loadResult.ProblemDetails"
+                                 Fallback="Nie udało się wczytać danych konta."
+                                 HeadlineClass="t"/>
             </div>
         </div>
     }
@@ -105,11 +108,9 @@
                             </svg>
                         </span>
                         <div class="em-body">
-                            <span class="t">@_submitProblem.Title</span>
-                            @if (!string.IsNullOrWhiteSpace(_submitProblem.Detail))
-                            {
-                                <span class="s">@_submitProblem.Detail</span>
-                            }
+                            <ApiProblemAlert Problem="@_submitProblem"
+                                             Fallback="Nie udało się zaplanować usunięcia konta."
+                                             HeadlineClass="t"/>
                         </div>
                     </div>
                 }
@@ -187,21 +188,17 @@
 
         if (string.IsNullOrWhiteSpace(DeleteInput?.Password))
         {
-            _submitProblem = new Microsoft.AspNetCore.Mvc.ProblemDetails
-            {
-                Title = "Hasło jest wymagane",
-                Detail = "Podaj obecne hasło, aby potwierdzić usunięcie konta."
-            };
+            _submitProblem = ApiProblemCopy.FrontendAuthored(
+                "Hasło jest wymagane",
+                "Podaj obecne hasło, aby potwierdzić usunięcie konta.");
             return;
         }
 
         if (!string.Equals(DeleteInput.ConfirmPhrase, ConfirmPhrase, StringComparison.Ordinal))
         {
-            _submitProblem = new Microsoft.AspNetCore.Mvc.ProblemDetails
-            {
-                Title = "Nieprawidłowe potwierdzenie",
-                Detail = $"Wpisz {ConfirmPhrase} w polu potwierdzenia, aby kontynuować."
-            };
+            _submitProblem = ApiProblemCopy.FrontendAuthored(
+                "Nieprawidłowe potwierdzenie",
+                $"Wpisz {ConfirmPhrase} w polu potwierdzenia, aby kontynuować.");
             return;
         }
 
@@ -219,18 +216,14 @@
 
         if (result.IsUnauthorized)
         {
-            _submitProblem = new Microsoft.AspNetCore.Mvc.ProblemDetails
-            {
-                Title = "Sesja wygasła",
-                Detail = "Zaloguj się ponownie, aby usunąć konto."
-            };
+            _submitProblem = ApiProblemCopy.FrontendAuthored(
+                "Sesja wygasła",
+                "Zaloguj się ponownie, aby usunąć konto.");
             return;
         }
 
-        _submitProblem = result.ProblemDetails ?? new Microsoft.AspNetCore.Mvc.ProblemDetails
-        {
-            Title = "Nie udało się zaplanować usunięcia konta."
-        };
+        _submitProblem = result.ProblemDetails
+                         ?? ApiProblemCopy.FrontendAuthored("Nie udało się zaplanować usunięcia konta.");
     }
 
     /// <summary>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/Dashboard.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Dashboard/Dashboard.razor
@@ -33,7 +33,9 @@
                 </svg>
             </span>
             <div class="em-body">
-                <span class="t">@(_result.ProblemDetails?.Title ?? "Nie udało się wczytać statystyk.")</span>
+                <ApiProblemAlert Problem="@_result.ProblemDetails"
+                                 Fallback="Nie udało się wczytać statystyk."
+                                 HeadlineClass="t"/>
             </div>
         </div>
     }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Editor/Editor.razor
@@ -45,7 +45,9 @@
                     </svg>
                 </span>
                 <div class="em-body">
-                    <span class="t">@(_saveProblem.Title ?? "Nie udało się zapisać tłumaczenia.")</span>
+                    <ApiProblemAlert Problem="@_saveProblem"
+                                     Fallback="Nie udało się zapisać tłumaczenia."
+                                     HeadlineClass="t"/>
                 </div>
             </div>
             <section class="panel">
@@ -79,7 +81,9 @@
                     </svg>
                 </span>
                 <div class="em-body">
-                    <span class="t">@(_loadProblem.Title ?? "Nie udało się wczytać tłumaczenia.")</span>
+                    <ApiProblemAlert Problem="@_loadProblem"
+                                     Fallback="Nie udało się wczytać tłumaczenia."
+                                     HeadlineClass="t"/>
                 </div>
             </div>
         }
@@ -108,7 +112,7 @@
         @if (_saveProblem is not null)
         {
             <div class="status-message status-error" role="alert">
-                <p>@(_saveProblem.Title ?? "Nie udało się zapisać tłumaczenia.")</p>
+                <ApiProblemAlert Problem="@_saveProblem" Fallback="Nie udało się zapisać tłumaczenia."/>
             </div>
         }
         else if (Saved && _approveProblem is null)
@@ -121,7 +125,7 @@
         @if (_approveProblem is not null)
         {
             <div class="status-message status-error" role="alert">
-                <p>@(_approveProblem.Title ?? "Nie udało się zatwierdzić tłumaczenia.")</p>
+                <ApiProblemAlert Problem="@_approveProblem" Fallback="Nie udało się zatwierdzić tłumaczenia."/>
             </div>
         }
         else if (Approved && _saveProblem is null)

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
@@ -9,6 +9,7 @@
 @using LotroKoniecDev.TranslationSystem.Contracts.GameVersions
 @using LotroKoniecDev.TranslationSystem.Contracts.Hateoas
 @using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate
+@using LotroKoniecDev.Frontend.Infrastructure.Errors
 @inject GameVersionsLoader Loader
 
 <PageTitle>Wersje gry — lotro-translator.pl</PageTitle>
@@ -35,7 +36,9 @@
                 </svg>
             </span>
             <div class="em-body">
-                <span class="t">@(_versionsProblem.Title ?? "Nie udało się wczytać listy wersji gry.")</span>
+                <ApiProblemAlert Problem="@_versionsProblem"
+                                 Fallback="Nie udało się wczytać listy wersji gry."
+                                 HeadlineClass="t"/>
             </div>
         </div>
     }
@@ -43,7 +46,7 @@
     @if (_actionProblem is not null)
     {
         <div class="status-message status-error" role="alert">
-            <p>@(_actionProblem.Detail ?? _actionProblem.Title ?? "Operacja nie powiodła się.")</p>
+            <ApiProblemAlert Problem="@_actionProblem" Fallback="Operacja nie powiodła się."/>
         </div>
     }
     else if (_actionMessage is not null)
@@ -209,7 +212,7 @@
         string version = RegisterInput?.Version?.Trim() ?? string.Empty;
         if (version.Length == 0)
         {
-            _actionProblem = new ProblemDetails { Title = "Podaj wersję gry." };
+            _actionProblem = ApiProblemCopy.FrontendAuthored("Podaj wersję gry.");
             await LoadVersionsAsync();
             return;
         }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
@@ -9,6 +9,7 @@
 @using LotroKoniecDev.TranslationSystem.Contracts.Hateoas
 @using LotroKoniecDev.TranslationSystem.Contracts.Import
 @using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate
+@using LotroKoniecDev.Frontend.Infrastructure.Errors
 @inject ImportExportLoader Loader
 
 <PageTitle>Import / Eksport — lotro-translator.pl</PageTitle>
@@ -56,7 +57,9 @@
                 </svg>
             </span>
             <div class="em-body">
-                <span class="t">@(_versionsProblem.Title ?? "Nie udało się wczytać listy wersji gry.")</span>
+                <ApiProblemAlert Problem="@_versionsProblem"
+                                 Fallback="Nie udało się wczytać listy wersji gry."
+                                 HeadlineClass="t"/>
             </div>
         </div>
     }
@@ -77,9 +80,14 @@
 
                 @if (_importProblem is not null)
                 {
-                    <p class="status-line status-down" role="alert">
-                        <span class="dot"></span>@(_importProblem.Detail ?? _importProblem.Title ?? "Nie udało się zaimportować pliku.")
-                    </p>
+                    @* A div, not a p: the alert may render a <details> block, which a paragraph
+                       cannot legally contain. *@
+                    <div class="status-line status-line-block status-down" role="alert">
+                        <span class="dot"></span>
+                        <div class="status-line-body">
+                            <ApiProblemAlert Problem="@_importProblem" Fallback="Nie udało się zaimportować pliku."/>
+                        </div>
+                    </div>
                 }
                 else if (_summary is not null)
                 {
@@ -268,14 +276,14 @@
 
         if (input.File is null || input.File.Length == 0)
         {
-            _importProblem = new ProblemDetails { Title = "Wybierz plik exported.txt do wgrania." };
+            _importProblem = ApiProblemCopy.FrontendAuthored("Wybierz plik exported.txt do wgrania.");
             await LoadVersionsAsync();
             return;
         }
 
         if (input.GameVersionId == Guid.Empty)
         {
-            _importProblem = new ProblemDetails { Title = "Wybierz wersję gry." };
+            _importProblem = ApiProblemCopy.FrontendAuthored("Wybierz wersję gry.");
             await LoadVersionsAsync();
             return;
         }
@@ -285,11 +293,9 @@
         // import. Never compose the path from the id.
         if (ImportTargets.FindImportHref(_versions, input.GameVersionId) is not { } importHref)
         {
-            _importProblem = new ProblemDetails
-            {
-                Title = "Nie można zaimportować do tej wersji gry.",
-                Detail = "Serwer nie udostępnia importu dla wybranej wersji. Odśwież stronę i wybierz inną wersję."
-            };
+            _importProblem = ApiProblemCopy.FrontendAuthored(
+                "Nie można zaimportować do tej wersji gry.",
+                "Serwer nie udostępnia importu dla wybranej wersji. Odśwież stronę i wybierz inną wersję.");
             await LoadVersionsAsync();
             return;
         }

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExportEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExportEndpointsExtensions.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using Microsoft.AspNetCore.Mvc;
 
@@ -35,17 +36,18 @@ internal static class ImportExportEndpointsExtensions
     /// </summary>
     internal static async Task<IResult> DownloadTranslationFileAsync(
         ImportExportLoader loader,
+        ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
         ApiResult<string> result = await loader.DownloadTranslationFileAsync(cancellationToken);
 
         if (result.IsFailure)
         {
-            return Results.Problem(result.ProblemDetails ?? new ProblemDetails
-            {
-                Title = "Nie udało się pobrać pliku tłumaczenia.",
-                Status = StatusCodes.Status502BadGateway
-            });
+            return Results.Problem(ApiProblemCopy.Localize(
+                loggerFactory,
+                result.ProblemDetails,
+                "Nie udało się pobrać pliku tłumaczenia.",
+                StatusCodes.Status502BadGateway));
         }
 
         // BOM-less UTF-8: the upstream TMS endpoint serves the artifact as Encoding.UTF8 text and the

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
@@ -82,7 +82,9 @@
                 </svg>
             </span>
             <div class="em-body">
-                <span class="t">@(_result.ProblemDetails?.Title ?? "Nie udało się wczytać tłumaczeń.")</span>
+                <ApiProblemAlert Problem="@_result.ProblemDetails"
+                                 Fallback="Nie udało się wczytać tłumaczeń."
+                                 HeadlineClass="t"/>
             </div>
         </div>
     }
@@ -107,7 +109,7 @@
         @if (_bulkProblem is not null)
         {
             <div class="status-message status-error" role="alert">
-                <p>@(_bulkProblem.Detail ?? _bulkProblem.Title ?? "Nie udało się zatwierdzić tłumaczeń.")</p>
+                <ApiProblemAlert Problem="@_bulkProblem" Fallback="Nie udało się zatwierdzić tłumaczeń."/>
             </div>
         }
         else if (_bulkNotice is not null)

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Shared/ApiProblemAlert.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Shared/ApiProblemAlert.razor
@@ -1,0 +1,59 @@
+@using Microsoft.AspNetCore.Mvc
+@using LotroKoniecDev.Frontend.Infrastructure.Errors
+@inject ILogger<ApiProblemAlert> Logger
+
+@* The only way a page renders a failed call (ADR-0044): Polish copy keyed by the API's errorCode,
+   with the API's own English wording kept one click away for a bug report. The caller supplies the
+   box (`error-message` or `status-message status-error`); this renders its body. *@
+
+<span class="problem-headline @HeadlineClass">@_view.Message</span>
+@if (_view.SecondaryMessage is not null)
+{
+    <span class="problem-secondary s">@_view.SecondaryMessage</span>
+}
+@if (_view.TechnicalDetail is not null)
+{
+    <details class="problem-tech">
+        <summary>Szczegóły techniczne</summary>
+        <span class="problem-tech-body">@_view.TechnicalDetail</span>
+    </details>
+}
+
+@code {
+    private ApiProblemView _view = new(ApiProblemCopy.GenericMessage, null, null, null);
+    private string? _reportedErrorCode;
+
+    /// <summary>The failure to describe; <c>null</c> renders <see cref="Fallback"/>.</summary>
+    [Parameter]
+    public ProblemDetails? Problem { get; set; }
+
+    /// <summary>
+    /// The page's own contextual Polish sentence, used when the problem carries nothing usable.
+    /// A mapped error code and the HTTP-status copy both outrank it.
+    /// </summary>
+    [Parameter]
+    [EditorRequired]
+    public string Fallback { get; set; } = ApiProblemCopy.GenericMessage;
+
+    /// <summary>
+    /// Class for the headline element, so the component fits the caller's box unchanged — the rich
+    /// <c>error-message</c> box styles its title through <c>.em-body .t</c>.
+    /// </summary>
+    [Parameter]
+    public string? HeadlineClass { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        _view = ApiProblemCopy.Describe(Problem, Fallback);
+
+        // An API error that shipped before its Polish copy did. The user already sees the degraded
+        // message, so this is the moment the gap is worth reporting — but OnParametersSet runs on
+        // every parameter set, and a parent that re-renders after setting the problem (ImportExport
+        // reloads its version list) would otherwise log the same gap twice per request.
+        if (_view.UnmappedErrorCode is { } unmappedErrorCode && unmappedErrorCode != _reportedErrorCode)
+        {
+            _reportedErrorCode = unmappedErrorCode;
+            ApiProblemCopy.ReportUnmappedErrorCode(Logger, _view, Problem?.Status);
+        }
+    }
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/TranslationSystemEntryPointExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Discovery/TranslationSystemEntryPointExtensions.cs
@@ -1,3 +1,4 @@
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.Hateoas;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Hateoas.Abstractions;
@@ -46,10 +47,8 @@ internal static class TranslationSystemEntryPointExtensions
     /// affordance exists but is not this session's to use — the rel travels in <c>Detail</c> so a
     /// support report names the missing entry point instead of "coś poszło nie tak".
     /// </summary>
-    private static ProblemDetails MissingEntryPoint(string rel) => new()
-    {
-        Title = "Ta funkcja jest niedostępna",
-        Detail = $"Serwer nie udostępnia tej sesji zasobu „{rel}”. Zaloguj się ponownie lub spróbuj później.",
-        Status = StatusCodes.Status403Forbidden
-    };
+    private static ProblemDetails MissingEntryPoint(string rel) => ApiProblemCopy.FrontendAuthored(
+        "Ta funkcja jest niedostępna",
+        $"Serwer nie udostępnia tej sesji zasobu „{rel}”. Zaloguj się ponownie lub spróbuj później.",
+        StatusCodes.Status403Forbidden);
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemCopy.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemCopy.cs
@@ -1,0 +1,382 @@
+using System.Collections.Frozen;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LotroKoniecDev.Frontend.Infrastructure.Errors;
+
+/// <summary>
+/// The single source of Polish copy for a failed API call (ADR-0044). The APIs write English —
+/// a domain message keyed by a machine-readable <c>errorCode</c>, or, for a status the
+/// <c>UseStatusCodePages</c> middleware synthesizes, a bare English reason phrase with no code at
+/// all. So the default is to translate, and only a <see cref="ProblemDetails"/> the Frontend
+/// authored itself (via <see cref="FrontendAuthored"/>) is rendered as-is.
+/// <para>
+/// The default runs that way round deliberately: an unrecognised problem degrades to Polish, so a
+/// surface nobody anticipated cannot leak English. Getting the marker wrong shows a generic Polish
+/// sentence instead of a specific one — never the bug this exists to fix.
+/// </para>
+/// </summary>
+internal static class ApiProblemCopy
+{
+    internal const string ErrorCodeExtensionKey = "errorCode";
+
+    /// <summary>
+    /// Marks a <see cref="ProblemDetails"/> the Frontend wrote itself — already Polish, already
+    /// user-facing, nothing to translate. Stamped only by <see cref="FrontendAuthored"/> and
+    /// stripped from anything parsed off the wire, so an API body can never claim it.
+    /// </summary>
+    internal const string FrontendAuthoredExtensionKey = "frontendAuthored";
+
+    /// <summary>
+    /// Where <see cref="Localize"/> parks the API's own wording. A raw problem body has no
+    /// collapsible block to hide it in, so it moves out of <c>Detail</c> instead of being dropped.
+    /// </summary>
+    internal const string TechnicalDetailExtensionKey = "technicalDetail";
+
+    /// <summary>The correlation token both APIs stamp on every problem body.</summary>
+    internal const string TraceIdExtensionKey = "traceId";
+
+    /// <summary>
+    /// The last resort: an API-authored failure whose code is unmapped and whose status carries no
+    /// copy either. Reaching it is a gap in <see cref="PolishByErrorCode"/>, and
+    /// <c>ApiProblemAlert</c> logs the code when it does.
+    /// </summary>
+    internal const string GenericMessage = "Operacja nie powiodła się. Spróbuj ponownie za chwilę.";
+
+    /// <summary>
+    /// Polish copy per API error code. Covers every code <c>TranslationSystem.API</c> and
+    /// <c>AuthSystem.API</c> can produce — the domain error catalogues, the per-slice validation
+    /// errors and the shared exception handlers. A code missing here degrades to
+    /// <see cref="PolishByStatusCode"/>, never to the API's English.
+    /// </summary>
+    private static readonly FrozenDictionary<string, string> PolishByErrorCode =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // ── TMS · game versions ────────────────────────────────────────────────────────────
+            ["GameVersionEntity.NotFound"] =
+                "Nie znaleziono wskazanej wersji gry.",
+            ["GameVersionEntity.LotroNotationVersion.AlreadyTaken"] =
+                "Taka wersja gry jest już zarejestrowana.",
+            ["GameVersionEntity.LotroNotationVersion.NullOrEmpty"] =
+                "Podaj numer wersji gry.",
+            ["GameVersionEntity.LotroNotationVersion.LongerThanAllowed"] =
+                "Numer wersji gry jest za długi.",
+            ["GameVersionEntity.LotroNotationVersion.InvalidFormat"] =
+                "Numer wersji gry musi składać się z liczb rozdzielonych kropkami, na przykład „48.0” albo „47.1.1”.",
+            ["GameVersionEntity.SupersededCannotBeProcessed"] =
+                "Ta wersja gry została zastąpiona nowszą i nie może już zostać przetworzona.",
+            ["GameVersionEntity.ProcessedCannotBeSuperseded"] =
+                "Ta wersja gry jest już przetworzona i nie można oznaczyć jej jako zastąpionej.",
+            ["GameVersionEntity.OnlyUnprocessedCanBeDeleted"] =
+                "Usunąć można tylko wersję gry, do której nie zaimportowano jeszcze tekstów.",
+            ["GameVersionEntity.CannotDeleteReferencedVersion"] =
+                "Tej wersji gry nie można usunąć, bo są z nią powiązane tłumaczenia.",
+            ["GameVersions.Validation"] =
+                "Podane dane wersji gry są nieprawidłowe.",
+
+            // ── TMS · translations ─────────────────────────────────────────────────────────────
+            ["TranslationEntity.NotFound"] =
+                "Nie znaleziono tego tłumaczenia.",
+            ["TranslationEntity.CannotEditRemoved"] =
+                "Tego tłumaczenia nie można edytować — odpowiadający mu tekst został usunięty z gry.",
+            ["TranslationEntity.CannotApproveWithoutTranslation"] =
+                "Nie można zatwierdzić pustego tłumaczenia — najpierw wpisz polski tekst.",
+            ["TranslationEntity.CannotApproveRemoved"] =
+                "Tego tłumaczenia nie można zatwierdzić — odpowiadający mu tekst został usunięty z gry.",
+            ["TranslationEntity.FileId.Invalid"] =
+                "Nieprawidłowy identyfikator pliku.",
+            ["TranslationEntity.GossipId.Invalid"] =
+                "Nieprawidłowy identyfikator fragmentu.",
+            ["Translations.Validation"] =
+                "Tłumaczenie nie może być puste i nie może przekraczać dozwolonej długości.",
+            ["Translations.UnsupportedLanguage"] =
+                "Ten język nie jest obsługiwany — dostępny jest wyłącznie polski.",
+
+            // ── TMS · translation file ─────────────────────────────────────────────────────────
+            ["TranslationFiles.NotFound"] =
+                "Plik z tłumaczeniami nie został jeszcze zbudowany. Zatwierdź przynajmniej jedno tłumaczenie i spróbuj ponownie.",
+            ["TranslationFiles.UnsupportedLanguage"] =
+                "Ten język nie jest obsługiwany — dostępny jest wyłącznie polski.",
+
+            // ── TMS · import ───────────────────────────────────────────────────────────────────
+            ["Import.Validation"] =
+                "Podane dane importu są nieprawidłowe.",
+            ["Import.ParseFailed"] =
+                "Plik zawiera wiersze, których nie udało się odczytać. Import został odrzucony w całości, "
+                + "żeby uszkodzony plik nie skasował istniejących tłumaczeń.",
+            ["Import.InvalidRow"] =
+                "Plik zawiera nieprawidłowy wiersz.",
+            ["Import.DuplicateFragmentKey"] =
+                "Plik zawiera ten sam fragment więcej niż raz.",
+            ["Import.EmptyUpload"] =
+                "Plik nie zawiera żadnych tekstów do zaimportowania.",
+            ["Import.MassRemovalBlocked"] =
+                "Import usunąłby zbyt dużą część aktywnych tekstów i został wstrzymany. "
+                + "Jeśli to zamierzone, powtórz import z zaznaczoną opcją wymuszenia.",
+
+            // ── TMS · translator profile ───────────────────────────────────────────────────────
+            ["TranslatorEntity.NotFound"] =
+                "Nie znaleziono profilu tłumacza.",
+            ["TranslatorEntity.DisplayName.NullOrEmpty"] =
+                "Podaj nazwę wyświetlaną.",
+            ["TranslatorEntity.DisplayName.LongerThanAllowed"] =
+                "Nazwa wyświetlana jest za długa.",
+            ["TranslatorEntity.Email.LongerThanAllowed"] =
+                "Adres e-mail jest za długi.",
+            ["TranslatorEntity.Email.InvalidFormat"] =
+                "Adres e-mail jest nieprawidłowy.",
+            ["Translators.Unauthenticated"] =
+                "Twoja sesja wygasła. Zaloguj się ponownie.",
+
+            // ── Auth · accounts ────────────────────────────────────────────────────────────────
+            ["Auth.UserAlreadyExistsByEmail"] =
+                "Konto z tym adresem e-mail już istnieje.",
+            ["Auth.UserAlreadyExistsByUsername"] =
+                "Konto z tą nazwą użytkownika już istnieje.",
+            ["Auth.RegistrationFailed"] =
+                "Nie udało się założyć konta. Sprawdź podane dane i spróbuj ponownie.",
+            ["Auth.UserNotFound"] =
+                "Nie znaleziono konta.",
+            ["Auth.InvalidCurrentPassword"] =
+                "Aktualne hasło jest nieprawidłowe.",
+            ["Auth.PasswordChangeFailed"] =
+                "Nie udało się zmienić hasła. Nowe hasło może nie spełniać wymagań.",
+            ["Auth.InvalidPasswordResetToken"] =
+                "Link do zmiany hasła jest nieprawidłowy lub wygasł. Poproś o nowy.",
+            ["Auth.PasswordResetFailed"] =
+                "Nie udało się ustawić nowego hasła. Może ono nie spełniać wymagań.",
+            ["Auth.InvalidEmailConfirmationToken"] =
+                "Link potwierdzający adres e-mail jest nieprawidłowy lub wygasł. Poproś o nowy.",
+            ["Auth.EmailConfirmationFailed"] =
+                "Nie udało się potwierdzić adresu e-mail.",
+            ["Auth.DeletionAlreadyScheduled"] =
+                "Usunięcie konta jest już zaplanowane.",
+            ["Auth.DeletionSchedulingFailed"] =
+                "Nie udało się zaplanować usunięcia konta. Twoje konto pozostaje bez zmian — spróbuj ponownie później.",
+            ["Auth.AccountDeletionFailed"] =
+                "Nie udało się usunąć konta. Spróbuj ponownie później.",
+            ["Auth.InvalidCancelDeletionToken"] =
+                "Link anulujący usunięcie konta jest nieprawidłowy lub wygasł.",
+            ["Auth.CancelDeletionFailed"] =
+                "Nie udało się anulować usunięcia konta. Spróbuj ponownie później.",
+
+            // ── Auth · per-slice request validation ────────────────────────────────────────────
+            ["RegisterUser.Validation"] =
+                "Formularz rejestracji zawiera nieprawidłowe dane.",
+            ["ChangePassword.Validation"] =
+                "Formularz zmiany hasła zawiera nieprawidłowe dane.",
+            ["ForgotPassword.Validation"] =
+                "Podany adres e-mail jest nieprawidłowy.",
+            ["ResetPassword.Validation"] =
+                "Formularz zmiany hasła zawiera nieprawidłowe dane.",
+            ["ConfirmEmail.Validation"] =
+                "Link potwierdzający adres e-mail jest niekompletny lub nieprawidłowy.",
+            ["ResendEmailConfirmation.Validation"] =
+                "Podany adres e-mail jest nieprawidłowy.",
+            ["DeleteAccount.Validation"] =
+                "Formularz usunięcia konta zawiera nieprawidłowe dane.",
+            ["CancelAccountDeletion.Validation"] =
+                "Link anulujący usunięcie konta jest niekompletny lub nieprawidłowy.",
+
+            // ── Shared exception handlers (both APIs) ──────────────────────────────────────────
+            ["Validation.FluentValidation"] =
+                "Formularz zawiera nieprawidłowe dane.",
+            ["Db.ConcurrencyConflict"] =
+                "Dane zostały w międzyczasie zmienione przez kogoś innego. Odśwież stronę i spróbuj ponownie.",
+            ["Http.BadRequest"] =
+                "Serwer nie przyjął żądania — dane są nieprawidłowe lub niekompletne.",
+            ["Http.PayloadTooLarge"] =
+                "Wysyłany plik jest za duży.",
+            ["Http.InvalidArgument"] =
+                "Żądanie zawiera nieprawidłowe dane.",
+            ["Internal.UnhandledException"] =
+                "Wystąpił nieoczekiwany błąd serwera. Spróbuj ponownie za chwilę."
+        }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The degradation path for an API-authored failure whose code has no copy yet: say what the
+    /// status means in Polish rather than fall back to the API's English. Deliberately outranks the
+    /// call site's own fallback, which only says that something failed.
+    /// </summary>
+    private static readonly FrozenDictionary<int, string> PolishByStatusCode =
+        new Dictionary<int, string>
+        {
+            [StatusCodes.Status400BadRequest] = "Przesłane dane są nieprawidłowe.",
+            [StatusCodes.Status401Unauthorized] = "Twoja sesja wygasła. Zaloguj się ponownie.",
+            [StatusCodes.Status403Forbidden] = "Nie masz uprawnień do wykonania tej operacji.",
+            [StatusCodes.Status404NotFound] = "Nie znaleziono żądanych danych.",
+            [StatusCodes.Status405MethodNotAllowed] = "Ta operacja nie jest dostępna dla tego zasobu.",
+            [StatusCodes.Status408RequestTimeout] = "Serwer nie doczekał się całego żądania. Spróbuj ponownie.",
+            [StatusCodes.Status409Conflict] = "Operacja jest w konflikcie z aktualnym stanem danych.",
+            [StatusCodes.Status415UnsupportedMediaType] = "Serwer nie przyjmuje pliku w tym formacie.",
+            [StatusCodes.Status413PayloadTooLarge] = "Wysyłany plik jest za duży.",
+            [StatusCodes.Status422UnprocessableEntity] = "Operacja jest w konflikcie z aktualnym stanem danych.",
+            [StatusCodes.Status429TooManyRequests] = "Zbyt wiele żądań. Odczekaj chwilę i spróbuj ponownie.",
+            [StatusCodes.Status500InternalServerError] = "Wystąpił nieoczekiwany błąd serwera. Spróbuj ponownie za chwilę.",
+            [StatusCodes.Status502BadGateway] = "Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.",
+            [StatusCodes.Status503ServiceUnavailable] = "Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.",
+            [StatusCodes.Status504GatewayTimeout] = "Serwer nie odpowiedział w wyznaczonym czasie. Spróbuj ponownie."
+        }.ToFrozenDictionary();
+
+    /// <summary>
+    /// Turns a failure into what the page shows. <paramref name="fallbackMessage"/> is the page's own
+    /// contextual Polish sentence, used when there is no problem object at all or when a
+    /// Frontend-authored problem carries no text.
+    /// </summary>
+    public static ApiProblemView Describe(ProblemDetails? problem, string fallbackMessage)
+    {
+        string fallback = FirstNonBlank(fallbackMessage) ?? GenericMessage;
+
+        if (problem is null)
+        {
+            return new ApiProblemView(fallback, null, null, null);
+        }
+
+        if (IsFrontendAuthored(problem))
+        {
+            // Already Polish. Its title and detail are both user-facing, so neither is dropped.
+            return FirstNonBlank(problem.Title) is { } polishTitle
+                ? new ApiProblemView(polishTitle, FirstNonBlank(problem.Detail), null, null)
+                : new ApiProblemView(FirstNonBlank(problem.Detail) ?? fallback, null, null, null);
+        }
+
+        string? errorCode = ReadErrorCode(problem);
+        string? technicalDetail = BuildTechnicalDetail(errorCode, problem);
+
+        if (errorCode is not null && PolishByErrorCode.TryGetValue(errorCode, out string? mapped))
+        {
+            return new ApiProblemView(mapped, null, technicalDetail, null);
+        }
+
+        // No code at all is the UseStatusCodePages shape — a bare English reason phrase like
+        // "Unauthorized". It degrades exactly like an unmapped code, and is just as untranslatable
+        // by hand, so the status copy answers both.
+        string degraded = problem.Status is { } status && PolishByStatusCode.TryGetValue(status, out string? byStatus)
+            ? byStatus
+            : fallback;
+
+        return new ApiProblemView(degraded, null, technicalDetail, errorCode);
+    }
+
+    /// <summary>
+    /// A problem the Frontend wrote for its own reasons — a Polly transport failure, a rel the
+    /// server does not advertise, an inline form guard. Polish by construction, never translated.
+    /// </summary>
+    public static ProblemDetails FrontendAuthored(string title, string? detail = null, int? status = null)
+        => new()
+        {
+            Title = title,
+            Detail = detail,
+            Status = status,
+            Extensions = { [FrontendAuthoredExtensionKey] = true }
+        };
+
+    /// <summary>
+    /// Removes the Frontend-authored marker from a problem parsed off the wire, so an API response
+    /// carrying that member (ours never does) cannot pass its English through untranslated.
+    /// </summary>
+    public static void StripFrontendAuthoredMarker(ProblemDetails problem)
+    {
+        ArgumentNullException.ThrowIfNull(problem);
+        problem.Extensions.Remove(FrontendAuthoredExtensionKey);
+    }
+
+    private static bool IsFrontendAuthored(ProblemDetails problem)
+        => problem.Extensions.TryGetValue(FrontendAuthoredExtensionKey, out object? marker)
+           && marker is true;
+
+    /// <summary>
+    /// The same translation for a route that answers with a raw problem body instead of a rendered
+    /// page — the file-download endpoints, whose failure the browser shows verbatim.
+    /// </summary>
+    public static ProblemDetails Localize(
+        ILoggerFactory loggerFactory,
+        ProblemDetails? problem,
+        string fallbackMessage,
+        int fallbackStatus)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        ApiProblemView view = Describe(problem, fallbackMessage);
+        ReportUnmappedErrorCode(loggerFactory.CreateLogger(nameof(ApiProblemCopy)), view, problem?.Status);
+
+        ProblemDetails localized = new()
+        {
+            Title = view.Message,
+            Detail = view.SecondaryMessage,
+            Status = problem?.Status ?? fallbackStatus,
+            Type = problem?.Type
+        };
+
+        if (view.TechnicalDetail is { } technicalDetail)
+        {
+            localized.Extensions[TechnicalDetailExtensionKey] = technicalDetail;
+        }
+
+        // The trace id is the one token that ties a support report to the server-side log; it is the
+        // API's, not ours to mint, so it rides across rather than being rebuilt away.
+        if (problem?.Extensions.TryGetValue(TraceIdExtensionKey, out object? traceId) is true)
+        {
+            localized.Extensions[TraceIdExtensionKey] = traceId;
+        }
+
+        return localized;
+    }
+
+    /// <summary>
+    /// Reports an API error code that shipped before its Polish copy. Shared by both renderers so
+    /// the gap is never silent, whichever surface degraded (ADR-0044 §3).
+    /// </summary>
+    public static void ReportUnmappedErrorCode(ILogger logger, ApiProblemView view, int? status)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        if (view.UnmappedErrorCode is { } unmappedErrorCode)
+        {
+            LogUnmappedErrorCode(logger, unmappedErrorCode, status, null);
+        }
+    }
+
+    private static readonly Action<ILogger, string, int?, Exception?> LogUnmappedErrorCode =
+        LoggerMessage.Define<string, int?>(
+            LogLevel.Warning,
+            new EventId(1, nameof(LogUnmappedErrorCode)),
+            "API error code {ErrorCode} (status {StatusCode}) has no Polish copy; showed the status fallback.");
+
+    /// <summary>
+    /// The <c>errorCode</c> arrives as a <see cref="JsonElement"/> when the problem was deserialized
+    /// from the wire and as a plain <see cref="string"/> when it was constructed in-process.
+    /// </summary>
+    private static string? ReadErrorCode(ProblemDetails problem)
+    {
+        if (!problem.Extensions.TryGetValue(ErrorCodeExtensionKey, out object? rawErrorCode))
+        {
+            return null;
+        }
+
+        string? errorCode = rawErrorCode switch
+        {
+            string text => text,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            _ => null
+        };
+
+        return string.IsNullOrWhiteSpace(errorCode) ? null : errorCode;
+    }
+
+    /// <summary>
+    /// The code and the API's own wording, whichever of the two the problem actually carries.
+    /// A problem with neither (a body-less status) has nothing worth showing.
+    /// </summary>
+    private static string? BuildTechnicalDetail(string? errorCode, ProblemDetails problem)
+        => (errorCode, FirstNonBlank(problem.Detail, problem.Title)) switch
+        {
+            (not null, { } apiMessage) => $"{errorCode} — {apiMessage}",
+            (not null, null) => errorCode,
+            (null, { } apiMessage) => apiMessage,
+            _ => null
+        };
+
+    private static string? FirstNonBlank(params string?[] candidates)
+        => Array.Find(candidates, candidate => !string.IsNullOrWhiteSpace(candidate));
+}

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemView.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemView.cs
@@ -1,0 +1,24 @@
+namespace LotroKoniecDev.Frontend.Infrastructure.Errors;
+
+/// <summary>
+/// What a page shows for one failed call.
+/// </summary>
+/// <param name="Message">The Polish headline.</param>
+/// <param name="SecondaryMessage">
+/// The elaboration under the headline. Only a Frontend-authored problem has one — it writes a short
+/// Polish title plus a longer Polish detail, and both are already user-facing. An API-authored
+/// problem's elaboration is English and travels in <paramref name="TechnicalDetail"/> instead.
+/// </param>
+/// <param name="TechnicalDetail">
+/// The API's error code and its own English wording, kept collapsible so a bug report can quote it.
+/// Null for a Frontend-authored problem, which has nothing to hide.
+/// </param>
+/// <param name="UnmappedErrorCode">
+/// Set only when the API sent a code <see cref="ApiProblemCopy"/> has no copy for, so the renderer
+/// can log the gap.
+/// </param>
+internal sealed record ApiProblemView(
+    string Message,
+    string? SecondaryMessage,
+    string? TechnicalDetail,
+    string? UnmappedErrorCode);

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using Microsoft.AspNetCore.Mvc;
 using Polly.CircuitBreaker;
 using Polly.Timeout;
@@ -254,6 +255,10 @@ internal static class HttpClientApiExtensions
                 if (problem is not null)
                 {
                     problem.Status ??= (int)response.StatusCode;
+
+                    // Whatever the body claims, it came off the wire and is English until proven
+                    // otherwise — it does not get to wear the Frontend-authored marker (ADR-0044 §2).
+                    ApiProblemCopy.StripFrontendAuthoredMarker(problem);
                     return problem;
                 }
             }
@@ -263,12 +268,10 @@ internal static class HttpClientApiExtensions
             }
         }
 
-        return new ProblemDetails
-        {
-            Title = "Żądanie nie powiodło się",
-            Detail = "Serwer odrzucił żądanie bez szczegółów błędu.",
-            Status = (int)response.StatusCode
-        };
+        return ApiProblemCopy.FrontendAuthored(
+            "Żądanie nie powiodło się",
+            "Serwer odrzucił żądanie bez szczegółów błędu.",
+            (int)response.StatusCode);
     }
 
     /// <summary>
@@ -284,23 +287,17 @@ internal static class HttpClientApiExtensions
 
     private static ProblemDetails MapTransportFailureToProblemDetails(Exception ex) => ex switch
     {
-        BrokenCircuitException => new ProblemDetails
-        {
-            Title = "Usługa chwilowo niedostępna",
-            Detail = "Połączenie z serwerem zostało tymczasowo wstrzymane. Spróbuj ponownie za chwilę.",
-            Status = StatusCodes.Status503ServiceUnavailable
-        },
-        TimeoutRejectedException or TaskCanceledException => new ProblemDetails
-        {
-            Title = "Przekroczono czas oczekiwania",
-            Detail = "Serwer nie odpowiedział w wyznaczonym czasie. Spróbuj ponownie.",
-            Status = StatusCodes.Status504GatewayTimeout
-        },
-        _ => new ProblemDetails
-        {
-            Title = "Błąd połączenia",
-            Detail = "Nie udało się połączyć z serwerem. Spróbuj ponownie za chwilę.",
-            Status = StatusCodes.Status503ServiceUnavailable
-        }
+        BrokenCircuitException => ApiProblemCopy.FrontendAuthored(
+            "Usługa chwilowo niedostępna",
+            "Połączenie z serwerem zostało tymczasowo wstrzymane. Spróbuj ponownie za chwilę.",
+            StatusCodes.Status503ServiceUnavailable),
+        TimeoutRejectedException or TaskCanceledException => ApiProblemCopy.FrontendAuthored(
+            "Przekroczono czas oczekiwania",
+            "Serwer nie odpowiedział w wyznaczonym czasie. Spróbuj ponownie.",
+            StatusCodes.Status504GatewayTimeout),
+        _ => ApiProblemCopy.FrontendAuthored(
+            "Błąd połączenia",
+            "Nie udało się połączyć z serwerem. Spróbuj ponownie za chwilę.",
+            StatusCodes.Status503ServiceUnavailable)
     };
 }

--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -903,6 +903,19 @@ code {
     font-size: 14.5px;
 }
 
+/* Multi-line variant: the dot stays on the first line when the body wraps or carries a details block. */
+.status-line-block {
+    align-items: flex-start;
+}
+
+.status-line-block .dot {
+    margin-top: 7px;
+}
+
+.status-line-body {
+    min-width: 0;
+}
+
 .status-line .dot {
     width: 9px;
     height: 9px;
@@ -1014,6 +1027,33 @@ code {
 .error-message .em-retry {
     flex: 0 0 auto;
     margin: 0;
+}
+
+/* ───────── API problem alert body (ADR-0044) ───────── */
+.problem-headline,
+.problem-secondary {
+    display: block;
+}
+
+.problem-tech {
+    margin-top: 6px;
+    font-size: 12.5px;
+    color: var(--text-mute);
+}
+
+.problem-tech > summary {
+    cursor: pointer;
+    user-select: none;
+    color: inherit;
+}
+
+.problem-tech .problem-tech-body {
+    display: block;
+    margin-top: 4px;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
 }
 
 /* ───────── Data table ───────── */

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
@@ -6,6 +6,7 @@ using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
 using LotroKoniecDev.AuthSystem.Contracts.Hateoas;
 using LotroKoniecDev.Frontend.Components.Pages.Account;
 using LotroKoniecDev.Frontend.Infrastructure.Discovery;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.AuthSystemHttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
@@ -23,6 +24,7 @@ using NSubstitute;
 using AuthDiscoveryResponse = LotroKoniecDev.AuthSystem.Contracts.Discovery.DiscoveryResponse;
 using TranslationDiscoveryResponse = LotroKoniecDev.TranslationSystem.Contracts.Discovery.DiscoveryResponse;
 using TranslationRels = LotroKoniecDev.TranslationSystem.Contracts.Hateoas.Rels;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Account;
 
@@ -52,7 +54,7 @@ public sealed class AccountEndpointsExtensionsTests
         AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         file.ContentType.ShouldBe("application/json");
@@ -66,7 +68,7 @@ public sealed class AccountEndpointsExtensionsTests
         AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -81,7 +83,7 @@ public sealed class AccountEndpointsExtensionsTests
         AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -100,7 +102,7 @@ public sealed class AccountEndpointsExtensionsTests
             """{ "title": "Usługa chwilowo niedostępna", "status": 503 }"""));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, tmsClient, CancellationToken.None);
+            loader, _discoveryCache, tmsClient, NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -118,7 +120,7 @@ public sealed class AccountEndpointsExtensionsTests
             """{ "title": "Błąd serwera", "status": 500 }"""));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, tmsClient, CancellationToken.None);
+            loader, _discoveryCache, tmsClient, NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         file.ContentType.ShouldBe("application/json");
@@ -139,7 +141,7 @@ public sealed class AccountEndpointsExtensionsTests
             JsonSerializer.Serialize(CreateContribution(), ApiJsonOptions));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, CreateTmsClient(tmsHandler), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClient(tmsHandler), NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -158,7 +160,7 @@ public sealed class AccountEndpointsExtensionsTests
             .Returns(ApiResult.Failure<TranslationDiscoveryResponse>(new ProblemDetails { Status = 503 }));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -174,7 +176,7 @@ public sealed class AccountEndpointsExtensionsTests
             StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "this is not json"));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, tmsClient, CancellationToken.None);
+            loader, _discoveryCache, tmsClient, NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -190,7 +192,7 @@ public sealed class AccountEndpointsExtensionsTests
             StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, string.Empty));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, tmsClient, CancellationToken.None);
+            loader, _discoveryCache, tmsClient, NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         string json = Encoding.UTF8.GetString(file.FileContents.ToArray());
@@ -209,10 +211,40 @@ public sealed class AccountEndpointsExtensionsTests
                 """{ "title": "Nie znaleziono użytkownika", "status": 404 }""")));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);
 
         ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
         problem.ProblemDetails.Status.ShouldBe(404);
+    }
+
+    [Fact]
+    public async Task DownloadAccountExportAsync_WhenUpstreamReturnsAnEnglishProblem_RewritesItInPolish()
+    {
+        // A download route answers with a raw problem body the browser shows verbatim, so it carries
+        // the same errorCode→Polish rule as a rendered page (#548 / ADR-0044).
+        StubDiscoveryWithExportLink();
+        AccountLoader loader = new(
+            _discoveryCache,
+            CreateClient(StubHttpMessageHandler.RespondWith(
+                HttpStatusCode.NotFound,
+                """
+                {
+                  "title": "Not Found",
+                  "status": 404,
+                  "detail": "User not found.",
+                  "errorCode": "Auth.UserNotFound",
+                  "traceId": "00-abc-def-01"
+                }
+                """)));
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);
+
+        ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
+        problem.ProblemDetails.Status.ShouldBe(404);
+        problem.ProblemDetails.Title.ShouldBe("Nie znaleziono konta.");
+        problem.ProblemDetails.Extensions[ApiProblemCopy.TechnicalDetailExtensionKey]
+            .ShouldBe("Auth.UserNotFound — User not found.");
     }
 
     [Fact]
@@ -229,7 +261,7 @@ public sealed class AccountEndpointsExtensionsTests
             CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "{}")));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
-            loader, _discoveryCache, CreateTmsClientReturningContribution(), CancellationToken.None);
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);
 
         ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
         problem.ProblemDetails.Status.ShouldBe(503);

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountTests.cs
@@ -5,6 +5,7 @@ using LotroKoniecDev.AuthSystem.Contracts.Hateoas;
 using LotroKoniecDev.Frontend.Components.Pages.Account;
 using LotroKoniecDev.Frontend.Components.Shared;
 using LotroKoniecDev.Frontend.Infrastructure.Discovery;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.AuthSystemHttpClients;
 using LotroKoniecDev.Hateoas.Abstractions;
@@ -125,11 +126,11 @@ public sealed class AccountTests : BunitContext
         _discoveryCache.GetAuthSystemDiscoveryAsync(Arg.Any<CancellationToken>())
             .Returns(ApiResult.Success(discovery));
         _client.GetApiResultAsync<AccountDataExportResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(ApiResult.Failure<AccountDataExportResponse>(new ProblemDetails
-            {
-                Title = "Nie udało się wczytać danych konta",
-                Status = (int)HttpStatusCode.BadGateway
-            }));
+            // A Frontend-authored failure (the shape HttpClientApiExtensions produces for a transport
+            // error) — already Polish, so it renders verbatim rather than through the copy map.
+            .Returns(ApiResult.Failure<AccountDataExportResponse>(ApiProblemCopy.FrontendAuthored(
+                "Nie udało się wczytać danych konta",
+                status: (int)HttpStatusCode.BadGateway)));
 
         IRenderedComponent<AccountComponent> component = Render<AccountComponent>();
 

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Editor/EditorTests.cs
@@ -250,6 +250,32 @@ public sealed class EditorTests : BunitContext
     }
 
     [Fact]
+    public async Task Save_WhenTheApiRejectsAnEmptyTranslation_ShowsPolishAndNotTheApiEnglish()
+    {
+        // The exact surface #548 reports: the API rejects an empty translation by design and used to
+        // paint its English "Validation Error" into the Polish page.
+        Guid id = Guid.NewGuid();
+        StubLoad(BuildDetail(sourceText: "Hello.", translatedText: "Cześć.", canEdit: true));
+        _client
+            .PutApiResultAsync<TranslationDetailResponse>(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<TranslationDetailResponse>(new()
+            {
+                Title = "Validation Error",
+                Detail = "'Translated Text' must not be empty.",
+                Status = 400,
+                Extensions = { ["errorCode"] = "Translations.Validation" }
+            }));
+        IRenderedComponent<EditorComponent> component = RenderEditor(id);
+
+        await component.Find("form").SubmitAsync();
+
+        IElement error = component.Find(".status-message.status-error");
+        error.QuerySelector(".problem-headline")!.TextContent
+            .ShouldBe("Tłumaczenie nie może być puste i nie może przekraczać dozwolonej długości.");
+        error.QuerySelector(".problem-headline")!.TextContent.ShouldNotContain("Validation Error");
+    }
+
+    [Fact]
     public async Task Approve_WhenApproveFails_DoesNotRedirectAndShowsTheErrorInline()
     {
         // Symmetric to the save-failure path: a rejected approve (API 403 / 409 / 422 / …) must not

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
@@ -158,6 +158,35 @@ public sealed class GameVersionsTests : BunitContext
     }
 
     [Fact]
+    public async Task Delete_WhenTheApiRefusesInEnglish_ShowsPolishInTheSharedActionErrorBlock()
+    {
+        // #548: the shared _actionProblem block (reused verbatim by register) used to paint the API's
+        // English straight into the Polish page. Register's own submit is undrivable in bUnit SSR —
+        // see the class summary — so delete pins the block both actions render through.
+        AuthorizeAs("Sam");
+        StubVersions(Version("48.0", GameVersionStatus.Unprocessed, canDelete: true));
+        _client.DeleteApiResultAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure(new()
+            {
+                Title = "Data Conflict",
+                Detail = "Game version with ID '…' is referenced by one or more translations and cannot be deleted.",
+                Status = 422,
+                Extensions = { ["errorCode"] = "GameVersionEntity.CannotDeleteReferencedVersion" }
+            }));
+        IRenderedComponent<GameVersionsComponent> component = RenderPage();
+
+        await component.Find(".col-actions form").SubmitAsync();
+
+        IElement error = component.Find(".status-message.status-error");
+        error.QuerySelector(".problem-headline")!.TextContent
+            .ShouldBe("Tej wersji gry nie można usunąć, bo są z nią powiązane tłumaczenia.");
+        error.QuerySelector(".problem-headline")!.TextContent.ShouldNotContain("Data Conflict");
+        // The API's own wording survives for a bug report, but only behind the technical-details block.
+        error.QuerySelector("details.problem-tech .problem-tech-body")!.TextContent
+            .ShouldContain("is referenced by one or more translations");
+    }
+
+    [Fact]
     public void Render_WhenNoVersionsExist_ShowsTheEmptyStateInsteadOfTheTable()
     {
         AuthorizeAs("Frodo");

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportEndpointsExtensionsTests.cs
@@ -1,12 +1,14 @@
 using System.Net;
 using System.Text;
 using LotroKoniecDev.Frontend.Components.Pages.ImportExport;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Discovery;
 using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
 using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.ImportExport;
 
@@ -25,7 +27,7 @@ public sealed class ImportExportEndpointsExtensionsTests
         const string body = "# polish.txt\n620756992||1001||Witaj w Śródziemiu!||NULL||NULL||1";
         ImportExportLoader loader = CreateLoader(HttpStatusCode.OK, body);
 
-        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, CancellationToken.None);
+        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         file.FileDownloadName.ShouldBe(ImportExportLoader.DownloadFileName);
@@ -39,7 +41,7 @@ public sealed class ImportExportEndpointsExtensionsTests
         // The patcher parser int.Parses the first field, so a leading BOM would break it.
         ImportExportLoader loader = CreateLoader(HttpStatusCode.OK, "620756992||1001||Witaj||NULL||NULL||1");
 
-        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, CancellationToken.None);
+        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, NullLoggerFactory.Instance, CancellationToken.None);
 
         FileContentHttpResult file = result.ShouldBeOfType<FileContentHttpResult>();
         byte[] preamble = Encoding.UTF8.GetPreamble();
@@ -54,10 +56,36 @@ public sealed class ImportExportEndpointsExtensionsTests
             HttpStatusCode.NotFound,
             """{ "title": "Brak pliku tłumaczenia", "status": 404 }""");
 
-        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, CancellationToken.None);
+        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, NullLoggerFactory.Instance, CancellationToken.None);
 
         ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
         problem.ProblemDetails.Status.ShouldBe(404);
+    }
+
+    [Fact]
+    public async Task DownloadTranslationFileAsync_WhenUpstreamReturnsAnEnglishProblem_RewritesItInPolish()
+    {
+        // The browser shows this body verbatim — it is a download route, not a rendered page — so the
+        // same errorCode→Polish rule applies here as on a page (#548 / ADR-0044).
+        ImportExportLoader loader = CreateLoader(
+            HttpStatusCode.NotFound,
+            """
+            {
+              "title": "Not Found",
+              "status": 404,
+              "detail": "No translation file has been built for 'pl' yet.",
+              "errorCode": "TranslationFiles.NotFound"
+            }
+            """);
+
+        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, NullLoggerFactory.Instance, CancellationToken.None);
+
+        ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
+        problem.ProblemDetails.Status.ShouldBe(404);
+        problem.ProblemDetails.Title.ShouldBe(
+            "Plik z tłumaczeniami nie został jeszcze zbudowany. Zatwierdź przynajmniej jedno tłumaczenie i spróbuj ponownie.");
+        problem.ProblemDetails.Extensions[ApiProblemCopy.TechnicalDetailExtensionKey]
+            .ShouldBe("TranslationFiles.NotFound — No translation file has been built for 'pl' yet.");
     }
 
     [Fact]
@@ -69,7 +97,7 @@ public sealed class ImportExportEndpointsExtensionsTests
             StubDiscoveryCache.AdvertisingGet(Rels.TranslationFile),
             CreateClient(StubHttpMessageHandler.Throw(new HttpRequestException("connection refused"))));
 
-        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, CancellationToken.None);
+        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, NullLoggerFactory.Instance, CancellationToken.None);
 
         ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
         problem.ProblemDetails.Status.ShouldBe(StatusCodes.Status503ServiceUnavailable);

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Shared/ApiProblemAlertTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Shared/ApiProblemAlertTests.cs
@@ -1,0 +1,138 @@
+using AngleSharp.Dom;
+using LotroKoniecDev.Frontend.Components.Shared;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
+using LotroKoniecDev.Frontend.Tests.Unit.Shared;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Shared;
+
+/// <summary>
+/// The one component every page renders a failed call through (#548 / ADR-0044). These lock down what
+/// reaches the screen: Polish copy for an API failure, the API's English kept behind a collapsed
+/// <c>details</c>, and a logged warning when a code shipped without copy.
+/// </summary>
+public sealed class ApiProblemAlertTests : BunitContext
+{
+    private readonly CapturingLoggerProvider _loggerProvider = new();
+
+    public ApiProblemAlertTests()
+    {
+        Services.AddLogging(builder => builder.AddProvider(_loggerProvider));
+    }
+
+    [Fact]
+    public void Render_ForAMappedApiFailure_ShowsPolishAndKeepsTheEnglishOutOfTheHeadline()
+    {
+        ProblemDetails problem = ApiProblem(
+            "GameVersionEntity.LotroNotationVersion.AlreadyTaken",
+            422,
+            "Data Conflict",
+            "The lotronotationversion value '48.0' is already taken.");
+
+        IRenderedComponent<ApiProblemAlert> component = Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Problem, problem)
+            .Add(alert => alert.Fallback, "Operacja nie powiodła się."));
+
+        component.Find(".problem-headline").TextContent
+            .ShouldBe("Taka wersja gry jest już zarejestrowana.");
+        component.Find(".problem-headline").TextContent.ShouldNotContain("already taken");
+    }
+
+    [Fact]
+    public void Render_ForAnApiFailure_KeepsTheCodeAndEnglishInACollapsedDetailsBlock()
+    {
+        ProblemDetails problem = ApiProblem(
+            "Import.ParseFailed",
+            422,
+            "Data Conflict",
+            "The upload has 3 unparseable line(s); first failure — line 42: unexpected pipe.");
+
+        IRenderedComponent<ApiProblemAlert> component = Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Problem, problem)
+            .Add(alert => alert.Fallback, "Nie udało się zaimportować pliku."));
+
+        IElement details = component.Find("details.problem-tech");
+        details.HasAttribute("open").ShouldBeFalse();
+        details.QuerySelector("summary")!.TextContent.ShouldBe("Szczegóły techniczne");
+        details.QuerySelector(".problem-tech-body")!.TextContent
+            .ShouldBe("Import.ParseFailed — The upload has 3 unparseable line(s); first failure — line 42: unexpected pipe.");
+    }
+
+    [Fact]
+    public void Render_ForAFrontendAuthoredProblem_ShowsBothPolishLinesAndNoTechnicalDetails()
+    {
+        ProblemDetails problem = ApiProblemCopy.FrontendAuthored(
+            "Nie można zaimportować do tej wersji gry.",
+            "Serwer nie udostępnia importu dla wybranej wersji. Odśwież stronę i wybierz inną wersję.");
+
+        IRenderedComponent<ApiProblemAlert> component = Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Problem, problem)
+            .Add(alert => alert.Fallback, "Nie udało się zaimportować pliku."));
+
+        component.Find(".problem-headline").TextContent.ShouldBe("Nie można zaimportować do tej wersji gry.");
+        component.Find(".problem-secondary").TextContent
+            .ShouldBe("Serwer nie udostępnia importu dla wybranej wersji. Odśwież stronę i wybierz inną wersję.");
+        component.FindAll("details.problem-tech").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WithNoProblem_ShowsTheCallSiteFallbackAlone()
+    {
+        IRenderedComponent<ApiProblemAlert> component = Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Fallback, "Nie udało się wczytać statystyk."));
+
+        component.Find(".problem-headline").TextContent.ShouldBe("Nie udało się wczytać statystyk.");
+        component.FindAll(".problem-secondary").ShouldBeEmpty();
+        component.FindAll("details.problem-tech").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WithAHeadlineClass_KeepsTheCallersBoxStylingIntact()
+    {
+        // The rich `error-message` box styles its title through `.em-body .t`; the component has to
+        // carry that class or every load-failure box loses its heading style.
+        IRenderedComponent<ApiProblemAlert> component = Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Fallback, "Nie udało się wczytać statystyk.")
+            .Add(alert => alert.HeadlineClass, "t"));
+
+        component.Find(".problem-headline").ClassList.ShouldContain("t");
+    }
+
+    [Fact]
+    public void Render_ForAnUnmappedErrorCode_ShowsTheStatusCopyAndLogsTheGap()
+    {
+        ProblemDetails problem = ApiProblem("Catalog.SomethingNobodyMappedYet", 403, "Forbidden", "Not your row.");
+
+        IRenderedComponent<ApiProblemAlert> component = Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Problem, problem)
+            .Add(alert => alert.Fallback, "Operacja nie powiodła się."));
+
+        component.Find(".problem-headline").TextContent
+            .ShouldBe("Nie masz uprawnień do wykonania tej operacji.");
+        _loggerProvider.Entries.ShouldContain(entry =>
+            entry.Level == LogLevel.Warning && entry.Message.Contains("Catalog.SomethingNobodyMappedYet"));
+    }
+
+    [Fact]
+    public void Render_ForAMappedErrorCode_LogsNothing()
+    {
+        ProblemDetails problem = ApiProblem("Auth.InvalidCurrentPassword", 400, "Validation Error", "Wrong.");
+
+        Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Problem, problem)
+            .Add(alert => alert.Fallback, "Nie udało się zmienić hasła."));
+
+        _loggerProvider.Entries.ShouldBeEmpty();
+    }
+
+    private static ProblemDetails ApiProblem(string errorCode, int status, string title, string detail)
+        => new()
+        {
+            Title = title,
+            Detail = detail,
+            Status = status,
+            Extensions = { [ApiProblemCopy.ErrorCodeExtensionKey] = errorCode }
+        };
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Errors/ApiProblemCopyTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Errors/ApiProblemCopyTests.cs
@@ -1,0 +1,372 @@
+using System.Net;
+using System.Text.Json;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Tests.Unit.Shared;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Errors;
+
+/// <summary>
+/// The Polish-copy lookup for API failures (#548 / ADR-0044). The contract under test: an
+/// API-authored problem is keyed by its <c>errorCode</c> and its English wording never becomes the
+/// message, while a Frontend-authored problem (no code, already Polish) passes through untouched.
+/// </summary>
+public sealed class ApiProblemCopyTests
+{
+    private const string PageFallback = "Nie udało się wczytać listy wersji gry.";
+
+    [Fact]
+    public void Describe_WhenThereIsNoProblem_UsesTheCallSiteFallback()
+    {
+        ApiProblemView view = ApiProblemCopy.Describe(null, PageFallback);
+
+        view.Message.ShouldBe(PageFallback);
+        view.SecondaryMessage.ShouldBeNull();
+        view.TechnicalDetail.ShouldBeNull();
+        view.UnmappedErrorCode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Describe_ForAFrontendAuthoredProblem_KeepsBothPolishLines()
+    {
+        // The Frontend writes a short Polish title plus a longer Polish detail; both are user-facing.
+        ProblemDetails problem = ApiProblemCopy.FrontendAuthored(
+            "Hasła nie są zgodne",
+            "Nowe hasło i jego powtórzenie muszą być identyczne.");
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe("Hasła nie są zgodne");
+        view.SecondaryMessage.ShouldBe("Nowe hasło i jego powtórzenie muszą być identyczne.");
+        view.TechnicalDetail.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Describe_ForAFrontendAuthoredProblemWithOnlyADetail_PromotesTheDetailToTheHeadline()
+    {
+        ProblemDetails problem = ApiProblemCopy.FrontendAuthored(
+            title: "   ",
+            detail: "Serwer nie odpowiedział w wyznaczonym czasie.");
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe("Serwer nie odpowiedział w wyznaczonym czasie.");
+        view.SecondaryMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Describe_ForAFrontendAuthoredProblemWithNoText_UsesTheCallSiteFallback()
+    {
+        ApiProblemView view = ApiProblemCopy.Describe(ApiProblemCopy.FrontendAuthored("  "), PageFallback);
+
+        view.Message.ShouldBe(PageFallback);
+        view.TechnicalDetail.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("Unauthorized", 401, "Twoja sesja wygasła. Zaloguj się ponownie.")]
+    [InlineData("Forbidden", 403, "Nie masz uprawnień do wykonania tej operacji.")]
+    [InlineData("Not Found", 404, "Nie znaleziono żądanych danych.")]
+    [InlineData("Method Not Allowed", 405, "Ta operacja nie jest dostępna dla tego zasobu.")]
+    [InlineData("Unsupported Media Type", 415, "Serwer nie przyjmuje pliku w tym formacie.")]
+    public void Describe_ForAStatusCodePagesProblemWithNoErrorCode_TranslatesInsteadOfPassingTheEnglishThrough(
+        string apiReasonPhrase,
+        int status,
+        string expectedMessage)
+    {
+        // Both APIs run AddProblemDetails() + UseStatusCodePages(), which writes a bare English reason
+        // phrase and NO errorCode — see the committed ProblemDetailsSnapshotTests contracts. Treating
+        // "no code" as "the Frontend wrote it, so it is already Polish" would paint "Unauthorized"
+        // onto the page, which is the very defect #548 reports.
+        ProblemDetails problem = new() { Title = apiReasonPhrase, Status = status };
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe(expectedMessage);
+        view.Message.ShouldNotContain(apiReasonPhrase);
+        view.TechnicalDetail.ShouldBe(apiReasonPhrase);
+    }
+
+    [Fact]
+    public void Describe_WhenAnApiBodyClaimsToBeFrontendAuthored_StillTranslatesIt()
+    {
+        // The marker is ours alone; ParseProblemDetails strips it off anything parsed from the wire,
+        // so a body carrying that member cannot smuggle its English past the lookup.
+        ProblemDetails wireProblem = new()
+        {
+            Title = "Forbidden",
+            Status = 403,
+            Extensions = { [ApiProblemCopy.FrontendAuthoredExtensionKey] = true }
+        };
+
+        ApiProblemCopy.StripFrontendAuthoredMarker(wireProblem);
+        ApiProblemView view = ApiProblemCopy.Describe(wireProblem, PageFallback);
+
+        view.Message.ShouldBe("Nie masz uprawnień do wykonania tej operacji.");
+    }
+
+    [Fact]
+    public async Task ParseProblemDetails_ForABodyClaimingTheFrontendMarker_StripsItAtTheHttpSeam()
+    {
+        HttpClient httpClient = new(StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.Forbidden,
+            $$"""{ "title": "Forbidden", "status": 403, "{{ApiProblemCopy.FrontendAuthoredExtensionKey}}": true }"""))
+        {
+            BaseAddress = new Uri("https://localhost:5002/")
+        };
+
+        ApiResult result = await httpClient.DeleteApiResultAsync("api/v1/game-versions/1");
+        ApiProblemView view = ApiProblemCopy.Describe(result.ProblemDetails, PageFallback);
+
+        view.Message.ShouldBe("Nie masz uprawnień do wykonania tej operacji.");
+    }
+
+    [Theory]
+    [InlineData("GameVersionEntity.LotroNotationVersion.AlreadyTaken", 422, "Taka wersja gry jest już zarejestrowana.")]
+    [InlineData("GameVersionEntity.LotroNotationVersion.InvalidFormat", 400, "Numer wersji gry musi składać się z liczb rozdzielonych kropkami, na przykład „48.0” albo „47.1.1”.")]
+    [InlineData("GameVersionEntity.CannotDeleteReferencedVersion", 422, "Tej wersji gry nie można usunąć, bo są z nią powiązane tłumaczenia.")]
+    [InlineData("TranslationEntity.CannotApproveWithoutTranslation", 422, "Nie można zatwierdzić pustego tłumaczenia — najpierw wpisz polski tekst.")]
+    [InlineData("Translations.Validation", 400, "Tłumaczenie nie może być puste i nie może przekraczać dozwolonej długości.")]
+    [InlineData("Auth.InvalidCurrentPassword", 400, "Aktualne hasło jest nieprawidłowe.")]
+    [InlineData("Validation.FluentValidation", 400, "Formularz zawiera nieprawidłowe dane.")]
+    [InlineData("Internal.UnhandledException", 500, "Wystąpił nieoczekiwany błąd serwera. Spróbuj ponownie za chwilę.")]
+    public void Describe_WhenTheErrorCodeIsMapped_ShowsThePolishCopy(
+        string errorCode,
+        int status,
+        string expectedMessage)
+    {
+        ProblemDetails problem = ApiProblem(errorCode, status, "Validation Error", "The English wording.");
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe(expectedMessage);
+        view.UnmappedErrorCode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Describe_WhenTheErrorCodeIsMapped_KeepsTheApiWordingAsTechnicalDetailOnly()
+    {
+        // The numbers an admin needs (line numbers, row counts) live in the API's own message, so it
+        // is kept — one click away, never as the message itself.
+        ProblemDetails problem = ApiProblem(
+            "Import.MassRemovalBlocked",
+            422,
+            "Data Conflict",
+            "The upload would remove 812 of 1000 active row(s) (81%), exceeding the 30% safety threshold.");
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldNotContain("The upload would remove");
+        view.TechnicalDetail.ShouldBe(
+            "Import.MassRemovalBlocked — The upload would remove 812 of 1000 active row(s) (81%), "
+            + "exceeding the 30% safety threshold.");
+    }
+
+    [Fact]
+    public void Describe_WhenTheApiSendsNoDetail_FallsBackToTheApiTitleForTheTechnicalDetail()
+    {
+        ProblemDetails problem = ApiProblem("Internal.UnhandledException", 500, "Internal Server Error", detail: null);
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.TechnicalDetail.ShouldBe("Internal.UnhandledException — Internal Server Error");
+    }
+
+    [Fact]
+    public void Describe_WhenTheApiSendsNeitherTitleNorDetail_UsesTheBareCodeAsTechnicalDetail()
+    {
+        ProblemDetails problem = ApiProblem("Internal.UnhandledException", 500, title: null, detail: null);
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.TechnicalDetail.ShouldBe("Internal.UnhandledException");
+    }
+
+    [Theory]
+    [InlineData(400, "Przesłane dane są nieprawidłowe.")]
+    [InlineData(401, "Twoja sesja wygasła. Zaloguj się ponownie.")]
+    [InlineData(403, "Nie masz uprawnień do wykonania tej operacji.")]
+    [InlineData(404, "Nie znaleziono żądanych danych.")]
+    [InlineData(422, "Operacja jest w konflikcie z aktualnym stanem danych.")]
+    [InlineData(500, "Wystąpił nieoczekiwany błąd serwera. Spróbuj ponownie za chwilę.")]
+    public void Describe_WhenTheErrorCodeIsUnmapped_DegradesToThePolishStatusCopyAndReportsTheCode(
+        int status,
+        string expectedMessage)
+    {
+        ProblemDetails problem = ApiProblem("Catalog.SomethingNobodyMappedYet", status, "Validation Error", "English.");
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe(expectedMessage);
+        view.UnmappedErrorCode.ShouldBe("Catalog.SomethingNobodyMappedYet");
+        view.TechnicalDetail.ShouldBe("Catalog.SomethingNobodyMappedYet — English.");
+    }
+
+    [Fact]
+    public void Describe_WhenTheErrorCodeAndTheStatusAreBothUnmapped_UsesTheCallSiteFallback()
+    {
+        ProblemDetails problem = ApiProblem("Catalog.SomethingNobodyMappedYet", 418, "Error", "English.");
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe(PageFallback);
+        view.UnmappedErrorCode.ShouldBe("Catalog.SomethingNobodyMappedYet");
+    }
+
+    [Fact]
+    public void Describe_WhenTheErrorCodeIsUnmappedAndTheProblemCarriesNoStatus_UsesTheCallSiteFallback()
+    {
+        ProblemDetails problem = new()
+        {
+            Title = "Validation Error",
+            Extensions = { [ApiProblemCopy.ErrorCodeExtensionKey] = "Catalog.SomethingNobodyMappedYet" }
+        };
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe(PageFallback);
+        view.UnmappedErrorCode.ShouldBe("Catalog.SomethingNobodyMappedYet");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Describe_WhenTheErrorCodeIsBlank_DegradesByStatusRatherThanShowingTheEnglish(string blankErrorCode)
+    {
+        ProblemDetails problem = new()
+        {
+            Title = "Service Unavailable",
+            Status = 503,
+            Extensions = { [ApiProblemCopy.ErrorCodeExtensionKey] = blankErrorCode }
+        };
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe("Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.");
+        view.UnmappedErrorCode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Describe_WhenTheErrorCodeIsNotAString_DegradesByStatusRatherThanShowingTheEnglish()
+    {
+        ProblemDetails problem = new()
+        {
+            Title = "Service Unavailable",
+            Status = 503,
+            Extensions = { [ApiProblemCopy.ErrorCodeExtensionKey] = 42 }
+        };
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe("Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.");
+        view.UnmappedErrorCode.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Describe_WhenTheCallSiteFallbackIsBlank_FloorsOnTheGenericMessage(string blankFallback)
+    {
+        // Every branch shares the same floor, so no call site can render an empty red box.
+        ApiProblemCopy.Describe(null, blankFallback).Message.ShouldBe(ApiProblemCopy.GenericMessage);
+        ApiProblemCopy.Describe(ApiProblemCopy.FrontendAuthored("  "), blankFallback).Message
+            .ShouldBe(ApiProblemCopy.GenericMessage);
+        ApiProblemCopy.Describe(ApiProblem("Catalog.Unmapped", 418, "Error", "English."), blankFallback).Message
+            .ShouldBe(ApiProblemCopy.GenericMessage);
+    }
+
+    [Fact]
+    public void Describe_WhenTheErrorCodeArrivesAsAJsonElement_StillResolvesTheCopy()
+    {
+        // The wire shape: deserializing ProblemDetails puts unknown members into Extensions as
+        // JsonElement, not string. Reading only `is string` would silently miss every real response.
+        JsonElement wireErrorCode = JsonSerializer.Deserialize<JsonElement>("\"Auth.UserAlreadyExistsByEmail\"");
+        ProblemDetails problem = new()
+        {
+            Title = "Data Conflict",
+            Detail = "A user with this email address already exists.",
+            Status = 422,
+            Extensions = { [ApiProblemCopy.ErrorCodeExtensionKey] = wireErrorCode }
+        };
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe("Konto z tym adresem e-mail już istnieje.");
+        view.UnmappedErrorCode.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Describe_OnAProblemParsedFromARealApiResponse_ShowsThePolishCopy()
+    {
+        // End to end across the seam that actually produces the ProblemDetails a page renders: the
+        // body below is exactly what ErrorExtensions.ToProblemDetails writes for a rejected save.
+        const string apiResponseBody = """
+            {
+              "type": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+              "title": "Validation Error",
+              "status": 400,
+              "detail": "'Translated Text' must not be empty.",
+              "errorCode": "Translations.Validation"
+            }
+            """;
+        HttpClient httpClient = new(StubHttpMessageHandler.RespondWith(HttpStatusCode.BadRequest, apiResponseBody))
+        {
+            BaseAddress = new Uri("https://localhost:5002/")
+        };
+
+        ApiResult result = await httpClient.PutApiResultAsync("api/v1/translations/620756992/1001", new { });
+        ApiProblemView view = ApiProblemCopy.Describe(result.ProblemDetails, "Nie udało się zapisać tłumaczenia.");
+
+        result.IsFailure.ShouldBeTrue();
+        view.Message.ShouldBe("Tłumaczenie nie może być puste i nie może przekraczać dozwolonej długości.");
+        view.TechnicalDetail.ShouldBe("Translations.Validation — 'Translated Text' must not be empty.");
+    }
+
+    [Fact]
+    public void Localize_ForAnUnmappedErrorCode_LogsTheGapAndKeepsTheTraceIdAndType()
+    {
+        // The download routes have no collapsible block and no component, so the warning and the
+        // correlation token have to survive here or the gap is silent (ADR-0044 §3).
+        ProblemDetails problem = ApiProblem("Catalog.SomethingNobodyMappedYet", 403, "Forbidden", "Not your row.");
+        problem.Type = "https://tools.ietf.org/html/rfc9110#section-15.5.4";
+        problem.Extensions[ApiProblemCopy.TraceIdExtensionKey] = "00-abc-def-01";
+        CapturingLoggerProvider loggerProvider = new();
+        using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
+
+        ProblemDetails localized = ApiProblemCopy.Localize(loggerFactory, problem, PageFallback, 502);
+
+        localized.Title.ShouldBe("Nie masz uprawnień do wykonania tej operacji.");
+        localized.Status.ShouldBe(403);
+        localized.Type.ShouldBe("https://tools.ietf.org/html/rfc9110#section-15.5.4");
+        localized.Extensions[ApiProblemCopy.TraceIdExtensionKey].ShouldBe("00-abc-def-01");
+        loggerProvider.Entries.ShouldContain(entry =>
+            entry.Level == LogLevel.Warning && entry.Message.Contains("Catalog.SomethingNobodyMappedYet"));
+    }
+
+    [Fact]
+    public void Localize_ForAMappedErrorCode_LogsNothing()
+    {
+        CapturingLoggerProvider loggerProvider = new();
+        using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
+
+        ApiProblemCopy.Localize(
+            loggerFactory,
+            ApiProblem("TranslationFiles.NotFound", 404, "Not Found", "No translation file yet."),
+            PageFallback,
+            502);
+
+        loggerProvider.Entries.ShouldBeEmpty();
+    }
+
+    private static ProblemDetails ApiProblem(string errorCode, int status, string? title, string? detail)
+        => new()
+        {
+            Title = title,
+            Detail = detail,
+            Status = status,
+            Extensions = { [ApiProblemCopy.ErrorCodeExtensionKey] = errorCode }
+        };
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Shared/CapturingLoggerProvider.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Shared/CapturingLoggerProvider.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Shared;
+
+/// <summary>
+/// Captures what the code under test logged. Used where the log IS the observable behavior — the
+/// unmapped-error-code warning of ADR-0044 is invisible in the rendered markup by design, so a
+/// null logger would let the gap go unnoticed in exactly the way the ADR forbids.
+/// </summary>
+internal sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly List<LogEntry> _entries = [];
+
+    public IReadOnlyList<LogEntry> Entries => _entries;
+
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(_entries);
+
+    public void Dispose()
+    {
+    }
+
+    internal sealed record LogEntry(LogLevel Level, string Message);
+
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly List<LogEntry> _entries;
+
+        public CapturingLogger(List<LogEntry> entries)
+        {
+            _entries = entries;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+            _entries.Add(new LogEntry(logLevel, formatter(state, exception)));
+        }
+    }
+}


### PR DESCRIPTION
Closes #548

## What

The Frontend is Polish-only but rendered the API's `ProblemDetails` verbatim, and those messages are English. A translator saving an empty translation got a red box reading `Validation Error`; an admin registering a bad game version got `'Version' must not be empty.`

Fixed app-wide, as the ticket asked ("decide once for the whole app, not per page"), not by widening the fallbacks.

## How

**The copy lives in the Frontend, keyed by the API's `errorCode`** (ADR-0044). Both APIs already stamp that code on every failure they author, so nothing changed server-side. Localizing in the API was rejected: it also serves the CLI (M2-20) and the M4 app, and its `ProblemDetails` is a shared contract, not one client's UI copy.

`ApiProblemCopy` maps all ~60 codes both APIs can produce. `ApiProblemAlert` is the single component all 14 render sites now go through.

**Translation is the default; only a problem the Frontend authored itself passes through.** The obvious rule — "no `errorCode` means we wrote it, so it is already Polish" — is wrong, and the repo's own committed contract proves it:

```json
{ "title": "Unauthorized", "status": 401, "traceId": "…" }
```

`AddProblemDetails()` + `UseStatusCodePages()` emit a bare English reason phrase with no code for 401/403/404/405/415/429 — the most common failures in the app. Keying off the code's absence would have painted `Unauthorized` onto the page, i.e. this very bug on the highest-traffic path. So `ApiProblemCopy.FrontendAuthored` marks ours explicitly, the HTTP seam strips that marker off anything read from the wire, and everything else is translated. Forgetting the marker costs specificity; forgetting an API surface would cost correctness.

**Unmapped codes degrade to Polish by HTTP status** and log a warning naming the code — never to English.

**The API's own wording survives** in a collapsed `<details>` block, so `Import.ParseFailed`'s line number and `Import.MassRemovalBlocked`'s row counts stay available for a bug report without reaching the page in English. The two file-download routes have no component to render through, so they call `ApiProblemCopy.Localize`, which does the same and keeps the API's `traceId`.

## Scope note

Load failures were worse than the ticket described: they rendered `Title` alone, which is *always* one of the six English error-type names. Same fix covers them.

## Testing

- 536 frontend unit tests green (46 new/changed); every other pure suite green; 0 warnings.
- Page-level pins for both surfaces the ticket names, asserting the Polish text and the absence of the English.
- The 401/403/404/405/415 theory is verified by mutation: restoring the old discriminator turns 10 tests red.
- `check-ssr-purity`, `check-frontend-hypermedia`, `check-dockerfile-restore-graph` all pass.

Visual diff is zero — both existing alert shells keep their markup and CSS classes. One markup change was required: the import error box became a `div`, because a `<details>` cannot legally live inside a `<p>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3R4Cew6w6tfHQ8GqnCoR