### PR TITLE
Bug: an outage renders a generic placeholder because the unparseable-body problem is marked frontend-authored, bypassing the status copy

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemCopy.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemCopy.cs
@@ -272,6 +272,18 @@ internal static class ApiProblemCopy
         };
 
     /// <summary>
+    /// A failure whose body carried nothing to translate — an absent or unparseable error body, such
+    /// as the HTML a reverse proxy answers with when the upstream is down. It stays deliberately
+    /// unmarked so <see cref="Describe"/> degrades it down the status ladder (ADR-0044 §3); marking
+    /// it would assert "already Polish" about a placeholder and skip the ladder entirely (#637).
+    /// </summary>
+    public static ProblemDetails StatusOnly(int status)
+        => new()
+        {
+            Status = status
+        };
+
+    /// <summary>
     /// Removes the Frontend-authored marker from a problem parsed off the wire, so an API response
     /// carrying that member (ours never does) cannot pass its English through untranslated.
     /// </summary>

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
@@ -240,8 +240,9 @@ internal static class HttpClientApiExtensions
 
     /// <summary>
     /// Deserializes the API's error body into <see cref="ProblemDetails"/>. Not every error carries
-    /// one — a bare <c>401</c> from the JWT bearer challenge has an empty body — so an empty or
-    /// malformed body is synthesized into a generic <see cref="ProblemDetails"/> that still carries
+    /// one — a bare <c>401</c> from the JWT bearer challenge has an empty body, and a stopped
+    /// upstream answers through the reverse proxy with the proxy's own HTML — so an empty or
+    /// malformed body is synthesized into a bare <see cref="ProblemDetails"/> that still carries
     /// the real status code, keeping classifications like <c>IsUnauthorized</c> intact instead of
     /// crashing the SSR page on a <see cref="JsonException"/>.
     /// </summary>
@@ -268,10 +269,7 @@ internal static class HttpClientApiExtensions
             }
         }
 
-        return ApiProblemCopy.FrontendAuthored(
-            "Żądanie nie powiodło się",
-            "Serwer odrzucił żądanie bez szczegółów błędu.",
-            (int)response.StatusCode);
+        return ApiProblemCopy.StatusOnly((int)response.StatusCode);
     }
 
     /// <summary>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
@@ -218,6 +218,24 @@ public sealed class AccountEndpointsExtensionsTests
     }
 
     [Fact]
+    public async Task DownloadAccountExportAsync_WhenTheProxyAnswersForAStoppedUpstream_ServesThePolishStatusCopy()
+    {
+        StubDiscoveryWithExportLink();
+        AccountLoader loader = new(
+            _discoveryCache,
+            CreateClient(StubHttpMessageHandler.RespondWith(
+                HttpStatusCode.BadGateway,
+                "<html><head><title>502 Bad Gateway</title></head><body></body></html>")));
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);
+
+        ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
+        problem.ProblemDetails.Status.ShouldBe(StatusCodes.Status502BadGateway);
+        problem.ProblemDetails.Title.ShouldBe("Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.");
+    }
+
+    [Fact]
     public async Task DownloadAccountExportAsync_WhenUpstreamReturnsAnEnglishProblem_RewritesItInPolish()
     {
         // A download route answers with a raw problem body the browser shows verbatim, so it carries

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportEndpointsExtensionsTests.cs
@@ -103,6 +103,23 @@ public sealed class ImportExportEndpointsExtensionsTests
         problem.ProblemDetails.Status.ShouldBe(StatusCodes.Status503ServiceUnavailable);
     }
 
+    [Fact]
+    public async Task DownloadTranslationFileAsync_WhenTheProxyAnswersForAStoppedUpstream_ServesThePolishStatusCopy()
+    {
+        // The staging outage of #637: tms-api down, so Caddy answers 502 with its own HTML and the
+        // body carries no problem to translate.
+        ImportExportLoader loader = CreateLoader(
+            HttpStatusCode.BadGateway,
+            "<html><head><title>502 Bad Gateway</title></head><body></body></html>");
+
+        IResult result = await ImportExportEndpointsExtensions.DownloadTranslationFileAsync(loader, NullLoggerFactory.Instance, CancellationToken.None);
+
+        ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
+        problem.ProblemDetails.Status.ShouldBe(StatusCodes.Status502BadGateway);
+        problem.ProblemDetails.Title.ShouldBe("Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.");
+        problem.ProblemDetails.Extensions.ShouldNotContainKey(ApiProblemCopy.TechnicalDetailExtensionKey);
+    }
+
     private static ImportExportLoader CreateLoader(HttpStatusCode statusCode, string body) =>
         new(
             StubDiscoveryCache.AdvertisingGet(Rels.TranslationFile),

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Shared/ApiProblemAlertTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Shared/ApiProblemAlertTests.cs
@@ -41,6 +41,20 @@ public sealed class ApiProblemAlertTests : BunitContext
     }
 
     [Fact]
+    public void Render_ForAStatusOnlyProblem_ShowsTheStatusCopyAloneAndNeverAnEmptyBox()
+    {
+        // What an outage leaves: a status and nothing else (#637). There is no English to collapse,
+        // so the headline has to carry the whole message on its own.
+        IRenderedComponent<ApiProblemAlert> component = Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Problem, ApiProblemCopy.StatusOnly(502))
+            .Add(alert => alert.Fallback, "Nie udało się wczytać listy wersji gry."));
+
+        component.Find(".problem-headline").TextContent
+            .ShouldBe("Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.");
+        component.FindAll("details").ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Render_ForAnApiFailure_KeepsTheCodeAndEnglishInACollapsedDetailsBlock()
     {
         ProblemDetails problem = ApiProblem(

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Errors/ApiProblemCopyTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Errors/ApiProblemCopyTests.cs
@@ -267,6 +267,42 @@ public sealed class ApiProblemCopyTests
     }
 
     [Theory]
+    [InlineData(500, "Wystąpił nieoczekiwany błąd serwera. Spróbuj ponownie za chwilę.")]
+    [InlineData(502, "Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.")]
+    [InlineData(503, "Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.")]
+    [InlineData(504, "Serwer nie odpowiedział w wyznaczonym czasie. Spróbuj ponownie.")]
+    [InlineData(401, "Twoja sesja wygasła. Zaloguj się ponownie.")]
+    public void Describe_ForAStatusOnlyProblem_ShowsTheStatusCopy(int status, string expectedCopy)
+    {
+        // What a stopped upstream produces: the proxy's non-JSON body leaves nothing to translate,
+        // so the status ladder is the whole answer (#637).
+        ApiProblemView view = ApiProblemCopy.Describe(ApiProblemCopy.StatusOnly(status), PageFallback);
+
+        view.Message.ShouldBe(expectedCopy);
+        view.TechnicalDetail.ShouldBeNull();
+        view.SecondaryMessage.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(501)]
+    [InlineData(418)]
+    public void Describe_ForAStatusOnlyProblemWhoseStatusHasNoCopy_FallsBackToTheCallSiteSentence(int status)
+    {
+        ApiProblemCopy.Describe(ApiProblemCopy.StatusOnly(status), PageFallback).Message.ShouldBe(PageFallback);
+    }
+
+    [Fact]
+    public void Describe_ForAnEmptyProblemBodyOffTheWire_ConvergesOnTheSameCopyAsTheStatusOnlySynthesis()
+    {
+        // "{}" parses, so it takes the other branch of ParseProblemDetails and keeps only the
+        // backfilled status — it must not read differently from the unparseable case.
+        ProblemDetails parsedFromEmptyObject = new() { Status = 502 };
+
+        ApiProblemCopy.Describe(parsedFromEmptyObject, PageFallback).Message
+            .ShouldBe(ApiProblemCopy.Describe(ApiProblemCopy.StatusOnly(502), PageFallback).Message);
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("   ")]
     public void Describe_WhenTheCallSiteFallbackIsBlank_FloorsOnTheGenericMessage(string blankFallback)

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientApiExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientApiExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using Polly.CircuitBreaker;
 using Polly.Timeout;
@@ -161,6 +162,27 @@ public sealed class HttpClientApiExtensionsTests
         result.ProblemDetails!.Status.ShouldBe(403);
         result.IsForbidden.ShouldBeTrue();
         result.IsUnauthorized.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("<html><head><title>502 Bad Gateway</title></head><body></body></html>")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("null")]
+    [InlineData("[]")]
+    [InlineData("plain text")]
+    public async Task GetApiResultAsync_WhenTheErrorBodyCarriesNoProblem_SynthesizesOneThatStaysTranslatable(string body)
+    {
+        // The marker means "already Polish, render as-is", so stamping it here skipped the status
+        // ladder and rendered a placeholder during the staging outage (#637).
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.BadGateway, body));
+
+        ApiResult<string> result = await httpClient.GetApiResultAsync<string>("translation-files/pl");
+
+        result.ProblemDetails!.Extensions.ShouldNotContainKey(ApiProblemCopy.FrontendAuthoredExtensionKey);
+        result.ProblemDetails.Title.ShouldBeNull();
+        result.ProblemDetails.Detail.ShouldBeNull();
+        result.ProblemDetails.Status.ShouldBe(502);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #637

## What

When the API is down, the reverse proxy answers the frontend with a **502 whose body is the proxy's
HTML**, not `problem+json`. `ParseProblemDetails` could not parse it, synthesized a placeholder, and
stamped it `frontendAuthored` — the marker that means "already Polish, render as-is". That
short-circuited `ApiProblemCopy` **before** the Polish status map, so an outage read:

> „Żądanie nie powiodło się" / „Serwer odrzucił żądanie bez szczegółów błędu."

instead of the copy ADR-0044 §3 mandates. The second sentence is also factually wrong — the server
did not reject anything, it was unreachable.

The synthesis now carries **only the status**, unmarked, so it degrades down the ADR-0044 ladder:
mapped `errorCode` → status copy → the call site's own sentence. A new `ApiProblemCopy.StatusOnly`
factory keeps the marker semantics next to the marker and leaves no raw `new ProblemDetails` in the
Frontend, which that ADR's Consequences explicitly require.

## Why it was not caught

Every existing test fed a well-formed `ProblemDetails`, so the synthesized-placeholder path never met
the copy map. The two tests that did cover an empty and a non-JSON body asserted only `Status` and the
`IsUnauthorized`/`IsForbidden` classification — never what the user reads.

## How it was found

Running the owner-only outage pass of **QA-FE-21 (#632)** against deployed staging: `tms-api` stopped,
the anonymous `polish.txt` download requested through the real Caddy ingress. Captured:

```
status=502  content-type=application/problem+json
{"title":"Żądanie nie powiodło się","status":502,
 "detail":"Serwer odrzucił żądanie bez szczegółów błędu."}
```

The copy *improves on retry* — once the circuit breaker opens the message becomes the correct
„Usługa chwilowo niedostępna…" — so the worst copy landed on the **first** failure.

Staging was degraded ~40s and is fully healthy again.

## Tests

13 new cases across four files, red before the fix:

- **Seam** (`HttpClientApiExtensionsTests`) — a `[Theory]` over every body shape that reaches the
  synthesis (proxy HTML, empty, whitespace, `null`, `[]`, plain text) asserting the seam's own
  contract: no marker, no title, no detail, status preserved.
- **Copy ladder** (`ApiProblemCopyTests`) — 500/502/503/504/401 status copy, unmapped statuses
  (501/418) falling back to the call site's sentence, and `{}` converging on the same copy as the
  unparseable case.
- **Rendering surfaces** — both download routes (`ImportExport`, `Account`) serve the Polish status
  copy with no technical-detail extension, and `ApiProblemAlert` renders headline-only with no
  `details` block. That last one is the empty-box guard.

`dotnet build` 0 warnings · Frontend unit suite 559 passed · 13,469 pure unit tests green · SSR-purity
and client-hypermedia guards pass.

## Notes for the reviewer

- **This does not make #632's quoted string render**, and that is correct: 502 is a mapped status and
  ADR-0044 §3 says the status map deliberately outranks the call-site fallback. #632 has been
  re-baselined in a comment — its expected strings were wrong.
- A pre-existing sibling hole (a **200** with a non-JSON body throws out of the SSR render) was found
  during review and filed as **#638** rather than grown into this PR.
