### PR TITLE
Bug: an empty 200 body on a value-promising ApiResult<T> call succeeds with a null Value the callers dereference

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountEndpointsExtensions.cs
@@ -72,9 +72,9 @@ internal static class AccountEndpointsExtensions
 
         // The TMS leg is addressed by the 'contribution-data-export' rel (#610). An unresolvable
         // rel degrades exactly like a failed call does — it never falls back to a guessed path,
-        // and it never fails the download (ADR-0032). A 200 whose body does not parse is a failed
-        // call too — the HTTP seam owns that degradation (#638) — and a 200 empty body succeeds
-        // with a null value; both leave translationData null.
+        // and it never fails the download (ADR-0032). A 200 whose body does not parse, or is
+        // empty, is a failed call too — the HTTP seam owns that degradation (#638, #653) — so a
+        // success here always carries a value, and every other outcome leaves translationData null.
         ApiResult<string> contributionHref = await discoveryCache.ResolveTranslationSystemHrefAsync(
             Rels.ContributionDataExport,
             cancellationToken);

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/HttpClients/HttpClientApiExtensions.cs
@@ -197,13 +197,6 @@ internal static class HttpClientApiExtensions
 
             if (response.IsSuccessStatusCode)
             {
-                // A success with no body (e.g. 204 No Content) has nothing to deserialize — surface the
-                // default value rather than failing on an empty string.
-                if (string.IsNullOrWhiteSpace(content))
-                {
-                    return ApiResult.Success<T>(default!);
-                }
-
                 return ParseSuccessBody<T>(content);
             }
 
@@ -242,15 +235,24 @@ internal static class HttpClientApiExtensions
     /// Deserializes a success body into <typeparamref name="T"/>. A success status does not prove the
     /// body is the API's answer — a reverse proxy serves its maintenance page with a <c>200</c>, an
     /// auth redirect lands an HTML login page on an API URL — so a body that does not read as
-    /// <typeparamref name="T"/> (or reads as the <c>null</c> literal) is the same outage class as an
-    /// unreadable error body and degrades the same way: a status-only <see cref="ProblemDetails"/> the
-    /// copy ladder answers in Polish (#637), never a <see cref="JsonException"/> escaping the SSR
-    /// render (#638). It carries <c>502 Bad Gateway</c> rather than the status it wore: what came back
-    /// is an invalid upstream response whatever the status line said, <c>200</c> has no failure copy,
-    /// and a download route localizing it would otherwise answer the browser with a <c>200</c> problem.
+    /// <typeparamref name="T"/> (or reads as the <c>null</c> literal, or is empty — #653) is the same
+    /// outage class as an unreadable error body and degrades the same way: a status-only
+    /// <see cref="ProblemDetails"/> the copy ladder answers in Polish (#637), never a
+    /// <see cref="JsonException"/> escaping the SSR render (#638) and never a <c>null</c>
+    /// <see cref="ApiResult{T}.Value"/> for the caller to dereference. Every generic verb promises a
+    /// value, so <c>204 No Content</c> is not modelled here — the body-less <see cref="ApiResult"/> verbs
+    /// and <c>PostForHeadersApiResultAsync</c> are where nothing was promised. It carries
+    /// <c>502 Bad Gateway</c> rather than the status it wore: what came back is an invalid upstream
+    /// response whatever the status line said, <c>200</c> has no failure copy, and a download route
+    /// localizing it would otherwise answer the browser with a <c>200</c> problem.
     /// </summary>
     private static ApiResult<T> ParseSuccessBody<T>(string content)
     {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return ApiResult.Failure<T>(ApiProblemCopy.StatusOnly(StatusCodes.Status502BadGateway));
+        }
+
         try
         {
             T? value = JsonSerializer.Deserialize<T>(content, JsonOptions);

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientApiExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/HttpClientApiExtensionsTests.cs
@@ -298,17 +298,47 @@ public sealed class HttpClientApiExtensionsTests
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public async Task GetApiResultAsync_WhenASuccessBodyIsEmpty_SucceedsWithTheDefaultValue(string body)
+    public async Task GetApiResultAsync_WhenASuccessBodyIsEmpty_FailsWithATranslatableBadGatewayProblem(string body)
     {
-        // The boundary next to the unreadable-body rule: nothing at all is a 204-shaped success, not
-        // garbage — the caller gets the default and decides, exactly as before #638.
+        // The rule next to #638's: a value-promising call that gets nothing back has not been answered
+        // either. It used to succeed with a null Value that every caller dereferences (#653) — now it is
+        // the same unreadable-body class as a maintenance page, and degrades the same way. Only the
+        // body-less verbs and PostForHeadersApiResultAsync model 204.
         HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, body));
 
         ApiResult<PublicProgressResponse> result =
             await httpClient.GetApiResultAsync<PublicProgressResponse>("progress");
 
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(StatusCodes.Status502BadGateway);
+        result.ProblemDetails.Extensions.ShouldNotContainKey(ApiProblemCopy.FrontendAuthoredExtensionKey);
+        result.ProblemDetails.Title.ShouldBeNull();
+        result.ProblemDetails.Detail.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetApiResultAsync_WhenASuccessBodyIsEmpty_DescribesAsTheSameCopyAsAProxyBadGateway()
+    {
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, string.Empty));
+
+        ApiResult<PublicProgressResponse> result =
+            await httpClient.GetApiResultAsync<PublicProgressResponse>("progress");
+
+        ApiProblemCopy.Describe(result.ProblemDetails, "Nie udało się wczytać postępu.").Message
+            .ShouldBe("Usługa jest chwilowo niedostępna. Spróbuj ponownie za chwilę.");
+    }
+
+    [Fact]
+    public async Task PostApiResultAsync_WhenTheBodyLessVerbGetsNoContent_Succeeds()
+    {
+        // The other side of the boundary: 204 stays a success where nothing was promised. This is the
+        // approve/delete path — it must not inherit the value-promising verbs' empty-body rule.
+        HttpClient httpClient = CreateClient(StubHttpMessageHandler.RespondWith(HttpStatusCode.NoContent, string.Empty));
+
+        ApiResult result = await httpClient.PostApiResultAsync("translations/1/approve", new { });
+
         result.IsSuccess.ShouldBeTrue();
-        result.Value.ShouldBeNull();
+        result.ProblemDetails.ShouldBeNull();
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/TranslationSystemClientTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/HttpClients/TranslationSystemClientTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using LotroKoniecDev.Frontend.Infrastructure.Errors;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Infrastructure.HttpClients.TranslationSystemHttpClients;
+using Microsoft.AspNetCore.Http;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
 
@@ -24,15 +26,18 @@ public sealed class TranslationSystemClientTests
     }
 
     [Fact]
-    public async Task GetApiResultAsync_WhenSuccessHasEmptyBody_ReturnsSuccessWithDefaultValue()
+    public async Task GetApiResultAsync_WhenSuccessHasEmptyBody_ReturnsFailureWithATranslatableBadGatewayProblem()
     {
+        // A value-promising call answered with nothing — even a genuine 204 — is not answered (#653):
+        // the typed client hands the seam's rule through unchanged instead of a null Value.
         StubHttpMessageHandler handler = StubHttpMessageHandler.RespondWith(HttpStatusCode.NoContent, string.Empty);
         ITranslationSystemClient client = CreateClient(handler);
 
         ApiResult<string> result = await client.GetApiResultAsync<string>("anything");
 
-        result.IsSuccess.ShouldBeTrue();
-        result.Value.ShouldBeNull();
+        result.IsFailure.ShouldBeTrue();
+        result.ProblemDetails!.Status.ShouldBe(StatusCodes.Status502BadGateway);
+        result.ProblemDetails.Extensions.ShouldNotContainKey(ApiProblemCopy.FrontendAuthoredExtensionKey);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #653

## What

`HttpClientApiExtensions.SendForApiResultAsync<T>` no longer turns an empty/whitespace **success** body into `ApiResult.Success<T>(default!)`. It now flows into `ParseSuccessBody<T>`, which fails it with `ApiProblemCopy.StatusOnly(502)` — the same outcome #638 gave a non-JSON success body.

## Why

Every `<T>` call site in `src/Frontend/` dereferences `Value` on success (none targets a 204 endpoint), so a 200 with no body surfaced as `ArgumentNullException` / NRE downstream instead of the Polish status copy, and the anonymous discovery entry would have cached that `null` in `HybridCache`. Now the discovery factory throws `DiscoveryUnavailableException` for it like any other failed call, so the entry is discarded and retried.

204 is still modelled where nothing was promised: the body-less `ApiResult` verbs and `PostForHeadersApiResultAsync` are untouched. Call-site audit: `ApproveTranslation`, `DeleteGameVersion` and `DeleteAccount` are the only `Results.NoContent()` endpoints and all three are consumed through those verbs.

## Tests

- `GetApiResultAsync_WhenASuccessBodyIsEmpty_SucceedsWithTheDefaultValue` — the pin for the old rule — flipped deliberately to `…FailsWithATranslatableBadGatewayProblem` (`""` and `"   "`), asserting the 502 status, no Frontend-authored marker, no title/detail.
- New `…WhenASuccessBodyIsEmpty_DescribesAsTheSameCopyAsAProxyBadGateway` — the page shows the same Polish sentence as for the proxy's 502 (ADR-0044 invariant).
- New `PostApiResultAsync_WhenTheBodyLessVerbGetsNoContent_Succeeds` — pins the other side of the boundary.
- `TranslationSystemClientTests.GetApiResultAsync_WhenSuccessHasEmptyBody_…` — the second pin (a real 204 on a `<T>` verb) flipped to the failure.
- Frontend unit suite 577/577, Architecture 21/21, patcher unit 4023/4023, `dotnet build LotroKoniecDev.slnx` with 0 warnings.

Also synced the `AccountEndpointsExtensions` comment that still described the old rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNSqxD2K2eDPTiWJc2auUW
