### PR TITLE
624 ur 23 a superseded game version cannot be deleted and blocks its own version number forever

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -308,9 +308,12 @@ All routes are under `/api/v1` unless noted. All require a bearer token except
 `{ version }` (dotted notation, e.g. `"48.0"`, ≤ 12 chars; canonicalized — `48` = `48.0`).
 
 **`DELETE /game-versions/{id}`** (#209) removes a manually-registered version that was added by
-mistake. The guard is strict: only an `Unprocessed` version with **no translation referencing it**
-may be deleted — otherwise **422** (`GameVersionEntity.OnlyUnprocessedCanBeDeleted` /
-`GameVersionEntity.CannotDeleteReferencedVersion`); an unknown id is **404**.
+mistake. Only a `Processed` version is kept — it is the one an import was applied against. An
+`Unprocessed` or `Superseded` version with **no translation referencing it** may be deleted, which
+is what frees a version number burned by a wrong registration (#624); otherwise **422**
+(`GameVersionEntity.ProcessedCannotBeDeleted` / `GameVersionEntity.CannotDeleteReferencedVersion`);
+an unknown id is **404**. The duplicate check on `POST` ignores status on purpose — deleting the
+dead row is the way back, not a second row carrying the same version string.
 
 ### 8.2 Translations
 
@@ -500,7 +503,7 @@ Sent only with `Accept: application/vnd.dev-lotrokoniecdev.hateoas.json`.
 | `approve` | POST | `/api/v1/translations/{id}/approve` | caller is `Admin` **and** status ∈ {Draft, NeedsReview}, not removed |
 | `bulk-approve` | POST | `/api/v1/translations/approve` | on the translations collection, caller is `Admin` |
 | `register` | POST | `/api/v1/game-versions` | on the game-versions collection, caller is `Admin` |
-| `delete` | DELETE | `/api/v1/game-versions/{id}` | caller is `Admin` **and** the version is `Unprocessed` |
+| `delete` | DELETE | `/api/v1/game-versions/{id}` | caller is `Admin` **and** the version is not `Processed` (#624) |
 | `first-page` / `previous-page` / `next-page` / `last-page` | GET | the list page | the target page exists |
 
 ### 10.2 `auth-api` rels (`AuthSystem.Contracts/Hateoas/Rels.cs`)

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -132,9 +132,12 @@ treści to `LotroNotationVersion` (VO w postaci kanonicznej). Status: `Unprocess
 - `MarkSuperseded()` — `Processed` nie może być cofnięty do `Superseded` (przetworzona praca nigdy nie
   jest cofana); spiętrzone nieprzetworzone wersje są masowo oznaczane, gdy nowsza zostaje przetworzona
   (`GameVersion.cs:40`).
-- `EnsureCanBeDeleted()` — guard kasowania (#209): tylko wersja `Unprocessed` może zostać usunięta;
-  przetworzona/superseded jest wpleciona w cykl aktualizacji. Cross-agregatowy warunek „żadne
-  tłumaczenie jej nie referuje" zostaje w handlerze `DeleteGameVersion` (`GameVersion.cs:58`).
+- `EnsureCanBeDeleted()` — guard kasowania (#209, poprawiony w #624): usunąć nie można tylko wersji
+  `Processed` — to jedyny status, przeciw któremu wykonano import, więc tłumaczenia na niego wskazują.
+  `Unprocessed` i `Superseded` można wycofać; `Superseded` to wersja zarejestrowana i pominięta
+  (`MarkSuperseded` odrzuca `Processed`), więc nic jej nie referuje, a blokada kasowania paliła jej
+  numer wersji na zawsze. Cross-agregatowy warunek „żadne tłumaczenie jej nie referuje" zostaje
+  w handlerze `DeleteGameVersion` (`GameVersion.cs:58`).
 - `Create(version, detectedAt)` — fabryka; powstaje jako `Unprocessed` (`GameVersion.cs:68`).
 
 ### 3. Translator (ADR-0004)

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -113,7 +113,7 @@ nieustawiany). Wersja powstaje jako **`Unprocessed`**.
 | INV-3.2 | 🟢 `Superseded` **nigdy** nie może być przetworzony | `MarkAsProcessed` na `Superseded` → fail; inaczej → `Processed` (re-upload do `Processed` legalny i idempotentny). | `GameVersionEntity.SupersededCannotBeProcessed` (`GameVersion.cs:28-30`) |
 | INV-3.3 | 🟢 `Processed` **nie cofa się** do `Superseded` | `MarkSuperseded` na `Processed` → fail (przetworzona praca nigdy nie jest cofana). Spiętrzone `Unprocessed` są masowo oznaczane, gdy nowsza zostaje przetworzona. | `GameVersionEntity.ProcessedCannotBeSuperseded` (`GameVersion.cs:42-44`) |
 | INV-3.4 | 🟢 `LotroNotationVersion`/`DetectedAt` niezmienne | `get`-only, ustawiane w konstruktorze. ⚠️ `DetectedAt` = porządek wersji (chronologia rejestracji; **brak parsowania semver**). | `GameVersion.cs:13-14` |
-| INV-3.7 | 🟢 Tylko `Unprocessed` może być **usunięta** | `EnsureCanBeDeleted` na `Processed`/`Superseded` → fail — wersja wpleciona w cykl aktualizacji (spec 0001). Warunek cross-agregatowy w handlerze (INV-9.6). | `GameVersionEntity.OnlyUnprocessedCanBeDeleted` (`GameVersion.cs:58-66`) |
+| INV-3.7 | 🟢 `Processed` nie może być **usunięta**; `Unprocessed`/`Superseded` mogą | `EnsureCanBeDeleted` na `Processed` → fail — to jedyny status, przeciw któremu wykonano import, więc tłumaczenia na niego wskazują (spec 0001). `Superseded` = zarejestrowana i pominięta (`MarkSuperseded` odrzuca `Processed`), więc nic jej nie referuje i musi dać się wycofać, inaczej jej numer wersji przepada na zawsze (#624). Warunek cross-agregatowy w handlerze (INV-9.6). | `GameVersionEntity.ProcessedCannotBeDeleted` (`GameVersion.cs:58-69`) |
 
 | Value Object | Reguła | Dokładna wartość | Błąd |
 |--------------|--------|------------------|------|
@@ -224,7 +224,7 @@ all-or-nothing, idempotentny re-upload). Błędy importu = `DataConflict` → **
 | INV-9.3 | 🔵 Register zwraca **201** z `Location` na item-endpoint | `/api/v1/game-versions/{id}`. | `RegisterGameVersion.cs:108-111` |
 | INV-9.4 | 🔵 Lista niestronicowana, domyślny sort `DetectedAt` malejąco + opcjonalny `?sort=` | Niewiele wierszy (jeden na update gry); klucze `version`/`detectedAt`/`status` (sort po **stringu**, nie semantycznie); nieznany klucz degraduje do `DetectedAt` **rosnąco**. | `ListGameVersions.cs:42-47`, `:67-74` |
 | INV-9.5 | 🔵 Get-one: id `Empty` → `NotFound` | Short-circuit przed DB. | `GetGameVersion.cs:38-42` |
-| INV-9.6 | 🔵 Delete (#209, admin): tylko `Unprocessed` **i** niereferowana | Guard domenowy `EnsureCanBeDeleted` (INV-3.7) + cross-agregatowy check `AnyReferencesGameVersionAsync` w handlerze → 422; nieznany id → 404; sukces → **204**. Link HATEOAS `delete` tylko dla admina na wersji `Unprocessed`. | `GameVersionEntity.CannotDeleteReferencedVersion` (`DeleteGameVersion.cs:76-93`) |
+| INV-9.6 | 🔵 Delete (#209, admin): każda **poza** `Processed`, **i** niereferowana | Guard domenowy `EnsureCanBeDeleted` (INV-3.7) + cross-agregatowy check `AnyReferencesGameVersionAsync` w handlerze → 422; nieznany id → 404; sukces → **204**. Link HATEOAS `delete` dla admina na wersji innej niż `Processed` (#624). Duplikat przy `POST` nadal ignoruje status — powrotem z błędnej rejestracji jest usunięcie martwego wiersza, nie drugi wiersz z tym samym numerem. | `GameVersionEntity.CannotDeleteReferencedVersion` (`DeleteGameVersion.cs:76-93`) |
 
 ---
 

--- a/docs/adr/0045-the-game-version-reaches-clients-through-our-api.md
+++ b/docs/adr/0045-the-game-version-reaches-clients-through-our-api.md
@@ -138,9 +138,9 @@ Two constraints on this:
 
 Detection provenance (manual vs watcher) and dismissal do not belong in `GameVersionStatus`. That
 enum models one question — has this version's export been imported — and every existing invariant
-hangs off it (`EnsureCanBeDeleted` admits only `Unprocessed`, `MarkSuperseded` refuses `Processed`,
-the import sweep queries `GetUnprocessedDetectedBeforeAsync`). A fourth state would thread through
-all of them. Provenance and dismissal are orthogonal fields on the aggregate.
+hangs off it (`EnsureCanBeDeleted` refuses `Processed`, `MarkSuperseded` refuses `Processed`, the
+import sweep queries `GetUnprocessedDetectedBeforeAsync`). A fourth state would thread through all
+of them. Provenance and dismissal are orthogonal fields on the aggregate.
 
 ### 7. The preflight update check reads the TMS
 
@@ -189,7 +189,11 @@ HTTP, exactly as spec 0012's Assumptions require.
 
 ## Prerequisite defect — a bogus version can become permanently unusable
 
-§5 is only safe once this is fixed, and it is reachable today from an admin typo alone:
+> **Resolved by #624 (2026-08-08).** `EnsureCanBeDeleted` now refuses only `Processed`, and the
+> `delete` rel is advertised for every other status, so retiring the dead row is the recovery route
+> this section demanded. The trap below is kept as the record of *why*; §5 is no longer blocked.
+
+§5 is only safe once this is fixed, and it was reachable from an admin typo alone:
 
 1. Version `50` is registered by mistake (`Unprocessed`).
 2. A later import of the real `49.2` sweeps every older unprocessed row into `Superseded`
@@ -197,15 +201,17 @@ HTTP, exactly as spec 0012's Assumptions require.
 3. Update 50 actually ships. Registration is refused — `ExistsByVersionAsync` ignores status
    (`GameVersionRepository.cs:47-52`). Import is refused — the `import` rel is withheld for
    `Superseded` (`GameVersionAggregateLinkFactory.cs:47`) and `MarkAsProcessed` rejects it
-   (`GameVersion.cs:28-31`). Deletion is refused — `EnsureCanBeDeleted` admits only `Unprocessed`
-   (`GameVersion.cs:58-66`).
+   (`GameVersion.cs:28-31`). Deletion was refused too — `EnsureCanBeDeleted` admitted only
+   `Unprocessed`.
 
 `MarkSuperseded` has one call site and no inverse anywhere in `src/`. Canonicalization
-(ADR-0003) means `50`, `50.0` and `50.0.0` are the same value, so there is no spelling around it.
-The version number is dead: hand-written SQL, or a deliberately wrong row, are the only exits.
+(ADR-0003) means `50`, `50.0` and `50.0.0` are the same value, so there was no spelling around it.
+The version number was dead: hand-written SQL, or a deliberately wrong row, were the only exits.
 
 A watcher that registers automatically turns a rare typo into a recurring, unattended path into
-that state. The recovery route must exist before detection goes auto-active.
+that state, which is why the recovery route had to exist before detection goes auto-active. #624
+made it deletion: the duplicate check stays status-blind on purpose, so retiring the dead row is the
+one way back and two rows can never carry the same version string.
 
 ## Consequences
 

--- a/docs/specs/0005-game-versions-management-ui.md
+++ b/docs/specs/0005-game-versions-management-ui.md
@@ -7,6 +7,14 @@
 - **Related:** Spec 0001 (game-update lifecycle), ADR-0003 (LotroNotationVersion canonical form),
   #107/M2-19 (GameVersion endpoints), #158/M3-12 (HATEOAS-driven affordances), `Components/Pages/ImportExport/` (sibling slice)
 
+> **Amendment 2026-08-08 (#624 / UR-23) — the delete guard is `not Processed`, not `Unprocessed`.**
+> Every "only `Unprocessed` may be deleted" statement below now reads "everything except
+> `Processed`". A `Superseded` row was registered and then skipped — `MarkSuperseded` refuses a
+> processed version, so no import ever landed against it and nothing references it — and refusing to
+> delete it burned its version number forever (it could not be deleted, imported into, or registered
+> again). The error is now `GameVersionEntity.ProcessedCannotBeDeleted`. The register duplicate check
+> and the cross-aggregate reference check are unchanged.
+
 ## Business context
 
 After a LOTRO update the admin reacts to detected game versions (spec 0001): a forum watcher
@@ -60,13 +68,13 @@ and delete a still-unprocessed version they registered by mistake.
   resource advertises the admin-only `register` / `delete` rel — never a locally recomputed role (#158).
 - Duplicate version (normalized per ADR-0003: `48` ≡ `48.0` ≡ `48.0.0`) → the API returns a
   conflict; surface the `ProblemDetails` and keep the list intact.
-- **Delete guard (server-side, authoritative):** load the version → not found ⇒ 404; status is not
-  `Unprocessed` ⇒ conflict (`CannotDeleteProcessedVersion`); any translation references it ⇒ conflict
-  (`CannotDeleteReferencedVersion`); else remove + save ⇒ 204. Under the lifecycle an Unprocessed
-  version has never been imported against, so the referenced check is defense-in-depth (it should
-  not normally trigger).
-- The `delete` rel is emitted per item for admins **only when `Status == Unprocessed`** (cheap,
-  status is on the response); the referenced check stays server-side.
+- **Delete guard (server-side, authoritative):** load the version → not found ⇒ 404; status is
+  `Processed` ⇒ conflict (`ProcessedCannotBeDeleted`); any translation references it ⇒ conflict
+  (`CannotDeleteReferencedVersion`); else remove + save ⇒ 204. Under the lifecycle neither an
+  Unprocessed nor a Superseded version has ever been imported against, so the referenced check is
+  defense-in-depth (it should not normally trigger).
+- The `delete` rel is emitted per item for admins **when `Status != Processed`** (cheap, status is on
+  the response); the referenced check stays server-side.
 - Empty list → friendly empty state; the register form (when admin) still shows so the first version
   can be added.
 - Failed list fetch → surface the error; the register form / delete buttons cannot show (rels can't
@@ -88,6 +96,12 @@ and delete a still-unprocessed version they registered by mistake.
   (404 not found / 409 conflict when Processed/Superseded/referenced).
 - **Errors:** new `DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted` (covers Processed
   **and** Superseded) and `CannotDeleteReferencedVersion` (both `TypeOfError.DataConflict` → 422).
+  *(Amendment 2026-08-08, #624/UR-23: the status guard was too wide. `MarkSuperseded` refuses a
+  processed version, so a superseded row is one that was registered and then skipped — never
+  imported against, referenced by nothing — and blocking its deletion sealed its version number
+  forever. Only `Processed` is blocked now, and the error is
+  `GameVersionEntity.ProcessedCannotBeDeleted`. The duplicate check on register and the
+  cross-aggregate reference check are unchanged.)*
 - **Files touched:** new `Features/GameVersions/DeleteGameVersion.cs`, repository `Delete` +
   referenced-check, `Rels.Delete`, the GameVersion link factory; new
   `Components/Pages/GameVersions/{GameVersions.razor, GameVersionsLoader.cs}`; nav link in
@@ -98,9 +112,9 @@ and delete a still-unprocessed version they registered by mistake.
 - [ ] `/game-versions` lists versions **newest-first** with version, detected-at, and a status badge.
 - [ ] A non-admin translator sees the list but **no register form and no delete buttons**.
 - [ ] An admin sees the register form; submitting a valid version POSTs and the new row appears.
-- [ ] An admin sees a delete button only on **Unprocessed** rows; deleting removes the row.
-- [ ] `DELETE` on a Processed/Superseded version ⇒ conflict; on an unknown id ⇒ 404; on a referenced
-      version ⇒ conflict — each surfaced as `ProblemDetails`, list preserved.
+- [ ] An admin sees a delete button on every row except **Processed** ones; deleting removes the row.
+- [ ] `DELETE` on a Processed version ⇒ conflict; on an unknown id ⇒ 404; on a referenced version ⇒
+      conflict — each surfaced as `ProblemDetails`, list preserved.
 - [ ] A duplicate/invalid register surfaces the API `ProblemDetails` without losing the list.
 - [ ] An empty list shows the empty state; a failed fetch surfaces the error.
 - [ ] The sidebar shows a "Wersje gry" link.

--- a/docs/tms-handbook.md
+++ b/docs/tms-handbook.md
@@ -211,8 +211,11 @@ A `GameVersion` also has a small state machine:
   48.1 becomes Superseded automatically.
 
 Forbidden moves are enforced in code: a Processed version can never become Superseded, and a
-Superseded version can never be Processed. Only an Unprocessed version that no translation
-points to may be deleted (for fixing typos in manually registered versions).
+Superseded version can never be Processed. A Processed version can never be deleted either — it is
+the one an import was applied against. An Unprocessed or Superseded version that no translation
+points to may be deleted (for fixing typos in manually registered versions). Superseded counts here
+because it was registered and then skipped: no import ever landed against it, so nothing references
+it, and refusing to delete it used to burn that version number forever (#624).
 
 Game version names are **canonical**: `48`, `48.0` and `48.0.0` are the same version. The system
 removes meaningless trailing zeros before storing or comparing (ADR-0003). Without this rule,
@@ -734,9 +737,11 @@ keeps its own tiny, always-converging copy of each user's public profile.
 3. Submitting calls `POST /api/v1/game-versions`. The handler validates the version text,
    canonicalizes it (`48.0` → `48`), rejects duplicates **after** canonicalization, and stores
    a new `Unprocessed` version.
-4. A mistyped version can be deleted — but only while it is still `Unprocessed` **and** no
-   translation row references it. Both checks are server-side; the frontend's delete button is,
-   again, only rendered when the API advertises a `delete` link.
+4. A mistyped version can be deleted as long as it is not `Processed` **and** no translation row
+   references it. That includes a `Superseded` row — one the admin registered by mistake and then
+   skipped by importing the real version — which is how its version number is freed for the real
+   update when it eventually ships (#624). Both checks are server-side; the frontend's delete button
+   is, again, only rendered when the API advertises a `delete` link.
 
 ### 5.4 The import — uploading a fresh export
 

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersions.razor
@@ -19,8 +19,8 @@
         <h1>Wersje gry</h1>
         <p class="lede">
             Przeglądaj wykryte wersje gry LOTRO i ich stan w cyklu aktualizacji. Administrator może ręcznie
-            zarejestrować wersję, gdy odczyt z forum jest niedostępny, oraz usunąć błędnie dodaną, jeszcze
-            nieprzetworzoną wersję.
+            zarejestrować wersję, gdy odczyt z forum jest niedostępny, oraz usunąć błędnie dodaną wersję —
+            dopóki nie zaimportowano do niej tekstów.
         </p>
     </div>
 </section>
@@ -129,8 +129,9 @@
                                 </span>
                             </td>
                             <td class="col-actions">
-                                @* The `delete` rel is emitted only for an admin on an Unprocessed version (#158),
-                                   and it carries the URI to call — the page never composes one (#610). *@
+                                @* The `delete` rel is emitted only for an admin on a version no import has
+                                   landed against (#158, #624), and it carries the URI to call — the page
+                                   never composes one (#610). *@
                                 @if (version.Links.FindLink(Rels.Delete) is { } deleteLink)
                                 {
                                     <form method="post" @formname="@DeleteFormName(version.Id)"

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersionsLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/GameVersions/GameVersionsLoader.cs
@@ -66,9 +66,9 @@ internal sealed class GameVersionsLoader
     }
 
     /// <summary>
-    /// Deletes a mistaken, still-unprocessed entry by following its own <c>delete</c> link.
-    /// <paramref name="deleteHref"/> is the server-advertised URI — present only for an admin on an
-    /// <c>Unprocessed</c> row, which is the whole gate.
+    /// Deletes a mistaken entry by following its own <c>delete</c> link.
+    /// <paramref name="deleteHref"/> is the server-advertised URI — present only for an admin on a row
+    /// no import has landed against (#624), which is the whole gate.
     /// </summary>
     public Task<ApiResult> DeleteGameVersionAsync(
         string deleteHref,

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemCopy.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemCopy.cs
@@ -67,8 +67,8 @@ internal static class ApiProblemCopy
                 "Ta wersja gry została zastąpiona nowszą i nie może już zostać przetworzona.",
             ["GameVersionEntity.ProcessedCannotBeSuperseded"] =
                 "Ta wersja gry jest już przetworzona i nie można oznaczyć jej jako zastąpionej.",
-            ["GameVersionEntity.OnlyUnprocessedCanBeDeleted"] =
-                "Usunąć można tylko wersję gry, do której nie zaimportowano jeszcze tekstów.",
+            ["GameVersionEntity.ProcessedCannotBeDeleted"] =
+                "Tej wersji gry nie można usunąć, bo zaimportowano już do niej teksty.",
             ["GameVersionEntity.CannotDeleteReferencedVersion"] =
                 "Tej wersji gry nie można usunąć, bo są z nią powiązane tłumaczenia.",
             ["GameVersions.Validation"] =

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/DeleteGameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/GameVersions/DeleteGameVersion.cs
@@ -17,11 +17,12 @@ using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregat
 namespace LotroKoniecDev.TranslationSystem.API.Features.GameVersions;
 
 /// <summary>
-/// Deletes a manually-registered game version that was added by mistake (#209). The guard is strict:
-/// only an <see cref="Primitives.Aggregates.GameVersionAggregate.Enums.GameVersionStatus.Unprocessed"/>
-/// version with no translation referencing it can be removed — a processed or superseded version is
-/// woven into the update lifecycle (spec 0001) and removing it would orphan the rows that point at it
-/// (422). Requires the admin policy; an unknown id is a 404.
+/// Deletes a manually-registered game version that was added by mistake (#209). Only a
+/// <see cref="Primitives.Aggregates.GameVersionAggregate.Enums.GameVersionStatus.Processed"/> version is
+/// kept — it is the one an import was applied against, and removing it would orphan the rows that point
+/// at it (422). An unprocessed or superseded version with no translation referencing it can be removed,
+/// which is what frees a version number burned by a wrong registration (#624). Requires the admin
+/// policy; an unknown id is a 404.
 /// </summary>
 internal sealed class DeleteGameVersion : IEndpoint
 {
@@ -79,9 +80,9 @@ internal sealed class DeleteGameVersion : IEndpoint
                 return deletableResult;
             }
 
-            // Cross-aggregate safety net: under the lifecycle an Unprocessed version has never been
-            // imported against, so nothing should reference it — but a referenced version must never be
-            // removed, or its translations would point at a missing version.
+            // Cross-aggregate safety net: under the lifecycle neither an Unprocessed nor a Superseded
+            // version has ever been imported against, so nothing should reference it — but a referenced
+            // version must never be removed, or its translations would point at a missing version.
             if (await _translationRepository.AnyReferencesGameVersionAsync(command.Id, cancellationToken))
             {
                 return Result.Failure(DomainErrors.GameVersionEntity.CannotDeleteReferencedVersion(command.Id));

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/GameVersionAggregateLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/GameVersionAggregateFactories/GameVersionAggregateLinkFactory.cs
@@ -30,9 +30,11 @@ internal sealed class GameVersionAggregateLinkFactory : IGameVersionAggregateLin
             method: HttpMethods.Get,
             values: new { id = id.Value }));
 
-        // Deleting a mistaken manual registration is an admin action, and only an unprocessed version
-        // may be removed (a processed/superseded one is referenced by translations — spec 0001).
-        if (callerIsAdmin && status is GameVersionStatus.Unprocessed)
+        // Deleting a mistaken manual registration is an admin action. Only a processed version is kept —
+        // it is the one translations point at (spec 0001). A superseded version was registered and then
+        // skipped, so retiring it is exactly how the admin frees its version number again (#624). Stated
+        // as an allow-list to mirror EnsureCanBeDeleted, so the rel can never outrun the domain guard.
+        if (callerIsAdmin && status is GameVersionStatus.Unprocessed or GameVersionStatus.Superseded)
         {
             links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: nameof(DeleteGameVersion),

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
@@ -50,16 +50,21 @@ public sealed class GameVersion : AggregateRoot<GameVersionId>
     }
 
     /// <summary>
-    /// Guards deletion: only an <see cref="GameVersionStatus.Unprocessed"/> version may be removed. A
-    /// processed or superseded version has been woven into the update lifecycle (spec 0001) and removing
-    /// it would orphan the translations that reference it. The cross-aggregate "no translation references
-    /// this version" check stays in the delete handler — the aggregate only owns the status invariant.
+    /// Guards deletion: only a <see cref="GameVersionStatus.Processed"/> version is kept, because it is the
+    /// one an import has been applied against and its translations point at it (spec 0001). A
+    /// <see cref="GameVersionStatus.Superseded"/> version was registered and then skipped —
+    /// <see cref="MarkSuperseded"/> refuses a processed version, so nothing was ever imported into it and
+    /// nothing references it. Leaving it undeletable burned its version number forever (#624). The
+    /// cross-aggregate "no translation references this version" check stays in the delete handler — the
+    /// aggregate only owns the status invariant.
     /// </summary>
     public Result EnsureCanBeDeleted()
     {
-        if (Status is not GameVersionStatus.Unprocessed)
+        // Stated as an allow-list, not as "anything but Processed": a status added later must be
+        // triaged deliberately rather than inherit deletability by default.
+        if (Status is not (GameVersionStatus.Unprocessed or GameVersionStatus.Superseded))
         {
-            return Result.Failure(DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted(Id));
+            return Result.Failure(DomainErrors.GameVersionEntity.ProcessedCannotBeDeleted(Id));
         }
 
         return Result.Success();

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Core/Errors/GameVersionAggregateDomainErrors.cs
@@ -27,11 +27,11 @@ public static partial class DomainErrors
                 $"Game version with ID '{id.Value}' is already processed and cannot be superseded.",
                 "ProcessedCannotBeSuperseded");
 
-        public static Error OnlyUnprocessedCanBeDeleted(GameVersionId id)
+        public static Error ProcessedCannotBeDeleted(GameVersionId id)
             => InvalidOperation(
                 nameof(GameVersionEntity),
-                $"Game version with ID '{id.Value}' is not unprocessed and cannot be deleted; only unprocessed versions can be deleted.",
-                "OnlyUnprocessedCanBeDeleted");
+                $"Game version with ID '{id.Value}' is processed and cannot be deleted; an import has been applied against it.",
+                "ProcessedCannotBeDeleted");
 
         public static Error CannotDeleteReferencedVersion(GameVersionId id)
             => InvalidOperation(

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Errors/ApiProblemCopyTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Errors/ApiProblemCopyTests.cs
@@ -128,6 +128,7 @@ public sealed class ApiProblemCopyTests
     [InlineData("GameVersionEntity.LotroNotationVersion.AlreadyTaken", 422, "Taka wersja gry jest już zarejestrowana.")]
     [InlineData("GameVersionEntity.LotroNotationVersion.InvalidFormat", 400, "Numer wersji gry musi składać się z liczb rozdzielonych kropkami, na przykład „48.0” albo „47.1.1”.")]
     [InlineData("GameVersionEntity.CannotDeleteReferencedVersion", 422, "Tej wersji gry nie można usunąć, bo są z nią powiązane tłumaczenia.")]
+    [InlineData("GameVersionEntity.ProcessedCannotBeDeleted", 422, "Tej wersji gry nie można usunąć, bo zaimportowano już do niej teksty.")]
     [InlineData("TranslationEntity.CannotApproveWithoutTranslation", 422, "Nie można zatwierdzić pustego tłumaczenia — najpierw wpisz polski tekst.")]
     [InlineData("Translations.Validation", 400, "Tłumaczenie nie może być puste i nie może przekraczać dozwolonej długości.")]
     [InlineData("Auth.InvalidCurrentPassword", 400, "Aktualne hasło jest nieprawidłowe.")]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/DeleteGameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/GameVersions/DeleteGameVersionTests.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LotroKoniecDev.SharedKernel.Authorization;
@@ -67,9 +68,11 @@ public sealed class DeleteGameVersionTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Delete_ProcessedVersion_ShouldReturn422AndKeepIt()
+    public async Task Delete_ProcessedVersion_ShouldReturn422WithTheProcessedErrorCodeAndKeepIt()
     {
-        // Arrange — a processed version is woven into the lifecycle and cannot be removed.
+        // Arrange — a processed version is the one an import landed against and cannot be removed. The
+        // literal errorCode is asserted on purpose: it is the wire contract the Frontend's Polish copy
+        // is keyed on, and comparing a Result against its own factory would not catch a rename.
         using HttpClient client = AdminClient();
         GameVersionId id = await SeedVersionAsync("48.0", GameVersionStatus.Processed);
 
@@ -78,13 +81,15 @@ public sealed class DeleteGameVersionTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        (await ReadErrorCodeAsync(response)).ShouldBe("GameVersionEntity.ProcessedCannotBeDeleted");
         (await ListVersionStringsAsync(client)).ShouldContain("48");
     }
 
     [Fact]
-    public async Task Delete_SupersededVersion_ShouldReturn422AndKeepIt()
+    public async Task Delete_SupersededVersion_ShouldReturn204AndRemoveItFromTheList()
     {
-        // Arrange — a superseded version is also outside the deletable (unprocessed) state.
+        // Arrange — superseded means "registered, then skipped": no import ever landed against it, so
+        // it is exactly the row an admin must be able to clean up (#624).
         using HttpClient client = AdminClient();
         GameVersionId id = await SeedVersionAsync("48.0", GameVersionStatus.Superseded);
 
@@ -92,7 +97,25 @@ public sealed class DeleteGameVersionTests : IAsyncLifetime
         HttpResponseMessage response = await client.DeleteAsync($"{Route}/{id.Value}");
 
         // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        (await ListVersionStringsAsync(client)).ShouldNotContain("48");
+    }
+
+    [Fact]
+    public async Task Delete_SupersededVersionReferencedByATranslation_ShouldReturn422AndKeepIt()
+    {
+        // Arrange — the cross-aggregate net is the safety line the relaxed status guard leans on, so it
+        // must still refuse a referenced version whatever its status.
+        using HttpClient client = AdminClient();
+        GameVersionId id = await SeedVersionAsync("48.0", GameVersionStatus.Superseded);
+        await SeedTranslationReferencingAsync(id);
+
+        // Act
+        HttpResponseMessage response = await client.DeleteAsync($"{Route}/{id.Value}");
+
+        // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        (await ReadErrorCodeAsync(response)).ShouldBe("GameVersionEntity.CannotDeleteReferencedVersion");
         (await ListVersionStringsAsync(client)).ShouldContain("48");
     }
 
@@ -117,7 +140,6 @@ public sealed class DeleteGameVersionTests : IAsyncLifetime
     public async Task Delete_AsTranslator_ShouldReturn403()
     {
         // Arrange — deletion is an admin-only action.
-        using HttpClient adminClient = AdminClient();
         GameVersionId id = await SeedVersionAsync("48.0", GameVersionStatus.Unprocessed);
 
         // Act
@@ -135,6 +157,74 @@ public sealed class DeleteGameVersionTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task MistypedVersion_AfterBeingSuperseded_CanBeDeletedAndItsNumberReusedForTheRealUpdate()
+    {
+        // Arrange — the whole trap of #624 over the public endpoints only: a typo registers "50", the
+        // real "49.2" is registered and imported, which supersedes the typo and used to seal its
+        // version number for good (undeletable, un-importable, un-registrable).
+        using HttpClient admin = AdminClient();
+
+        // The supersede sweep is keyed on a strict DetectedAt `<`, stamped from the real clock at
+        // registration — two HTTP round trips apart, so the typo is reliably the older row.
+        Guid mistypedId = await RegisterVersionAsync(admin, "50");
+        Guid realId = await RegisterVersionAsync(admin, "49.2");
+        (await ImportAsync(admin, realId, Line(1, "Alpha"))).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await GetVersionAsync(admin, mistypedId)).Status.ShouldBe(GameVersionStatus.Superseded);
+
+        // Registering the number again is still a conflict while the dead row exists — deleting it is
+        // the intended way back, not a second row carrying the same version string.
+        HttpResponseMessage blockedRegister =
+            await admin.PostAsJsonAsync(Route, new RegisterGameVersionRequest("50"));
+        blockedRegister.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+
+        // Act — retire the dead row, then walk the real Update 50 in.
+        HttpResponseMessage delete = await admin.DeleteAsync($"{Route}/{mistypedId}");
+        Guid reRegisteredId = await RegisterVersionAsync(admin, "50");
+        HttpResponseMessage import = await ImportAsync(admin, reRegisteredId, Line(1, "Alpha"), Line(2, "Beta"));
+
+        // Assert
+        delete.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        import.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await GetVersionAsync(admin, reRegisteredId)).Status.ShouldBe(GameVersionStatus.Processed);
+        (await ListVersionStringsAsync(admin)).ShouldBe(["50", "49.2"], ignoreOrder: true);
+    }
+
+    private async Task<Guid> RegisterVersionAsync(HttpClient admin, string version)
+    {
+        HttpResponseMessage response = await admin.PostAsJsonAsync(Route, new RegisterGameVersionRequest(version));
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+        GameVersionResponse? body = await response.Content.ReadFromJsonAsync<GameVersionResponse>(JsonOptions);
+        body.ShouldNotBeNull();
+        return body.Id.Value;
+    }
+
+    private static async Task<HttpResponseMessage> ImportAsync(HttpClient admin, Guid versionId, params string[] lines)
+    {
+        ByteArrayContent fileContent = new(Encoding.UTF8.GetBytes(string.Join('\n', lines)));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        using MultipartFormDataContent form = new() { { fileContent, "file", "exported.txt" } };
+
+        return await admin.PostAsync($"{Route}/{versionId}/import", form);
+    }
+
+    private async Task<GameVersionResponse> GetVersionAsync(HttpClient client, Guid id)
+    {
+        GameVersionResponse? version = await (await client.GetAsync($"{Route}/{id}"))
+            .Content.ReadFromJsonAsync<GameVersionResponse>(JsonOptions);
+        version.ShouldNotBeNull();
+        return version;
+    }
+
+    private static string Line(int gossipId, string text) => $"620756992||{gossipId}||{text}||NULL||NULL||1";
+
+    private static async Task<string?> ReadErrorCodeAsync(HttpResponseMessage response)
+    {
+        await using Stream stream = await response.Content.ReadAsStreamAsync();
+        using JsonDocument document = await JsonDocument.ParseAsync(stream);
+        return document.RootElement.TryGetProperty("errorCode", out JsonElement code) ? code.GetString() : null;
     }
 
     private async Task<string[]> ListVersionStringsAsync(HttpClient client)

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/GameVersionAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/GameVersionAggregateHateoasTests.cs
@@ -16,8 +16,8 @@ namespace LotroKoniecDev.TranslationSystem.API.Tests.Integration.Tests.Hateoas;
 
 /// <summary>
 /// Verifies the game-version aggregate's HATEOAS links: per-item <c>self</c> (resolving to the new
-/// item endpoint) plus the role-gated <c>delete</c> action (admins only, on unprocessed versions) and
-/// <c>import</c> action (admins only, on anything not superseded — #608), the collection <c>self</c>,
+/// item endpoint) plus the role-gated <c>delete</c> action (admins only, on anything not processed —
+/// #624) and <c>import</c> action (admins only, on anything not superseded — #608), the collection <c>self</c>,
 /// and the role-gated <c>register</c> action (admins only). Plain
 /// <c>application/json</c> requests must carry no links and still deserialize.
 /// </summary>
@@ -126,7 +126,7 @@ public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
     [Fact]
     public async Task ListGameVersions_AsAdmin_WhenVersionIsProcessed_DoesNotAdvertiseDeleteOnTheItem()
     {
-        // Arrange — only an unprocessed version may be deleted; a processed one offers self only.
+        // Arrange — a processed version is the one an import landed against, so it is never deletable.
         GameVersionId id = await SeedProcessedAsync("48.0");
 
         // Act
@@ -217,6 +217,40 @@ public sealed class GameVersionAggregateHateoasTests : IAsyncLifetime
         // Assert
         response.Links.ShouldContain(l => l.Rel == Rels.Self);
         response.Links.ShouldNotContain(l => l.Rel == Rels.Import);
+    }
+
+    [Fact]
+    public async Task GetGameVersion_AsAdmin_WhenSuperseded_AdvertisesDelete()
+    {
+        // Arrange — retiring a skipped version is how the admin frees its version number, so the button
+        // has to be on the page rather than reachable only by calling the API by hand (#624).
+        GameVersionId id = await SeedSupersededAsync("47.0");
+
+        // Act
+        GameVersionResponse response = await GetHateoasAsync<GameVersionResponse>(
+            AdminClient(), $"{Route}/{id.Value}");
+
+        // Assert
+        LinkDto delete = response.Links.Where(l => l.Rel == Rels.Delete).ShouldHaveSingleItem();
+        delete.Method.ShouldBe("DELETE");
+        delete.Href.ShouldEndWith($"{Route}/{id.Value}");
+    }
+
+    [Fact]
+    public async Task ListGameVersions_AsAdmin_WhenVersionIsSuperseded_AdvertisesDeleteOnTheItem()
+    {
+        // Arrange — the versions page renders its delete button off the list's per-item rel.
+        GameVersionId id = await SeedSupersededAsync("47.0");
+
+        // Act
+        CollectionResponse<GameVersionResponse> response =
+            await GetHateoasAsync<CollectionResponse<GameVersionResponse>>(AdminClient(), Route);
+
+        // Assert
+        GameVersionResponse item = response.Items.First(i => i.Id == id);
+        LinkDto delete = item.Links.Where(l => l.Rel == Rels.Delete).ShouldHaveSingleItem();
+        delete.Method.ShouldBe("DELETE");
+        delete.Href.ShouldEndWith($"{Route}/{id.Value}");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/GameVersions/DeleteGameVersionHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/GameVersions/DeleteGameVersionHandlerTests.cs
@@ -69,7 +69,7 @@ public sealed class DeleteGameVersionHandlerTests
 
         // Assert
         result.IsFailure.ShouldBeTrue();
-        result.Error.ShouldBe(DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted(gameVersion.Id));
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.ProcessedCannotBeDeleted(gameVersion.Id));
         // The status guard short-circuits before the cross-aggregate reference check.
         await _translationRepository.DidNotReceive().AnyReferencesGameVersionAsync(Arg.Any<GameVersionId>(), Arg.Any<CancellationToken>());
         _gameVersionRepository.DidNotReceive().Remove(Arg.Any<GameVersion>());
@@ -111,5 +111,45 @@ public sealed class DeleteGameVersionHandlerTests
         result.IsSuccess.ShouldBeTrue();
         _gameVersionRepository.Received(1).Remove(gameVersion);
         await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenSupersededAndUnreferenced_ShouldRemoveAndPersist()
+    {
+        // Arrange — a version that was registered and then skipped was never imported against, so
+        // retiring it is how the admin frees its version number again (#624).
+        GameVersion gameVersion = UnprocessedVersion();
+        gameVersion.MarkSuperseded();
+        _gameVersionRepository.GetByIdAsync(gameVersion.Id, Arg.Any<CancellationToken>())
+            .Returns(Maybe<GameVersion>.From(gameVersion));
+
+        // Act
+        Result result = await CreateHandler().Handle(new DeleteGameVersion.Command(gameVersion.Id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        _gameVersionRepository.Received(1).Remove(gameVersion);
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenSupersededButReferencedByATranslation_ShouldReturnConflictAndNotDelete()
+    {
+        // Arrange — the cross-aggregate net still stands whatever the status (#624 leaves it untouched).
+        GameVersion gameVersion = UnprocessedVersion();
+        gameVersion.MarkSuperseded();
+        _gameVersionRepository.GetByIdAsync(gameVersion.Id, Arg.Any<CancellationToken>())
+            .Returns(Maybe<GameVersion>.From(gameVersion));
+        _translationRepository.AnyReferencesGameVersionAsync(gameVersion.Id, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        Result result = await CreateHandler().Handle(new DeleteGameVersion.Command(gameVersion.Id), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.CannotDeleteReferencedVersion(gameVersion.Id));
+        _gameVersionRepository.DidNotReceive().Remove(Arg.Any<GameVersion>());
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/GameVersionTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/GameVersionAggregate/GameVersionTests.cs
@@ -162,13 +162,14 @@ public sealed class GameVersionTests
 
         // Assert
         result.IsFailure.ShouldBeTrue();
-        result.Error.ShouldBe(DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted(gameVersion.Id));
+        result.Error.ShouldBe(DomainErrors.GameVersionEntity.ProcessedCannotBeDeleted(gameVersion.Id));
     }
 
     [Fact]
-    public void EnsureCanBeDeleted_WhenSuperseded_ShouldReturnFailure()
+    public void EnsureCanBeDeleted_WhenSuperseded_ShouldSucceed()
     {
-        // Arrange
+        // Arrange — superseded means "registered, then skipped": MarkSuperseded refuses a processed
+        // version, so no import ever landed against this one and nothing references it (#624).
         GameVersion gameVersion = CreateGameVersion();
         gameVersion.MarkSuperseded();
 
@@ -176,7 +177,6 @@ public sealed class GameVersionTests
         Result result = gameVersion.EnsureCanBeDeleted();
 
         // Assert
-        result.IsFailure.ShouldBeTrue();
-        result.Error.ShouldBe(DomainErrors.GameVersionEntity.OnlyUnprocessedCanBeDeleted(gameVersion.Id));
+        result.IsSuccess.ShouldBeTrue();
     }
 }


### PR DESCRIPTION
- **Bug: a superseded game version could never be deleted and burned its version number (UR-23)**
- **Docs: record the relaxed game-version delete guard (UR-23)**
