### PR TITLE
Bug: a 200 response with a non-JSON body throws out of the SSR render instead of degrading

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
@@ -69,32 +69,27 @@ internal static class AccountEndpointsExtensions
         }
 
         TranslatorDataExportResponse? translationData = null;
-        try
-        {
-            // The TMS leg is addressed by the 'contribution-data-export' rel (#610). An unresolvable
-            // rel degrades exactly like a failed call does — it never falls back to a guessed path,
-            // and it never fails the download (ADR-0032).
-            ApiResult<string> contributionHref = await discoveryCache.ResolveTranslationSystemHrefAsync(
-                Rels.ContributionDataExport,
-                cancellationToken);
 
-            if (contributionHref.IsSuccess)
+        // The TMS leg is addressed by the 'contribution-data-export' rel (#610). An unresolvable
+        // rel degrades exactly like a failed call does — it never falls back to a guessed path,
+        // and it never fails the download (ADR-0032). A 200 whose body does not parse is a failed
+        // call too — the HTTP seam owns that degradation (#638) — and a 200 empty body succeeds
+        // with a null value; both leave translationData null.
+        ApiResult<string> contributionHref = await discoveryCache.ResolveTranslationSystemHrefAsync(
+            Rels.ContributionDataExport,
+            cancellationToken);
+
+        if (contributionHref.IsSuccess)
+        {
+            ApiResult<TranslatorDataExportResponse> contributionResult =
+                await translationSystemClient.GetApiResultAsync<TranslatorDataExportResponse>(
+                    contributionHref.Value,
+                    cancellationToken);
+
+            if (contributionResult.IsSuccess)
             {
-                ApiResult<TranslatorDataExportResponse> contributionResult =
-                    await translationSystemClient.GetApiResultAsync<TranslatorDataExportResponse>(
-                        contributionHref.Value,
-                        cancellationToken);
-
-                if (contributionResult.IsSuccess)
-                {
-                    translationData = contributionResult.Value;
-                }
+                translationData = contributionResult.Value;
             }
-        }
-        catch (JsonException)
-        {
-            // A 200 whose body doesn't parse is still a failed TMS leg — degrade, don't fail
-            // the download (ADR-0032). The null-check above likewise covers a 200 empty body.
         }
 
         AccountDataExportFile exportFile = new(

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
@@ -13,7 +13,9 @@ namespace LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 /// success deserializes the body, an error status deserializes the API's <c>ProblemDetails</c>, and a
 /// transport failure (no HTTP status — Polly timeout/circuit-open, socket error) is mapped to a Polish
 /// <c>ProblemDetails</c> so the SSR page renders a message instead of crashing. The Frontend is
-/// Polish-only, so these messages are inlined rather than localized.
+/// Polish-only, so these messages are inlined rather than localized. Nothing here throws for what
+/// came off the wire: a body that is not the API's answer — on an error status <em>or</em> a success
+/// one — is a failed result, never an exception escaping the render.
 /// </summary>
 internal static class HttpClientApiExtensions
 {
@@ -196,15 +198,13 @@ internal static class HttpClientApiExtensions
             if (response.IsSuccessStatusCode)
             {
                 // A success with no body (e.g. 204 No Content) has nothing to deserialize — surface the
-                // default value rather than throwing a JsonException on an empty string.
+                // default value rather than failing on an empty string.
                 if (string.IsNullOrWhiteSpace(content))
                 {
                     return ApiResult.Success<T>(default!);
                 }
 
-                T value = JsonSerializer.Deserialize<T>(content, JsonOptions)
-                          ?? throw new JsonException($"Failed to deserialize {typeof(T).Name}");
-                return ApiResult.Success(value);
+                return ParseSuccessBody<T>(content);
             }
 
             return ApiResult.Failure<T>(ParseProblemDetails(content, response));
@@ -236,6 +236,35 @@ internal static class HttpClientApiExtensions
         {
             return ApiResult.Failure(MapTransportFailureToProblemDetails(ex));
         }
+    }
+
+    /// <summary>
+    /// Deserializes a success body into <typeparamref name="T"/>. A success status does not prove the
+    /// body is the API's answer — a reverse proxy serves its maintenance page with a <c>200</c>, an
+    /// auth redirect lands an HTML login page on an API URL — so a body that does not read as
+    /// <typeparamref name="T"/> (or reads as the <c>null</c> literal) is the same outage class as an
+    /// unreadable error body and degrades the same way: a status-only <see cref="ProblemDetails"/> the
+    /// copy ladder answers in Polish (#637), never a <see cref="JsonException"/> escaping the SSR
+    /// render (#638). It carries <c>502 Bad Gateway</c> rather than the status it wore: what came back
+    /// is an invalid upstream response whatever the status line said, <c>200</c> has no failure copy,
+    /// and a download route localizing it would otherwise answer the browser with a <c>200</c> problem.
+    /// </summary>
+    private static ApiResult<T> ParseSuccessBody<T>(string content)
+    {
+        try
+        {
+            T? value = JsonSerializer.Deserialize<T>(content, JsonOptions);
+            if (value is not null)
+            {
+                return ApiResult.Success(value);
+            }
+        }
+        catch (JsonException)
+        {
+            // Fall through to the synthesized ProblemDetails below.
+        }
+
+        return ApiResult.Failure<T>(ApiProblemCopy.StatusOnly(StatusCodes.Status502BadGateway));
     }
 
     /// <summary>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
@@ -171,6 +171,8 @@ public sealed class AccountEndpointsExtensionsTests
     [Fact]
     public async Task DownloadAccountExportAsync_WhenTmsReturnsAMalformedBody_StillServesTheFileWithIsCompleteFalse()
     {
+        // A 200 whose body is not JSON is a failed TMS leg — the seam degrades it (#638), and the
+        // route degrades the file rather than failing the download (ADR-0032).
         AccountLoader loader = CreateLoaderReturning(AccountLoaderTests.CreateEnvelope());
         ITranslationSystemClient tmsClient = CreateTmsClient(
             StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, "this is not json"));
@@ -226,6 +228,27 @@ public sealed class AccountEndpointsExtensionsTests
             CreateClient(StubHttpMessageHandler.RespondWith(
                 HttpStatusCode.BadGateway,
                 "<html><head><title>502 Bad Gateway</title></head><body></body></html>")));
+
+        IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
+            loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);
+
+        ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
+        problem.ProblemDetails.Status.ShouldBe(StatusCodes.Status502BadGateway);
+        problem.ProblemDetails.Title.ShouldBe("Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.");
+    }
+
+    [Fact]
+    public async Task DownloadAccountExportAsync_WhenTheAuthLegAnswersAMaintenancePageWithA200_ServesThePolishStatusCopyInsteadOfThrowing()
+    {
+        // The #637 outage class wearing a success status: the proxy's maintenance page comes back as
+        // 200 + HTML. That used to throw JsonException out of the route (#638); it is a failed auth
+        // leg like any other and answers with the same Polish sentence the proxy's own 502 does.
+        StubDiscoveryWithExportLink();
+        AccountLoader loader = new(
+            _discoveryCache,
+            CreateClient(StubHttpMessageHandler.RespondWith(
+                HttpStatusCode.OK,
+                "<html><head><title>Maintenance</title></head><body>Back soon</body></html>")));
 
         IResult result = await AccountEndpointsExtensions.DownloadAccountExportAsync(
             loader, _discoveryCache, CreateTmsClientReturningContribution(), NullLoggerFactory.Instance, CancellationToken.None);

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientApiExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientApiExtensionsTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.TranslationSystem.Contracts.Progress;
+using LotroKoniecDev.TranslationSystem.Contracts.Translators;
+using Microsoft.AspNetCore.Http;
 using Polly.CircuitBreaker;
 using Polly.Timeout;
 
@@ -198,6 +201,128 @@ public sealed class HttpClientApiExtensionsTests
         result.ProblemDetails!.Title.ShouldBe("Brak autoryzacji");
         result.ProblemDetails.Status.ShouldBe(401);
         result.IsUnauthorized.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("<html><head><title>Maintenance</title></head><body>Back soon</body></html>")]
+    [InlineData("<!DOCTYPE html><html><body><form action=\"/login\"></form></body></html>")]
+    [InlineData("plain text")]
+    [InlineData("null")]
+    [InlineData("[]")]
+    [InlineData("42")]
+    [InlineData("\"a string where an object was expected\"")]
+    [InlineData("""{ "total": "abc" }""")]
+    [InlineData("""{ "total": 1""")]
+    public async Task GetApiResultAsync_WhenASuccessBodyIsNotTheApisJson_FailsWithATranslatableBadGatewayProblem(string body)
+    {
+        // A proxy serving its maintenance page with a 200, or an auth redirect landing a login page on
+        // an API URL: the status says success, the body is not the API's answer. That used to throw
+        // JsonException out of the SSR render (#638); it is the #637 outage class and degrades the same
+        // way — a status-only problem the ladder answers in Polish, never an exception.
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, body));
+
+        ApiResult<PublicProgressResponse> result =
+            await httpClient.GetApiResultAsync<PublicProgressResponse>("progress");
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(StatusCodes.Status502BadGateway);
+        result.ProblemDetails.Extensions.ShouldNotContainKey(ApiProblemCopy.FrontendAuthoredExtensionKey);
+        result.ProblemDetails.Title.ShouldBeNull();
+        result.ProblemDetails.Detail.ShouldBeNull();
+        result.IsUnauthorized.ShouldBeFalse();
+        result.IsForbidden.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetApiResultAsync_WhenAStronglyTypedIdInTheSuccessBodyIsMalformed_FailsWithATranslatableBadGatewayProblem()
+    {
+        // The repo's own StronglyTypedIdJsonConverter is the one converter in the seam that is not
+        // STJ's: a bad GUID must still surface as a JsonException it swallows, not as a FormatException
+        // that would escape the render the same way the raw JsonException did (#638).
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            """
+            {
+              "profile": {
+                "translatorId": "not-a-guid",
+                "identityId": "also-not-a-guid",
+                "displayName": "Frodo",
+                "email": null,
+                "provisionedAt": "2026-07-11T10:00:00+00:00"
+              },
+              "contributions": null
+            }
+            """));
+
+        ApiResult<TranslatorDataExportResponse> result =
+            await httpClient.GetApiResultAsync<TranslatorDataExportResponse>("translators/me/data-export");
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(StatusCodes.Status502BadGateway);
+        result.ProblemDetails.Extensions.ShouldNotContainKey(ApiProblemCopy.FrontendAuthoredExtensionKey);
+    }
+
+    [Fact]
+    public async Task GetApiResultAsync_WhenASuccessBodyIsNotTheApisJson_DescribesAsTheSameCopyAsAProxyBadGateway()
+    {
+        // The end-to-end promise of the seam: what the page shows for a 200 maintenance page is
+        // exactly what it shows for the proxy's own 502 — one outage class, one sentence.
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            "<html><body>Maintenance</body></html>"));
+
+        ApiResult<PublicProgressResponse> result =
+            await httpClient.GetApiResultAsync<PublicProgressResponse>("progress");
+
+        ApiProblemCopy.Describe(result.ProblemDetails, "Nie udało się wczytać postępu.").Message
+            .ShouldBe("Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.");
+    }
+
+    [Fact]
+    public async Task PostApiResultAsync_WhenASuccessBodyIsNotTheApisJson_FailsWithATranslatableBadGatewayProblem()
+    {
+        // Every generic verb funnels through the same seam — the contract is not GET-only.
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.Created,
+            "<html><body>Maintenance</body></html>"));
+
+        ApiResult<PublicProgressResponse> result = await httpClient.PostApiResultAsync<PublicProgressResponse>(
+            "progress",
+            new { Name = "x" });
+
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(StatusCodes.Status502BadGateway);
+        result.ProblemDetails.Extensions.ShouldNotContainKey(ApiProblemCopy.FrontendAuthoredExtensionKey);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetApiResultAsync_WhenASuccessBodyIsEmpty_SucceedsWithTheDefaultValue(string body)
+    {
+        // The boundary next to the unreadable-body rule: nothing at all is a 204-shaped success, not
+        // garbage — the caller gets the default and decides, exactly as before #638.
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, body));
+
+        ApiResult<PublicProgressResponse> result =
+            await httpClient.GetApiResultAsync<PublicProgressResponse>("progress");
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetApiResultAsync_WhenASuccessBodyIsTheApisJson_DeserializesIt()
+    {
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(
+            HttpStatusCode.OK,
+            """{ "total": 200, "translated": 150, "approved": 80, "currentGameVersion": "48.1" }"""));
+
+        ApiResult<PublicProgressResponse> result =
+            await httpClient.GetApiResultAsync<PublicProgressResponse>("progress");
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe(new PublicProgressResponse(200, 150, 80, "48.1"));
     }
 
     private static HttpClient CreateClient(StubHttpMessageHandler handler)


### PR DESCRIPTION
Closes #638

## What

`HttpClientApiExtensions.SendForApiResultAsync<T>` only mapped an exception to a `ProblemDetails` when `IsTransportFailure` said so. A **success status whose body is not the API's JSON** — a reverse proxy serving its maintenance page as 200, an auth redirect landing an HTML login page on an API URL — threw `JsonException` during deserialization and escaped the SSR render (the page crashed instead of degrading). Same outage class as #637.

## The seam's contract (the decision the ticket asked for)

A success status whose body does not deserialize to `T` (malformed JSON, wrong JSON shape, a converter violation, or the `null` literal) is a **failed `ApiResult` carrying `ApiProblemCopy.StatusOnly(502)`** — the same synthesized shape #637 uses for an unreadable *error* body — so the copy ladder answers in Polish ("Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.") and every generic verb (GET/POST/PUT/PATCH/multipart) inherits it.

Why 502 rather than the wire status: what came back is an invalid upstream response whatever the status line said; 200 has no failure copy on the ladder; and `ApiProblemCopy.Localize` (the download routes) uses `problem.Status ?? fallbackStatus`, so a 200 would answer the browser with a 200 problem body. `IsUnauthorized`/`IsForbidden` stay false — synthesizing a 401 for the "login page on an API URL" variant would be a guess that could bounce the user through login on an infrastructure fault.

An **empty/whitespace success body keeps meaning 204 → `Success(default)`** (unchanged, now pinned by a test).

## Changes

- `HttpClientApiExtensions`: new private `ParseSuccessBody<T>` (mirrors `ParseProblemDetails`'s try/catch-fall-through shape); class summary updated.
- `AccountEndpointsExtensions`: the local `catch (JsonException)` around the TMS leg is gone — the seam owns it. `TokenEndpointClient` keeps its own catch (OIDC token endpoint, a different seam).

## Acceptance criteria → proof

| AC | Test |
|---|---|
| A 200 with an HTML body yields a failed `ApiResult` with a Polish message, never an exception | `HttpClientApiExtensionsTests.GetApiResultAsync_WhenASuccessBodyIsNotTheApisJson_FailsWithATranslatableBadGatewayProblem` (theory: HTML ×2, plain text, `null`, `[]`, `42`, string, `{"total":"abc"}`, truncated JSON) + `…_DescribesAsTheSameCopyAsAProxyBadGateway` + `…WhenAStronglyTypedIdInTheSuccessBodyIsMalformed…` + the POST fact |
| A page rendering that failure shows a friendly alert, not the error page | by composition: the seam yields exactly the `StatusOnly(502)` that `ApiProblemAlertTests.Render_ForAStatusOnlyProblem_ShowsTheStatusCopyAloneAndNeverAnEmptyBox` renders; every page renders failures through `ApiProblemAlert` (ADR-0044 §5). Download route: `AccountEndpointsExtensionsTests.DownloadAccountExportAsync_WhenTheAuthLegAnswersAMaintenancePageWithA200_ServesThePolishStatusCopyInsteadOfThrowing` (previously a throw out of the route) |
| No English reaches the page (ADR-0044) | the theory asserts `Title`/`Detail` null and no `frontendAuthored` marker; the route test asserts the Polish title |

## Verification

- `dotnet build LotroKoniecDev.slnx` — 0 warnings.
- `Frontend.Tests.Unit` 575/575, `Tests.Unit` 4023/4023, `Architecture.Tests.Unit` 21/21.
- `check-client-hypermedia.sh` + `check-ssr-purity.sh` green.
- `code-reviewer` gate: APPROVE, no must-fix; its one recommendation (pin the converter-violation family) is folded in.

## Deferred (reviewer note, out of #638's scope)

For value-promising `<T>` calls, an *empty* success body still yields `Success(null)` and the callers dereference `Value`. Not reachable from Kestrel/Caddy today; a follow-up ticket is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNSqxD2K2eDPTiWJc2auUW
