### PR TITLE
[Bug] [UI] An over-range page strands the user: empty state renders without the pager

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Translations/Translations.razor
@@ -232,51 +232,65 @@
             {
                 @resultsTable
             }
+        }
 
-            @* The pager controls' availability is driven by the server's pagination link rels (#158); the
-               user-facing /translations?... URLs stay FE-built via ToPageRelativeUri so they remain clean. *@
-            @if (pageData.Links.HasLink(Rels.PreviousPage) || pageData.Links.HasLink(Rels.NextPage))
-            {
-                <nav class="pager" aria-label="Stronicowanie">
-                    @if (pageData.Links.HasLink(Rels.FirstPage))
-                    {
-                        <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(1)" rel="first">« Pierwsza</a>
-                    }
-                    else
-                    {
-                        <span class="btn btn-ghost is-disabled" aria-disabled="true">« Pierwsza</span>
-                    }
+        @* The pager controls' availability is driven by the server's pagination link rels (#158); the
+           user-facing /translations?... URLs stay FE-built via ToPageRelativeUri so they remain clean.
 
-                    @if (pageData.Links.HasLink(Rels.PreviousPage))
-                    {
-                        <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.Page - 1)" rel="prev">← Poprzednia</a>
-                    }
-                    else
-                    {
-                        <span class="btn btn-ghost is-disabled" aria-disabled="true">← Poprzednia</span>
-                    }
+           It sits OUTSIDE the empty-state branch on purpose (#634). An over-range page (?page=99 of 3)
+           is empty yet still carries first-page/last-page — the API emits those absolute jumps
+           precisely so an overshooting caller has a way back (#545) — and rendering the empty state
+           without a pager left the user with no control at all, only the URL bar. A genuine
+           no-matches page carries no pagination rel whatsoever, so it stays pager-less on the same
+           rule; nothing here recomputes availability from Page/TotalPages.
 
-                    <span class="pager-status">@pageData.Page / @pageData.TotalPages</span>
+           The gate names all four rels rather than previous||next: those two happen to accompany the
+           boundary rels in every reachable state today, but that is a coupling across two codebases,
+           not a rule anything enforces. *@
+        @if (pageData.Links.HasLink(Rels.FirstPage)
+             || pageData.Links.HasLink(Rels.PreviousPage)
+             || pageData.Links.HasLink(Rels.NextPage)
+             || pageData.Links.HasLink(Rels.LastPage))
+        {
+            <nav class="pager" aria-label="Stronicowanie">
+                @if (pageData.Links.HasLink(Rels.FirstPage))
+                {
+                    <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(1)" rel="first">« Pierwsza</a>
+                }
+                else
+                {
+                    <span class="btn btn-ghost is-disabled" aria-disabled="true">« Pierwsza</span>
+                }
 
-                    @if (pageData.Links.HasLink(Rels.NextPage))
-                    {
-                        <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.Page + 1)" rel="next">Następna →</a>
-                    }
-                    else
-                    {
-                        <span class="btn btn-ghost is-disabled" aria-disabled="true">Następna →</span>
-                    }
+                @if (pageData.Links.HasLink(Rels.PreviousPage))
+                {
+                    <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.Page - 1)" rel="prev">← Poprzednia</a>
+                }
+                else
+                {
+                    <span class="btn btn-ghost is-disabled" aria-disabled="true">← Poprzednia</span>
+                }
 
-                    @if (pageData.Links.HasLink(Rels.LastPage))
-                    {
-                        <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.TotalPages)" rel="last">Ostatnia »</a>
-                    }
-                    else
-                    {
-                        <span class="btn btn-ghost is-disabled" aria-disabled="true">Ostatnia »</span>
-                    }
-                </nav>
-            }
+                <span class="pager-status">@pageData.Page / @pageData.TotalPages</span>
+
+                @if (pageData.Links.HasLink(Rels.NextPage))
+                {
+                    <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.Page + 1)" rel="next">Następna →</a>
+                }
+                else
+                {
+                    <span class="btn btn-ghost is-disabled" aria-disabled="true">Następna →</span>
+                }
+
+                @if (pageData.Links.HasLink(Rels.LastPage))
+                {
+                    <a class="btn btn-ghost" href="@_query.ToPageRelativeUri(pageData.TotalPages)" rel="last">Ostatnia »</a>
+                }
+                else
+                {
+                    <span class="btn btn-ghost is-disabled" aria-disabled="true">Ostatnia »</span>
+                }
+            </nav>
         }
     }
 </section>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Translations/TranslationsTests.cs
@@ -141,6 +141,40 @@ public sealed class TranslationsTests : BunitContext
         component.FindAll("nav.pager").ShouldBeEmpty();
     }
 
+    /// <summary>
+    /// The two ways a page can render zero rows are not the same state (#634). Overshooting the last
+    /// page still carries the server's absolute jumps, so the pager is the only way back; a filter
+    /// that matched nothing carries no rel and has nowhere to go. The distinction is the rel set, not
+    /// the row count — which is why the pager cannot live inside the empty-state branch.
+    /// </summary>
+    [Fact]
+    public void Render_WhenPageIsOverRange_RendersTheEmptyStateWithAWayBack()
+    {
+        // ?page=99 of 3: the API omits next-page but still emits the absolute jumps plus previous-page
+        StubPage(OverRangePageOf(page: 99, links:
+        [
+            PageLink(Rels.FirstPage), PageLink(Rels.PreviousPage), PageLink(Rels.LastPage)
+        ]));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("div.empty").Count.ShouldBe(1);
+        component.FindAll("a[rel=first]").Count.ShouldBe(1);
+        component.FindAll("a[rel=last]").Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Render_WhenNothingMatchedTheFilter_RendersTheEmptyStateWithNoPager()
+    {
+        // TotalPages = 0, so the API emits no pagination rel at all — there is genuinely nowhere to go
+        StubPage(OverRangePageOf(page: 1, links: []));
+
+        IRenderedComponent<TranslationsComponent> component = RenderPage();
+
+        component.FindAll("div.empty").Count.ShouldBe(1);
+        component.FindAll("nav.pager").ShouldBeEmpty();
+    }
+
     [Fact]
     public void Render_WhenCollectionHasBulkApproveRel_ShowsTheCheckboxColumnAndBulkButton()
     {
@@ -363,6 +397,22 @@ public sealed class TranslationsTests : BunitContext
         };
 
     private const string BulkApproveHref = "https://tms.example/api/v1/translations/approve";
+
+    /// <summary>
+    /// A page that renders zero rows. The rel set is what separates the two reasons it can be empty:
+    /// an over-range page carries the boundary jumps, a no-matches page carries nothing.
+    /// </summary>
+    private static PaginationResponse<TranslationListItemResponse> OverRangePageOf(
+        int page,
+        IReadOnlyCollection<LinkDto> links) =>
+        new()
+        {
+            Items = [],
+            Page = page,
+            PageSize = 1,
+            TotalCount = links.Count == 0 ? 0 : 3,
+            Links = links
+        };
 
     private static PaginationResponse<TranslationListItemResponse> MultiPageOf(int page, IReadOnlyCollection<LinkDto> links) =>
         new()


### PR DESCRIPTION
Closes #634

## What

`/translations?page=99` on a 3-page result set rendered "Brak wyników" with **no pagination controls at all**. The only way back was editing the URL by hand.

## Why

The whole results area is an `@if (pageData.Items.Count == 0)` / `else` pair and the pager lived inside the `else`. Zero rows meant no pager, regardless of why there were zero rows.

But the two ways a page can render zero rows are not the same state:

| State | `TotalPages` | Rels the API emits | Correct behaviour |
|---|---|---|---|
| Filter matched nothing | `0` | none | No pager — nowhere to go |
| Caller overshot the last page | `> 0` | `first-page`, `last-page`, `previous-page` | Pager — the way back |

#545 made the API emit the boundary rels as **absolute jumps** precisely so an overshooting caller has an escape hatch; the frontend was discarding them.

**The distinction is the rel set, not the row count** — which is why the pager cannot live inside the empty-state branch. Moving it out is the whole fix: a no-matches page carries no pagination rel, so it stays pager-less on the existing rule, with no second condition and no recomputation from `Page`/`TotalPages`.

## Changes

- `Translations.razor` — the pager block moves out of the `else` (inner logic byte-identical, only re-indented). The empty state itself is untouched.
- The gate widens from `previous||next` to all four rels. Those two do accompany the boundary rels in every state reachable today, but that is a coupling across two codebases rather than a rule anything enforces, and the gate should not depend on it.

## Testing

`dotnet build` green, zero warnings. Frontend unit 542/542, architecture 21/21, TMS API unit 5101/5101; SSR-purity and client-hypermedia guards pass.

Two new tests, mirroring the existing `Render_When*Rel*` shape:
- over-range (empty `Items`, boundary rels present) → empty state **and** enabled "Pierwsza"/"Ostatnia"
- no-matches (empty `Items`, no rels) → empty state, no pager

Confirmed red before the fix: reverting only the `.razor` change fails the over-range test and leaves the no-matches one green, so it is genuinely pinning the defect rather than the new markup.

## Note for the reviewer

On an over-range page the server also advertises `previous-page`, which from page 99 points at page 98 — still out of range. Following it now lands on another empty page **that keeps its pager**, so the user is never stranded and "Pierwsza"/"Ostatnia" remain one click away. Clamping that rel would be an API-side change and this ticket is frontend-only, so it is left alone; the acceptance criteria explicitly forbid deciding availability locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Lp7V4GTGuUNcTW6jVGTRZ