### PR TITLE
chore(deps): bump Testcontainers to 4.14.0 to clear the SSH.NET advisory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,9 +87,12 @@
          package here makes; noted so the next person hitting it knows where it comes from. -->
     <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageVersion Include="Testcontainers" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.13.0" />
+    <!-- 4.14.0 is the first Testcontainers that depends on SSH.NET 2026.0.0; every earlier version
+         pins SSH.NET 2025.1.0, which GHSA-q939-rpr3-3284 (high) covers, so NuGetAudit fails restore
+         for every Testcontainers-using suite. Keep the three in lockstep. -->
+    <PackageVersion Include="Testcontainers" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Both E2E jobs went red on #645, a Dockerfile-only Dependabot PR that cannot possibly affect them. The failure is not that PR's — it is `main`'s, and every branch cut from it has it.

## What broke

`GHSA-q939-rpr3-3284` (high — arbitrary file write via server-controlled SCP filenames) landed against `SSH.NET <= 2025.1.0`. Testcontainers 4.13.0 pins exactly `2025.1.0` transitively. This repo runs `NuGetAudit=all` at `moderate` level under `TreatWarningsAsErrors`, so restore itself now fails:

```
error NU1903: Warning As Error: Package 'SSH.NET' 2025.1.0 has a known high severity vulnerability
```

That kills every suite referencing Testcontainers before a single test runs. #645 only surfaced it because the E2E workflow has no change gate — `Pull Request Verification` stayed green there since a Dockerfile diff skips the .NET leg. `main` last ran CI on 2026-08-06, before the advisory was published, so it is green in the UI and broken in fact.

## The fix

4.14.0 is the first Testcontainers release that depends on `SSH.NET 2026.0.0`, the patched version — confirmed against the published nuspecs, not inferred. No pin or override is needed, and no API changed. The three Testcontainers packages stay in lockstep, with the reason recorded next to them so the next person does not bump one and leave the others behind.

## Verification

- `dotnet restore` on the full solution: clean, no NU1903.
- All four Testcontainers-using suites build in Release with zero warnings — `TranslationSystem.E2E.Tests`, `Frontend.E2E.Tests`, `TranslationSystem.API.Tests.Integration`, `AuthSystem.API.Tests.Integration`.
- Both E2E suites run green locally against **real containers**, not just a compile: TMS E2E 6/6, Frontend E2E 11/11 (1m19s, Testcontainers + Playwright). So 4.14.0 is proven to still boot the stack, not merely to restore.

Once this is on `main`, #645 needs a rebase (or `@dependabot rebase`) to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UPfL1CDdfcVaNaYiYGonH