### PR TITLE
UR-20: Import echo-guard — an echo of our own Polish is not a source change

### DIFF
--- a/docs/knowledge-base/update-49/RESULTS.md
+++ b/docs/knowledge-base/update-49/RESULTS.md
@@ -264,6 +264,9 @@ exporcie to **nasz polski**, nie angielski. Spec 0001 zakłada angielski source 
 (incoming text == aktualny polski content wiersza → traktuj jako echo/unchanged, nie ruszaj
 source) + jednorazowa naprawa zatrutych source'ów + docelowo eksport z czystego źródła
 (revert-file generowany z TMS przed exportem albo czysta kopia DAT).
+**Status:** echo-guard **wdrożony 2026-08-17 (#563 UR-20, spec 0012)** — porównanie po hashu
+trójki `(TranslatedText, ArgsOrder, ArgsId)`, licznik `Echoed` w `ImportSummary`; naprawa
+zatrutych source'ów = #564 (UR-21).
 
 ## Experiments E1–E4 — results (2026-08-02, #557)
 

--- a/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
+++ b/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
@@ -141,6 +141,10 @@ For every row of the uploaded export, compared against the stored source state b
   source-changed rule applies.
 - **Unchanged** (pair known, source identical): no-op. *No diff = SSG touched nothing = the
   stored state stands* — sound because `export` is a deterministic full dump of all text subfiles.
+  **Echo amendment (spec 0012, #563):** an incoming source that differs from the stored English but
+  equals the row's own current Polish (with the source's args columns) is an *echo* of our patch —
+  the admin exports from a patched DAT — and is treated as Unchanged (restore when soft-removed),
+  never as source-changed; counted separately in `ImportSummary.Echoed`.
 - The diff transaction is all-or-nothing; a failed upload leaves the previous state intact.
 - **Truncation guard (both, decided):** a partially written/corrupt `exported.txt` would
   masquerade as a mass removal (and mass invalidation), so the import defends itself twice —
@@ -219,7 +223,7 @@ For every row of the uploaded export, compared against the stored source state b
   detection/processing state.
 - **Upload & diff:** re-shaped #97 — `POST /api/v1/game-versions/{id}/import` (multipart
   `exported.txt`, authorized: admin). Response: `ImportSummary { Added, SourceChanged,
-  Invalidated, Removed, Unchanged, Warnings }`. Errors as ProblemDetails via `Result` failures
+  Invalidated, Removed, Unchanged, Echoed, Warnings }`. Errors as ProblemDetails via `Result` failures
   (validation → 400, unknown version → 404, truncation guard → 422).
 - **Distribution:** re-shaped #102 — `GET /api/v1/translation-files/{lang}` (anonymous, `pl`
   only for now) → streamed translation file + `ETag`; honors `If-None-Match` → 304. (Route

--- a/docs/specs/0012-update-resilience.md
+++ b/docs/specs/0012-update-resilience.md
@@ -118,8 +118,21 @@ faster repair) — not a correctness or UX requirement.
 
 ### Server side — import echo-guard + source hygiene (extends spec 0001)
 
-- **Echo-guard:** on import, an incoming row whose text equals the row's current Polish content
-  is an echo of our own patch ⇒ treat as Unchanged (do not touch SourceText, do not invalidate).
+- **Echo-guard (#563 UR-20 — implemented 2026-08-17):** on import, an incoming row whose text
+  equals the row's current Polish content is an echo of our own patch ⇒ treat as Unchanged (do not
+  touch SourceText, do not invalidate). As built: the diff compares the incoming source hash against
+  a second per-row hash, the **echo hash** = `(TranslatedText, Source.ArgsOrder, Source.ArgsId)` —
+  the exact triple the artifact carries and a patched DAT exports back (the patcher writes the text
+  verbatim, never changes the argument count, and the exporter re-emits identity args from that
+  count). The source check runs first, so an already-poisoned row (source == Polish, see #564) is
+  plain Unchanged, never an echo. An echo on a soft-removed row follows the identical-source re-add
+  rule (restore). A different Polish text — e.g. an older Polish still resident after a re-edit
+  (approve P1 → admin patches → translator re-edits to P2 → the next export echoes P1) — is
+  indistinguishable from a real change and re-creates a poisoned source of the kind #564 repairs;
+  catching it needs the row's Polish history (TP-15 / #50, post-MVP). Echoes are counted in
+  `ImportSummary.Echoed` (a subset of `Unchanged`; the import page shows it as "W tym echo patcha")
+  and in the import-passes log line — observability only, no warning: with today's manual ceremony
+  every export comes from a patched DAT, so echoes are the norm, not an anomaly.
 - **One-time source repair** for already-poisoned rows (today: 8).
 - **Pristine-source direction (optional, Q-gated):** generate a revert file from TMS SourceText
   before export, or keep a pristine DAT copy (the Russians re-download the original DAT for the
@@ -212,8 +225,11 @@ code ticket. It carries no milestone and stays that way: the backlog loop must n
 - [ ] Orchestrator branch B: at most one launcher kill per detection, only pre-client,
       only after conservative quiesce; relaunch reaches login cleanly (E4 ✅ confirmed clean,
       3× reproduced).
-- [ ] Echo-guard: importing a patched-DAT export against a translated corpus invalidates ONLY
-      rows whose English actually changed (fixture: resident-Polish echo rows + one revert).
+- [x] Echo-guard: importing a patched-DAT export against a translated corpus invalidates ONLY
+      rows whose English actually changed (fixture: resident-Polish echo rows + one revert) —
+      **#563 done 2026-08-17**: `TranslationDiffServiceTests` (echo matrix incl. the U49 shape),
+      `ImportExportedTextsTests.Import_ExportFromPatchedDat_…` (echo rows + collateral revert +
+      one real English change, end-to-end through the artifact).
 - [ ] ~~Repair-set: post-update repair touches only rows in update-touched SubFiles~~ —
       dropped from MVP per E3 (full-corpus re-patch = 14.7 s; repair-set is an optional
       later optimization).

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/ImportExport/ImportExport.razor
@@ -190,6 +190,10 @@
                     <span class="num @(summary.Unchanged == 0 ? "zero" : null)">@summary.Unchanged</span>
                     <span class="lbl">Bez zmian</span>
                 </article>
+                <article class="stat-tile" title="Wiersze, których „źródłem” w pliku był nasz własny polski tekst (eksport z patchowanego DAT) — policzone jako bez zmian, angielski źródłowy nietknięty.">
+                    <span class="num @(summary.Echoed == 0 ? "zero" : null)">@summary.Echoed</span>
+                    <span class="lbl">W tym echo patcha</span>
+                </article>
             </section>
 
             @if (summary.Warnings.Count > 0)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.API/Features/Import/ImportExportedTexts.cs
@@ -190,7 +190,7 @@ internal sealed partial class ImportExportedTexts : IEndpoint
             LogImportPasses(
                 _logger,
                 incomingCount, uploadPassMilliseconds, diffPassMilliseconds, applyPassMilliseconds,
-                plan.AddedCount, plan.SourceChangedByKey.Count, plan.RemovedIds.Count, plan.RestoredIds.Count);
+                plan.AddedCount, plan.SourceChangedByKey.Count, plan.RemovedIds.Count, plan.RestoredIds.Count, plan.EchoedCount);
 
             // Version processing changes the distributed set (removed rows drop out, re-added rows
             // return), so the pre-built translation file is regenerated after the import commits
@@ -466,11 +466,12 @@ internal sealed partial class ImportExportedTexts : IEndpoint
                 Invalidated: plan.InvalidatedCount,
                 Removed: plan.RemovedIds.Count,
                 Unchanged: plan.UnchangedCount,
+                Echoed: plan.EchoedCount,
                 Warnings: warnings);
         }
 
-        [LoggerMessage(EventId = EventIds.ImportPassesCompleted, Level = LogLevel.Information, Message = "Import passes for {IncomingRows} incoming row(s): upload pass {UploadPassMs} ms, diff pass {DiffPassMs} ms, apply pass {ApplyPassMs} ms (added {Added}, source-changed {SourceChanged}, removed {Removed}, restored {Restored}).")]
-        private static partial void LogImportPasses(ILogger logger, int incomingRows, long uploadPassMs, long diffPassMs, long applyPassMs, int added, int sourceChanged, int removed, int restored);
+        [LoggerMessage(EventId = EventIds.ImportPassesCompleted, Level = LogLevel.Information, Message = "Import passes for {IncomingRows} incoming row(s): upload pass {UploadPassMs} ms, diff pass {DiffPassMs} ms, apply pass {ApplyPassMs} ms (added {Added}, source-changed {SourceChanged}, removed {Removed}, restored {Restored}, echoed {Echoed}).")]
+        private static partial void LogImportPasses(ILogger logger, int incomingRows, long uploadPassMs, long diffPassMs, long applyPassMs, int added, int sourceChanged, int removed, int restored, int echoed);
     }
 
     public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Import/ImportSummary.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Contracts/Import/ImportSummary.cs
@@ -3,7 +3,10 @@ namespace LotroKoniecDev.TranslationSystem.Contracts.Import;
 /// <summary>
 /// The outcome of a version-bound import (spec 0001): how many rows the diff added, had their
 /// English source changed, were invalidated (source-changed rows that carried Polish), soft-removed
-/// or left untouched, plus any non-fatal notices (e.g. restored re-added rows).
+/// or left untouched, how many rows were echoes of our own Polish coming back from a patched DAT
+/// (spec 0012 — already counted in <paramref name="Unchanged"/>, or among the restored rows when
+/// they were soft-removed; reported for observability), plus any non-fatal notices (e.g. restored
+/// re-added rows).
 /// </summary>
 public sealed record ImportSummary(
     int Added,
@@ -11,4 +14,5 @@ public sealed record ImportSummary(
     int Invalidated,
     int Removed,
     int Unchanged,
+    int Echoed,
     IReadOnlyCollection<string> Warnings);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/SourceHash.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/SourceHash.cs
@@ -28,6 +28,17 @@ public readonly record struct SourceHash(ulong High, ulong Low)
     }
 
     /// <summary>
+    /// The hash a DAT patched with this row's Polish echoes back when it is exported again (spec
+    /// 0012): the current Polish text framed with the source's own args columns — the patcher writes
+    /// the text verbatim and never changes the argument count, and the exporter re-emits the args
+    /// columns from that count, so an unchanged fragment comes back as exactly this triple. Hashed
+    /// through <see cref="Compute(string, string?, string?)"/> so it compares against an incoming
+    /// source hash-to-hash. <c>null</c> when the row carries no Polish — nothing of ours can echo.
+    /// </summary>
+    public static SourceHash? ComputeEcho(string? translatedText, string? argsOrder, string? argsId)
+        => translatedText is null ? null : Compute(translatedText, argsOrder, argsId);
+
+    /// <summary>
     /// Hashes the triple in its persisted (value-object-normalized) representation — callers must
     /// pass args columns the way <see cref="TranslationSource"/> stores them (<c>null</c> when
     /// absent, never the raw <c>NULL</c> literal), or the two sides of the diff would disagree.

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/StoredSourceDigest.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/StoredSourceDigest.cs
@@ -5,13 +5,19 @@ namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregat
 
 /// <summary>
 /// One stored translation row compacted for the import diff (spec 0006): its identity, fragment
-/// key, the 128-bit source hash and the two status facts the five outcomes depend on — never the
-/// source strings, never a tracked aggregate. The catalog side streams these so the diff's working
-/// set scales with the plan, not the catalog.
+/// key, the 128-bit source hash, the echo hash of its Polish (spec 0012) and the two status facts
+/// the outcomes depend on — never the source strings, never a tracked aggregate. The catalog side
+/// streams these so the diff's working set scales with the plan, not the catalog.
 /// </summary>
+/// <param name="EchoHash">
+/// The hash of the triple a patched DAT echoes back for this row — its current Polish text with the
+/// source's args columns (<see cref="SourceHash.ComputeEcho"/>) — or <c>null</c> when the row has
+/// no Polish. An incoming row that hash-matches it is an echo of our own patch, not a source change.
+/// </param>
 public readonly record struct StoredSourceDigest(
     TranslationId Id,
     FragmentKeyValue Key,
     SourceHash SourceHash,
+    SourceHash? EchoHash,
     TranslationStatus Status,
     bool IsRemoved);

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffPlan.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffPlan.cs
@@ -26,6 +26,14 @@ public sealed class TranslationDiffPlan
     public int UnchangedCount { get; }
 
     /// <summary>
+    /// Rows whose incoming "source" was our own Polish echoed back from a patched DAT (spec 0012)
+    /// — matched through <see cref="StoredSourceDigest.EchoHash"/> and treated as an identical
+    /// source, so they are already counted in <see cref="UnchangedCount"/> (or in
+    /// <see cref="RestoredIds"/> when they were soft-removed). Reported for observability only.
+    /// </summary>
+    public int EchoedCount { get; }
+
+    /// <summary>
     /// Source-changed rows that carried Polish work and were therefore invalidated.
     /// </summary>
     public int InvalidatedCount { get; }
@@ -57,6 +65,7 @@ public sealed class TranslationDiffPlan
         IReadOnlyList<TranslationId> removedIds,
         IReadOnlyList<TranslationId> restoredIds,
         int unchangedCount,
+        int echoedCount,
         int invalidatedCount,
         int comparableExistingCount)
     {
@@ -70,6 +79,7 @@ public sealed class TranslationDiffPlan
         RemovedIds = removedIds;
         RestoredIds = restoredIds;
         UnchangedCount = unchangedCount;
+        EchoedCount = echoedCount;
         InvalidatedCount = invalidatedCount;
         ComparableExistingCount = comparableExistingCount;
     }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffService.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/TranslationAggregate/Services/TranslationDiffService.cs
@@ -12,6 +12,17 @@ namespace LotroKoniecDev.TranslationSystem.Domain.Aggregates.TranslationAggregat
 /// the database; the import handler realizes the plan inside its transaction after the truncation
 /// guard passes.
 /// </summary>
+/// <remarks>
+/// Echo-guard (spec 0012): the admin exports from their own patched DAT, so a resident row comes
+/// back with our Polish as its "source". Without the guard every translated-and-resident row would
+/// read as source-changed on every update — a mass false invalidation that also overwrites the
+/// English with Polish. An incoming row that differs from the stored source but hash-matches the
+/// row's <see cref="StoredSourceDigest.EchoHash"/> is therefore an echo: treated exactly like an
+/// identical source (unchanged, or restored when soft-removed) and counted separately for
+/// observability. The guard sees only the row's <em>current</em> Polish — an older Polish still
+/// resident after a re-edit is indistinguishable from a real change and poisons the source the way
+/// #564 repairs; catching it needs the row's Polish history (TP-15 / #50, post-MVP).
+/// </remarks>
 public static class TranslationDiffService
 {
     /// <summary>
@@ -31,6 +42,7 @@ public static class TranslationDiffService
         List<TranslationId> removedIds = [];
         List<TranslationId> restoredIds = [];
         int unchangedCount = 0;
+        int echoedCount = 0;
         int invalidatedCount = 0;
         int comparableExistingCount = 0;
 
@@ -51,8 +63,16 @@ public static class TranslationDiffService
                 continue;
             }
 
-            if (incomingHash == stored.SourceHash)
+            // The source check runs first, so a row whose stored source already equals its Polish (a
+            // poisoned source from a pre-guard import) counts as plain unchanged, never as an echo.
+            bool isEcho = incomingHash != stored.SourceHash && incomingHash == stored.EchoHash;
+            if (incomingHash == stored.SourceHash || isEcho)
             {
+                if (isEcho)
+                {
+                    echoedCount++;
+                }
+
                 if (stored.IsRemoved)
                 {
                     restoredIds.Add(stored.Id);
@@ -78,6 +98,7 @@ public static class TranslationDiffService
             removedIds,
             restoredIds,
             unchangedCount,
+            echoedCount,
             invalidatedCount,
             comparableExistingCount);
     }

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Persistence/DomainRepositories/TranslationRepository.cs
@@ -31,7 +31,7 @@ internal sealed class TranslationRepository : GenericRepository<Translation, Tra
     /// </summary>
     private const string SourceDigestQuery =
         """
-        SELECT "Id", "FileId", "GossipId", "SourceText", "ArgsOrder", "ArgsId", "Status", "RemovedInVersion"
+        SELECT "Id", "FileId", "GossipId", "SourceText", "ArgsOrder", "ArgsId", "Status", "RemovedInVersion", "TranslatedText"
         FROM translation."Translations"
         """;
 
@@ -66,11 +66,16 @@ internal sealed class TranslationRepository : GenericRepository<Translation, Tra
             string text = reader.GetString(3);
             string? argsOrder = reader.IsDBNull(4) ? null : reader.GetString(4);
             string? argsId = reader.IsDBNull(5) ? null : reader.GetString(5);
+            string? translatedText = reader.IsDBNull(8) ? null : reader.GetString(8);
 
+            // Both hashes are computed from the row's own columns and the strings dropped before the
+            // next read: the echo hash frames the Polish with the SOURCE's args columns, because that
+            // is the triple the artifact carries and a patched DAT echoes back (spec 0012).
             yield return new StoredSourceDigest(
                 TranslationId.FromValue(reader.GetGuid(0)),
                 new FragmentKeyValue(reader.GetInt32(1), reader.GetInt64(2)),
                 SourceHash.Compute(text, argsOrder, argsId),
+                SourceHash.ComputeEcho(translatedText, argsOrder, argsId),
                 Enum.Parse<TranslationStatus>(reader.GetString(6)),
                 !reader.IsDBNull(7));
         }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportLoaderTests.cs
@@ -230,6 +230,7 @@ public sealed class ImportExportLoaderTests
         result.Value.Invalidated.ShouldBe(1);
         result.Value.Removed.ShouldBe(4);
         result.Value.Unchanged.ShouldBe(10);
+        result.Value.Echoed.ShouldBe(7);
         result.Value.Warnings.ShouldHaveSingleItem();
     }
 
@@ -292,7 +293,7 @@ public sealed class ImportExportLoaderTests
         new(GameVersionId.Create(GameVersionGuid), "48.0", DateTimeOffset.UnixEpoch, GameVersionStatus.Unprocessed);
 
     private static ImportSummary SummaryFixture() =>
-        new(Added: 3, SourceChanged: 2, Invalidated: 1, Removed: 4, Unchanged: 10, Warnings: ["1 wiersz przywrócony."]);
+        new(Added: 3, SourceChanged: 2, Invalidated: 1, Removed: 4, Unchanged: 10, Echoed: 7, Warnings: ["1 wiersz przywrócony."]);
 
     private static ImportExportLoader CreateLoader(
         HttpStatusCode statusCode,

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Integration/Tests/Import/ImportExportedTextsTests.cs
@@ -232,6 +232,104 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Import_ExportFromPatchedDat_ShouldTreatEchoesAsUnchangedAndInvalidateOnlyTheRealEnglishChange()
+    {
+        // Arrange — the U49 shape (spec 0012 / #563): a translated, approved corpus, then an export
+        // taken from the admin's OWN patched DAT. Resident rows 1-2 come back carrying our Polish as
+        // their "source" (echo; row 2 is placeholder-bearing, so its args columns ride along and pin
+        // the projection's echo triple), row 3 was collateral-reverted to its identical English,
+        // row 4's English really changed (its chunk was replaced, so it reads English too), row 5 is
+        // untranslated and untouched.
+        const string placeholderPolish = "Witaj <--DO_NOT_TOUCH!--> przyjacielu";
+        GameVersionId firstVersion = await SeedVersionAsync("48.8");
+        using HttpClient client = AdminClient();
+        static MultipartFormDataContent Baseline() =>
+            ExportContent(
+                Line(1, "Alpha"),
+                LineWithArgs(2, "Greet <--DO_NOT_TOUCH!--> friend", "1-1"),
+                Line(3, "Gamma"),
+                Line(4, "Delta"),
+                Line(5, "Epsilon"));
+        await client.PostAsync(ImportRoute(firstVersion), Baseline());
+        foreach ((int gossipId, string polish) in new[] { (1, "Alfa"), (2, placeholderPolish), (3, "Gama"), (4, "Delty") })
+        {
+            await AttachPolishAsync(gossipId, polish);
+            await ApprovePolishAsync(gossipId);
+        }
+
+        // Pin the pre-import artifact to all four approved rows (an idempotent re-upload schedules a
+        // rebuild; the approvals above went straight to the DB and did not), so the final poll
+        // strictly witnesses the invalidated row LEAVING the file rather than an intermediate build.
+        await client.PostAsync(ImportRoute(firstVersion), Baseline());
+        await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            "/api/v1/translation-files/pl",
+            (candidate, content) => candidate.IsSuccessStatusCode && content.Contains($"{FileId}||4||Delty||NULL||NULL||1"));
+
+        DateTimeOffset residentUpdatedAt = (await GetTranslationAsync(1))!.UpdatedAt;
+        GameVersionId secondVersion = await SeedVersionAsync("49.1");
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            ImportRoute(secondVersion),
+            ExportContent(
+                Line(1, "Alfa"),
+                LineWithArgs(2, placeholderPolish, "1-1"),
+                Line(3, "Gamma"),
+                Line(4, "Delta reworded"),
+                Line(5, "Epsilon")));
+        ImportSummary? summary = await response.Content.ReadFromJsonAsync<ImportSummary>();
+
+        // Assert — only the real English change is invalidated; the echoes are visible in the
+        // summary and byte-for-byte untouched (source, Polish, status, timestamp).
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        summary.ShouldNotBeNull();
+        summary.Added.ShouldBe(0);
+        summary.SourceChanged.ShouldBe(1);
+        summary.Invalidated.ShouldBe(1);
+        summary.Removed.ShouldBe(0);
+        summary.Unchanged.ShouldBe(4);
+        summary.Echoed.ShouldBe(2);
+
+        Translation? echoed = await GetTranslationAsync(1);
+        echoed!.Source.Text.ShouldBe("Alpha");
+        echoed.TranslatedText.ShouldBe("Alfa");
+        echoed.Status.ShouldBe(TranslationStatus.Approved);
+        echoed.PreviousSourceText.ShouldBeNull();
+        echoed.LastSourceChangeInVersion.ShouldBeNull();
+        echoed.UpdatedAt.ShouldBe(residentUpdatedAt);
+
+        Translation? echoedWithArgs = await GetTranslationAsync(2);
+        echoedWithArgs!.Source.Text.ShouldBe("Greet <--DO_NOT_TOUCH!--> friend");
+        echoedWithArgs.Source.ArgsOrder.ShouldBe("1-1");
+        echoedWithArgs.Source.ArgsId.ShouldBe("1-1");
+        echoedWithArgs.TranslatedText.ShouldBe(placeholderPolish);
+        echoedWithArgs.Status.ShouldBe(TranslationStatus.Approved);
+
+        Translation? collateral = await GetTranslationAsync(3);
+        collateral!.Source.Text.ShouldBe("Gamma");
+        collateral.Status.ShouldBe(TranslationStatus.Approved);
+
+        Translation? invalidated = await GetTranslationAsync(4);
+        invalidated!.Status.ShouldBe(TranslationStatus.NeedsReview);
+        invalidated.PreviousSourceText.ShouldBe("Delta");
+        invalidated.Source.Text.ShouldBe("Delta reworded");
+        invalidated.TranslatedText.ShouldBe("Delty");
+
+        // The distributed file keeps every echoed (still Approved) row and drops only the invalidated
+        // one, once the import's debounced background rebuild converges (PERF-04).
+        (HttpResponseMessage download, string file) = await TranslationFileDownloadPolling.DownloadWhenConvergedAsync(
+            _factory.CreateClient(),
+            "/api/v1/translation-files/pl",
+            (candidate, content) => candidate.IsSuccessStatusCode && !content.Contains($"{FileId}||4||"));
+        download.StatusCode.ShouldBe(HttpStatusCode.OK);
+        file.ShouldContain($"{FileId}||1||Alfa||NULL||NULL||1");
+        file.ShouldContain($"{FileId}||2||{placeholderPolish}||1-1||1-1||1");
+        file.ShouldContain($"{FileId}||3||Gama||NULL||NULL||1");
+        file.ShouldNotContain($"{FileId}||4||");
+    }
+
+    [Fact]
     public async Task Import_MassRemovalWithoutOverride_ShouldReturn422AndLeaveStateIntact()
     {
         // Arrange — baseline three rows, then upload that drops two of them (67% > 20%).
@@ -753,6 +851,10 @@ public sealed class ImportExportedTextsTests : IAsyncLifetime
         => $"/api/v1/game-versions/{versionId.Value}/import";
 
     private static string Line(int gossipId, string text) => $"{FileId}||{gossipId}||{text}||NULL||NULL||1";
+
+    // The exporter emits identity args from the fragment's argument count (args_order == args_id),
+    // for the pristine English and for a patched fragment alike (spec 0012 echo triple).
+    private static string LineWithArgs(int gossipId, string text, string args) => $"{FileId}||{gossipId}||{text}||{args}||{args}||1";
 
     private static MultipartFormDataContent ExportContent(params string[] lines) => TextContent(string.Join('\n', lines));
 

--- a/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.API.Tests.Unit/Tests/Features/Import/ImportExportedTextsHandlerTests.cs
@@ -16,6 +16,8 @@ using LotroKoniecDev.TranslationSystem.Persistence.DbContexts.Abstractions;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.GameVersionAggregate.Enums;
 using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslationAggregate.Enums;
+using LotroKoniecDev.TranslationSystem.Primitives.Aggregates.TranslatorAggregate;
 using NSubstitute;
 
 namespace LotroKoniecDev.TranslationSystem.API.Tests.Unit.Tests.Features.Import;
@@ -93,6 +95,13 @@ public sealed class ImportExportedTextsHandlerTests
             VersionId,
             new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero)).Value;
 
+    private static Translation TranslatedRow(int gossipId, string text, string polish)
+    {
+        Translation translation = ExistingRow(gossipId, text);
+        translation.ProvideTranslation(polish, TranslatorId.Create(), new DateTimeOffset(2026, 6, 2, 0, 0, 0, TimeSpan.Zero));
+        return translation;
+    }
+
     private static async IAsyncEnumerable<StoredSourceDigest> DigestStream(params Translation[] translations)
     {
         await Task.Yield();
@@ -102,6 +111,7 @@ public sealed class ImportExportedTextsHandlerTests
                 translation.Id,
                 FragmentKeyValue.From(translation.FragmentKey),
                 SourceHash.Compute(translation.Source),
+                SourceHash.ComputeEcho(translation.TranslatedText, translation.Source.ArgsOrder, translation.Source.ArgsId),
                 translation.Status,
                 translation.IsRemoved);
         }
@@ -361,6 +371,38 @@ public sealed class ImportExportedTextsHandlerTests
         result.Value.Added.ShouldBe(0);
         result.Value.Unchanged.ShouldBe(0);
         result.Value.Warnings.ShouldContain(warning => warning.Contains("1 previously-removed row"));
+    }
+
+    [Fact]
+    public async Task Handle_WhenUploadEchoesTheRowsOwnPolish_ShouldLeaveTheRowUntouchedAndCountTheEcho()
+    {
+        // Arrange — an export from the admin's patched DAT (spec 0012): row 1 comes back as our own
+        // Polish, row 2 as an untouched English source; neither is a source change.
+        GivenVersion(UnprocessedVersion());
+        Translation resident = TranslatedRow(1, "Alpha", "Alfa");
+        GivenExisting(resident, ExistingRow(2, "Beta"));
+        // Hand the aggregate back should the handler wrongly route it through the source-change leg,
+        // so the assertions below observe a real mutation instead of an unreachable stub.
+        _translationRepository.GetByIdsAsync(
+                Arg.Is<IReadOnlyList<TranslationId>>(ids => ids!.Contains(resident.Id)),
+                Arg.Any<CancellationToken>())
+            .Returns([resident]);
+        string export = Export(Line(1, "Alfa"), Line(2, "Beta"));
+
+        // Act
+        Result<ImportSummary> result = await CreateHandler().Handle(Command(VersionId, export), CancellationToken.None);
+
+        // Assert — the echo is reported and counted inside Unchanged; the row's English source,
+        // Polish and status stand.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Echoed.ShouldBe(1);
+        result.Value.Unchanged.ShouldBe(2);
+        result.Value.SourceChanged.ShouldBe(0);
+        result.Value.Invalidated.ShouldBe(0);
+        resident.Source.Text.ShouldBe("Alpha");
+        resident.TranslatedText.ShouldBe("Alfa");
+        resident.Status.ShouldBe(TranslationStatus.Draft);
+        resident.PreviousSourceText.ShouldBeNull();
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/SourceHashTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/SourceHashTests.cs
@@ -92,6 +92,30 @@ public sealed class SourceHashTests
     }
 
     [Fact]
+    public void ComputeEcho_WithoutPolish_ShouldBeNull()
+    {
+        // Act — an untranslated row has nothing of ours that could echo back from a patched DAT.
+        SourceHash? echo = SourceHash.ComputeEcho(null, "1-2", "1-2");
+
+        // Assert
+        echo.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ComputeEcho_WithPolish_ShouldEqualTheIncomingHashOfThePatchedTriple()
+    {
+        // Arrange — the incoming side of an echo is the exported row (our Polish as text, the
+        // source's identity args), hashed through the VO like every upload row (spec 0012).
+        TranslationSource echoedRow = TranslationSource.Create("Witaj <--DO_NOT_TOUCH!--> przyjacielu", "1-1", "1-1").Value;
+
+        // Act
+        SourceHash? echo = SourceHash.ComputeEcho("Witaj <--DO_NOT_TOUCH!--> przyjacielu", "1-1", "1-1");
+
+        // Assert
+        echo.ShouldBe(SourceHash.Compute(echoedRow));
+    }
+
+    [Fact]
     public void Compute_LargeText_ShouldHashWithoutError()
     {
         // Arrange — a multi-kilobyte fragment exercises the pooled-buffer path beyond typical sizes.

--- a/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationDiffServiceTests.cs
+++ b/tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit/Tests/Aggregates/TranslationAggregate/TranslationDiffServiceTests.cs
@@ -16,8 +16,15 @@ public sealed class TranslationDiffServiceTests
         string text,
         string? argsOrder = null,
         TranslationStatus status = TranslationStatus.Untranslated,
-        bool isRemoved = false)
-        => new(TranslationId.Create(), new FragmentKeyValue(fileId, gossipId), Hash(text, argsOrder), status, isRemoved);
+        bool isRemoved = false,
+        string? polish = null)
+        => new(
+            TranslationId.Create(),
+            new FragmentKeyValue(fileId, gossipId),
+            Hash(text, argsOrder),
+            SourceHash.ComputeEcho(polish, argsOrder, argsOrder),
+            status,
+            isRemoved);
 
     private static KeyValuePair<FragmentKeyValue, SourceHash> Incoming(
         int fileId,
@@ -239,5 +246,169 @@ public sealed class TranslationDiffServiceTests
         incoming.Count.ShouldBe(1);
         incoming.ContainsKey(new FragmentKeyValue(1, 9)).ShouldBeTrue();
         plan.AddedCount.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData(TranslationStatus.Draft)]
+    [InlineData(TranslationStatus.Approved)]
+    [InlineData(TranslationStatus.NeedsReview)]
+    public async Task ComputePlanAsync_WhenIncomingSourceIsTheRowsOwnPolish_ShouldBeUnchangedEcho(TranslationStatus status)
+    {
+        // Arrange — the export came from a patched DAT, so the resident row carries our Polish as
+        // its "source" (spec 0012); whatever the status, the current Polish is what would echo.
+        StoredSourceDigest stored = Stored(1, 1, "Alpha", status: status, polish: "Alfa");
+        Dictionary<FragmentKeyValue, SourceHash> incoming = Map(Incoming(1, 1, "Alfa"));
+
+        // Act
+        TranslationDiffPlan plan = await TranslationDiffService.ComputePlanAsync(Existing(stored), incoming, CancellationToken.None);
+
+        // Assert
+        plan.EchoedCount.ShouldBe(1);
+        plan.UnchangedCount.ShouldBe(1);
+        plan.SourceChangedByKey.ShouldBeEmpty();
+        plan.InvalidatedCount.ShouldBe(0);
+        plan.RestoredIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ComputePlanAsync_WhenIncomingSourceIsSomeoneElsesPolish_ShouldBeSourceChange()
+    {
+        // Arrange — only the row's OWN Polish is an echo; a different Polish text is a real change
+        // (e.g. an older Polish still resident after a re-edit — the guard cannot know it).
+        StoredSourceDigest stored = Stored(1, 1, "Alpha", status: TranslationStatus.Approved, polish: "Alfa");
+        Dictionary<FragmentKeyValue, SourceHash> incoming = Map(Incoming(1, 1, "Alfa stara"));
+
+        // Act
+        TranslationDiffPlan plan = await TranslationDiffService.ComputePlanAsync(Existing(stored), incoming, CancellationToken.None);
+
+        // Assert
+        plan.EchoedCount.ShouldBe(0);
+        plan.SourceChangedByKey.Count.ShouldBe(1);
+        plan.InvalidatedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ComputePlanAsync_WhenRowHasNoPolish_ShouldNeverEcho()
+    {
+        // Arrange — an untranslated row has nothing of ours that could come back; any differing text
+        // is a source change even if it happens to look Polish.
+        StoredSourceDigest stored = Stored(1, 1, "Alpha");
+        Dictionary<FragmentKeyValue, SourceHash> incoming = Map(Incoming(1, 1, "Alfa"));
+
+        // Act
+        TranslationDiffPlan plan = await TranslationDiffService.ComputePlanAsync(Existing(stored), incoming, CancellationToken.None);
+
+        // Assert
+        plan.EchoedCount.ShouldBe(0);
+        plan.SourceChangedByKey.Count.ShouldBe(1);
+        plan.InvalidatedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ComputePlanAsync_WhenPolishEchoesWithIdenticalArgs_ShouldBeUnchangedEcho()
+    {
+        // Arrange — a placeholder-bearing row: the patched DAT keeps the argument count, so the
+        // export re-emits the source's identity args next to our Polish. Text AND args match the
+        // echo triple.
+        StoredSourceDigest stored = Stored(1, 1, "Hail <--DO_NOT_TOUCH!--> friend", argsOrder: "1-1", status: TranslationStatus.Approved, polish: "Witaj <--DO_NOT_TOUCH!--> przyjacielu");
+        Dictionary<FragmentKeyValue, SourceHash> incoming = Map(Incoming(1, 1, "Witaj <--DO_NOT_TOUCH!--> przyjacielu", argsOrder: "1-1"));
+
+        // Act
+        TranslationDiffPlan plan = await TranslationDiffService.ComputePlanAsync(Existing(stored), incoming, CancellationToken.None);
+
+        // Assert
+        plan.EchoedCount.ShouldBe(1);
+        plan.UnchangedCount.ShouldBe(1);
+        plan.SourceChangedByKey.ShouldBeEmpty();
+        plan.InvalidatedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ComputePlanAsync_WhenPolishEchoesWithDifferentArgs_ShouldBeSourceChange()
+    {
+        // Arrange — the echo is the whole triple: our Polish text with the source's args columns. A
+        // changed argument structure is a real change even when the text is our own Polish.
+        StoredSourceDigest stored = Stored(1, 1, "Alpha", argsOrder: "1-2", status: TranslationStatus.Approved, polish: "Alfa");
+        Dictionary<FragmentKeyValue, SourceHash> incoming = Map(Incoming(1, 1, "Alfa", argsOrder: "1-2-3"));
+
+        // Act
+        TranslationDiffPlan plan = await TranslationDiffService.ComputePlanAsync(Existing(stored), incoming, CancellationToken.None);
+
+        // Assert
+        plan.EchoedCount.ShouldBe(0);
+        plan.SourceChangedByKey.Count.ShouldBe(1);
+        plan.InvalidatedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ComputePlanAsync_WhenStoredSourceAlreadyEqualsThePolish_ShouldBePlainUnchangedNotEcho()
+    {
+        // Arrange — a poisoned row (its source was overwritten with the Polish echo by a pre-guard
+        // import): the source check wins, so it is unchanged and NOT counted as an echo — the echo
+        // counter reports guard hits only.
+        StoredSourceDigest stored = Stored(1, 1, "Alfa", status: TranslationStatus.Approved, polish: "Alfa");
+        Dictionary<FragmentKeyValue, SourceHash> incoming = Map(Incoming(1, 1, "Alfa"));
+
+        // Act
+        TranslationDiffPlan plan = await TranslationDiffService.ComputePlanAsync(Existing(stored), incoming, CancellationToken.None);
+
+        // Assert
+        plan.UnchangedCount.ShouldBe(1);
+        plan.EchoedCount.ShouldBe(0);
+        plan.SourceChangedByKey.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ComputePlanAsync_WhenRemovedRowReappearsAsItsOwnPolish_ShouldRestoreAndCountEcho()
+    {
+        // Arrange — an echo proves the fragment still holds our patch, i.e. its source never really
+        // changed, so a soft-removed row follows the identical-source re-add rule and is restored.
+        StoredSourceDigest removed = Stored(1, 1, "Alpha", status: TranslationStatus.Approved, isRemoved: true, polish: "Alfa");
+        Dictionary<FragmentKeyValue, SourceHash> incoming = Map(Incoming(1, 1, "Alfa"));
+
+        // Act
+        TranslationDiffPlan plan = await TranslationDiffService.ComputePlanAsync(Existing(removed), incoming, CancellationToken.None);
+
+        // Assert
+        plan.RestoredIds.Count.ShouldBe(1);
+        plan.RestoredIds[0].ShouldBe(removed.Id);
+        plan.EchoedCount.ShouldBe(1);
+        plan.UnchangedCount.ShouldBe(0);
+        plan.SourceChangedByKey.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ComputePlanAsync_OnPatchedDatExport_ShouldInvalidateOnlyTheRealEnglishChange()
+    {
+        // Arrange — the U49 shape (spec 0012 AC): a translated corpus, an export from the admin's
+        // patched DAT. Rows 1-2 echo our Polish, row 3 was collateral-reverted to its identical
+        // English (a client-side repair, not a TMS event), row 4's English really changed, row 5 is
+        // untranslated and untouched.
+        StoredSourceDigest[] existing =
+        [
+            Stored(1, 1, "Alpha", status: TranslationStatus.Approved, polish: "Alfa"),
+            Stored(1, 2, "Beta", status: TranslationStatus.Approved, polish: "Bety"),
+            Stored(1, 3, "Gamma", status: TranslationStatus.Approved, polish: "Gama"),
+            Stored(1, 4, "Delta", status: TranslationStatus.Approved, polish: "Delty"),
+            Stored(1, 5, "Epsilon")
+        ];
+        Dictionary<FragmentKeyValue, SourceHash> incoming = Map(
+            Incoming(1, 1, "Alfa"),
+            Incoming(1, 2, "Bety"),
+            Incoming(1, 3, "Gamma"),
+            Incoming(1, 4, "Delta reworded"),
+            Incoming(1, 5, "Epsilon"));
+
+        // Act
+        TranslationDiffPlan plan = await TranslationDiffService.ComputePlanAsync(Existing(existing), incoming, CancellationToken.None);
+
+        // Assert
+        plan.EchoedCount.ShouldBe(2);
+        plan.UnchangedCount.ShouldBe(4);
+        plan.SourceChangedByKey.Count.ShouldBe(1);
+        plan.SourceChangedByKey.ContainsKey(new FragmentKeyValue(1, 4)).ShouldBeTrue();
+        plan.InvalidatedCount.ShouldBe(1);
+        plan.AddedCount.ShouldBe(0);
+        plan.RemovedIds.ShouldBeEmpty();
     }
 }


### PR DESCRIPTION
Closes #563

## What

The admin exports texts from their own patched DAT, so every resident row comes back with our Polish as its "source". Before this change an import into a translated database read each of those rows as source-changed: mass false invalidation plus the English source overwritten with Polish (spec 0012, `update-49/RESULTS.md` scenario F).

The diff now carries a second per-row hash, the **echo hash** = `(TranslatedText, Source.ArgsOrder, Source.ArgsId)` — the exact triple the artifact carries and a patched DAT exports back. An incoming row that differs from the stored source but matches the echo hash is an **echo**: treated as Unchanged (restore when soft-removed), `SourceText` untouched, no invalidation. Echoes are counted in `ImportSummary.Echoed` (subset of `Unchanged`), in the import-passes log line, and shown as a tile on the import page.

- `SourceHash.ComputeEcho`, `StoredSourceDigest.EchoHash`, echo branch in `TranslationDiffService`, `TranslationDiffPlan.EchoedCount`
- `TranslationRepository.StreamSourceDigestsAsync` reads `TranslatedText` and hashes it row by row (working set unchanged: one row)
- `ImportSummary.Echoed` + `ImportExportedTexts` summary/log; frontend tile "W tym echo patcha"
- The source check runs first, so an already-poisoned row (source == Polish, #564's job) is plain Unchanged, never an echo
- Known limit (documented in code + spec): only the row's current Polish is known — an older Polish still resident after a re-edit reads as a real change

## Tests

- `TranslationDiffServiceTests`: echo across Draft/Approved/NeedsReview, no-Polish rows never echo, a different Polish is a change, echo with different args is a change, poisoned rows are plain unchanged, removed+echo restores, the U49-shaped plan (2 echoes + collateral revert + 1 real English change + untranslated)
- `ImportExportedTextsHandlerTests`: echo leaves the aggregate untouched and reports `Echoed`
- `ImportExportedTextsTests` (real PostgreSQL): the U49-shaped fixture end-to-end — only the real English change is invalidated, echoes are byte-for-byte untouched (incl. `UpdatedAt`), and the artifact keeps the echoed rows while dropping the invalidated one
- `ImportExportLoaderTests`: the new counter deserializes

Docs: spec 0012 echo-guard section + AC ticked, spec 0001 diff-rules pointer, `update-49/RESULTS.md` status line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNSqxD2K2eDPTiWJc2auUW
