### PR TITLE
Bug: first-page/last-page are advertised on the page they point at, so the pager cannot disable them (#545)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -163,9 +163,10 @@ Hypermedia links are **opt-in** (the shared `MediaTypes` convention, spec 0002 �
 
 Links are **state- and role-aware**: a soft-removed translation advertises only `self`; `approve`
 appears only for an `Admin` on a `Draft`/`NeedsReview` row; `register` (game version) only for an
-`Admin`. Pagination links (`first-page`/`previous-page`/`next-page`/`last-page`) appear only when the
-target page exists. Treat the link set as the authoritative "what can I do next" — don't hard-code
-URLs you can read from a rel.
+`Admin`. Pagination links (`first-page`/`previous-page`/`next-page`/`last-page`) appear only when they
+lead somewhere else — a boundary rel is omitted on the very page it points at, so a client can render
+the control as disabled without recomputing anything (#545). Treat the link set as the authoritative
+"what can I do next" — don't hard-code URLs you can read from a rel.
 
 ---
 
@@ -504,7 +505,8 @@ Sent only with `Accept: application/vnd.dev-lotrokoniecdev.hateoas.json`.
 | `bulk-approve` | POST | `/api/v1/translations/approve` | on the translations collection, caller is `Admin` |
 | `register` | POST | `/api/v1/game-versions` | on the game-versions collection, caller is `Admin` |
 | `delete` | DELETE | `/api/v1/game-versions/{id}` | caller is `Admin` **and** the version is not `Processed` (#624) |
-| `first-page` / `previous-page` / `next-page` / `last-page` | GET | the list page | the target page exists |
+| `previous-page` / `next-page` | GET | the list page | that neighbouring page exists |
+| `first-page` / `last-page` | GET | the list page | the target page exists **and is not the current one** (#545); both survive an over-range page, so an overshooting caller can get back |
 
 ### 10.2 `auth-api` rels (`AuthSystem.Contracts/Hateoas/Rels.cs`)
 

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/PaginationLinkFactories/PaginationLinkFactory.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Hateoas/PaginationLinkFactories/PaginationLinkFactory.cs
@@ -27,14 +27,20 @@ internal sealed class PaginationLinkFactory : IPaginationLinkFactory
             method: HttpMethods.Get,
             values: BuildRouteValues(paginationResponse.Page, paginationResponse.PageSize, additionalRouteValues)));
 
-        if (paginationResponse.TotalPages > 0)
+        // A boundary rel that points at the page you are already on is a no-op the pager renders as an
+        // enabled button (#545). Unlike previous/next these are ABSOLUTE jumps, so they survive an
+        // over-range page (?page=99 of 3) — that is the only way back for a caller who overshot.
+        if (paginationResponse.Page != 1)
         {
             links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: endpointName,
                 rel: Rels.FirstPage,
                 method: HttpMethods.Get,
                 values: BuildRouteValues(1, paginationResponse.PageSize, additionalRouteValues)));
+        }
 
+        if (paginationResponse.Page != paginationResponse.TotalPages && paginationResponse.TotalPages > 0)
+        {
             links.AddIfPresent(await _linkFactory.CreateAsync(
                 endpoint: endpointName,
                 rel: Rels.LastPage,

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
@@ -91,6 +91,47 @@ public sealed class TranslationsTests : BunitContext
     }
 
     [Fact]
+    public void Render_WhenFirstPageRelAbsent_RendersADisabledFirstControl()
+    {
+        // The QA symptom of #545: on page 1 the server omits first-page, so "Pierwsza" must be an
+        // inert span rather than a link that reloads the page the user is already on.
+        StubPage(MultiPageOf(page: 1, links: [PageLink(Rels.NextPage), PageLink(Rels.LastPage)]));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("a[rel=first]").ShouldBeEmpty();
+        component.FindAll("span.is-disabled").ShouldContain(span => span.TextContent.Contains("Pierwsza"));
+    }
+
+    [Fact]
+    public void Render_WhenLastPageRelAbsent_RendersADisabledLastControl()
+    {
+        // The other half of #545, on the last page.
+        StubPage(MultiPageOf(page: 2, links: [PageLink(Rels.PreviousPage), PageLink(Rels.FirstPage)]));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("a[rel=last]").ShouldBeEmpty();
+        component.FindAll("span.is-disabled").ShouldContain(span => span.TextContent.Contains("Ostatnia"));
+    }
+
+    [Fact]
+    public void Render_WhenBoundaryRelsPresent_RendersThemAsEnabledControls()
+    {
+        // A middle page carries all four, so none of them degrades to a disabled span.
+        StubPage(MultiPageOf(page: 2, links:
+        [
+            PageLink(Rels.FirstPage), PageLink(Rels.PreviousPage), PageLink(Rels.NextPage), PageLink(Rels.LastPage)
+        ]));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("a[rel=first]").Count.ShouldBe(1);
+        component.FindAll("a[rel=last]").Count.ShouldBe(1);
+        component.FindAll("span.is-disabled").ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Render_WhenNoPaginationRelsPresent_RendersNoPager()
     {
         StubPage(SinglePageOf(Row(canEdit: true)));

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/TranslationAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Hateoas/TranslationAggregateHateoasTests.cs
@@ -180,10 +180,11 @@ public sealed class TranslationAggregateHateoasTests : IAsyncLifetime
         item.Links.ShouldContain(l => l.Rel == Rels.Upsert && l.Method == "PUT");
         item.Links.ShouldContain(l => l.Rel == Rels.Approve && l.Method == "POST");
 
-        // Assert — pagination links on the envelope
+        // Assert — pagination links on the envelope. One row fits on one page, so every boundary rel
+        // would point at the page we are already on and none is advertised (#545).
         response.Links.ShouldContain(l => l.Rel == Rels.Self && l.Method == "GET");
-        response.Links.ShouldContain(l => l.Rel == Rels.FirstPage);
-        response.Links.ShouldContain(l => l.Rel == Rels.LastPage);
+        response.Links.ShouldNotContain(l => l.Rel == Rels.FirstPage);
+        response.Links.ShouldNotContain(l => l.Rel == Rels.LastPage);
 
         // Assert — the admin-only bulk-approve collection affordance (#322) drives the FE checkbox toolbar.
         response.Links.ShouldContain(l => l.Rel == Rels.BulkApprove && l.Method == "POST");
@@ -194,19 +195,23 @@ public sealed class TranslationAggregateHateoasTests : IAsyncLifetime
     {
         // Arrange — the public read-only list (#309): items must not advertise transitions an
         // anonymous visitor cannot take (self targets the translator-only detail GET), while the
-        // envelope keeps its pagination navigation, which is plain browsing.
-        Translation row = await SeedAsync(Row(1, "Aragorn", TranslationStatus.Draft));
+        // envelope keeps its pagination navigation, which is plain browsing. Two rows one per page,
+        // so the pager links this test is about actually exist.
+        Translation row = await SeedAsync(Row(1, "Aragorn", TranslationStatus.Draft), Row(2, "Boromir"));
 
         // Act
         PaginationResponse<TranslationListItemResponse> response =
             await GetHateoasAsync<PaginationResponse<TranslationListItemResponse>>(
-                _factory.CreateClient(), "/api/v1/translations?page=1&pageSize=50");
+                _factory.CreateClient(), "/api/v1/translations?page=1&pageSize=1");
 
         // Assert
         response.Items.First(i => i.Id == row.Id).Links.ShouldBeEmpty();
         response.Links.ShouldContain(l => l.Rel == Rels.Self && l.Method == "GET");
-        response.Links.ShouldContain(l => l.Rel == Rels.FirstPage);
+        response.Links.ShouldContain(l => l.Rel == Rels.NextPage);
         response.Links.ShouldContain(l => l.Rel == Rels.LastPage);
+        // On page 1 the backward jumps lead nowhere, so the pager renders them disabled (#545).
+        response.Links.ShouldNotContain(l => l.Rel == Rels.FirstPage);
+        response.Links.ShouldNotContain(l => l.Rel == Rels.PreviousPage);
         // The bulk-approve affordance is reviewer-only, so the anonymous envelope must not carry it.
         response.Links.ShouldNotContain(l => l.Rel == Rels.BulkApprove);
     }
@@ -249,6 +254,44 @@ public sealed class TranslationAggregateHateoasTests : IAsyncLifetime
         response.Links.ShouldContain(l => l.Rel == Rels.LastPage);
         response.Links.ShouldContain(l => l.Rel == Rels.PreviousPage);
         response.Links.ShouldContain(l => l.Rel == Rels.NextPage);
+    }
+
+    [Fact]
+    public async Task ListTranslations_OnTheLastPage_OmitsTheForwardJumps()
+    {
+        // Arrange — three rows, one per page, so page 3 is the last page.
+        await SeedAsync(Row(1, "a"), Row(2, "b"), Row(3, "c"));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> response =
+            await GetHateoasAsync<PaginationResponse<TranslationListItemResponse>>(
+                AdminClient(), "/api/v1/translations?page=3&pageSize=1");
+
+        // Assert — both forward controls lead nowhere here and the pager renders them disabled (#545).
+        response.Page.ShouldBe(3);
+        response.Links.ShouldNotContain(l => l.Rel == Rels.LastPage);
+        response.Links.ShouldNotContain(l => l.Rel == Rels.NextPage);
+        response.Links.ShouldContain(l => l.Rel == Rels.FirstPage);
+        response.Links.ShouldContain(l => l.Rel == Rels.PreviousPage);
+    }
+
+    [Fact]
+    public async Task ListTranslations_PastTheLastPage_StillOffersBothAbsoluteJumpsBack()
+    {
+        // Arrange — page is clamped at the lower bound only, so an over-range page is reachable and
+        // must not become a dead end: next is genuinely gone, but first/last are absolute jumps.
+        await SeedAsync(Row(1, "a"), Row(2, "b"), Row(3, "c"));
+
+        // Act
+        PaginationResponse<TranslationListItemResponse> response =
+            await GetHateoasAsync<PaginationResponse<TranslationListItemResponse>>(
+                AdminClient(), "/api/v1/translations?page=99&pageSize=1");
+
+        // Assert
+        response.Items.ShouldBeEmpty();
+        response.Links.ShouldContain(l => l.Rel == Rels.FirstPage);
+        response.Links.ShouldContain(l => l.Rel == Rels.LastPage);
+        response.Links.ShouldNotContain(l => l.Rel == Rels.NextPage);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_Anonymously_MatchesThePublicHateoasContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_Anonymously_MatchesThePublicHateoasContract.verified.json
@@ -45,16 +45,6 @@
       "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
       "rel": "self",
       "method": "GET"
-    },
-    {
-      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
-      "rel": "first-page",
-      "method": "GET"
-    },
-    {
-      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
-      "rel": "last-page",
-      "method": "GET"
     }
   ]
 }

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_AsAdmin_MatchesTheHateoasContract.verified.json
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Snapshots/TranslationContractSnapshotTests.ListTranslations_AsAdmin_MatchesTheHateoasContract.verified.json
@@ -88,16 +88,6 @@
       "method": "GET"
     },
     {
-      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
-      "rel": "first-page",
-      "method": "GET"
-    },
-    {
-      "href": "http://localhost/api/v1/translations?page=1&pageSize=50",
-      "rel": "last-page",
-      "method": "GET"
-    },
-    {
       "href": "http://localhost/api/v1/translations/approve",
       "rel": "bulk-approve",
       "method": "POST"

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Hateoas/PaginationLinkFactoryTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Hateoas/PaginationLinkFactoryTests.cs
@@ -1,0 +1,121 @@
+using LotroKoniecDev.Hateoas.Abstractions;
+using LotroKoniecDev.Hateoas.LinkFactories;
+using LotroKoniecDev.TranslationSystem.API.Hateoas.PaginationLinkFactories;
+using LotroKoniecDev.TranslationSystem.Contracts.Common;
+using LotroKoniecDev.TranslationSystem.Contracts.Hateoas;
+using NSubstitute;
+
+namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Hateoas;
+
+public sealed class PaginationLinkFactoryTests
+{
+    private const string EndpointName = "ListTranslations";
+
+    private readonly ILinkFactory _linkFactory = Substitute.For<ILinkFactory>();
+    private readonly PaginationLinkFactory _sut;
+
+    public PaginationLinkFactoryTests()
+    {
+        _linkFactory
+            .CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object?>())
+            .Returns(call => new LinkDto("/api/v1/translations", call.ArgAt<string>(1), call.ArgAt<string>(2)));
+
+        _sut = new PaginationLinkFactory(_linkFactory);
+    }
+
+    [Theory]
+    [InlineData(1, 3, 50, false, false, false, false)]
+    [InlineData(1, 2, 1, false, true, false, true)]
+    [InlineData(2, 2, 1, true, false, true, false)]
+    [InlineData(2, 3, 1, true, true, true, true)]
+    [InlineData(1, 0, 50, false, false, false, false)]
+    [InlineData(99, 3, 1, true, true, true, false)]
+    [InlineData(5, 0, 50, true, false, true, false)]
+    public async Task CreatePaginationLinks_AcrossThePageBoundaries_AdvertisesARelOnlyWhenItLeadsElsewhere(
+        int page,
+        int totalCount,
+        int pageSize,
+        bool expectFirst,
+        bool expectLast,
+        bool expectPrevious,
+        bool expectNext)
+    {
+        // Arrange
+        PaginationResponse<string> response = new()
+        {
+            Items = [],
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = totalCount
+        };
+
+        // Act
+        IReadOnlyList<LinkDto> links = await _sut.CreatePaginationLinksAsync(EndpointName, response);
+
+        // Assert
+        links.Any(l => l.Rel == Rels.Self).ShouldBeTrue();
+        links.Any(l => l.Rel == Rels.FirstPage).ShouldBe(expectFirst);
+        links.Any(l => l.Rel == Rels.LastPage).ShouldBe(expectLast);
+        links.Any(l => l.Rel == Rels.PreviousPage).ShouldBe(expectPrevious);
+        links.Any(l => l.Rel == Rels.NextPage).ShouldBe(expectNext);
+    }
+
+    [Fact]
+    public async Task CreatePaginationLinks_OnASinglePage_AdvertisesNothingButSelf()
+    {
+        // The pager is hidden entirely in this state, so any boundary rel here is a control the user
+        // could click to reload the page they are already on (#545).
+        PaginationResponse<string> response = new()
+        {
+            Items = [],
+            Page = 1,
+            PageSize = 50,
+            TotalCount = 3
+        };
+
+        IReadOnlyList<LinkDto> links = await _sut.CreatePaginationLinksAsync(EndpointName, response);
+
+        links.ShouldHaveSingleItem().Rel.ShouldBe(Rels.Self);
+    }
+
+    [Fact]
+    public async Task CreatePaginationLinks_OnAnOverRangePage_KeepsBothAbsoluteJumpsSoTheCallerCanGetBack()
+    {
+        // Page is clamped at the lower bound only, so ?page=99 of 3 is reachable. previous/next are
+        // relative and next is correctly absent; first/last are absolute and stay the way back.
+        PaginationResponse<string> response = new()
+        {
+            Items = [],
+            Page = 99,
+            PageSize = 1,
+            TotalCount = 3
+        };
+
+        IReadOnlyList<LinkDto> links = await _sut.CreatePaginationLinksAsync(EndpointName, response);
+
+        links.Select(l => l.Rel).ShouldBe([Rels.Self, Rels.FirstPage, Rels.LastPage, Rels.PreviousPage], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task CreatePaginationLinks_WhenTheLinkFactoryRefusesARel_OmitsItRatherThanEmittingNull()
+    {
+        // ILinkFactory returns null when the caller would be rejected by the target endpoint's own
+        // policy (ADR-0040); the pagination set must degrade to what is left.
+        _linkFactory
+            .CreateAsync(Arg.Any<string>(), Rels.LastPage, Arg.Any<string>(), Arg.Any<object?>())
+            .Returns((LinkDto?)null);
+
+        PaginationResponse<string> response = new()
+        {
+            Items = [],
+            Page = 1,
+            PageSize = 1,
+            TotalCount = 2
+        };
+
+        IReadOnlyList<LinkDto> links = await _sut.CreatePaginationLinksAsync(EndpointName, response);
+
+        links.Any(l => l.Rel == Rels.LastPage).ShouldBeFalse();
+        links.Any(l => l.Rel == Rels.NextPage).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Closes #545

## What

`first-page` and `last-page` were advertised whenever the list had any page at all, so on page 1 `first-page` pointed at page 1, and on the last page `last-page` pointed at the last page. The pager disables a control by the **absence** of its rel — that is exactly how `previous-page`/`next-page` already behaved — so both boundary buttons stayed clickable and reloaded the page the user was already on.

A boundary rel is now omitted on the page it points at.

## Why this shape

The frontend was never the defect: it already degrades a missing rel to an inert `<span class="is-disabled">`. Fixing it FE-side would mean the client recomputing what the server already knows, against ADR-0040 (a rel is an affordance, and the server decides whether it is offered).

One deliberate exception: an over-range page (`?page=99` of 3) keeps **both** `first-page` and `last-page`. Page is clamped at the lower bound only, so that state is reachable — and `first`/`last` are absolute jumps, unlike `previous`/`next`, so they are the only way back for a caller who overshot. Dropping them there would turn an over-range URL into a dead end.

The single-page case needed no change: the pager is hidden entirely there, and the QA report already noted it works.

## Tests

- `PaginationLinkFactoryTests` (new, unit) — the boundary matrix as a `[Theory]`, plus the single-page, over-range and "link factory refused the rel" (ADR-0040 null) cases.
- `TranslationAggregateHateoasTests` — new last-page and past-the-last-page cases over real PostgreSQL; the existing single-page and anonymous cases restated (the anonymous one now seeds two rows at `pageSize=1` so the pager links it is about actually exist).
- `TranslationsTests` (FE) — first/last both ways: absent rel renders a disabled span, present rel renders a link.
- Two `*.verified.json` snapshots re-accepted: the single-page list envelope now carries `self` only. Diffs read and intended.

## Verification

- `dotnet build LotroKoniecDev.slnx` — succeeded, 0 warnings.
- `TranslationSystem.API.Tests.Unit` — 5101 passed.
- `Frontend.Tests.Unit` — 540 passed.
- `TranslationSystem.API.Tests.Integration` — 240 passed (real PostgreSQL via Testcontainers).

## Docs

`docs/API.md` — the rel table now states the boundary condition, and the hypermedia section explains that an omitted boundary rel is how a client knows to render the control disabled.
