### PR TITLE
Bug: unconfirmed account login claims invalid credentials instead of naming the confirmation gap

### DIFF
--- a/docs/adr/0046-the-unconfirmed-email-login-branch-names-its-reason-behind-a-verified-password.md
+++ b/docs/adr/0046-the-unconfirmed-email-login-branch-names-its-reason-behind-a-verified-password.md
@@ -90,12 +90,25 @@ The link is `/Account/ResendConfirmation?email=<escaped>`, which is the first pl
 puts an e-mail in a **query string**. `SensitiveDataRedactor.RedactQueryString` masks e-mails in
 request logs, but it matched the raw query text on a literal `@` — and `Uri.EscapeDataString` writes
 `%40`. Shipping the link without touching the redactor would have persisted whole addresses in the
-logs of every environment.
+Serilog request log of every environment.
 
 The redactor now recognises both spellings of the separator, so `?email=alice%40example.com` logs as
 `?email=a***%40example.com`. Decoding the query before matching was rejected: the function returns
 the query verbatim apart from the redactions, so decoding would have to be undone on the way out,
 and a decode step in a logging hot path is a new way to throw on malformed input.
+
+Two limits of that fix, stated so they are not mistaken for coverage:
+
+- **It covers the Serilog request log, which is not the only log that sees a URL.** In
+  **Development** the Serilog override is `"Microsoft": "Information"`, so
+  `Microsoft.AspNetCore.Hosting.Diagnostics` also emits its own `Request starting … GET /path?query`
+  line — unredacted, to the console and to `./Logs/auth-system-.log`. Staging and Production set
+  `"Microsoft": "Warning"` and never emit it. Dev logs are local and short-lived, so this is
+  accepted rather than fixed; raising it to a redacted enricher would mean owning the framework's
+  log line too.
+- **Only single encoding is handled.** `%2540` — an address inside a URL that is itself escaped into
+  a query parameter, the shape a `returnUrl` would carry — matches neither `@` nor `%40`. Nothing
+  builds such a link today. The fix, if one ever does, is another alternation, not a decode step.
 
 ## Consequences
 

--- a/docs/adr/0046-the-unconfirmed-email-login-branch-names-its-reason-behind-a-verified-password.md
+++ b/docs/adr/0046-the-unconfirmed-email-login-branch-names-its-reason-behind-a-verified-password.md
@@ -1,0 +1,126 @@
+# ADR-0046: The unconfirmed-e-mail login branch names its reason, behind a verified password
+
+**Status:** Accepted
+**Date:** 2026-08-08
+**Decision-makers:** Solo maintainer
+**Related:** #560 (the defect), #554 (the QA ticket whose expectation it contradicted), ADR-0022 (e-mail is the login identifier), ADR-0031 (the deletion grace period whose branch set the precedent), `Login.cshtml.cs`, `ResendConfirmation.cshtml.cs`, `SensitiveDataRedactor`
+
+## Context
+
+`/Account/Login` answered every credential failure with one shared sentence:
+
+> Nieprawidłowy e-mail lub hasło. Jeśli konto zostało dopiero co utworzone, dokończ rejestrację,
+> potwierdzając swój adres e-mail — kliknij link aktywacyjny, który do Ciebie wysłaliśmy.
+
+A QA tester logged in with a correct password on an unconfirmed account, was told the credentials
+were invalid, and filed it as a bug. The report was closed as by design on the anti-enumeration
+rationale, then reopened: **that rationale does not reach this branch.**
+
+The handler's branches, in execution order, split cleanly by what a caller must already know:
+
+| # | Branch | Reachable without a valid password? |
+|---|---|---|
+| 1 | user not found | yes (+ dummy hash for timing parity) |
+| 2 | deletion scheduled | **no** — verifies the password first, then names the deletion date |
+| 3 | locked out | yes (+ dummy hash) |
+| 4 | wrong password | yes |
+| 5 | **e-mail not confirmed** | **no** — runs *after* branch 4 |
+
+Branches 1, 3 and 4 must stay identical: they answer someone who has proven nothing, so any
+difference between them tells an attacker whether an address is registered. That is real account
+enumeration and the generic message is the right answer there.
+
+Branch 5 is not in that set. It is only reachable by a caller who has already presented the correct
+password, and branch 2 — one screen up, in the same handler — already returns a *specific* message
+in exactly that position, naming the scheduled deletion date. So the two branches have identical
+exposure, and the codebase had already accepted revealing a reason at that point. Staying generic at
+branch 5 was an inconsistency, not a security boundary.
+
+The cost of being vague was not cosmetic. A user who never received the activation e-mail was told
+their password was wrong, so the corrective action they were nudged towards — the password reset —
+is the one action that cannot fix their account. The trailing activation hint was the compromise
+that was supposed to cover this, and it demonstrably did not: the tester read the first sentence,
+which asserts something false, and stopped.
+
+## Decision
+
+### 1. Branch 5 gets its own message; branches 1, 3 and 4 keep the shared one
+
+The unconfirmed-e-mail branch says what is actually wrong, and offers the action that fixes it — a
+link to `/Account/ResendConfirmation` carrying the address so the form arrives prefilled.
+
+The shared message loses its trailing activation hint and shrinks to `Nieprawidłowy e-mail lub
+hasło.` The hint existed solely as the compromise for the case that now has its own message; on the
+three branches that keep the generic text it was noise appended to every mistyped password.
+
+**The invariant that replaces "all branches are identical":** the specific text and the resend link
+are reachable **only** behind a verified password. A wrong password against an unconfirmed account
+returns the generic message, exactly like a wrong password against any other account — so nothing
+about an address can be learned without already holding its password. This is what the tests pin;
+it is the property that matters, and the old "every branch is byte-identical" assertion was a proxy
+for it that also forbade branch 2.
+
+### 2. The residual leak, stated plainly
+
+A caller holding a correct password for an **unconfirmed** account now learns that the password is
+correct, where before they could not distinguish it from a wrong one.
+
+Accepted, because the marginal information is small:
+
+- For a **confirmed** account the same pair already yields a session, which is a louder confirmation
+  than any message.
+- Reaching the branch requires the password, so it adds nothing to address enumeration — the thing
+  the generic message exists to prevent.
+- Failed attempts still count towards lockout (`AccessFailedAsync` on branch 4), so it is not a
+  cheap oracle to grind.
+
+Rejected alternative: **keep one generic message but reword it** so it no longer asserts the
+credentials are wrong (`Nie udało się zalogować. Sprawdź dane logowania lub dokończ rejestrację…`).
+It leaks nothing and fixes the literal complaint, but it leaves the genuine new user guessing which
+of two unrelated things went wrong, and it keeps branch 2 as an unexplained exception to a rule the
+codebase claims to follow. Fixing the inconsistency is worth more than the sliver of ambiguity.
+
+Also rejected: **auto-resending** the activation link from the login branch. It turns the login form
+into a mail-sending vector keyed by a password guess, and the user already has a rate-limited page
+that does it deliberately.
+
+### 3. The prefilled address forced the request-log redactor to grow
+
+The link is `/Account/ResendConfirmation?email=<escaped>`, which is the first place in the app that
+puts an e-mail in a **query string**. `SensitiveDataRedactor.RedactQueryString` masks e-mails in
+request logs, but it matched the raw query text on a literal `@` — and `Uri.EscapeDataString` writes
+`%40`. Shipping the link without touching the redactor would have persisted whole addresses in the
+logs of every environment.
+
+The redactor now recognises both spellings of the separator, so `?email=alice%40example.com` logs as
+`?email=a***%40example.com`. Decoding the query before matching was rejected: the function returns
+the query verbatim apart from the redactions, so decoding would have to be undone on the way out,
+and a decode step in a logging hot path is a new way to throw on malformed input.
+
+## Consequences
+
+### Good
+
+- The one message a blocked new user reads now names their actual problem and links to the fix,
+  one click away, with the address already filled in.
+- The handler is internally consistent: reason-specific behind a verified password (branches 2, 5),
+  uniformly opaque in front of one (branches 1, 3, 4).
+- The generic message is a single short sentence again, instead of one that appends registration
+  advice to every typo.
+- Request logs mask percent-encoded addresses, which was a latent gap the moment anything linked an
+  e-mail through a query string — and something eventually would have.
+
+### Neutral
+
+- `LoginPage_ShouldReturnIdenticalMessage_ForEveryCredentialFailure` was a deliberately pinned
+  assertion and it changed deliberately. It still runs, over the three branches the rule applies to,
+  and a new sibling test pins the invariant that replaces it for branch 5.
+- QA #554's expectation ("the message tells the user to confirm rather than claiming wrong
+  credentials") is now what the code does; the "disputed expectation" note on that ticket can go.
+
+### The limit of this decision
+
+It says nothing about the **lockout** branch, which stays generic on purpose — it runs before the
+password check, so naming it would leak account existence to an unauthenticated caller. If lockout
+is ever moved behind the password check, that is a separate decision and needs its own reasoning,
+not an appeal to this one.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
@@ -409,6 +409,16 @@
             color: oklch(0.82 0.06 25);
             font-size: 12.5px;
         }
+        .auth-alert .alert-action {
+            display: inline-block;
+            margin-top: 8px;
+            font-size: 12.5px;
+            font-weight: 600;
+            color: oklch(0.95 0.05 25);
+            text-decoration: underline;
+            text-underline-offset: 3px;
+        }
+        .auth-alert .alert-action:hover { color: var(--text); }
 
         /* ── Secondary info strip ── */
         .auth-meta {
@@ -555,6 +565,11 @@
                                     <div>
                                         <span class="t">Nie udało się zalogować</span>
                                         <span class="s">@Model.ErrorMessage</span>
+                                        @if (Model.ResendConfirmationEmail is { } resendConfirmationEmail)
+                                        {
+                                            <a class="alert-action"
+                                               href="/Account/ResendConfirmation?email=@Uri.EscapeDataString(resendConfirmationEmail)">Wyślij link ponownie →</a>
+                                        }
                                     </div>
                                 </div>
                             }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml.cs
@@ -15,15 +15,22 @@ namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
 internal sealed partial class LoginModel : PageModel
 {
     /// <summary>
-    /// Single source of truth for every credential-failure branch. Kept identical across
-    /// user-not-found, lockout, wrong-password and unconfirmed-email so no branch ever reveals
-    /// which check failed (anti-enumeration). The activation hint is generic — it neither confirms
-    /// the account exists nor that it is unconfirmed — yet still nudges a brand-new user to finish
-    /// registration.
+    /// Single source of truth for the credential-failure branches a caller can reach without proving
+    /// they know the password — user-not-found, lockout and wrong-password. Kept identical across the
+    /// three so none of them reveals whether the address is registered (anti-enumeration). The
+    /// branches that run behind a verified password (deletion-scheduled, unconfirmed e-mail) name
+    /// their reason instead; ADR-0046 has the exposure argument.
     /// </summary>
-    private const string GenericCredentialErrorMessage =
-        "Nieprawidłowy e-mail lub hasło. Jeśli konto zostało dopiero co utworzone, " +
-        "dokończ rejestrację, potwierdzając swój adres e-mail — kliknij link aktywacyjny, który do Ciebie wysłaliśmy.";
+    private const string GenericCredentialErrorMessage = "Nieprawidłowy e-mail lub hasło.";
+
+    /// <summary>
+    /// Reached only after <c>CheckPasswordAsync</c> succeeded, so it cannot tell an unauthenticated
+    /// caller anything about the address (ADR-0046). Being vague here was actively harmful: it
+    /// pointed a user whose only problem is an unopened activation e-mail at the password reset,
+    /// which cannot fix their account.
+    /// </summary>
+    private const string EmailNotConfirmedErrorMessage =
+        "To konto nie zostało jeszcze aktywowane. Sprawdź skrzynkę — wysłaliśmy na Twój adres link aktywacyjny.";
 
     /// <summary>
     /// Pre-computed hash for timing-equalization on the credential-failure branches that would
@@ -87,6 +94,14 @@ internal sealed partial class LoginModel : PageModel
         FrontendUrl.For(_openIddictSettings.Value.WebClient, FrontendLoginPath);
 
     public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// The address the "resend the activation link" affordance carries, set only on the
+    /// unconfirmed-e-mail branch so the link never appears without a verified password (ADR-0046).
+    /// Taken from the store rather than from the posted form — the page has no reason to reflect an
+    /// arbitrary input into a URL.
+    /// </summary>
+    public string? ResendConfirmationEmail { get; set; }
 
     public void OnGet(string? returnUrl = null)
     {
@@ -166,9 +181,12 @@ internal sealed partial class LoginModel : PageModel
             LogEmailNotConfirmed(_logger, user.Id, HttpContext.Connection.RemoteIpAddress);
             // Identity is configured with RequireConfirmedEmail, but the interactive login path uses
             // CheckPasswordAsync, which does not run PreSignInCheck. Enforce confirmation explicitly.
-            // Same generic message as the other branches — never reveal that the account exists but is
-            // unconfirmed — and placed after the password hash above so there is no timing oracle.
-            ErrorMessage = GenericCredentialErrorMessage;
+            // The position of this check is load-bearing, not incidental: naming the unconfirmed state
+            // is only safe because the password was verified above (ADR-0046). Moving it in front of
+            // the password check turns this message — and the resend link — into an account-enumeration
+            // oracle for an unauthenticated caller.
+            ErrorMessage = EmailNotConfirmedErrorMessage;
+            ResendConfirmationEmail = user.Email;
             return Page();
         }
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResendConfirmation.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResendConfirmation.cshtml.cs
@@ -22,9 +22,16 @@ internal sealed class ResendConfirmationModel : PageModel
 
     public bool IsSubmitted { get; set; }
 
-    public void OnGet()
+    /// <summary>
+    /// <paramref name="email"/> arrives from the login page's unconfirmed-account alert (ADR-0046)
+    /// and is a form default, nothing more: the POST handler still owns the anti-enumeration
+    /// behaviour, so an address typed into the query by hand reveals exactly as much as one typed
+    /// into the field.
+    /// </summary>
+    public void OnGet(string? email)
     {
         IsSubmitted = false;
+        Email = email?.Trim() ?? string.Empty;
     }
 
     public async Task<IActionResult> OnPostAsync(CancellationToken cancellationToken)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -258,6 +258,7 @@ try
     const string authEndpointRateLimitPolicy = "auth-endpoint-limit";
     const string forgotPasswordRateLimitPolicy = "forgot-password-limit";
     const string resendConfirmationRateLimitPolicy = "resend-confirmation-limit";
+    const string resendConfirmationPageViewPartition = "resend-confirmation-page-view";
 
     builder.Services.AddRateLimiter(options =>
     {
@@ -292,15 +293,22 @@ try
                     Window = TimeSpan.FromMinutes(15)
                 }));
 
-        // Separate rate limiting for email confirmation resend
+        // Separate rate limiting for email confirmation resend. The budget belongs to the SEND: the
+        // policy rides an [EnableRateLimiting] attribute on the Razor PageModel, and a Razor Page is
+        // one endpoint for both verbs, so a verb-blind partition spends the 3-per-15-minutes window on
+        // page views — three of them and the user cannot even reach the form. That is the form
+        // ADR-0046 made the advertised one-click fix for a blocked login, so the distinction is
+        // load-bearing, not cosmetic. Rendering a form costs nothing; sending mail is what needs the cap.
         options.AddPolicy(resendConfirmationRateLimitPolicy, httpContext =>
-            RateLimitPartition.GetFixedWindowLimiter(
-                partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                factory: _ => new FixedWindowRateLimiterOptions
-                {
-                    PermitLimit = 3,
-                    Window = TimeSpan.FromMinutes(15)
-                }));
+            HttpMethods.IsPost(httpContext.Request.Method)
+                ? RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 3,
+                        Window = TimeSpan.FromMinutes(15)
+                    })
+                : RateLimitPartition.GetNoLimiter<string>(resendConfirmationPageViewPartition));
     });
 
     WebApplication app = builder.Build();

--- a/src/Utilities/LotroKoniecDev.Logging/Redaction/SensitiveDataRedactor.cs
+++ b/src/Utilities/LotroKoniecDev.Logging/Redaction/SensitiveDataRedactor.cs
@@ -9,11 +9,14 @@ namespace LotroKoniecDev.Logging.Redaction;
 /// <c>password</c>) are replaced wholesale, and any e-mail address surviving in a non-sensitive value
 /// has its local part masked, so neither a replayable token nor a piece of PII is persisted in plain
 /// text. All methods are total — a logging hot path must never throw — and operate on the raw query
-/// string without decoding, which is sufficient because query e-mails carry a literal <c>@</c>.
+/// string without decoding, so the separator is recognised in both spellings a query can carry: the
+/// literal <c>@</c> and the <c>%40</c> that <c>Uri.EscapeDataString</c> produces (ADR-0046).
 /// </summary>
 public static partial class SensitiveDataRedactor
 {
     private const string RedactedValue = "***";
+
+    private const string PercentEncodedAt = "%40";
 
     /// <summary>
     /// Query-parameter names whose value is a secret and must never be logged. Matched
@@ -69,7 +72,7 @@ public static partial class SensitiveDataRedactor
     /// <summary>
     /// Masks the local part of an e-mail, keeping only its first character (e.g.
     /// <c>alice@example.com</c> becomes <c>a***@example.com</c>). Anything without a non-empty local
-    /// part and an <c>@</c> is treated as fully sensitive and replaced with <c>***</c>.
+    /// part and a separator is treated as fully sensitive and replaced with <c>***</c>.
     /// </summary>
     public static string MaskEmail(string value)
     {
@@ -79,6 +82,11 @@ public static partial class SensitiveDataRedactor
         }
 
         int atIndex = value.IndexOf('@', StringComparison.Ordinal);
+        if (atIndex < 0)
+        {
+            atIndex = value.IndexOf(PercentEncodedAt, StringComparison.Ordinal);
+        }
+
         return atIndex <= 0 ? RedactedValue : string.Concat(value[0].ToString(), RedactedValue, value[atIndex..]);
     }
 
@@ -105,7 +113,9 @@ public static partial class SensitiveDataRedactor
 
     private static string MaskEmailsIn(string value)
     {
-        if (value.Length == 0 || !value.Contains('@', StringComparison.Ordinal))
+        bool mayHoldEmail = value.Contains('@', StringComparison.Ordinal)
+            || value.Contains(PercentEncodedAt, StringComparison.Ordinal);
+        if (!mayHoldEmail)
         {
             return value;
         }
@@ -113,6 +123,6 @@ public static partial class SensitiveDataRedactor
         return EmailRegex().Replace(value, match => MaskEmail(match.Value));
     }
 
-    [GeneratedRegex(@"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"[A-Za-z0-9._%+-]+(?:@|%40)[A-Za-z0-9.-]+\.[A-Za-z]{2,}", RegexOptions.CultureInvariant)]
     private static partial Regex EmailRegex();
 }

--- a/src/Utilities/LotroKoniecDev.Logging/Redaction/SensitiveDataRedactor.cs
+++ b/src/Utilities/LotroKoniecDev.Logging/Redaction/SensitiveDataRedactor.cs
@@ -9,8 +9,11 @@ namespace LotroKoniecDev.Logging.Redaction;
 /// <c>password</c>) are replaced wholesale, and any e-mail address surviving in a non-sensitive value
 /// has its local part masked, so neither a replayable token nor a piece of PII is persisted in plain
 /// text. All methods are total — a logging hot path must never throw — and operate on the raw query
-/// string without decoding, so the separator is recognised in both spellings a query can carry: the
-/// literal <c>@</c> and the <c>%40</c> that <c>Uri.EscapeDataString</c> produces (ADR-0046).
+/// string without decoding, so the separator is recognised in its literal <c>@</c> form and in the
+/// single-encoded <c>%40</c> that <c>Uri.EscapeDataString</c> produces (ADR-0046). Deeper nesting is
+/// NOT covered: an address escaped twice (<c>%2540</c>, as it would be inside a <c>returnUrl</c>
+/// carrying a link that itself carries an address) matches neither form and survives the mask. No
+/// such link exists today; the fix is another alternation here, not a decode step in a hot path.
 /// </summary>
 public static partial class SensitiveDataRedactor
 {

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AuthorizationCodeFlowTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/AuthorizationCodeFlowTests.cs
@@ -305,12 +305,12 @@ public sealed partial class AuthorizationCodeFlowTests : AsyncLifetimeTestBase
         // Act
         HttpResponseMessage response = await _noRedirectClient.SendAsync(request);
 
-        // Assert — login is rejected: the page is re-rendered (200) with the generic error, NOT a
-        // redirect (302), which is what a successful sign-in would return.
+        // Assert — login is rejected: the page is re-rendered (200) with the unconfirmed-account
+        // error (ADR-0046), NOT a redirect (302), which is what a successful sign-in would return.
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         string html = await response.Content.ReadAsStringAsync();
-        html.ShouldContain("Nieprawidłowy e-mail lub hasło");
+        html.ShouldContain("To konto nie zostało jeszcze aktywowane");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
@@ -19,8 +19,13 @@ public sealed partial class LoginPageTests : EndpointsTestBase
 
     public LoginPageTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
 
+    /// <summary>
+    /// ADR-0046: this branch runs after the password check, so it names the actual problem instead of
+    /// asserting the credentials are wrong — and carries the address into the resend page, which is
+    /// the only action that unblocks the account.
+    /// </summary>
     [Fact]
-    public async Task LoginPage_ShouldGuideToConfirmEmail_WhenAccountIsUnconfirmed()
+    public async Task LoginPage_ShouldNameTheUnconfirmedAccount_WhenThePasswordIsCorrect()
     {
         // Arrange — a registered account whose e-mail was never confirmed, with a valid password
         (RegisterRequest request, _) =
@@ -33,11 +38,38 @@ public sealed partial class LoginPageTests : EndpointsTestBase
             ["Password"] = request.Password
         });
 
-        // Assert — the message guides the user to activate, without ever stating the account exists but is unconfirmed
+        // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         string html = await response.Content.ReadAsStringAsync();
-        html.ShouldContain("Nieprawidłowy e-mail lub hasło");
-        html.ShouldContain("aktywacyjny");
+        html.ShouldContain("To konto nie zostało jeszcze aktywowane");
+        html.ShouldNotContain("Nieprawidłowy e-mail lub hasło");
+        html.ShouldContain($"/Account/ResendConfirmation?email={Uri.EscapeDataString(request.Email)}");
+    }
+
+    /// <summary>
+    /// The affordance half of the invariant below: a caller without the password is not offered the
+    /// resend link either, so the link cannot become the oracle the message no longer is. The page
+    /// always carries a bare <c>/Account/ResendConfirmation</c> in its footer — only the address-bearing
+    /// form of it is account-specific.
+    /// </summary>
+    [Fact]
+    public async Task LoginPage_ShouldNotOfferTheResendLink_WhenTheUnconfirmedAccountsPasswordIsWrong()
+    {
+        // Arrange
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserUnconfirmedAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        // Act
+        HttpResponseMessage response = await PostToLoginPageAsync(new Dictionary<string, string>
+        {
+            ["Email"] = request.Email,
+            ["Password"] = request.Password + "WRONG"
+        });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldNotContain("/Account/ResendConfirmation?email=");
     }
 
     [Fact]
@@ -60,8 +92,15 @@ public sealed partial class LoginPageTests : EndpointsTestBase
         html.ShouldContain("Nieprawidłowy e-mail lub hasło");
     }
 
+    /// <summary>
+    /// The anti-enumeration invariant, as ADR-0046 restated it: every branch reachable **without** a
+    /// verified password answers identically — including an unconfirmed account probed with the wrong
+    /// password — so nothing about an address is learnable without already holding its password. The
+    /// two branches behind a verified password (deletion scheduled, unconfirmed e-mail) name their
+    /// reason on purpose and are pinned separately.
+    /// </summary>
     [Fact]
-    public async Task LoginPage_ShouldReturnIdenticalMessage_ForEveryCredentialFailure()
+    public async Task LoginPage_ShouldReturnIdenticalMessage_ForEveryFailureReachableWithoutThePassword()
     {
         // Arrange — a confirmed account (wrong-password + lockout branches) and an unconfirmed one
         (RegisterRequest confirmed, _) =
@@ -72,7 +111,7 @@ public sealed partial class LoginPageTests : EndpointsTestBase
             await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
         await LockOutAsync(lockedOut.Username);
 
-        // Act — one probe per credential-failure branch of /Account/Login
+        // Act — one probe per credential-failure branch a caller can reach without the password
         string nonExistentMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
         {
             ["Email"] = "nobody-" + Faker.Random.AlphaNumeric(8) + "@example.com",
@@ -83,10 +122,10 @@ public sealed partial class LoginPageTests : EndpointsTestBase
             ["Email"] = confirmed.Email,
             ["Password"] = confirmed.Password + "WRONG"
         });
-        string unconfirmedMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
+        string unconfirmedWrongPasswordMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
         {
             ["Email"] = unconfirmed.Email,
-            ["Password"] = unconfirmed.Password
+            ["Password"] = unconfirmed.Password + "WRONG"
         });
         string lockedOutMessage = await PostAndExtractRenderedAlertAsync(new Dictionary<string, string>
         {
@@ -97,7 +136,7 @@ public sealed partial class LoginPageTests : EndpointsTestBase
         // Assert — no branch reveals which check failed: identical text is the anti-enumeration invariant
         nonExistentMessage.ShouldNotBeNullOrWhiteSpace();
         wrongPasswordMessage.ShouldBe(nonExistentMessage);
-        unconfirmedMessage.ShouldBe(nonExistentMessage);
+        unconfirmedWrongPasswordMessage.ShouldBe(nonExistentMessage);
         lockedOutMessage.ShouldBe(nonExistentMessage);
     }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResendConfirmationPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/ResendConfirmationPageTests.cs
@@ -28,6 +28,32 @@ public sealed partial class ResendConfirmationPageTests : EndpointsTestBase
         html.ShouldContain("Wyślij link aktywacyjny");
     }
 
+    /// <summary>
+    /// The receiving end of the login page's unconfirmed-account link (ADR-0046). The <c>+</c> earns
+    /// the row: a link built without escaping would arrive here decoded as a space, and the prefilled
+    /// address would be a different one than the account's.
+    /// </summary>
+    [Fact]
+    public async Task ResendConfirmationPage_ShouldPrefillTheAddress_WhenItArrivesInTheQuery()
+    {
+        // Arrange
+        const string email = "alice+tag@example.com";
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.GetAsync(
+            new Uri($"/Account/ResendConfirmation?email={Uri.EscapeDataString(email)}", UriKind.Relative));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await response.Content.ReadAsStringAsync();
+        Match input = EmailInputRegex().Match(html);
+        input.Success.ShouldBeTrue("Expected the resend page to render an e-mail input.");
+        // Decoded, because Razor writes the '+' as the entity '&#x2B;' — what matters is the address
+        // the browser puts back in the field, not the encoder's spelling of it.
+        WebUtility.HtmlDecode(input.Value).ShouldContain($"value=\"{email}\"");
+    }
+
     [Fact]
     public async Task LoginPage_ShouldOfferLinkToResendConfirmation()
     {
@@ -222,4 +248,7 @@ public sealed partial class ResendConfirmationPageTests : EndpointsTestBase
 
     [GeneratedRegex("""name="__RequestVerificationToken".*?value="([^"]+)""")]
     private static partial Regex AntiForgeryTokenRegex();
+
+    [GeneratedRegex("""<input[^>]*name="Email"[^>]*>""")]
+    private static partial Regex EmailInputRegex();
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/RateLimiting/ResendConfirmationRateLimitingTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/RateLimiting/ResendConfirmationRateLimitingTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.RateLimiting;
+
+/// <summary>
+/// The resend limiter exists to stop e-mail bombing, so its budget belongs to the send — not to
+/// looking at the form. <c>[EnableRateLimiting]</c> sits on the PageModel and a Razor Page is one
+/// endpoint for both verbs, so without a verb-aware partition three page views exhaust a 15-minute
+/// window and the user cannot even reach the form. ADR-0046 turned that page into the advertised
+/// one-click remediation for a blocked login, which is what makes the distinction matter.
+/// The suite's Testing host keeps the limiter middleware off; these force-arm it on a derived host,
+/// mirroring <see cref="ConnectRateLimitingTests"/>.
+/// </summary>
+public sealed class ResendConfirmationRateLimitingTests : EndpointsTestBase
+{
+    /// <summary>Mirrors the resend-confirmation-limit policy: 3 permits per 15 minutes per client IP.</summary>
+    private const int ResendConfirmationPermitLimit = 3;
+
+    private static readonly Uri ResendConfirmationPage = new("/Account/ResendConfirmation", UriKind.Relative);
+
+    public ResendConfirmationRateLimitingTests(AuthSystemApiFactory appFactory) : base(appFactory)
+    {
+    }
+
+    [Fact]
+    public async Task ResendConfirmationPage_ShouldNeverThrottleAPageView()
+    {
+        // Arrange — well past the permit limit, the traffic a user generates by opening the page,
+        // going back to the login and following the resend link again
+        using WebApplicationFactory<Program> limitedHost = CreateRateLimitedHost();
+        using HttpClient client = limitedHost.CreateClient();
+
+        HttpStatusCode[] statusCodes = new HttpStatusCode[ResendConfirmationPermitLimit * 2 + 1];
+
+        // Act
+        for (int i = 0; i < statusCodes.Length; i++)
+        {
+            using HttpResponseMessage response = await client.GetAsync(ResendConfirmationPage);
+            statusCodes[i] = response.StatusCode;
+        }
+
+        // Assert
+        statusCodes.ShouldAllBe(statusCode => statusCode == HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ResendConfirmationPage_ShouldStillThrottleSends()
+    {
+        // Arrange — page views must not have widened the hole the limiter exists to close
+        using WebApplicationFactory<Program> limitedHost = CreateRateLimitedHost();
+        using HttpClient client = limitedHost.CreateClient();
+
+        HttpStatusCode[] statusCodes = new HttpStatusCode[ResendConfirmationPermitLimit + 1];
+
+        // Act
+        for (int i = 0; i < statusCodes.Length; i++)
+        {
+            using FormUrlEncodedContent send = new(new Dictionary<string, string>
+            {
+                ["Email"] = $"burst-{i}@lotro-translator.pl"
+            });
+            using HttpResponseMessage response = await client.PostAsync(ResendConfirmationPage, send);
+            statusCodes[i] = response.StatusCode;
+        }
+
+        // Assert
+        statusCodes.Take(ResendConfirmationPermitLimit)
+            .ShouldAllBe(statusCode => statusCode != HttpStatusCode.TooManyRequests);
+        statusCodes[ResendConfirmationPermitLimit].ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    private WebApplicationFactory<Program> CreateRateLimitedHost()
+    {
+        return Factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "RateLimiting:ForceEnable", "true" }
+                });
+            });
+        });
+    }
+}

--- a/tests/LotroKoniecDev.Logging.Tests.Unit/Redaction/SensitiveDataRedactorTests.cs
+++ b/tests/LotroKoniecDev.Logging.Tests.Unit/Redaction/SensitiveDataRedactorTests.cs
@@ -111,6 +111,22 @@ public sealed class SensitiveDataRedactorTests
         result.ShouldBe("?email=a***@example.com");
     }
 
+    /// <summary>
+    /// The shape a link built with <c>Uri.EscapeDataString</c> puts on the wire (ADR-0046). The query
+    /// is matched raw and never decoded, so a matcher that only knows the literal <c>@</c> lets the
+    /// whole address through into the request log.
+    /// </summary>
+    [Theory]
+    [InlineData("?email=alice%40example.com", "?email=a***%40example.com")]
+    [InlineData("?email=alice%2Btag%40example.com", "?email=a***%40example.com")]
+    [InlineData("?email=alice%40example.com&page=2", "?email=a***%40example.com&page=2")]
+    public void RedactQueryString_PercentEncodedEmailValue_MasksLocalPart(string queryString, string expected)
+    {
+        string result = SensitiveDataRedactor.RedactQueryString(queryString);
+
+        result.ShouldBe(expected);
+    }
+
     [Fact]
     public void RedactQueryString_EmailInArbitraryParameterName_IsStillMasked()
     {
@@ -140,6 +156,8 @@ public sealed class SensitiveDataRedactorTests
     [InlineData("b@c.com", "b***@c.com")]
     [InlineData("bob.smith@contoso.co.uk", "b***@contoso.co.uk")]
     [InlineData("alice+tag@example.com", "a***@example.com")]
+    [InlineData("alice%40example.com", "a***%40example.com")]
+    [InlineData("alice%2Btag%40example.com", "a***%40example.com")]
     public void MaskEmail_ValidEmail_MasksEverythingAfterTheFirstCharacterOfTheLocalPart(
         string email,
         string expected)
@@ -153,6 +171,7 @@ public sealed class SensitiveDataRedactorTests
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("@example.com")]
+    [InlineData("%40example.com")]
     [InlineData("not-an-email")]
     public void MaskEmail_MissingLocalPartOrAtSign_ReturnsFullyRedacted(string value)
     {


### PR DESCRIPTION
Closes #560

## What

The unconfirmed-e-mail branch of `/Account/Login` returned the same "wrong e-mail or password" text as every other credential failure. It now names the actual problem and offers the one action that fixes it.

## Why the anti-enumeration rationale did not reach this branch

The branch runs **after** `CheckPasswordAsync`, so it is unreachable without valid credentials — and the deletion-scheduled branch one screen up already returns a *specific* message in exactly that position. Identical exposure, opposite treatment: that was an inconsistency, not a security boundary.

Being vague was not cosmetic either. A user whose only problem was an unopened activation e-mail was told their password was wrong, so the corrective action they were nudged towards — the password reset — is the one action that cannot fix their account.

The invariant that replaces "every branch is byte-identical": **the specific text and the resend link are reachable only behind a verified password.** A wrong password against an unconfirmed account returns the generic message exactly like any other account, so nothing about an address is learnable without already holding its password.

Full reasoning, residual leak and rejected alternatives: **ADR-0046**.

## Changes

- **Login page** — the unconfirmed branch gets its own message plus a resend link carrying the account's address, so the form arrives prefilled. The shared message drops its trailing activation hint (it existed only as the compromise for this case) and shrinks back to one sentence. The position of the check is load-bearing and now says so in place.
- **Resend page** — `OnGet` accepts the address as a form default; the POST handler still owns all anti-enumeration behaviour.
- **Log redactor** — this is the first link in the app putting an e-mail in a query string, and `RedactQueryString` matched the raw query on a literal `@` while `Uri.EscapeDataString` writes `%40`. Without this, whole addresses would land in the request log of every environment.
- **Resend rate limiter** (found in review) — `[EnableRateLimiting]` sits on the PageModel and a Razor Page is one endpoint for both verbs, so the 3-per-15-minutes budget was spent on page **views**: three of them and the form itself 429s. The policy now partitions on the verb. Pre-existing, but this PR makes that page the advertised one-click path, so it is fixed here.

## Testing

`dotnet build` green, zero warnings. Auth integration 345/345, Logging unit 42/42, patcher unit 4023/4023, frontend unit 540/540; SSR-purity, client-hypermedia and Dockerfile-restore-graph guards pass.

- The anti-enumeration test now probes an unconfirmed account with a **wrong** password as its fourth branch — pinning the property that matters instead of forbidding the deletion-scheduled branch too. That verified file was a deliberate pin and it changed deliberately.
- New: the specific message + link at a correct password; no link at a wrong one; the prefill surviving the URL round trip (the `+` case proves the escaping); `%40` masking; page views never throttled while the fourth send still is.

## Note for the reviewer

`previous-page` on an over-range page is out of scope here, but worth knowing: an unconfirmed-account resend link is a plain GET, so a user who reloads it repeatedly no longer degrades anything.

Two documentation limits are stated rather than fixed, both in ADR-0046: Development's `"Microsoft": "Information"` override still logs the raw request line (Staging/Production do not), and `%2540` double-encoding is not matched by the redactor. Nothing builds such a link today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Lp7V4GTGuUNcTW6jVGTRZ