### PR TITLE
ADR-0047: stale Polish never lands over changed English — per-row source guard; spec 0012 Tier 1 re-cut

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,9 +290,9 @@ VarLen: 0-127 = 1 byte; 128-32767 = 2 bytes (high bit flag)
 
 ```
 # Comments start with #
-file_id||gossip_id||translated_text||args_order||args_id||approved
-620756992||1001||Witaj w Srodziemiu!||NULL||NULL||1
-620756992||1002||Tekst z <--DO_NOT_TOUCH!--> argumentem||1||1||1
+file_id||gossip_id||translated_text||args_order||args_id||approved||source_digest
+620756992||1001||Witaj w Srodziemiu!||NULL||NULL||1||3f9a1c0e7b2d4a55
+620756992||1002||Tekst z <--DO_NOT_TOUCH!--> argumentem||1||1||1||9c02e4d1a7f0b366
 ```
 
 - `<--DO_NOT_TOUCH!-->` = argument placeholder
@@ -327,7 +327,8 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
   contexts is a golden fixture pinned on both sides.
 - **The `||` separator is deliberately NOT escaped — the line is CARVED, never `Split` (ADR-0042).**
   Each context's `TranslationLineCarver` scans **forward** for the two id separators and **backward**
-  for the three trailing ones (slicing before each backward search), so content may contain `||` and
+  for the trailing ones — three or four, sniffed from the last field: `0`/`1` is `approved`, 16 hex
+  is `source_digest` (ADR-0047) — slicing before each backward search, so content may contain `||` and
   may end in any run of `|`. `string.Split` resolves every boundary greedily left to right, which
   silently ate a trailing pipe into the args column (#597); never reintroduce it here. Nothing but
   content can hold a `|`, so both boundaries are recoverable by construction — no escape needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ A KittySaver slice is one file: `internal sealed class <Action> : IEndpoint` con
 | Deploy/operate the stack, or set env vars per environment | `docs/deployment/runbook.md` — env-var matrix (service × environment), secret generation, the issuer/redirect/authority/CORS gotchas, bring-up sequence + DB migrations. Ingress/routing shape: ADR-0034 (Caddy) + **ADR-0041** (why there is no gateway behind it) |
 | Add a proxy/gateway, expose a new service, or wire a client to an API path | **ADR-0041** — there is no API gateway: Caddy owns transport, the discovery document owns semantics, the frontend BFF owns aggregation. Clients resolve endpoints by **rel name** (ADR-0040's vocabulary), never by hardcoded path |
 | Touch the update lifecycle (GameVersion, import diff, invalidation, distribution, CLI sync) | `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md` — the agreed domain spec |
+| Touch update-day behavior on the client (sentinel, orchestrator, any new DAT write path) | `docs/specs/0012-update-resilience.md` (Tier 0/1 rules as amended 2026-08-17) + **ADR-0047** — every write goes through the per-row source guard; the no-masking invariant has no path exceptions |
 | Touch the game-content catalog (CatalogEntry/TextSlot, Companion zip import, catalog browser, memberships) | `docs/specs/0008-game-content-catalog-layer.md` (agreed) + `docs/knowledge-base/lotro-companion-data-model.md` (the verified `key:<FileId>:<GossipId>` join — never join on text). Naming rule: **never "entity"** in this layer (DDD-Entity misconception) |
 | Implement a feature whose business rules are fuzzy | **`/spec`** first (seed → questions → agreed spec in `docs/specs/`) |
 | Write or hand over a **manual QA ticket** (external tester) | **`/qa-ticket`** — every scenario verified against HEAD first; `/qa-ticket #<n>` re-baselines an existing one |
@@ -312,6 +313,18 @@ file_id||gossip_id||translated_text||args_order||args_id||approved
   patcher warn-skips such a row **before** it loads or mutates a subfile
   (`Fragment.IsWritablePiece`). `Fragment.Write` still throws — deliberately, as the last resort —
   and `PatchingService` never catches mid-write.
+- **Stale Polish never lands over changed English — an INVARIANT, enforced per row at write time
+  (ADR-0047, #659).** Owner's rule (2026-08-17): if SSG changed a row's English in version N+1 and
+  the newest approved translation is still for N, the player sees English — *whatever path writes
+  the DAT* (routine `launch` hash-patch, `patch`, the spec-0012 sentinel, the update-day
+  orchestrator). TMS-side exclusion of invalidated rows (spec 0001) holds only after the new export
+  is imported; the client closes the pre-import window: the artifact carries per row a
+  `source_digest` (7th column — 16 hex of the framed SHA-256 the TMS computes as `SourceHash`), and
+  the patcher writes a row only when the fragment holds that English or what the patcher itself
+  last wrote there (`<file>.ledger` sidecar); anything else is skipped and reported as
+  `source moved`. No verdict, registration or watcher is load-bearing for this, and there is no
+  operator override. A six-column translation file is not patchable. Digest parity between the two
+  contexts is a golden fixture pinned on both sides.
 - **The `||` separator is deliberately NOT escaped — the line is CARVED, never `Split` (ADR-0042).**
   Each context's `TranslationLineCarver` scans **forward** for the two id separators and **backward**
   for the three trailing ones (slicing before each backward search), so content may contain `||` and

--- a/docs/adr/0045-the-game-version-reaches-clients-through-our-api.md
+++ b/docs/adr/0045-the-game-version-reaches-clients-through-our-api.md
@@ -242,11 +242,16 @@ one way back and two rows can never carry the same version string.
   as an alertable state when #85 is built.
 - #85 becomes pre-launch work that ADR-0030 had deliberately parked, and it adds a hosted service
   plus SMTP to the TMS.
-- The guard covers the forced repair only. The routine launch path patches whenever the artifact
+- ~~The guard covers the forced repair only. The routine launch path patches whenever the artifact
   hash changed (`SimplifiedGameLaunchingStrategy.cs:85-99`), with no version gate, so an unrelated
   approve that rebuilds the artifact mid-window still re-injects pre-update Polish. Accepted for
   now — closing it means gating the ordinary patch on the verdict too, trading a masking risk for
-  a wider "no Polish at all" window. Revisit if a real update day shows it hurting.
+  a wider "no Polish at all" window. Revisit if a real update day shows it hurting.~~
+  **Superseded by ADR-0047 (2026-08-17).** The owner named "no stale Polish over changed English"
+  an invariant of the system, on every write path; it is now enforced per row at write time in the
+  patcher (artifact `source_digest` + local ledger), which also covers the pre-registration window
+  described in §Context above that this verdict never could. The verdict stays as the
+  preflight/UI signal (§2, §7, #562) and no longer gates the repair.
 - TMS unreachable ⇒ no repair. Tier 0 declines rather than masks, but also never heals a
   collateral revert while offline. Accepted: masking is the worse failure.
 - The distribution response grows contract surface that must hold on 304 — a header dropped on the

--- a/docs/adr/0045-the-game-version-reaches-clients-through-our-api.md
+++ b/docs/adr/0045-the-game-version-reaches-clients-through-our-api.md
@@ -85,8 +85,12 @@ Three rules are normative, not implementation detail:
   response that carried it. A verdict cached on disk and replayed on an offline launch, or under
   `--skip-sync`, would assert freshness nobody vouched for.
 
-The Tier-0 rule becomes: force-patch only when the server says the artifact is current. Spec
-0012's "artifact-version ≥ live forum version" phrasing is superseded by this.
+~~The Tier-0 rule becomes: force-patch only when the server says the artifact is current.~~ Spec
+0012's "artifact-version ≥ live forum version" phrasing is superseded by this. **Superseded by
+ADR-0047 (2026-08-17):** the verdict no longer gates the Tier-0 repair — admission is decided per row
+at write time by the source guard, so the repair runs from the local artifact, offline, whatever the
+verdict says. "Unknown means do not repair" and "response-scoped, never persisted" survive as the
+semantics of the verdict *as a preflight/UI signal*, which is all it is now.
 
 ### 4. #85 (M2-18 forum watcher) is what gives the guard useful coverage — promoted into UR
 
@@ -102,7 +106,10 @@ and there the verdict reads "current" and the sentinel repairs with pre-update P
 moves the start of coverage from admin-notice to publication.
 
 Therefore #85 moves from Post-MVP / Backlog into the UR — update-resilience milestone as a
-dependency of #562 (UR-22) and #565 (UR-10), and ships before the sentinel reaches players. It
+dependency of #562 (UR-22) ~~and #565 (UR-10), and ships before the sentinel reaches players~~
+(*superseded by ADR-0047, 2026-08-17: the sentinel's repair no longer depends on the verdict, so
+#85 is not on #565's path; it keeps its value for the update-check channel and for the TMS
+learning versions early*). It
 keeps the ADR-0030 §2 scope amendment (e-mail alert on detection), which was never mirrored onto
 the ticket — do that when it is picked up.
 

--- a/docs/adr/0047-stale-polish-never-lands-over-changed-english-the-patcher-checks-the-source-per-row.md
+++ b/docs/adr/0047-stale-polish-never-lands-over-changed-english-the-patcher-checks-the-source-per-row.md
@@ -36,6 +36,15 @@ writing the pre-update artifact over the post-update DAT. Code facts that pin th
   with pre-update Polish there. (3) The Tier-1 orchestrator (#566) patches **after** the launcher's
   apply burst, on update day, by construction — with the artifact it synced at launch, which is the
   pre-update one.
+- The echo-guard (#563, spec 0012) makes that window *silent* on the TMS side: an export taken
+  after such a write carries our Polish for the row, the import hash-matches it as an echo of our
+  own patch and treats it as Unchanged, so the row stays Approved and the artifact keeps shipping
+  the stale translation. Before the echo-guard the same export at least invalidated the row
+  (wrongly, with a poisoned source — the #564 class) and the artifact dropped it. The echo-guard is
+  right — mass false invalidation was the larger defect — but it moves the only remaining defence
+  to the write itself, which is this ADR. Until #659 lands, the manual ceremony after an SSG
+  update is therefore **export and import first, patch afterwards** (a hash-changing `launch` or a
+  manual `patch` between the update and the export is what writes the stale row).
 - The verdict cannot close the hole, structurally: it depends on the TMS *knowing* about the new
   version (manual registration or the #85 watcher), and the client is forbidden from finding out
   itself (ADR-0045 §1: no lotro.com read; `vnum-observations.md`: the DAT carries no content version).
@@ -96,8 +105,13 @@ exactly as `export` would compose it, and writes iff:
 - it equals the row's `source_digest` — the fragment holds the English this translation was made
   for (pristine, or collaterally reverted by the launcher — the case Tier 0/1 exist to repair); or
 - it equals the ledger's entry for `(FileId, GossipId)` (§4) — the fragment holds what this
-  patcher last wrote there, so a newer translation for the same English, or a no-op re-run, goes
-  through.
+  patcher last wrote there, so a newer translation for the same English goes through; or
+- it equals the digest of **this row's own translation** in export form (the Polish text with
+  identity args — the same function §4 applies after a write) — the fragment already holds exactly
+  what the row would write. The write is a no-op and always safe (nothing but our own patch puts
+  that text there), and it (re)seeds the ledger entry. This clause is what makes a DAT patched
+  before the ledger existed bootstrap by itself for every row on its current translation; a row
+  holding an *older* Polish still needs the ledger (§4).
 
 Anything else means the English moved under us: the row is **skipped and reported** as
 `source moved`, alongside the existing per-row warnings (ADR-0042 style), and counted in
@@ -119,8 +133,8 @@ successful patch actually wrote and swapped in atomically (temp file + rename).
 A missing or unreadable ledger is treated as empty. The consequence is bounded and safe in the
 invariant's direction: rows currently holding an *older* Polish are then unknown text and get
 skipped with warnings until an update reverts their SubFile or the DAT is restored pristine
-(the E2 restore path); rows holding the *current* translation still pass (§3, first bullet after
-the write is a no-op and re-seeds the ledger); rows holding English still pass. Losing the ledger
+(the E2 restore path); rows holding the *current* translation still pass (§3, third bullet — the
+no-op clause re-seeds the ledger); rows holding English still pass. Losing the ledger
 can never cause masking, only under-patching. That is the correct side to fail on.
 
 ### 5. The staleness verdict stops gating repair; the routine path needs no gate
@@ -204,10 +218,12 @@ Turns an offline, per-machine fact ("what did *this* patcher write into *this* D
 state keyed by a client identity the system does not have and does not want (no accounts on the
 player side). Rejected.
 
-### E. Skip the ledger — compare against the source digest only
+### E. Skip the ledger — compare against the source digest (and the row's own translation) only
 
-Blocks every re-patch of an already-Polish row: an updated translation for unchanged English could
-never land, and every no-op re-run would report the whole corpus as "source moved". Rejected.
+The no-op clause (§3, third bullet) covers the re-run, but an updated translation for unchanged
+English could still never land: the fragment holds the older Polish, which matches neither the
+English digest nor the new translation. Only a record of what *we* wrote admits that write.
+Rejected.
 
 ## Implementation Notes
 
@@ -231,7 +247,14 @@ never land, and every no-op re-run would report the whole corpus as "source move
   here; spec 0012 Tier 0 (verdict no longer gates repair; offline repair allowed) and Tier 1 (loop
   and branch B patch only through the guard); ADR-0045 Consequences bullet marked superseded;
   CLAUDE.md house rule (the invariant, one line).
-- **Tickets:** #659 (UR-27) implements this ADR and blocks #565 and #566; #660 (UR-28 / E6) is the
+- **Poisoned sources first (#564):** a row whose stored source is our Polish (the 8 rows #564
+  repairs) gets `source_digest = digest(Polish)`, so a pristine fragment (English) never matches
+  and an already-patched one always does — the guard would fossilise the poisoning. #659 depends
+  on #564.
+- **Warnings are aggregated, not streamed:** `source moved` can hit thousands of rows in one run
+  (a major that changed 1,644 sources — U49); the CLI reports a count plus a bounded sample, never
+  one line per row on the launch path.
+- **Tickets:** #659 (UR-27) implements this ADR and blocks #565 and #566; #564 (UR-21) precedes #659; #660 (UR-28 / E6) is the
   separate branch-B quiesce question and is unaffected by this decision.
 
 ## References

--- a/docs/adr/0047-stale-polish-never-lands-over-changed-english-the-patcher-checks-the-source-per-row.md
+++ b/docs/adr/0047-stale-polish-never-lands-over-changed-english-the-patcher-checks-the-source-per-row.md
@@ -53,7 +53,9 @@ writing the pre-update artifact over the post-update DAT. Code facts that pin th
   import diff's equality unit (`TranslationSystem.Domain/.../Services/SourceHash.cs`, #563 / spec
   0006). The patcher composes the very same triple when it exports: `text =
   string.Join(DatFileConstants.PieceSeparator, fragment.Pieces)`, args = identity `1-2-…-n` when
-  `fragment.HasArguments`, else `NULL` (`ExportTextsQueryHandler.cs:76-90`). A loaded fragment
+  `fragment.HasArguments`, else `null` (`ExportTextsQueryHandler.cs:76-90` writes the literal `NULL`
+  to the file; `SourceHash.Compute` takes the persisted form, `null` — the digest is over the
+  value-object form on both sides, never the wire literal). A loaded fragment
   therefore yields the digest of the English it currently holds, in milliseconds, offline.
 - Once the patcher has written a row, the fragment holds Polish, not the English the digest
   describes. Re-patching an already-Polish row (a newer translation for the same English, or a
@@ -88,14 +90,24 @@ The projector computes it from the row's stored `TranslationSource` at generatio
 Approved row's stored source *is* the English it was approved against, because a source change
 invalidates the row (spec 0001) and approval clears the invalidation. Nothing new is persisted; the
 digest that "is never persisted" for the diff becomes a wire value here, so its framing turns into a
-cross-context contract and is pinned by a parity fixture (§6). 64 bits is deliberate: the check
+cross-context contract and is pinned by a parity fixture (§6). The 16 hex characters are the first eight **bytes** of the digest in digest order
+(`Convert.ToHexString(digest[..8])`, lower-cased) — not the `High` `ulong`'s `x16` rendering, which
+is a different byte order; the parity fixture (§6) pins this. 64 bits is deliberate: the check
 asks "is the current text the one specific English this row was translated from", so a collision
 needs the changed English to hash to the old value — 2⁻⁶⁴ per changed row — while the full 128 bits
 would add ~30% to an artifact that every approve re-ships.
 
-`exported.txt` (the English source the CLI exports and the TMS imports) stays six columns — it has
-no translation to guard. The carver keeps its shape (ADR-0042: forward two, backward *n*), with
-*n* = 4 for translation files; the digest is hex, so it can never hold a `|`.
+**Both files carry the column.** `export` writes, per row, the digest of the very triple it just
+exported (its own English + identity args) — so a translator who edits `exported.txt` by hand still
+ends up with a patchable file, and the TMS import, when the column is present, recomputes
+`SourceHash` over the parsed triple and rejects the row on mismatch (ADR-0042 per-row rejection):
+a runtime parity check that fails loudly at import instead of as 800k `source moved` on players'
+boxes. Six-column input stays readable on both ends (older exports, hand-made files, the existing
+fixtures) — the last field tells them apart without ambiguity: `approved` is `0`/`1`, a digest is
+16 hex characters, nothing else can occupy that slot. So both carvers keep their shape (ADR-0042:
+forward two, backward *n*) with *n* sniffed from the last field (3 or 4), and the digest, being hex,
+can never hold a `|`. What differs is what a *missing* digest means: on the import side it is merely
+"no parity check for this row"; on the patch side it is "not patchable" (§3).
 
 ### 3. The write rule
 
@@ -107,8 +119,9 @@ exactly as `export` would compose it, and writes iff:
 - it equals the ledger's entry for `(FileId, GossipId)` (§4) — the fragment holds what this
   patcher last wrote there, so a newer translation for the same English goes through; or
 - it equals the digest of **this row's own translation** in export form (the Polish text with
-  identity args — the same function §4 applies after a write) — the fragment already holds exactly
-  what the row would write. The write is a no-op and always safe (nothing but our own patch puts
+  identity args taken from the fragment's `ArgRefs.Count`, exactly the function §4 applies after a
+  write — never from the row's own `args_order`, which may be `NULL` on a hand-made row) — the
+  fragment already holds exactly what the row would write. The write is a no-op and always safe (nothing but our own patch puts
   that text there), and it (re)seeds the ledger entry. This clause is what makes a DAT patched
   before the ledger existed bootstrap by itself for every row on its current translation; a row
   holding an *older* Polish still needs the ledger (§4).
@@ -119,23 +132,38 @@ Anything else means the English moved under us: the row is **skipped and reporte
 English into the Polish field" (spec 0001) still holds; the launcher already put the English there.
 
 A row **without** `source_digest` (a six-column translation file — hand-made, or an artifact from
-before this ADR) is not patchable: skipped with a warning, never written unguarded. The CLI's
-cached `polish.txt` re-downloads by itself once the server regenerates with the column (ETag).
+before this ADR) is not patchable: **skipped by the guard with a `no source digest` warning**, never
+written unguarded — and never rejected by the parser. The distinction is load-bearing: a parser
+rejection of every line is `NoTranslationsEveryLineRejected`, which the launch path turns into
+`RepatchFailed` and refuses to launch, and it would also break the ~30 existing parser tests that
+assert six-column lines parse (patcher house rule: assertions untouched). A wholly digest-less
+artifact therefore patches nothing, reports it, and lets the game start; the CLI's cached
+`polish.txt` re-downloads by itself once the server regenerates with the column (ETag).
 
 ### 4. A local ledger remembers what the patcher wrote
 
 A sidecar next to the translation file, `<file>.ledger` — the `.etag`/`.endpoint` pattern of
 `TranslationFileCache` — holds `file_id||gossip_id||digest` for every row written, where `digest`
 is the export-form digest of the fragment **after** the write (its Polish text with identity args —
-the same function as §3, applied to what the patcher just put there). It is rebuilt from the rows a
-successful patch actually wrote and swapped in atomically (temp file + rename).
+the same function as §3, applied to what the patcher just put there). It is **upserted, never rebuilt**: a
+successful write of a row upserts that row's entry; entries for rows *absent* from the current
+artifact (a row edited back to Draft, a soft-removed row) or skipped in this run are **kept**. A
+stale entry can never over-admit — its text sits on the fragment only if we put it there — whereas
+dropping one strands a fragment holding our older Polish: edit an Approved row (Draft, out of the
+artifact), let every player's next `launch` re-patch, re-approve it as P2, and a rebuilt ledger no
+longer knows P1, so P2 matches nothing and the row is `source moved` on every box until SSG replaces
+its SubFile. Rows whose `PutSubfileData` failed are not upserted (the DAT does not hold them). The
+file is written once after the loop, atomically (temp file + rename).
 
 A missing or unreadable ledger is treated as empty. The consequence is bounded and safe in the
 invariant's direction: rows currently holding an *older* Polish are then unknown text and get
 skipped with warnings until an update reverts their SubFile or the DAT is restored pristine
 (the E2 restore path); rows holding the *current* translation still pass (§3, third bullet — the
 no-op clause re-seeds the ledger); rows holding English still pass. Losing the ledger
-can never cause masking, only under-patching. That is the correct side to fail on.
+can never *cause* masking, only under-patching. Nor can the mechanism *remove* a mask written before
+this ADR (our Polish over new English by an unguarded patch): no clause admits a write and it never
+writes English, so such a row stays stale until SSG replaces its SubFile — a legacy state, bounded
+to boxes patched before #659 (today: the maintainer's). Failing toward English is the correct side.
 
 ### 5. The staleness verdict stops gating repair; the routine path needs no gate
 
@@ -145,8 +173,12 @@ offline repair of a collateral revert becomes safe, which the verdict design had
 Tier-1 orchestrator's post-apply patch is safe for the same reason. The verdict and the artifact's
 GameVersion metadata (#562) stay: they feed the preflight/update-check channel and the M4 UI ("your
 translation file is for 49.1; the game may be newer"), they just no longer decide whether a row may
-be written. ADR-0045's Consequences bullet that accepted routine-path masking "for now" is
-**superseded** by this ADR; ADR-0045 §1–3 and §5–9 stand.
+be written. Superseded in ADR-0045: the Consequences bullet that accepted routine-path masking "for now"; in
+**§3** the Tier-0 rule ("force-patch only when the server says the artifact is current" and "unknown
+means do not repair" *as a repair gate* — they survive only as preflight/UI semantics); and in **§4**
+the sentence making #85 a dependency of #565 that "ships before the sentinel reaches players" — #85
+keeps its value for the update-check channel and for the TMS learning versions early, it no longer
+gates client repair. ADR-0045 §1, §2 and §5–9 stand unchanged.
 
 ### 6. Digest parity is a test, not a convention
 
@@ -170,21 +202,36 @@ build, not an update day.
   would have opened (ADR-0045 Consequences) does not open.
 - The check is local and cheap: one SHA-256 over ~100 bytes per row on data already in memory —
   noise against the 14.7 s full-corpus patch (E3).
-- The orchestrator's convergent loop is safe to re-run after every apply burst; the sentinel's
-  sample can be as small as the wipe-detection needs, because repair coverage is decided per row at
-  write time, not by the sample.
+- The orchestrator's convergent loop is safe to re-run after every apply burst, and the Tier-0
+  repair (E5 iteration snapshot, #565) can write the whole wiped set blindly, because admission is
+  decided per row at write time — detection and admission stay separate layers.
 - The bootstrap on an already-patched DAT is automatic for rows on the current translation (§4).
 
 ### Negative / Accepted Trade-offs
 
-- A `||` format change: both parsers, both serializers, both golden fixture sets, plus a new parity
-  fixture — one ticket (#659), landed together. The `exported.txt` side is untouched.
+- A `||` format change on **both** files: both parsers (accepting six and seven columns), both
+  serializers, both golden fixture sets, plus a new parity fixture — one ticket (#659), landed
+  together. `translations/polish.txt`, `example_polish.txt` and the E2E artifacts get real digests
+  (the `export` header keeps saying "translate this file", and now that still works).
 - Every artifact grows by 18 bytes per row (`||` + 16 hex).
 - A lost ledger under-patches rows that hold an older Polish until an SSG update touches their
   SubFile or the DAT is restored; a crash mid-patch leaves the rows written after the last ledger
   swap in the same state on the next run. Both fail toward English, never toward masking. Accepted.
-- Six-column translation files stop patching. Test and dev fixtures gain the column; there is no
+- Six-column translation files stop patching (they still parse and still launch). There is no
   `--unguarded` switch, deliberately — the invariant has no operator override.
+- **Poisoning can recur, and the guard fossilises it.** The echo-guard recognises only the row's
+  *current* Polish (its documented limit): a row edited between the admin's last patch and their
+  export comes back as the older Polish, is filed as a source change and re-poisons the source
+  (#564's class). Once re-approved it ships `source_digest = digest(Polish)`, so a pristine or
+  collaterally-reverted fragment (English) never matches — that row is lost for Tier-0 repair on
+  every such box, with a false `source moved` diagnosis, until repaired the #564 way. Ceremony
+  after #659: **re-patch with the current artifact immediately before every export** (safe only
+  with the guard in place — before #659 the opposite rule holds, see Context). The structural fix is
+  the row's translation history (TP-15 / #50) or the pristine-source direction of spec 0012.
+- **Deploy ordering.** The stored artifact is regenerated only on the next approve/import signal
+  (`TranslationFileRebuildWorker`), so without a one-time regeneration every upgraded CLI would sit
+  on a six-column artifact — patching nothing — until someone approves something. #659 ships the
+  regeneration with the deploy (Implementation Notes).
 - The English text is still not present on the wire, so a translator-facing "the source changed"
   diagnosis on the client is impossible; that stays the TMS's job (spec 0001's
   `PreviousSourceText`).
@@ -225,12 +272,30 @@ English could still never land: the fragment holds the older Polish, which match
 English digest nor the new translation. Only a record of what *we* wrote admits that write.
 Rejected.
 
+### F. Keep the ledger inside the DAT (the Russians' NinjaMark pattern)
+
+A marker SubFile would travel with the DAT through restores and reinstalls, which the sidecar does
+not (a `-d` DAT swap or a reinstall leaves a ledger describing another file — safe direction,
+under-patching only). But it is a write into the game's archive on every patch, it is wiped by the
+very chunk replacements it would need to survive, and it puts our bookkeeping where SSG's launcher
+can and does rewrite. Rejected; the sidecar is keyed to the translation file next to it, and the
+"ledger describes another DAT" case degrades to warnings, not masking.
+
 ## Implementation Notes
 
-- **Contract:** `TranslationLineCarver` (both contexts) — backward search for four trailing
-  separators on translation files; `Translation` (patcher) and `ArtifactRow` (TMS) gain
-  `SourceDigest`; `TranslationFileParser` (patcher) surfaces a missing digest as a per-row rejection
-  reason; golden fixtures + round-trip tests on both sides.
+- **Contract:** `TranslationLineCarver` (both contexts) — backward search for **three or four**
+  trailing separators, decided by sniffing the last field (`0`/`1` ⇒ six columns, 16 lowercase hex ⇒
+  seven; anything else stays a per-row rejection as today); `Translation` (patcher) and
+  `ArtifactRow` (TMS) gain a nullable `SourceDigest`; the patcher `TranslationFileParser` accepts
+  both widths and **does not** reject a missing digest — that is the guard's `no source digest`
+  skip in `PatchingService` (§3); the TMS `TranslationExportParser` accepts both widths and, when a
+  digest is present, verifies it against `SourceHash.Compute` of the parsed triple (mismatch =
+  per-row rejection, ADR-0042 style — a wrong-file upload or an implementation drift fails loudly);
+  `ParserContractParityTests` gets a seven-column line; golden fixtures + round-trip tests on both
+  sides; the CLAUDE.md format block shows seven columns.
+- **Export:** `ExportTextsQueryHandler` writes the digest of the exported triple as the seventh
+  column (same function as the guard's — one `SourceDigest` type shared by export and guard, so they
+  cannot drift).
 - **TMS:** `PrecomputedTranslationFileProjector` computes `SourceHash` from the row's
   `TranslationSource` and passes the 16-hex prefix to `TranslationFileSerializer`. `SourceHash`
   gains the hex-prefix accessor and a doc line saying it is now a wire value.
@@ -240,21 +305,31 @@ Rejected.
   the write; `source moved` / `no source digest` warnings and counters in `PatchSummaryResponse`.
 - **Ledger:** `ITranslationLedger` port in `Application/Abstractions`, `TranslationFileCache`-style
   implementation in `Infrastructure/Storage` (`<file>.ledger`, atomic swap); read once before the
-  loop, rebuilt after it.
+  loop, **merged** after it — upsert written rows, keep everything else, never upsert a row whose
+  `PutSubfileData` failed (§4).
+- **Regeneration on deploy:** the API regenerates the stored artifact once at startup when it
+  predates the column (a format stamp in the artifact header comment, or the absence of the column
+  in its first data row) — otherwise upgraded CLIs patch nothing until the next approve.
 - **Parity:** one fixture file linked into `tests/LotroKoniecDev.Tests.Unit` and
   `tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit`.
 - **Docs:** spec 0001 §"Invalidation & fallback-to-English" names the pre-import window and points
   here; spec 0012 Tier 0 (verdict no longer gates repair; offline repair allowed) and Tier 1 (loop
   and branch B patch only through the guard); ADR-0045 Consequences bullet marked superseded;
   CLAUDE.md house rule (the invariant, one line).
-- **Poisoned sources first (#564):** a row whose stored source is our Polish (the 8 rows #564
+- **Poisoned sources first (#564):** a row whose stored source is our Polish (the rows #564
   repairs) gets `source_digest = digest(Polish)`, so a pristine fragment (English) never matches
-  and an already-patched one always does — the guard would fossilise the poisoning. #659 depends
-  on #564.
-- **Warnings are aggregated, not streamed:** `source moved` can hit thousands of rows in one run
-  (a major that changed 1,644 sources — U49); the CLI reports a count plus a bounded sample, never
-  one line per row on the launch path.
-- **Tickets:** #659 (UR-27) implements this ADR and blocks #565 and #566; #564 (UR-21) precedes #659; #660 (UR-28 / E6) is the
+  and an already-patched one always does — the guard fossilises the poisoning for pristine and
+  reverted boxes. #564 is an owner-run data repair (the English lives in the gitignored exports),
+  not a code dependency of #659: land it **before the first guarded artifact reaches a player**,
+  and expect it to recur until TP-15 (see Consequences).
+- **Warnings are aggregated, not streamed — inside `PatchingService`, not the CLI:** `source moved`
+  / `no source digest` can hit thousands of rows in one run (a major that changed 1,644 sources — U49;
+  a whole six-column artifact); today `PatchSummaryResponse.Warnings` is a flat list that
+  `PatchCommand` prints and `SimplifiedGameLaunchingStrategy` logs one by one, so the count + bounded
+  sample must be produced where both paths meet (precedent: the parser's 100-warning cap +
+  "…and N more").
+- **Tickets:** #659 (UR-27) implements this ADR and blocks #565 and #566; #564 (UR-21) precedes the
+  first guarded artifact in production (ordering, not a code dependency); #660 (UR-28 / E6) is the
   separate branch-B quiesce question and is unaffected by this decision.
 
 ## References

--- a/docs/adr/0047-stale-polish-never-lands-over-changed-english-the-patcher-checks-the-source-per-row.md
+++ b/docs/adr/0047-stale-polish-never-lands-over-changed-english-the-patcher-checks-the-source-per-row.md
@@ -1,0 +1,251 @@
+# ADR-0047: Stale Polish never lands over changed English — the patcher checks the row's source per row, at write time
+
+**Status:** Accepted
+**Date:** 2026-08-17
+**Decision-makers:** Solo maintainer
+**Related:** Patcher (`Features/Patching/PatchingService`, `Parsers/*`, `Infrastructure/Storage/TranslationFileCache`), TMS distribution (`Parsing/TranslationFileSerializer`, `Features/TranslationFiles/PrecomputedTranslationFileProjector`), `TranslationSystem.Domain` `SourceHash`, `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md` (§"Invalidation & fallback-to-English" — amended), `docs/specs/0012-update-resilience.md` (Tier 0 + Tier 1 — amended), ADR-0045 (one Consequences bullet superseded, the verdict demoted), ADR-0039/0042/0043 (the `||` contract), tickets #659 (UR-27, the implementation), #563 (UR-20, `SourceHash`), #565 (UR-10), #566 (UR-11), #660 (UR-28)
+
+## Context
+
+The owner stated the rule on 2026-08-17, after an adversarial review of the Tier-1 orchestrator
+ticket (#566), as an **invariant of the system**:
+
+> If SSG changed a row's English in game version N+1 and the newest approved translation in the
+> TMS is still the one for version N, the player sees English. Whatever path writes the DAT.
+
+The reason is not cosmetic: a quest text that says the old thing lies to the player about what to
+do in the game. English is a degraded session; stale Polish is a broken one.
+
+Spec 0001 already codifies the rule as "physics" (§"Invalidation & fallback-to-English"): the
+launcher chunk-patches fresh English into the player's DAT, and the TMS excludes invalidated rows
+from the translation file, so `patch` never re-applies stale Polish. That mechanism is correct
+**after** the new export has been imported. Between the SSG update and that import — hours to days,
+the exact window in which players update and launch — nothing on the client side stops a patch from
+writing the pre-update artifact over the post-update DAT. Code facts that pin the hole:
+
+- The patcher writes unconditionally: `PatchingService.ApplyTranslations` loads the SubFile,
+  `TryGetFragment`, then `fragment.Pieces = [.. pieces]` (`PatchingService.cs:157-160`). It never
+  looks at what the fragment holds. Nothing in the `||` row tells it what English the translation
+  was made against.
+- Three paths patch inside the window. (1) The routine `launch` re-patches whenever the artifact
+  hash changed (`SimplifiedGameLaunchingStrategy.cs:56-63`, `:85-99`) — one unrelated approve rebuilds
+  the artifact and re-injects every pre-update row; ADR-0045 Consequences recorded this as
+  "Accepted for now — revisit if a real update day shows it hurting". (2) The Tier-0 sentinel is
+  gated on the server's staleness verdict, but the verdict reads "current" until an admin registers
+  the new version (ADR-0045 §Context, the "window that matters most" paragraph) — the sentinel repairs
+  with pre-update Polish there. (3) The Tier-1 orchestrator (#566) patches **after** the launcher's
+  apply burst, on update day, by construction — with the artifact it synced at launch, which is the
+  pre-update one.
+- The verdict cannot close the hole, structurally: it depends on the TMS *knowing* about the new
+  version (manual registration or the #85 watcher), and the client is forbidden from finding out
+  itself (ADR-0045 §1: no lotro.com read; `vnum-observations.md`: the DAT carries no content version).
+- The information needed to decide per row exists on both sides. The TMS computes `SourceHash` —
+  a framed SHA-256 over the source triple `(Text, ArgsOrder, ArgsId)`, 128 bits kept — as the
+  import diff's equality unit (`TranslationSystem.Domain/.../Services/SourceHash.cs`, #563 / spec
+  0006). The patcher composes the very same triple when it exports: `text =
+  string.Join(DatFileConstants.PieceSeparator, fragment.Pieces)`, args = identity `1-2-…-n` when
+  `fragment.HasArguments`, else `NULL` (`ExportTextsQueryHandler.cs:76-90`). A loaded fragment
+  therefore yields the digest of the English it currently holds, in milliseconds, offline.
+- Once the patcher has written a row, the fragment holds Polish, not the English the digest
+  describes. Re-patching an already-Polish row (a newer translation for the same English, or a
+  no-op re-run) must stay possible, so "current text == expected English" alone is not enough:
+  the patcher also needs to recognise **its own** earlier write.
+- The `||` file is the inter-context contract (CLAUDE.md, ADR-0039/0042/0043): a column added to
+  it needs golden fixtures on both sides in the same change. There are no real users yet, so the
+  format change itself is free; the discipline is not.
+
+## Decision
+
+### 1. The invariant is enforced per row, at write time, in the patcher — nowhere else
+
+Version bookkeeping (verdicts, registrations, watchers) tells the client that *something* may
+have changed; only the row itself can tell whether *this* row did. The patcher becomes the single
+point of enforcement: before it writes a fragment it checks what the fragment holds, and it writes
+only when that content is one it is allowed to overwrite. Every path — `patch`, `launch`, the
+sentinel, the orchestrator's branches A/B and its convergent loop — goes through the same
+`PatchingService` and is covered by construction. No path is trusted to "know it is safe".
+
+### 2. The artifact carries the source digest per row
+
+The translation-file grammar gains a trailing seventh column, `source_digest`: the first 8 bytes
+of the framed SHA-256 the TMS already computes as `SourceHash`, as 16 lowercase hex characters.
+
+```
+file_id||gossip_id||translated_text||args_order||args_id||approved||source_digest
+620756992||1001||Witaj w Srodziemiu!||NULL||NULL||1||3f9a1c0e7b2d4a55
+```
+
+The projector computes it from the row's stored `TranslationSource` at generation time — an
+Approved row's stored source *is* the English it was approved against, because a source change
+invalidates the row (spec 0001) and approval clears the invalidation. Nothing new is persisted; the
+digest that "is never persisted" for the diff becomes a wire value here, so its framing turns into a
+cross-context contract and is pinned by a parity fixture (§6). 64 bits is deliberate: the check
+asks "is the current text the one specific English this row was translated from", so a collision
+needs the changed English to hash to the old value — 2⁻⁶⁴ per changed row — while the full 128 bits
+would add ~30% to an artifact that every approve re-ships.
+
+`exported.txt` (the English source the CLI exports and the TMS imports) stays six columns — it has
+no translation to guard. The carver keeps its shape (ADR-0042: forward two, backward *n*), with
+*n* = 4 for translation files; the digest is hex, so it can never hold a `|`.
+
+### 3. The write rule
+
+Before `fragment.Pieces = …`, the patcher computes the digest of the fragment's export-form triple
+exactly as `export` would compose it, and writes iff:
+
+- it equals the row's `source_digest` — the fragment holds the English this translation was made
+  for (pristine, or collaterally reverted by the launcher — the case Tier 0/1 exist to repair); or
+- it equals the ledger's entry for `(FileId, GossipId)` (§4) — the fragment holds what this
+  patcher last wrote there, so a newer translation for the same English, or a no-op re-run, goes
+  through.
+
+Anything else means the English moved under us: the row is **skipped and reported** as
+`source moved`, alongside the existing per-row warnings (ADR-0042 style), and counted in
+`PatchSummaryResponse`. Skipping writes nothing — "fallback to English requires no write of
+English into the Polish field" (spec 0001) still holds; the launcher already put the English there.
+
+A row **without** `source_digest` (a six-column translation file — hand-made, or an artifact from
+before this ADR) is not patchable: skipped with a warning, never written unguarded. The CLI's
+cached `polish.txt` re-downloads by itself once the server regenerates with the column (ETag).
+
+### 4. A local ledger remembers what the patcher wrote
+
+A sidecar next to the translation file, `<file>.ledger` — the `.etag`/`.endpoint` pattern of
+`TranslationFileCache` — holds `file_id||gossip_id||digest` for every row written, where `digest`
+is the export-form digest of the fragment **after** the write (its Polish text with identity args —
+the same function as §3, applied to what the patcher just put there). It is rebuilt from the rows a
+successful patch actually wrote and swapped in atomically (temp file + rename).
+
+A missing or unreadable ledger is treated as empty. The consequence is bounded and safe in the
+invariant's direction: rows currently holding an *older* Polish are then unknown text and get
+skipped with warnings until an update reverts their SubFile or the DAT is restored pristine
+(the E2 restore path); rows holding the *current* translation still pass (§3, first bullet after
+the write is a no-op and re-seeds the ledger); rows holding English still pass. Losing the ledger
+can never cause masking, only under-patching. That is the correct side to fail on.
+
+### 5. The staleness verdict stops gating repair; the routine path needs no gate
+
+With §1–4 in place the ADR-0045 verdict is no longer load-bearing for correctness. The Tier-0
+sentinel repairs from the local artifact regardless of the verdict and regardless of connectivity —
+offline repair of a collateral revert becomes safe, which the verdict design had to forbid. The
+Tier-1 orchestrator's post-apply patch is safe for the same reason. The verdict and the artifact's
+GameVersion metadata (#562) stay: they feed the preflight/update-check channel and the M4 UI ("your
+translation file is for 49.1; the game may be newer"), they just no longer decide whether a row may
+be written. ADR-0045's Consequences bullet that accepted routine-path masking "for now" is
+**superseded** by this ADR; ADR-0045 §1–3 and §5–9 stand.
+
+### 6. Digest parity is a test, not a convention
+
+The two contexts share the file, not code (CLAUDE.md): the patcher gets its own digest
+implementation over its own triple composition. A golden fixture — a handful of triples (with and
+without args, with placeholders, with the ADR-0039 escape characters in the text) and their
+expected 16-hex digests — is pinned by a unit test in **both** `LotroKoniecDev.Tests.Unit` and
+`TranslationSystem.Domain.Tests.Unit`, next to the `||` round-trip fixtures. The framing (marker +
+UTF-16 length + UTF-16 bytes per field, `null` ≠ empty) is documented on both types. Drift fails a
+build, not an update day.
+
+## Consequences
+
+### Positive
+
+- The invariant holds by construction on every write path, including the two that were built to
+  patch on update day (Tier 0 repair, Tier 1 orchestrator) — no path can mask, whether or not the
+  TMS has learned about the new version yet.
+- Correctness no longer depends on the freshness of a version registration, on the #85 watcher's
+  liveness, or on being online. The "no Polish at all" window that gating everything on the verdict
+  would have opened (ADR-0045 Consequences) does not open.
+- The check is local and cheap: one SHA-256 over ~100 bytes per row on data already in memory —
+  noise against the 14.7 s full-corpus patch (E3).
+- The orchestrator's convergent loop is safe to re-run after every apply burst; the sentinel's
+  sample can be as small as the wipe-detection needs, because repair coverage is decided per row at
+  write time, not by the sample.
+- The bootstrap on an already-patched DAT is automatic for rows on the current translation (§4).
+
+### Negative / Accepted Trade-offs
+
+- A `||` format change: both parsers, both serializers, both golden fixture sets, plus a new parity
+  fixture — one ticket (#659), landed together. The `exported.txt` side is untouched.
+- Every artifact grows by 18 bytes per row (`||` + 16 hex).
+- A lost ledger under-patches rows that hold an older Polish until an SSG update touches their
+  SubFile or the DAT is restored; a crash mid-patch leaves the rows written after the last ledger
+  swap in the same state on the next run. Both fail toward English, never toward masking. Accepted.
+- Six-column translation files stop patching. Test and dev fixtures gain the column; there is no
+  `--unguarded` switch, deliberately — the invariant has no operator override.
+- The English text is still not present on the wire, so a translator-facing "the source changed"
+  diagnosis on the client is impossible; that stays the TMS's job (spec 0001's
+  `PreviousSourceText`).
+
+## Alternatives Considered
+
+### A. Gate every patch path on the ADR-0045 verdict
+
+Closes the routine-path hole ADR-0045 accepted, but not the window before the new version is
+registered — the verdict reads "current" there — and it depends on the watcher's liveness (its own
+listed failure mode). It also widens the "no Polish at all" window: a stale verdict blocks the
+collateral repair too. Rejected. It enforces the invariant only when the server already knows,
+which is exactly when it is least needed.
+
+### B. Detect the update on the client and refuse to patch until the TMS catches up
+
+The orchestrator sees the apply burst and the sentinel sees reverts, so update *day* is
+detectable; the routine launch the day after is not, and the client is forbidden from reading the
+forum (ADR-0045 §1) and cannot read a content version from the DAT. Rejected. Partial coverage of an
+invariant is no coverage.
+
+### C. Ship the source English in the artifact and compare text
+
+Same decision as taken, with the comparison in clear text. Doubles the artifact (the source
+corpus is ~83 MB exported) for no gain: equality of a digest is equality of the text. Rejected in
+favour of the digest.
+
+### D. Keep the ledger inside the TMS (per-client history) instead of a local sidecar
+
+Turns an offline, per-machine fact ("what did *this* patcher write into *this* DAT") into server
+state keyed by a client identity the system does not have and does not want (no accounts on the
+player side). Rejected.
+
+### E. Skip the ledger — compare against the source digest only
+
+Blocks every re-patch of an already-Polish row: an updated translation for unchanged English could
+never land, and every no-op re-run would report the whole corpus as "source moved". Rejected.
+
+## Implementation Notes
+
+- **Contract:** `TranslationLineCarver` (both contexts) — backward search for four trailing
+  separators on translation files; `Translation` (patcher) and `ArtifactRow` (TMS) gain
+  `SourceDigest`; `TranslationFileParser` (patcher) surfaces a missing digest as a per-row rejection
+  reason; golden fixtures + round-trip tests on both sides.
+- **TMS:** `PrecomputedTranslationFileProjector` computes `SourceHash` from the row's
+  `TranslationSource` and passes the 16-hex prefix to `TranslationFileSerializer`. `SourceHash`
+  gains the hex-prefix accessor and a doc line saying it is now a wire value.
+- **Patcher:** a small `SourceDigest` twin in `LotroKoniecDev.Application` (or Domain) that composes
+  the export-form triple from a `Fragment` — shared with `ExportTextsQueryHandler`, so export and
+  guard cannot drift; the guard in `PatchingService.ApplyTranslations` between `TryGetFragment` and
+  the write; `source moved` / `no source digest` warnings and counters in `PatchSummaryResponse`.
+- **Ledger:** `ITranslationLedger` port in `Application/Abstractions`, `TranslationFileCache`-style
+  implementation in `Infrastructure/Storage` (`<file>.ledger`, atomic swap); read once before the
+  loop, rebuilt after it.
+- **Parity:** one fixture file linked into `tests/LotroKoniecDev.Tests.Unit` and
+  `tests/LotroKoniecDev.TranslationSystem.Domain.Tests.Unit`.
+- **Docs:** spec 0001 §"Invalidation & fallback-to-English" names the pre-import window and points
+  here; spec 0012 Tier 0 (verdict no longer gates repair; offline repair allowed) and Tier 1 (loop
+  and branch B patch only through the guard); ADR-0045 Consequences bullet marked superseded;
+  CLAUDE.md house rule (the invariant, one line).
+- **Tickets:** #659 (UR-27) implements this ADR and blocks #565 and #566; #660 (UR-28 / E6) is the
+  separate branch-B quiesce question and is unaffected by this decision.
+
+## References
+
+- Spec 0001 — `docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md`,
+  §"Invalidation & fallback-to-English (the physics)"
+- Spec 0012 — `docs/specs/0012-update-resilience.md`, Tier 0 / Tier 1 / Q4 (amended 2026-08-17)
+- ADR-0045 — the game version reaches clients through our API (verdict; §Consequences bullet
+  superseded here)
+- ADR-0039 (content escape), ADR-0042 (carving, per-row rejection), ADR-0043 (DAT bounds) — the
+  `||` contract this ADR extends
+- `docs/knowledge-base/update-49/RESULTS.md` — E1-F1 (launcher writes on every start), E2
+  (download leaves the DAT free; apply is a ~1 s burst; the forced-downgrade replay), E3 (14.7 s
+  full-corpus patch)
+- `docs/knowledge-base/vnum-observations.md` — no content version in the DAT
+- Tickets #659, #563, #565, #566, #660; #656 (E5 per-SubFile snapshot — detection of *where* the
+  launcher wrote, complementary to this ADR's *whether a row may be written*)

--- a/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
+++ b/docs/specs/0001-game-update-lifecycle-and-translation-invalidation.md
@@ -161,6 +161,19 @@ For every row of the uploaded export, compared against the stored source state b
   DAT (`dat-protection.md`); (2) the TMS excludes invalidated rows from the translation file, so
   `patch` never re-applies stale Polish over it. This is the codified form of the knowledge-base
   core insight "re-patching after game update is WRONG" (`update-detection-strategy.md`).
+  *Amendment (ADR-0047 / #659, 2026-08-17):* the owner named this an **invariant** — *if SSG
+  changed a row's English in version N+1 and the newest approved translation is still the one for
+  version N, the player sees English, whatever path writes the DAT.* Mechanism (2) enforces it only
+  **after** the new export is imported; between the SSG update and that import every artifact still
+  carries translations approved against the old English, and any patch (routine hash-patch after
+  an unrelated approve, the spec-0012 sentinel before the version is registered, the update-day
+  orchestrator by construction) would re-inject them. So a third mechanism closes the window on
+  the client: (3) the artifact carries per row the digest of the English the translation was
+  approved against, and the **patcher writes a row only when the fragment currently holds that
+  English or what the patcher itself last wrote there** (local ledger); anything else is left
+  alone and reported as `source moved`. Exclusion (2) remains the TMS-side truth; the guard (3) is
+  what makes the pre-import window safe. ADR-0047 has the ruling, the format change and the
+  rejected alternatives.
 - An invalidated translation is **explicitly visible to the admin/translators** as needing
   re-translation; supplying and approving a new Polish text clears the invalidation (the approve
   slice #101 gains this rule). The stale Polish is **kept** as the draft starting point, and the

--- a/docs/specs/0012-update-resilience.md
+++ b/docs/specs/0012-update-resilience.md
@@ -193,7 +193,10 @@ faster repair) — not a correctness or UX requirement.
   catching it needs the row's Polish history (TP-15 / #50, post-MVP). Echoes are counted in
   `ImportSummary.Echoed` (a subset of `Unchanged`; the import page shows it as "W tym echo patcha")
   and in the import-passes log line — observability only, no warning: with today's manual ceremony
-  every export comes from a patched DAT, so echoes are the norm, not an anomaly.
+  every export comes from a patched DAT, so echoes are the norm, not an anomaly. **Interaction
+  with the invariant (ADR-0047 Context):** an echo also hides a row whose *new* English our patch
+  overwrote in the pre-import window, so until #659 lands the post-update ceremony is export →
+  import first, patch afterwards.
 - **One-time source repair** for already-poisoned rows (today: 8).
 - **Pristine-source direction (optional, Q-gated):** generate a revert file from TMS SourceText
   before export, or keep a pristine DAT copy (the Russians re-download the original DAT for the

--- a/docs/specs/0012-update-resilience.md
+++ b/docs/specs/0012-update-resilience.md
@@ -84,14 +84,14 @@ corrections with stale Polish — and TMS imports stay correct at any corpus sca
 - **Anti-masking handshake** (revised by **ADR-0045**, 2026-08-06 — the client never reads
   lotro.com): the distribution response carries the GameVersion the artifact was generated for
   **and a server-computed staleness verdict** ("does the TMS know an Unprocessed version newer
-  than this artifact?"). The sentinel force-patches only when the server says the artifact is
-  current; otherwise it defers (fallback-to-English semantics preserved — never re-apply
+  than this artifact?"). ~~The sentinel force-patches only when the server says the artifact is
+  current; otherwise it defers~~ (fallback-to-English semantics preserved — never re-apply
   pre-update Polish over fresh English; a dropped artifact row can NEVER un-write stale Polish,
   because patch does not write absences). The client performs no version comparison — version
-  ordering stays in the TMS domain, deployable. Unknown verdict, missing artifact version or an
-  unreachable TMS ⇒ treat as "do not force-patch". The verdict is valid only for the response
-  that carried it and is never cached as authority. **Coverage limit:** the handshake gates the
-  *forced* repair only; the routine hash-triggered patch is ungated (ADR-0045 Consequences).
+  ordering stays in the TMS domain, deployable. ~~Unknown verdict, missing artifact version or an
+  unreachable TMS ⇒ treat as "do not force-patch".~~ The verdict is valid only for the response
+  that carried it and is never cached as authority. ~~**Coverage limit:** the handshake gates the
+  *forced* repair only; the routine hash-triggered patch is ungated (ADR-0045 Consequences).~~
   *Amended 2026-08-17 (ADR-0047 §5):* **the verdict no longer gates the repair.** The no-masking
   invariant is enforced per row at write time (artifact `source_digest` + local ledger — the
   patcher writes a row only over the English it was translated from or over its own earlier
@@ -205,9 +205,11 @@ faster repair) — not a correctness or UX requirement.
   needed by the Tier-0 handshake — ADR-0045), plus the touched-SubFiles set per version
   (repair-set). The artifact carries no version today, so this is a new column + migration, not
   an exposure of something already stored.
-- **Version detection is a prerequisite, not a convenience (ADR-0045 §4):** the verdict is only as
-  early as the TMS's knowledge of a new version, so the forum watcher (#85) moves into this
-  milestone. Its detections count immediately and are dismissible after the fact; #624 must land
+- **Version detection feeds the update-check channel, no longer the repair (ADR-0045 §4 as
+  superseded by ADR-0047):** the verdict is only as early as the TMS's knowledge of a new version,
+  so the forum watcher (#85) stays in this milestone for the preflight/UI signal and for the TMS
+  learning versions early — but the client repair no longer waits for it (admission is per row,
+  ADR-0047). Its detections count immediately and are dismissible after the fact; #624 must land
   first, because a wrongly registered version is currently unrecoverable once superseded.
 
 ## Experiments (inputs to final design; all local; Windows box)
@@ -292,6 +294,8 @@ execution order — the real chains are:
   **#566** UR-11 Tier-1 orchestrator → **#567** UR-12 forced-downgrade E2E
 - **#563** UR-20 import echo-guard → **#564** UR-21 one-time source repair
 - *(added 2026-08-17)* **#563** UR-20 (`SourceHash`) → **#659** UR-27 per-row source guard
+  (**#564** UR-21 lands before the first guarded artifact reaches production — ordering, not a
+  code dependency; it is owner-run)
   (ADR-0047) → **#565** UR-10 and **#566** UR-11; **#660** UR-28 (E6, owner-run) → the branch-B
   default of **#566**
 

--- a/docs/specs/0012-update-resilience.md
+++ b/docs/specs/0012-update-resilience.md
@@ -9,7 +9,9 @@
   Tier-0 detection revised below, #565 redesigned). Results:
   `docs/knowledge-base/update-49/RESULTS.md` §Experiments — incl. findings E1-F1 (DAT mtime
   volatile ⇒ Tier-0 content-sentinel revision below) and the forced-downgrade method (repeatable
-  update-cycle simulator; big-major burst shape still worth observing at the next real SSG major)
+  update-cycle simulator; big-major burst shape still worth observing at the next real SSG major).
+  **Amended 2026-08-17** — the owner's no-masking **invariant** + **ADR-0047** (per-row source
+  guard, #659) and the Tier-1 re-cut after the #566 adversarial review (Q6–Q8; E6 = #660)
 - **Date:** 2026-08-02 (seeded from the live-test 48.8→49.1 findings + owner discussion, same day)
 - **Author:** Artur Koniec (problem framing + orchestrator/kill concept) — structured against code,
   spec 0001 and the knowledge base by Claude
@@ -71,6 +73,14 @@ corrections with stale Polish — and TMS imports stay correct at any corpus sca
   whose key E1-F1 killed. The diff set doubles as the repair set for free. Coverage is total
   by construction, so the sampling-breadth knob disappears. Full data:
   `docs/knowledge-base/update-49/RESULTS.md` §E5; redesigned ticket: #565.
+  *Amended 2026-08-17 (ADR-0047):* the repair itself writes only through the per-row source guard —
+  in a wiped SubFile, a row whose fragment holds the English of its `source_digest` is restored
+  (collateral revert), a row holding any other text is `source moved` and skipped (the TMS
+  re-translates it). Detection (E5 metadata: *which SubFiles were replaced*) and admission
+  (ADR-0047: *which rows may be written*) are complementary layers; the guard is what makes the
+  repair safe without a verdict and offline (bullets below), and the snapshot refresh after a
+  successful repair is the self-limit — no persisted one-shot marker (its "per DAT-fingerprint"
+  key died with E1-F1 and was never replaced).
 - **Anti-masking handshake** (revised by **ADR-0045**, 2026-08-06 — the client never reads
   lotro.com): the distribution response carries the GameVersion the artifact was generated for
   **and a server-computed staleness verdict** ("does the TMS know an Unprocessed version newer
@@ -82,7 +92,15 @@ corrections with stale Polish — and TMS imports stay correct at any corpus sca
   unreachable TMS ⇒ treat as "do not force-patch". The verdict is valid only for the response
   that carried it and is never cached as authority. **Coverage limit:** the handshake gates the
   *forced* repair only; the routine hash-triggered patch is ungated (ADR-0045 Consequences).
-- Offline ⇒ never force-patch; proceed to launch (degrade to English for wiped rows).
+  *Amended 2026-08-17 (ADR-0047 §5):* **the verdict no longer gates the repair.** The no-masking
+  invariant is enforced per row at write time (artifact `source_digest` + local ledger — the
+  patcher writes a row only over the English it was translated from or over its own earlier
+  write), which also covers the pre-registration window the verdict never could. The verdict and
+  the artifact GameVersion (#562) stay as the preflight/UI signal; the sentinel repairs from the
+  local artifact whatever the verdict says.
+- ~~Offline ⇒ never force-patch; proceed to launch (degrade to English for wiped rows).~~
+  *Amended 2026-08-17 (ADR-0047):* offline ⇒ repair from the local artifact is **allowed** — the
+  guard makes it safe row by row; the launch still never blocks on the network (spec 0001 Q5).
 
 ### Tier 1 — update-day orchestrator (atomic UX; branches A/B/C)
 
@@ -91,20 +109,63 @@ state, not process semantics** (FileSystemWatcher + RW-open probe on the DAT):
 
 - **A — silent in-place patch:** probe succeeds while launcher sits at the login screen (DAT
   released after patch phase) ⇒ patch during credential typing. No kill, no restart, invisible.
-- **B — pre-creds launcher kill:** update quiesced but handle still held and lotroclient.exe not
+- **B — pre-creds launcher kill:** update quiesced but handle still held and `lotroclient64` not
   started ⇒ kill the LAUNCHER (pre-session UI shell — NOT the legacy client-kill), patch,
   relaunch launcher. One login total, reads as a normal update flow.
 - **C — player was faster (client running):** touch nothing; Tier 0 repairs next launch.
 - **Convergent re-patch loop:** after our patch, keep watching until game start; if the launcher
   writes the DAT again (next chunk burst), re-probe and re-patch. Early patches are harmless by
   construction; the last write wins. Kill (branch B) remains gated on a conservative quiesce
-  (30+ s no writes + launcher idle) because kill is the one invasive act. **E2-confirmed:** the
+  (30+ s no writes) because kill is the one invasive act. **E2-confirmed:** the
   download phase leaves the DAT free (~11 s window in the forced 48.8→49.1 replay) so a probe
   CAN succeed mid-update — the loop is what makes that harmless; the observed apply burst was
   ~1 s, making the 30 s quiesce very conservative for deltas of this size.
 - Rejected detectors: process-lifecycle signals (launcher exit / game start — structurally too
   late, that was legacy's error), and screenshot+LLM login-screen detection (dominated by the
   local file-state probe on cost, latency, offline operation, privacy and determinism).
+
+**Tier 1 rules — amended 2026-08-17** (adversarial review of #566; ADR-0047). The bullets above
+stay as the picture; where they are looser than the rules below, the rules win:
+
+1. **Every Tier-1 write goes through the guarded `PatchingService` (ADR-0047).** That is what makes
+   the pre-update artifact safe to apply *after* the launcher's burst: rows whose English changed
+   are skipped as `source moved`, collateral reverts are repaired. Without the guard the
+   post-apply patch masks by construction — #566 depends on #659.
+2. **What triggers a (re-)patch:** a **foreign** write burst that **changed the DAT size**
+   (the apply signature — E2: 1,893,807,856 → 1,894,856,432 B; the launcher's every-start write
+   leaves the size unchanged, E1-F1) followed by a successful probe, or a pending patch (hash
+   changed / sentinel detection) with a successful probe. The bare "the launcher wrote" event is
+   **not** a trigger — read literally it fires on every ordinary launch and degenerates into a
+   10–15 s re-patch per start, the very failure that killed the size+mtime fingerprint. Own writes
+   are filtered by suppressing the watcher during the patch plus a drain window (a generation
+   counter, never mtime — RESULTS.md: mtime volatility is unpredictable); a watcher buffer
+   overflow counts as activity, not silence.
+3. **Branch B is bounded per run, not "per detection":** **at most one kill per orchestrator run**
+   (one launch invocation). Preconditions, all required: an apply burst was observed in this run
+   (size changed) · a patch is pending · the probe has failed for 30+ s with no watcher activity ·
+   no `lotroclient64`. After the kill: guarded patch, then **relaunch unconditionally** (a failed
+   patch logs and still relaunches — never leave the player with a launcher we killed; note the
+   sibling `SimplifiedGameLaunchingStrategy` returns `RepatchFailed` *before* launching, do not
+   mirror that here). After the kill B is **disarmed for the rest of the run**; A and the loop stay
+   armed. "Launcher idle" is dropped — undefined; the list above is exhaustive.
+4. **B default-on is conditional on E6 (#660).** Its only safety gate is "no writes for 30 s while
+   the handle is held", and no experiment has shown that a watcher sees writes *during* a hold (E2
+   polled size/mtime, which moved only at burst end). If E6 says the watcher is blind mid-burst, a
+   long apply reads as silence and B kills mid-write — the case E4 never tested; then B ships
+   opt-in. Third-party holders (AV, backup, indexer, a second launcher) satisfy B's precondition
+   too — the one-kill cap is what keeps that harmless.
+5. **Terminators (not detectors):** game start (`lotroclient64` alive — by process **name**, not the
+   spawned PID: the launcher re-execs itself for UAC and `GameLauncher` drops the handle),
+   launcher exit with no client, and a wall-clock cap (implementation knob). On any terminator: one
+   last guarded patch if pending and the probe succeeds, then exit. Rejecting process signals as
+   *detectors* (structurally late) never forbade them as *terminators* — the design already uses
+   game start as one.
+6. **Play-mid-patch is accepted for MVP:** a client started during our exclusive hold cannot open
+   the DAT (E1: the client needs it for the whole session). Today's real artifact patches in
+   seconds, not the synthetic 14.7 s; the M4 GUI owns the "patching, please wait" UX; revisit the
+   repair-set (5.6 s, E3) if a real update day shows it hurting.
+7. Naming: `lotroclient64` (`x64\lotroclient64.exe`) everywhere; `IGameProcessDetector` cannot tell
+   the launcher from the client — B/C need their own port.
 
 ### Repair-set optimization (E3 verdict 2026-08-02: OPTIONAL, not required)
 
@@ -187,6 +248,10 @@ watcher (FileSystemWatcher cost ≈ zero).
 - **Q4 — Branch B default-on** with the one-shot guard per detection and the conservative
   quiesce (30+ s; E2 measured a ~1 s apply burst, so the margin is wide). Branch A stays the
   default path; B fires only when A is impossible.
+  *Amended 2026-08-17:* "per detection" was undefined and re-armed on the same file state after a
+  relaunch (its original key, "marker per DAT-fingerprint", died with E1-F1). Now: **at most one
+  kill per orchestrator run**, with the exhaustive precondition list of Tier 1 rule 3, and
+  **default-on only if E6 (#660) shows the quiesce is observable** — otherwise opt-in.
 - **Q5 — Placement: dedicated `UR` milestone**, gated before public launch — the patcher side
   (sentinel, orchestrator, forced-downgrade E2E) and the TMS side (echo-guard, artifact
   metadata/handshake, one-time source repair) ship under one milestone. Repair-set endpoint
@@ -198,6 +263,22 @@ watcher (FileSystemWatcher cost ≈ zero).
   the digit. Renumbering was rejected: it would break every `UR-nn` reference in ADR-0045, this
   spec and the ticket bodies to restore a signal nothing consumes.
 
+## Decisions — 2026-08-17 (after the #566 adversarial review; owner's invariant)
+
+- **Q6 — Masking is not a trade-off, it is an invariant violation.** Owner, verbatim in intent:
+  *if SSG changed a row's English in N+1 and the newest approved translation is for N, the player
+  sees English — whatever path writes the DAT.* Every write path (routine hash-patch, `patch`,
+  Tier 0, Tier 1 A/B/loop) is enforced **per row at write time in the patcher** — artifact
+  `source_digest` + local ledger, **ADR-0047**, ticket **#659** (UR-27), which now blocks #565 and
+  #566. ADR-0045's "accepted for now" routine-path masking is superseded; the verdict no longer
+  gates the repair. Decided by Claude under the owner's stated rule and mandate ("podejmiesz
+  decyzję za mnie") — the rule is the owner's, the mechanism follows from it.
+- **Q7 — Branch B: measure the gate before shipping the kill.** E6 (#660): does a
+  `FileSystemWatcher` see the launcher's writes while the DAT is held, or only at burst end? Until
+  the verdict, B is specified with the per-run cap and the exhaustive preconditions (Tier 1 rule
+  3) and its default-on is conditional (rule 4).
+- **Q8 — Play-mid-patch accepted for MVP** (Tier 1 rule 6); repair-set stays optional.
+
 Ticket cut (2026-08-02, extended 2026-08-06 by ADR-0045). Numbers are allocation order, **not**
 execution order — the real chains are:
 
@@ -207,6 +288,9 @@ execution order — the real chains are:
 - **#562** UR-22 → **#565** UR-10 Tier-0 wipe detection (iteration snapshot per E5) →
   **#566** UR-11 Tier-1 orchestrator → **#567** UR-12 forced-downgrade E2E
 - **#563** UR-20 import echo-guard → **#564** UR-21 one-time source repair
+- *(added 2026-08-17)* **#563** UR-20 (`SourceHash`) → **#659** UR-27 per-row source guard
+  (ADR-0047) → **#565** UR-10 and **#566** UR-11; **#660** UR-28 (E6, owner-run) → the branch-B
+  default of **#566**
 
 First real 49.1 import: **#559** (UR-02) — a manual ops run against a live game install, not a
 code ticket. It carries no milestone and stays that way: the backlog loop must never pick it up.
@@ -216,15 +300,29 @@ code ticket. It carries no milestone and stays that way: the backlog loop must n
 - [ ] After a simulated chunk-wipe (write-test DAT with a reverted SubFile), the next launch
       detects the revert via the ~~content sentinel~~ **iteration-snapshot diff (E5 revision)**
       and restores every artifact row (Tier 0).
-- [ ] Sentinel force-patches only when the server's staleness verdict says the artifact is
+- [ ] ~~Sentinel force-patches only when the server's staleness verdict says the artifact is
       current, and declines on stale/unknown/offline (handshake — ADR-0045; the client never
-      reads lotro.com and never compares versions itself).
+      reads lotro.com and never compares versions itself).~~ *Amended 2026-08-17 (ADR-0047):*
+      the client still never reads lotro.com and never compares versions; the repair is gated per
+      row by the source guard, not by the verdict, and runs offline.
+- [ ] **Invariant (ADR-0047, #659):** after the forced-downgrade replay applies 48.8→49.1, a
+      patch with the pre-update artifact leaves every row whose English changed in English and
+      repairs every collateral-reverted row — on every write path, offline, no version knowledge;
+      the `||` golden fixtures on both sides carry `source_digest` and round-trip; a six-column
+      translation file patches nothing and says why.
 - [ ] Orchestrator branch A: patch lands between launcher-release and Play without killing
       anything (E1 ✅ confirmed the window exists: DAT free at the login screen, full-corpus
       patch 14.7 s).
-- [ ] Orchestrator branch B: at most one launcher kill per detection, only pre-client,
-      only after conservative quiesce; relaunch reaches login cleanly (E4 ✅ confirmed clean,
-      3× reproduced).
+- [ ] Orchestrator branch B: at most one launcher kill **per run**, only pre-client, only after
+      an observed apply burst + a pending patch + 30 s of no observed writes; relaunch is
+      unconditional and reaches login cleanly (E4 ✅ confirmed clean, 3× reproduced — at the login
+      screen; a mid-apply kill is E6's question, #660).
+- [ ] Orchestrator loop: the launcher's every-start write (size unchanged) triggers **no**
+      re-patch; an apply burst (size changed) after our patch triggers exactly one guarded
+      re-patch; own writes never re-trigger.
+- [ ] Orchestrator terminates on game start, on launcher exit without a client, and on the
+      wall-clock cap — a player who closes the launcher without playing leaves no elevated process
+      behind.
 - [x] Echo-guard: importing a patched-DAT export against a translated corpus invalidates ONLY
       rows whose English actually changed (fixture: resident-Polish echo rows + one revert) —
       **#563 done 2026-08-17**: `TranslationDiffServiceTests` (echo matrix incl. the U49 shape),
@@ -237,6 +335,8 @@ code ticket. It carries no milestone and stays that way: the backlog loop must n
 ## Assumptions
 
 - Chunk/SubFile replacement model per `dat-protection.md` (9 live tests).
-- The official launcher's patcher is resumable/verifying (industry standard; E4/E2 sanity-check).
+- The official launcher's patcher is resumable/verifying (industry standard; E4/E2 sanity-check —
+  both from a coherent state: E4 killed at the login screen, E2 resumed from an older intact DAT;
+  a kill mid-apply is unverified, hence Tier 1 rule 4 / E6).
 - Patcher/TMS remain separate bounded contexts — repair-set and artifact-version travel through
   the HTTP contract, never shared code.


### PR DESCRIPTION
## What
Records a decision, no code: **ADR-0047** — stale Polish never lands over changed English; the patcher checks each row's source at write time (artifact `source_digest` + local ledger). Amends spec 0001 (physics section), spec 0012 (Tier 0/1 rules, Q4 amendment, Q6–Q8, AC, ticket chain), CLAUDE.md (house rule + routing row), and marks the ADR-0045 "accepted for now" masking bullet as superseded.

## Why
The owner stated the rule on 2026-08-17 as an invariant: if SSG changed a row's English in N+1 and the newest approved translation is still for N, the player sees English — whatever path writes the DAT. Spec 0001's exclusion enforces it only after the new export is imported; in the pre-import window the routine hash-patch (ADR-0045 accepted it), the sentinel (before version registration) and the update-day orchestrator (#566, by construction) all write the pre-update artifact over the new English. The verdict cannot close that window; a per-row check at write time can, on every path, offline.

The Tier 1 re-cut comes from an adversarial review of #566 (branch B / convergent loop): undefined "per detection" guard, launcher-write trigger that fires on every ordinary launch (E1-F1), no own-write filter, no terminator, non-unconditional relaunch, quiesce gate never measured. #566 and #565 were re-cut on GitHub in step with this spec.

## Tickets
- #659 (UR-27) — implements ADR-0047; blocks #565 and #566
- #660 (UR-28) — E6: is the branch-B quiesce observable at all (owner-run)
- #566 body rewritten, #565 amended (comments + Depends on)

Docs-only. Refs #659 #660 #565 #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
