### PR TITLE
Bug: the read-only DAT open never worked — the native read-only flag is bit 0x4, not 2 (TP-11 Option A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,11 +165,11 @@ dotnet test tests/LotroKoniecDev.Tests.Unit            # fast, pure unit (must a
 dotnet test tests/LotroKoniecDev.Tests.E2E             # full pipeline — auto-skips off-Windows
 dotnet test --filter "FullyQualifiedName~Fragment"     # filter by name
 
-# Run the CLI (Windows; needs LOTRO + admin for DAT write)
+# Run the CLI (Windows; needs LOTRO. `export` reads and needs NO admin — #629; only DAT writes do)
 dotnet run --project src/Patcher/LotroKoniecDev.Cli -- export                 # DAT → data/exported.txt
 dotnet run --project src/Patcher/LotroKoniecDev.Cli -- patch polish           # translations/polish.txt → DAT
 dotnet run --project src/Patcher/LotroKoniecDev.Cli -- launch polish          # hash-check → patch if changed → launch
-# or the elevated .bat wrappers: export.bat / patch.bat / lotro.bat
+# or the .bat wrappers: export.bat (no elevation) / patch.bat, lotro.bat (self-elevate)
 
 # GitHub tickets (BRD/spec-driven flow)
 gh issue list --state open                             # backlog; titles follow "M{milestone}-{nn}: Title"

--- a/README.md
+++ b/README.md
@@ -179,10 +179,11 @@ automatic `.backup` of the `DAT`), and maps failures to clear exit codes.
 ### Requirements & usage
 
 - **Windows** (x86/x64), [.NET 10 Runtime x86](https://dotnet.microsoft.com/download/dotnet/10.0),
-  and an installed copy of LOTRO. Writing into `Program Files` needs administrator rights.
+  and an installed copy of LOTRO. Writing into `Program Files` needs administrator rights; reading
+  does not, so `export` runs without an elevation prompt.
 
 ```bash
-export.bat                 # game DAT  → data/exported.txt
+export.bat                 # game DAT  → data/exported.txt (reads only — no elevation)
 patch.bat polish           # translations/polish.txt → game DAT (self-elevates)
 lotro.bat polish           # launch: hash-check → patch if changed → start the game
 # equivalent: dotnet run --project src/Patcher/LotroKoniecDev.Cli -- launch polish

--- a/docs/RUSSIAN_PROJECT_RESEARCH.md
+++ b/docs/RUSSIAN_PROJECT_RESEARCH.md
@@ -297,7 +297,12 @@ CloseDatFile(handle)
 ```
 
 **Flagi otwarcia:**
-- `OpenFlagsReadWrite = 130` (Read=2 | Write=128)
+- `OpenFlagsReadWrite = 130`, `OpenFlagsRead = 6`
+- Rozbicie „Read=2 | Write=128" było **błędne** (sprostowane 2026-08-07, #629): bit `2` siedzi w obu
+  stałych i nie wybiera niczego w kwestii dostępu. Jedynym bitem, który zmienia `dwDesiredAccess`
+  przekazywany do `CreateFileA`, jest `0x4` — z nim biblioteka otwiera `GENERIC_READ`, bez niego
+  `GENERIC_READ|GENERIC_WRITE`. Szczegóły:
+  [knowledge-base/datexport-readonly-open-2026-08-07.md](knowledge-base/datexport-readonly-open-2026-08-07.md)
 
 ---
 

--- a/docs/adr/0030-game-version-export-stays-manual-vm-runner-deferred.md
+++ b/docs/adr/0030-game-version-export-stays-manual-vm-runner-deferred.md
@@ -4,6 +4,9 @@
 Post-MVP/Backlog no longer holds (it becomes a correctness prerequisite of the client-facing
 anti-masking guard and moves into the UR milestone). §1 (VM runner deferred), the read-path and
 ceremony-script moves in §2, §3's reconsider triggers and §4's accepted staleness window all stand.
+**Amended 2026-08-07 (#629):** §2's read-path move was written against native flag `2`, which never
+produced a read-only handle — the selector is bit `0x4`. With `OpenFlagsRead = 6` the move is
+**delivered and verified** on the live Program Files DAT; the decision itself is unchanged.
 **Date:** 2026-07-11
 **Decision-makers:** Solo maintainer
 **Related:** Patcher (export/launch flow), `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md` (Out of scope), tickets #443 (TP-11), #85 (M2-18 forum watcher), #384 (TP-07), #52 (Discord notifications), knowledge-base live-test entries, ADR-0045 (game version served by our API)
@@ -47,6 +50,10 @@ Facts that constrain the choice today:
   twice empirically — a `launch` on 2026-04-23, an `export` on 2026-06-25
   (`live-test-2026-04-23.md`, `live-test-2026-06-25.md`). #443 Option A (same PR as this ADR)
   switches read paths to flag 2, pending real-Windows confirmation.
+  > **2026-08-07 (#629):** the confirmation came back negative and then positive. Flag `2` does not
+  > select read-only — bit `0x4` does, and flag `2` is present in the read-write constant too, so the
+  > "read" open kept asking for `GENERIC_READ|GENERIC_WRITE`. `OpenFlagsRead = 6` delivers what this
+  > bullet assumed: `docs/knowledge-base/datexport-readonly-open-2026-08-07.md`.
 
 ## Decision
 
@@ -61,8 +68,9 @@ needs a KVM host and hours, and its answers buy nothing actionable until the tri
 ### 2. The manual pipeline is instrumented — three concrete moves
 
 - **Read path de-elevated (#443 Option A, this PR).** `export` and version reads open the DAT
-  read-only (native flag 2); `export.bat` stops self-elevating. The ceremony loses its UAC step,
-  and any future runner's export task needs no elevation engineering at all.
+  read-only (native flag 2 — **corrected to 6 by #629**, the read-only bit is `0x4`);
+  `export.bat` stops self-elevating. The ceremony loses its UAC step, and any future runner's
+  export task needs no elevation engineering at all.
 - **Detection latency bounded (#85 scope amendment).** The M2-18 forum watcher additionally
   notifies the admin **by e-mail** when a new GameVersion is detected (previously: structured log
   only for MVP). Discord webhook stays post-MVP (#52). #85 currently sits in Post-MVP/Backlog per

--- a/docs/knowledge-base/README.md
+++ b/docs/knowledge-base/README.md
@@ -75,6 +75,13 @@ Detailed analysis: [live-test-2026-03-16.md](live-test-2026-03-16.md)
 - Legacy flow: harmful (double UAC, kills game) — confirmed bad
 - SKIP path: 2026-03-22 confirmed (hash match → launch in 255ms)
 
+### datexport.dll — the read-only open flag is bit `0x4`, and `export` needs NO elevation (2026-08-07)
+Detailed analysis: [datexport-readonly-open-2026-08-07.md](datexport-readonly-open-2026-08-07.md)
+- `OpenFlagsRead = 2` never set the read-only bit, so every "read" open asked the OS for `GENERIC_READ|`**`WRITE`** and failed on a file we cannot write; `= 6` (`0x2|0x4`) is the whole fix
+- Proven three ways: x86 disassembly of the open helper (`0x10012bb0`), a flag matrix over `attrib +R` / ACL / writable, and a **non-elevated `export` off the live Program Files DAT** — exit 0, DAT byte-identical
+- **Measurement trap:** `icacls /deny "(W)"` also denies `SYNCHRONIZE`, so it blocks reads and is not a Program Files proxy — build one with `/inheritance:r /grant:r "user:(RX)"` and assert both preconditions
+- Supersedes the "export from a backup copy" workaround in the 48.7 / 49 baselines; #443 Option A is delivered (#629)
+
 ### DAT Vnum — definitively schema-version, not content-version
 Detailed analysis: [vnum-observations.md](vnum-observations.md)
 - Vnum 112/3 unchanged across 45.x → 47.x → **48.0 major** → 48.7 → 48.8 → **49.1 major** — 6 cycles (two majors), zero movement (latest: [live-test-2026-08-02.md](live-test-2026-08-02.md))

--- a/docs/knowledge-base/dat-protection.md
+++ b/docs/knowledge-base/dat-protection.md
@@ -76,7 +76,9 @@ We assumed LOTRO's official launcher overwrites DAT files on update, wiping tran
   re-evaluated 2026-08-02 after the per-SubFile revert finding: the **problem class is real**
   (our old "non-problem" verdict is retired), but the in-DAT marker is the wrong implementation
   for us: it only fires when ITS OWN chunk is wiped (misses collateral wipes elsewhere), reading
-  it needs elevated DAT access on every launch (datexport opens with write intent), and our
+  it costs a full DAT open on every launch (no longer an *elevated* one — the read-only open works
+  since #629, see [datexport-readonly-open-2026-08-07.md](datexport-readonly-open-2026-08-07.md) —
+  but still an open on the SKIP path, which is the actual objection), and our
   lost-state edge already degrades gracefully (missing version file ⇒ hash=null ⇒ full re-patch).
   An external DAT fingerprint (size+mtime in the version file) detects strictly more, with zero
   DAT access on the SKIP path — see `update-49/RESULTS.md` §scenariusze (launch sentinel)

--- a/docs/knowledge-base/datexport-readonly-open-2026-08-07.md
+++ b/docs/knowledge-base/datexport-readonly-open-2026-08-07.md
@@ -1,0 +1,133 @@
+# datexport.dll: the read-only open flag is bit `0x4` (2026-08-07)
+
+**Status:** settled — measured two independent ways, then proven end-to-end against the live
+Program Files DAT. Supersedes the "`export` always needs elevation" claim in
+[live-test-2026-06-25.md](live-test-2026-06-25.md), [update-48.7/BASELINE.md](update-48.7/BASELINE.md)
+and [update-49/BASELINE.md](update-49/BASELINE.md).
+
+## The finding
+
+`OpenDatFileEx2`'s `flags` parameter selects the access the native library asks the OS for **on bit
+`0x4` only**. Our `DatExportNative.OpenFlagsRead` was `2`, which never set that bit — so every
+"read-only" open still requested `GENERIC_READ | GENERIC_WRITE` and failed on any file the caller
+cannot write. `OpenFlagsRead = 6` (`0x2 | 0x4`) is the fix, and it is the whole fix.
+
+The `Read (2) + Write (128) = 130` comment that shipped with the P/Invoke wrapper is what misled
+everyone, including the measurement that concluded the feature was impossible: `2` is present in
+**both** constants and selects nothing about access.
+
+## Evidence 1 — disassembly (static, no elevation needed)
+
+`datexport.dll` is x86, imagebase `0x10000000`, single `CreateFileA` import at IAT `0x1002d0e0`.
+The open helper at `0x10012bb0` (capstone + pefile):
+
+```asm
+mov  eax,[esp+0xc]      ; mode flags
+test al,8    -> ebx=2   ; CREATE_ALWAYS
+test al,0x10 -> ebx=4   ; OPEN_ALWAYS       (default ebx=3 = OPEN_EXISTING)
+and  eax,4              ; <-- the only bit that touches dwDesiredAccess
+mov  edi,0xC0000000     ; GENERIC_READ | GENERIC_WRITE
+je   0x10012bdf         ;   taken when (flags & 4) == 0
+mov  edi,0x80000000     ; GENERIC_READ only …
+xor  esi,esi            ; … and dwShareMode becomes FILE_SHARE_READ
+...
+push edi                ; dwDesiredAccess -> CreateFileA
+```
+
+`OpenDatFileEx2` itself (export RVA `0x4d90`) branches on the same bit before handing the flags
+down — `shr ecx,2 / not cl / test cl,1` → `or eax,0x1800` only when `0x4` is clear.
+
+So the library has always had a genuine read-only path. We never asked for it.
+
+## Evidence 2 — flag matrix (dynamic)
+
+32-bit PowerShell P/Invoke straight into the DLL (the CLI is `win-x86`, so a 64-bit host cannot load
+it), one 1.77 GB DAT, three ACL/attribute conditions:
+
+| flags | writable file | ACL `Users:(RX)` | `attrib +R` |
+|---|---|---|---|
+| `2` — the old `OpenFlagsRead` | OK | **FAIL** | **FAIL** |
+| `130` — `OpenFlagsReadWrite` | OK | **FAIL** | **FAIL** |
+| **`4`** | OK | **OK** | **OK** |
+| **`6`** (`0x2\|0x4`) | OK | **OK** | **OK** |
+| **`134`** (`0x2\|0x4\|0x80`) | OK | **OK** | **OK** |
+| `0` | OK | **FAIL** | **FAIL** |
+
+`GetNumSubfiles` returns the same 303,792 on every successful open, so `0x4` does not degrade the
+handle — it only changes what the OS is asked for.
+
+## Evidence 3 — end-to-end, live Program Files, non-elevated
+
+`OpenFlagsRead = 6`, `export` run from a **non-elevated** shell against
+`C:\Program Files (x86)\StandingStoneGames\The Lord of the Rings Online\client_local_English.dat`
+(`Users:(RX)`, write denied — confirmed before the run):
+
+- exit **0**, 281,253 text files / 800,864 fragments
+- live DAT SHA-256 `D2D25235…B721` **byte-identical** before and after
+- same DAT content exported from a writable copy → output **byte-identical** to the read-only run
+- the **directory** is not writable either (`TrustedInstaller`/`SYSTEM`/`Administrators` full, no
+  write for us; creating a file in it is denied), and the export still succeeded — so the "write
+  **or sidecar** intent" half of the 2026-06-25 theory is disproven too: the read path creates
+  nothing next to the DAT
+
+Suites after the change: Unit 3991/3991, Architecture 21/21, Infrastructure 42/42, **E2E 26/26** —
+including `ExportE2ETests.Export_ShouldExitWithZero_WhenDatCopyIsReadOnly`, the #446 feasibility gate
+that had been red on `main` since 2026-07-11, now passing **with its assertion untouched**.
+
+> **E2E flakiness worth knowing:** the suite makes one full 1.77 GB DAT copy per DAT-touching test
+> (14 today) and keeps them all until the fixture disposes, while `RunCliAsync` enforces a hard 120 s
+> per-process timeout. `Patch_ShouldFail_WhenTranslationFileHasOnlyGarbage` already runs ~76 s, so
+> under I/O pressure it tips over the limit and fails for reasons that have nothing to do with the
+> code — seen once here, with 7.1 GB of orphaned `%TEMP%\lotro_e2e_*` dirs left by a killed run
+> (24 min wall clock; the clean re-run was 14.6 min, 26/26). **Sweep `%TEMP%\lotro_e2e_*` before
+> trusting a red E2E run.**
+
+## The measurement trap that produced the wrong answer first
+
+The morning's investigation built its "faithful Program Files proxy" with
+`icacls <file> /deny "<user>:(W)"`. That is not a read-only file — `(W)` is `FILE_GENERIC_WRITE`,
+which **includes `SYNCHRONIZE`**, and without `SYNCHRONIZE` no `CreateFile` succeeds at all. The
+proxy was unreadable, every flag failed, and the conclusion generalised to "the library cannot open
+read-only".
+
+Build the proxy by **granting**, never by denying:
+
+```powershell
+icacls <file> /inheritance:r /grant:r "$env:USERDOMAIN\$env:USERNAME:(RX)"
+```
+
+…and assert both halves of the precondition before trusting the run: reads must succeed, writes must
+fail. `ExportE2ETests.Export_ShouldExitWithZero_WhenDatCopyGrantsReadButNotWrite` encodes exactly
+that, preconditions included.
+
+Note the two Windows refusals are **not** interchangeable. The read-only *attribute* (`attrib +R`)
+and an ACL without write are different mechanisms; the live DAT carries the ACL and no attribute.
+Both are pinned, separately.
+
+## Consequences
+
+- `export` and `ReadVersion` need **no elevation**. Only `patch` (and therefore `launch`'s PATCH
+  branch) does. `export.bat` correctly does not self-elevate; `patch.bat` / `lotro.bat` still do.
+- The standing "export from a backup copy" workaround in the update baselines is obsolete — export
+  straight from the live install.
+- #443 Option A is delivered, which restores its "small correctness fix worth doing regardless of
+  Option B" framing. It changes nothing about Option B (the VM runner): a fully-owned automation box
+  runs its export task pre-elevated anyway, which is why ADR-0030 deferred it on other grounds.
+
+## Method note
+
+The disassembly took about ten minutes with `pip install capstone pefile` and answered a question
+that had been standing since June. Reach for it before Process Monitor when the question is "can
+this native call ever do X" — ProcMon shows the one call you observed, the branch shows every call
+the library can make.
+
+## Cross-reference
+
+- [live-test-2026-06-25.md](live-test-2026-06-25.md) — where the write-intent claim was first recorded
+- [live-test-2026-07-11.md](live-test-2026-07-11.md) — the session that shipped Option A untested
+- [ADR-0030](../adr/0030-game-version-export-stays-manual-vm-runner-deferred.md) — the VM-runner
+  deferral, amended with this outcome
+- The Windows-only E2E blind spot bit for the second time here (the first was #197's path refactor,
+  E2E 0/23). `Tests.E2E` is Windows-only and off CI by design, so **after any patcher change to the
+  native interop, paths, CLI wiring or the .bat wrappers, run `dotnet test tests/LotroKoniecDev.Tests.E2E`
+  on Windows** — nothing else will tell you.

--- a/docs/knowledge-base/live-test-2026-06-25.md
+++ b/docs/knowledge-base/live-test-2026-06-25.md
@@ -72,6 +72,12 @@ Non-elevated export live DAT pada `DatFile.CannotOpen` (datexport.dll otwiera pl
 intentem). **Workaround (jak w kwietniu):** export/backup robić z kopii w katalogu projektu (writable),
 nie z live path. WRITE (patch/launch) wymaga elevacji — `lotro.bat`/`patch.bat` self-elevują przez UAC.
 
+> **Superseded 2026-08-07 (#629).** Obserwacja była prawdziwa dla flag `2`/`130`, ale wyjaśnienie nie:
+> `datexport.dll` **ma** ścieżkę read-only — selektorem jest bit `0x4`, którego nigdy nie ustawialiśmy.
+> Z `OpenFlagsRead = 6` non-elevated export z live Program Files działa (exit 0, DAT bajt-w-bajt
+> nietknięty). Workaround „export z kopii" jest zbędny —
+> [datexport-readonly-open-2026-08-07.md](datexport-readonly-open-2026-08-07.md).
+
 ## Archived files
 
 Full intel: `intel/update-48.7/` (gitignored) — pre/post DAT backups (1.76 GB każdy), pre/post exports

--- a/docs/knowledge-base/update-48.7/BASELINE.md
+++ b/docs/knowledge-base/update-48.7/BASELINE.md
@@ -33,6 +33,10 @@ Liczby (278,377 / 792,500) = identyczne z post-48.0 z kwietnia → zero zmian tr
 Export robiony z backupu (live DAT w Program Files odmawia otwarcia non-elevated — `datexport.dll`
 otwiera plik z write/sidecar intentem; znane ograniczenie, patrz RESULTS 48.0 §perms).
 
+> **Superseded 2026-08-07 (#629):** ograniczenie było nasze, nie biblioteki — read-only open siedzi na
+> bicie `0x4`. Kolejne exporty rób prosto z live path —
+> [../datexport-readonly-open-2026-08-07.md](../datexport-readonly-open-2026-08-07.md).
+
 ## Version file (pre-update)
 
 ```

--- a/docs/knowledge-base/update-49/BASELINE.md
+++ b/docs/knowledge-base/update-49/BASELINE.md
@@ -36,6 +36,10 @@ export pokazuje **+5 plików / +13 fragmentów** względem post-48.7.
 Export robiony z backupu (live DAT w Program Files odmawia otwarcia non-elevated — `datexport.dll`
 otwiera z write/sidecar intentem; znane ograniczenie, patrz RESULTS 48.0 §perms).
 
+> **Superseded 2026-08-07 (#629):** ograniczenie było nasze, nie biblioteki — read-only open siedzi na
+> bicie `0x4`. Kolejne exporty rób prosto z live path —
+> [../datexport-readonly-open-2026-08-07.md](../datexport-readonly-open-2026-08-07.md).
+
 ## Version file (pre-update)
 
 ```

--- a/export.bat
+++ b/export.bat
@@ -2,9 +2,11 @@
 setlocal
 cd /d "%~dp0"
 
-rem Export opens the DAT read-only (#443 Option A, native flag 2), so no elevation here.
-rem If a live-DAT export ever fails with DatFile.CannotOpen, run it from an elevated shell
-rem and report on #443 — that would disprove the read-only-flag assumption.
+rem Export opens the DAT read-only (#443 Option A, native flag 6 — the read-only bit is 0x4), so
+rem no elevation here. Verified 2026-08-07 against the live Program Files DAT from a non-elevated
+rem shell: exit 0, DAT byte-identical (#629). A DatFile.CannotOpen here means the file is not
+rem readable at all, not that it needs write access — check the path and the ACL, do not re-add
+rem the elevation block.
 rem Delayed expansion below inserts user arguments after cmd parsing, so metacharacters
 rem stay literal (AUDIT-SEC-06 hardening, kept even without the elevation boundary).
 set "LOTRO_WRAPPER_ARGS=%*"

--- a/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatExportNative.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatExportNative.cs
@@ -17,14 +17,21 @@ internal static partial class DatExportNative
     private const string DllName = "datexport.dll";
 
     /// <summary>
-    /// Flags for opening DAT files: Read (2) + Write (128) = 130.
+    /// Flags for opening DAT files read-write: 2 | 128.
     /// </summary>
     public const uint OpenFlagsReadWrite = 130;
 
     /// <summary>
-    /// Flags for opening DAT files read-only: Read (2).
+    /// Flags for opening DAT files read-only: 2 | ReadOnly (4).
     /// </summary>
-    public const uint OpenFlagsRead = 2;
+    // Bit 0x4 is the only flag that changes the access the native library asks the OS for: with it
+    // set, datexport.dll opens the file GENERIC_READ | FILE_SHARE_READ; without it, every open —
+    // whatever else the flags say — asks for GENERIC_READ | GENERIC_WRITE and therefore fails on a
+    // file the caller cannot write. This is NOT the 2 bit, which is present in both constants and
+    // selects nothing about access; assuming otherwise is what made #446 ship a read-only export
+    // path that still required elevation (#629). Measured, not inferred:
+    // docs/knowledge-base/datexport-readonly-open-2026-08-07.md.
+    public const uint OpenFlagsRead = 6;
 
     /// <summary>
     /// Opens a specified DAT file with extended configurations and retrieves detailed metadata about the file.

--- a/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatFileHandler.cs
+++ b/src/Patcher/LotroKoniecDev.Infrastructure/DatFile/DatFileHandler.cs
@@ -20,7 +20,10 @@ public sealed class DatFileHandler : IDatFileHandler, IDatVersionReader
     /// Opens a LOTRO DAT file given its file path and returns a handle to the open file.
     /// </summary>
     /// <param name="datFilePath">The file path to the DAT file to be opened. It must not be null, empty, or whitespace.</param>
-    /// <param name="access">The native open mode: read-only opens work without write permission on the file.</param>
+    /// <param name="access">
+    /// The native open mode. <see cref="DatFileAccess.Read"/> opens without write permission on the
+    /// file — verified against the live Program Files DAT, non-elevated (#629).
+    /// </param>
     /// <returns>
     /// A <see cref="Result{TValue}"/> containing the handle to the opened DAT file if the operation is successful;
     /// otherwise, a failure result with an error message describing why the file could not be opened.

--- a/tests/LotroKoniecDev.Tests.E2E/Tests/ExportE2ETests.cs
+++ b/tests/LotroKoniecDev.Tests.E2E/Tests/ExportE2ETests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using LotroKoniecDev.Application.Abstractions;
 using LotroKoniecDev.Application.Parsers;
 using LotroKoniecDev.Domain.Core.Monads;
@@ -101,9 +102,10 @@ public sealed class ExportE2ETests
     }
 
     /// <summary>
-    /// Option A (#443) feasibility gate on real Windows: a read-only DAT copy is the faithful
-    /// proxy for a non-elevated export of the live Program Files DAT, so the read-only open
-    /// path must succeed without write access to the file.
+    /// Option A (#443) feasibility gate on real Windows: the read-only open path must succeed
+    /// without write access to the file. The read-only attribute is the cheaper of the two ways
+    /// Windows refuses a write — <see cref="Export_ShouldExitWithZero_WhenDatCopyGrantsReadButNotWrite"/>
+    /// pins the ACL, which is what the live Program Files DAT actually carries.
     /// </summary>
     [SkippableFact]
     public async Task Export_ShouldExitWithZero_WhenDatCopyIsReadOnly()
@@ -133,5 +135,89 @@ public sealed class ExportE2ETests
         {
             File.SetAttributes(tempDatPath, File.GetAttributes(tempDatPath) & ~FileAttributes.ReadOnly);
         }
+    }
+
+    /// <summary>
+    /// The live Program Files DAT is not marked read-only — it carries an ACL granting Users
+    /// Read &amp; Execute and nothing else. That is a different refusal from the read-only
+    /// attribute, and it is the one #629 was wrong about, so it is pinned on its own.
+    /// </summary>
+    [SkippableFact]
+    public async Task Export_ShouldExitWithZero_WhenDatCopyGrantsReadButNotWrite()
+    {
+        Skip.If(!_fixture.IsDatFileAvailable, "DAT file not found in TestData/");
+        Skip.IfNot(OperatingSystem.IsWindows(), "ACLs are a Windows concept");
+
+        //Arrange
+        string tempDatPath = _fixture.CreateTempDatCopy();
+        string outputPath = Path.Combine(Path.GetDirectoryName(tempDatPath)!, "acl_export.txt");
+        string account = $"{Environment.UserDomainName}\\{Environment.UserName}";
+
+        // Grant Read & Execute and drop inheritance, mirroring the game directory's Users:(RX).
+        // Never express this as /deny "(W)": FILE_GENERIC_WRITE carries SYNCHRONIZE, so denying it
+        // blocks reads too and the copy stops being a Program Files proxy at all — the measurement
+        // trap that produced #629's false conclusion. The preconditions below are what catch it.
+        int aclExitCode = await RunIcaclsAsync($"\"{tempDatPath}\" /inheritance:r /grant:r \"{account}:(RX)\"");
+        aclExitCode.ShouldBe(0, "the test could not set up its own ACL");
+
+        try
+        {
+            CanOpen(tempDatPath, FileAccess.Read).ShouldBeTrue(
+                "precondition: the ACL must still allow reads, or this proves nothing");
+            CanOpen(tempDatPath, FileAccess.Write).ShouldBeFalse(
+                "precondition: the ACL must deny writes, or this proves nothing");
+
+            //Act
+            CliResult result = await _fixture.RunCliAsync(
+                $"export -d \"{tempDatPath}\" -o \"{outputPath}\"");
+
+            //Assert
+            result.ExitCode.ShouldBe((int)CliExitCode.Success, $"stderr: {result.Stderr}");
+            File.Exists(outputPath).ShouldBeTrue("Export file should exist");
+            int dataLineCount = File.ReadLines(outputPath)
+                .Count(l => !string.IsNullOrWhiteSpace(l) && !l.TrimStart().StartsWith('#'));
+            dataLineCount.ShouldBeGreaterThan(0,
+                "Export off a write-denied DAT should produce data lines beyond the header");
+        }
+        finally
+        {
+            // Best-effort restore so the fixture's temp sweep is not fighting our own ACL. Never
+            // assert here: a failure would replace whatever the test was actually reporting.
+            _ = await RunIcaclsAsync($"\"{tempDatPath}\" /inheritance:e /grant \"{account}:(F)\"");
+        }
+    }
+
+    private static bool CanOpen(string path, FileAccess access)
+    {
+        try
+        {
+            using FileStream stream = File.Open(path, FileMode.Open, access, FileShare.ReadWrite);
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<int> RunIcaclsAsync(string arguments)
+    {
+        using Process process = new();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "icacls",
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        process.Start();
+        await process.StandardError.ReadToEndAsync();
+        await process.StandardOutput.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return process.ExitCode;
     }
 }


### PR DESCRIPTION
Closes #629.

## What

`DatExportNative.OpenFlagsRead` goes from `2` to `6`. That is the fix.

`datexport.dll` selects the access it asks the OS for on **bit `0x4` only**. Flag `2` appears in
both our constants and selects nothing about access, so every "read-only" open still requested
`GENERIC_READ | GENERIC_WRITE` and failed on any file the caller cannot write — which is why #446
shipped a read-only export path that still needed elevation, and why its own feasibility gate has
been red on `main` since 2026-07-11.

The disassembly of the open helper at `0x10012bb0` (imagebase `0x10000000`):

```asm
and  eax,4              ; the only bit that touches dwDesiredAccess
mov  edi,0xC0000000     ; GENERIC_READ | GENERIC_WRITE
je   0x10012bdf         ;   taken when (flags & 4) == 0   <-- what we were doing
mov  edi,0x80000000     ; GENERIC_READ only, share becomes FILE_SHARE_READ
```

Also in this PR:

- **`export.bat` had a real regression, not just a stale comment.** #446 removed its self-elevation
  block on the false premise, so a live-DAT `export.bat` has failed since. Correct as of this change.
- **A second E2E gate** for the ACL condition the live DAT actually carries (`Users:(RX)`), next to
  the existing `attrib +R` one. It builds the ACL by *granting*, never by `/deny "(W)"` —
  `FILE_GENERIC_WRITE` carries `SYNCHRONIZE`, so a deny blocks reads too and the copy stops being a
  Program Files proxy at all. That is the measurement trap that produced #629's false conclusion, so
  the test asserts both halves of its precondition before believing its own result.
- **Docs.** A dated knowledge-base entry with the disassembly, the flag matrix and the live run;
  superseded pointers on the three places that stated the old conclusion as fact; the bit breakdown
  corrected in `RUSSIAN_PROJECT_RESEARCH.md` (`Read=2 | Write=128` is the sentence that misled both
  #446 and #629); a dated amendment on ADR-0030 recording that its §2 read-path move is delivered
  rather than pending.

## Why it matters beyond the red test

`export` no longer needs elevation at all — only `patch` does. The "export from a backup copy"
workaround standing in the 48.7 and 49 update baselines is obsolete.

Two claims in #629 turned out inverted, and the ticket carries a correction comment for both: the
XML doc on `DatFileHandler.Open()` that it wanted deleted as false was **true** (the code just did
not honour it), and #443's "Option A is a small correctness fix worth doing regardless of Option B's
fate" **stands** rather than being retracted. Option B is untouched — it never depended on A.

## Tests

- `dotnet build LotroKoniecDev.slnx` — **0 warnings**.
- Unit **3991/3991** · Architecture **21/21** · Infrastructure **42/42** · **E2E 26/26** on Windows
  against a real DAT, 14.6 min. The #446 gate passes **with its assertion untouched**; no existing
  assertion was weakened.
- Live proof: non-elevated `export` off
  `C:\Program Files (x86)\StandingStoneGames\...\client_local_English.dat` → exit 0, 281,253 files /
  800,864 fragments, DAT SHA-256 byte-identical before and after, output byte-identical to an export
  of the same content from a writable file. The game **directory** is not writable by us either, so
  the "write *or sidecar* intent" half of the old theory is disproven as well.

One caveat recorded in the knowledge-base entry: an earlier full E2E run failed
`Patch_ShouldFail_WhenTranslationFileHasOnlyGarbage`. It reproduces neither in isolation nor on a
clean re-run — it is I/O pressure against `RunCliAsync`'s hard 120 s per-process timeout (that test
already runs ~76 s) when orphaned `%TEMP%\lotro_e2e_*` copies pile up. Sweep them before trusting a
red E2E run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez7iLZFQ1FLMhyPpCXr5xd
