### PR TITLE
UR-09: E5 results — the per-SubFile iteration snapshot IS the wipe signal (1,277/1,277, 0 missed)

### DIFF
--- a/docs/knowledge-base/README.md
+++ b/docs/knowledge-base/README.md
@@ -82,6 +82,14 @@ Detailed analysis: [datexport-readonly-open-2026-08-07.md](datexport-readonly-op
 - **Measurement trap:** `icacls /deny "(W)"` also denies `SYNCHRONIZE`, so it blocks reads and is not a Program Files proxy — build one with `/inheritance:r /grant:r "user:(RX)"` and assert both preconditions
 - Supersedes the "export from a backup copy" workaround in the 48.7 / 49 baselines; #443 Option A is delivered (#629)
 
+### E5 — a per-SubFile size/iteration snapshot detects SSG chunk replacement (2026-08-17)
+Detailed analysis: [update-49/RESULTS.md](update-49/RESULTS.md) §E5 · tool: `scripts/experiments/e5-subfile-metadata-snapshot.ps1` (#656/#657)
+- **Detector predicate: iteration moved ∨ FileId vanished = chunk replaced since our patch.** Ground-truth coverage 1,277/1,277 touched SubFiles (899 iteration + 378 removed), **0 missed**; negative control (plain launcher start) all-zero despite E1-F1's every-start mtime write
+- Measured on a LIVE update (49.1→49.3 hit mid-experiment: 57 replaced / +122 / −9, all caught); the 48.8 backup was diffed **offline** via `-DatPath` — full update-cycle measurement without touching the live install
+- One non-elevated read-only open + `GetSubfileSizes` = 0.2 s warm / 1.4 s cold; `size` is a subset of `iteration`, `Version` is dead as a signal
+- Redesigns Tier-0 (#565): metadata snapshot replaces content sampling; the diff set is the repair set; the ADR-0047 row-level guard stays (write admission, complementary)
+- PowerShell interop trap: loading datexport.dll by absolute path needs `LoadLibraryExW` + `LOAD_WITH_ALTERED_SEARCH_PATH` or its beside-the-DLL dependencies (msvcr71 & co.) don't resolve (win32 error 126)
+
 ### DAT Vnum — definitively schema-version, not content-version
 Detailed analysis: [vnum-observations.md](vnum-observations.md)
 - Vnum 112/3 unchanged across 45.x → 47.x → **48.0 major** → 48.7 → 48.8 → **49.1 major** — 6 cycles (two majors), zero movement (latest: [live-test-2026-08-02.md](live-test-2026-08-02.md))
@@ -96,7 +104,7 @@ Detailed analysis: [dat-export-diff-2026-03-22.md](dat-export-diff-2026-03-22.md
 
 ### LOTRO Update History
 Detailed analysis: [lotro-update-history.md](lotro-update-history.md)
-- 45.1 → 45.4.1 → 46 → 46.1 → 47 (major) → 47.1 → 47.1.1 → 47.2 → 48.0 (major, 2026-04-23) → 48.7 (2026-06-25) → 48.8 (observed 2026-07-11) → 49 "In Good Company" (major, 2026-07-22) → 49.1 (observed 2026-08-02)
+- 45.1 → 45.4.1 → 46 → 46.1 → 47 (major) → 47.1 → 47.1.1 → 47.2 → 48.0 (major, 2026-04-23) → 48.7 (2026-06-25) → 48.8 (observed 2026-07-11) → 49 "In Good Company" (major, 2026-07-22) → 49.1 (observed 2026-08-02) → 49.3 (observed 2026-08-17 during E5)
 - 48.0 content: Hatokáli Fells, Rhûn expansion, Deluxe housing, Edit UI feature
 
 ### Game Update Detection & Translation Versioning
@@ -168,7 +176,7 @@ Same shape as the folders above (quest text in synthetic LEGAL-08 equivalents). 
 | File | What it is |
 |------|-----------|
 | [`BASELINE.md`](update-49/BASELINE.md) | Pre-update 48.8 snapshot: DAT hash, export stats, the polish.txt fork after LEGAL-08 (repo file synthetic vs DAT-resident set), 8/8 survival baseline |
-| [`RESULTS.md`](update-49/RESULTS.md) | Full 48.8→49.1 results: 7/8 survival, the per-SubFile revert mechanism + counter-proof, diff stats, vnum, WRITE test |
+| [`RESULTS.md`](update-49/RESULTS.md) | Full 48.8→49.1 results: 7/8 survival, the per-SubFile revert mechanism + counter-proof, diff stats, vnum, WRITE test; experiments E1–E4 (2026-08-02) and E5 (2026-08-17, incl. the live 49.1→49.3 measurement) |
 
 No launch log this cycle — our `launch` was deliberately skipped (see RESULTS §deviation).
 

--- a/docs/knowledge-base/lotro-update-history.md
+++ b/docs/knowledge-base/lotro-update-history.md
@@ -6,6 +6,11 @@ originSessionId: fcf33c21-a957-445f-bc57-c8ea7814f1b6
 ---
 # LOTRO Update History (observed)
 
+> **Addendum (2026-08-17):** → **49.3** observed mid-E5-experiment (launcher-reported; 49.2 —
+> if it existed — was never observed). Small point patch: 57 text SubFiles replaced, +122 added,
+> −9 removed vs 49.1 (measured via per-SubFile metadata, not export diff). First update measured
+> by the E5 snapshot signal — see [update-49/RESULTS.md](update-49/RESULTS.md) §E5.
+
 > **Addendum (2026-08-02):** → **49 "In Good Company" (MAJOR, released 2026-07-22)** + point
 > patch **49.1** (forum fetch during our test returned "49.1"). Client updated 2026-08-02:
 > +2,270 text files / +7,192 fragments, DAT +1 MiB exactly (in-place chunk rewrites). Survival
@@ -27,6 +32,7 @@ originSessionId: fcf33c21-a957-445f-bc57-c8ea7814f1b6
 → 48.8 (point — observed 2026-07-11)
 → 49 "In Good Company" (MAJOR — released 2026-07-22) → 49.1 (point — observed 2026-08-02,
   together +7,192 fragments / +2,270 text files vs 48.8)
+→ 49.3 (point — observed 2026-08-17; 57 text SubFiles replaced, +122/−9; 49.2 unobserved)
 ```
 
 All observed with **vnum 112/3 unchanged** — see [vnum-observations.md](vnum-observations.md).
@@ -43,6 +49,7 @@ All observed with **vnum 112/3 unchanged** — see [vnum-observations.md](vnum-o
 | **2026-06-25** | **48.0 → 48.7 (point)** | **Second live update, first via SKIP path. 4-channel survival verified. datexport.dll READ+WRITE compat with 48.7. vnum 112/3 (4th cycle). Forum-fetcher returned "48.7".** |
 | 2026-07-11 | 48.7 → 48.8 (point) | First real-world AUDIT-SEC run; survival + forced live WRITE-path re-patch OK. Forum-fetcher returned "48.8". |
 | **2026-08-02** | **48.8 → 49.1 (MAJOR)** | **Third live update-test. Survival 7/8 — first per-SubFile revert (SubFile 620757435 modified → chunk replaced). datexport.dll READ+WRITE compat with 49.1. vnum 112/3 (6th cycle). Forum-fetcher returned "49.1". First cycle with the TMS deployed — export-49 feeds the first real spec-0001 import.** |
+| 2026-08-17 | 49.1 → 49.3 (point) | E5 experiment (#656): update hit mid-protocol and became the live measurement — per-SubFile iteration caught all 57 replaced text SubFiles; negative control (plain launch) all-zero; 48.8 backup diffed offline for the 1,277/1,277 ground-truth cross-check. |
 
 ## Major update 48.0 content (from diff analysis)
 

--- a/docs/knowledge-base/update-49/RESULTS.md
+++ b/docs/knowledge-base/update-49/RESULTS.md
@@ -386,9 +386,66 @@ przerwa 19:40:22–19:41:53 to restart monitora przez usera przy ekranie logowan
    wolatylność mtime jest nieprzewidywalna; finding E1-F1 (content-sentinel zamiast
    size+mtime) stoi w mocy.
 
+## Experiment E5 — per-SubFile size/iteration snapshot (2026-08-17, #656) — ✅ **SYGNAŁ DZIAŁA: pokrycie 1,277/1,277, zero przegapionych**
+
+**Metoda:** `scripts/experiments/e5-subfile-metadata-snapshot.ps1` (PR #657 + fix loadera):
+read-only open (#629, **bez elevacji**), jedno `GetSubfileSizes` → CSV
+`FileId,Size,Iteration[,Version]` dla wszystkich SubFile'ów; `-Diff` porównuje dwa CSV.
+Gotcha narzędziowa: w hoście PowerShell zależności datexport.dll (msvcr71, msvcp71/90, zlib1T —
+leżą obok niej w repo) wymagają `LoadLibraryExW` + `LOAD_WITH_ALTERED_SEARCH_PATH`; goły
+`LoadLibraryW` po ścieżce absolutnej umiera z win32 error 126, bo loader szuka zależności
+w katalogach hosta, nie DLL-ki.
+
+**Odchylenie od protokołu (szczęśliwe):** między baseline'em after-patch a startem launchera SSG
+wydał **realny update 49.1→49.3** — krok „plain launch" stał się pomiarem na żywym update, a
+kontrola negatywna została wykonana po nim (gra już aktualna). Podmiana DAT na backup 48.8
+okazała się **zbędna**: backup przediffowano **offline** przez `-DatPath` — nowa technika,
+pomiar pełnego cyklu update bez dotykania żywej instalacji i bez re-downloadu.
+
+Stany: 48.8 backup = 308,511 SubFile'ów (278,983 text) · 49.1 = 310,782 (281,253) ·
+49.3 = 310,895 (281,366).
+
+| Diff | size | iteration | version | added | removed |
+|---|---|---|---|---|---|
+| **Kontrola negatywna** (plain launch na 49.3, bez update) | **0** | **0** | **0** | **0** | **0** |
+| **Realny update 49.1→49.3** (after-patch ↔ po launcherze) | 56 (54 text) | **57 (55 text)** | 0 | 122 (122 text) | 9 (9 text) |
+| **48.8 backup ↔ live 49.3** (offline) | 725 (713 text) | **937 (921 text)** | 68 | 2,769 (2,768 text) | 385 (385 text) |
+
+W obu pomiarach `any changed` = `iteration changed` — **iteration sama pokrywa komplet ruchu**
+(size zgubił 1 SubFile przy realnym update i 212 przy 48.8→49.3; version to podzbiór iteration
+i przy realnym update nie drgnął wcale — jako sygnał jest martwy, pętlę `-IncludeVersion`
+można w detektorze pominąć).
+
+**Cross-check z ground truth** (diff eksportów 48.8→49.1; ekstrakcja FileId z hunków
+odtworzyła dokładnie **1,277** dotkniętych istniejących SubFile'ów z tego dokumentu):
+**899 złapanych jako ruch iteration + 378 jako removed = 1,277/1,277, 0 przegapionych.**
+Nowe-w-49: 2,642/2,644 obecne w `added` (brakujące 2 usunięte z powrotem przez 49.3 — spójne).
+Bonus: 49.3 usunął 378 z SubFile'ów dotkniętych przez 49.1 i dodał 2,769 nowych — SSG
+restrukturyzuje pliki między point-release'ami częściej, niż sugerował sam diff treści.
+
+**Wnioski (gating #565 / spec 0012 Tier 0):**
+
+1. **Predykat detektora: `iteration się ruszyła ∨ FileId zniknął` = chunk wymieniony od
+   naszego patcha.** Pokrycie 100% względem znanego ground truth, zero fałszywych pozytywów
+   (nasz `PatchingService` zachowuje iteration/version przy zapisie — potwierdzone: baseline
+   zdjęty tuż po patchu, dalsze snapshoty bez patcha, żadnego szumu własnego).
+2. **Kontrola negatywna czysta mimo E1-F1** — launcher pisze do DAT (mtime) przy każdym
+   starcie, ale per-SubFile metadata stoi w miejscu. Dokładnie tej separacji szukaliśmy.
+3. **Koszt:** open+`GetSubfileSizes` 0.21–0.23 s (warm) / 1.3–1.4 s (cold), bez elevacji —
+   tańszy niż dzisiejsza ścieżka SKIP z hashem pliku tłumaczeń.
+4. **Diff-set = repair-set za darmo** — detektor od razu wie, KTÓRE SubFile'e wymieniono
+   (repair-set i tak opcjonalny po E3, ale przychodzi gratis).
+5. **Tier-0 (#565) przechodzi z content-samplingu na snapshot metadanych:** przy `patch`
+   zapisujemy mapę FileId→Iteration; przy `launch` jeden call + diff. Pytanie o szerokość
+   próbkowania (K) znika w całości. Row-level source guard (ADR-0047/#659) zostaje bez zmian —
+   to warstwa admisji zapisu, komplementarna wobec detekcji (zgodnie z komentarzem na #565
+   z 2026-08-17).
+
 ## Pliki intel (gitignored `intel/update-49/`)
 
 DAT backupy 48.8 + 49 + write-test (po ~1.76 GB), pełne exporty 48.8/49 (82.6/83.1 MB), pełny
-diff (1.76 MB), snapshoty polish.txt (resident pre-LEGAL-08 + repo post-LEGAL-08) i version file.
+diff (1.76 MB), snapshoty polish.txt (resident pre-LEGAL-08 + repo post-LEGAL-08) i version file,
+snapshoty E5 (`e5-*.csv` + `.meta.txt`, ~7 MB każdy: after-patch, after-real-update-49.3,
+after-plain-launch, backup-48.8-offline + listy zmienionych tekstowych FileId).
 Committed tutaj: BASELINE.md + RESULTS.md (synthetic). Kopia robocza `data/exported.txt` =
 export 49.1 (SHA256 `56F6D046…32B00`) — deliverable do importu w TMS (GameVersion **49.1**).

--- a/docs/specs/0012-update-resilience.md
+++ b/docs/specs/0012-update-resilience.md
@@ -4,7 +4,9 @@
   per Q5 in the dedicated **UR** milestone); experiments: **ALL FOUR done 2026-08-02**
   (E1: DAT free at the login screen; E3: full corpus 14.7 s — repair-set not required; E4:
   pre-creds kill clean 3×; E2: full forced-downgrade update cycle recorded — download leaves
-  the DAT free, apply is a ~1 s lock burst, login screen post-update free). Results:
+  the DAT free, apply is a ~1 s lock burst, login screen post-update free) **+ E5 done
+  2026-08-17** (per-SubFile iteration snapshot = complete wipe signal, 1,277/1,277 coverage —
+  Tier-0 detection revised below, #565 redesigned). Results:
   `docs/knowledge-base/update-49/RESULTS.md` §Experiments — incl. findings E1-F1 (DAT mtime
   volatile ⇒ Tier-0 content-sentinel revision below) and the forced-downgrade method (repeatable
   update-cycle simulator; big-major burst shape still worth observing at the next real SSG major)
@@ -51,14 +53,24 @@ corrections with stale Polish — and TMS imports stay correct at any corpus sca
 - ~~DAT fingerprint (size + LastWriteTime)~~ **REVISED per E1-F1 (2026-08-02): the launcher
   writes the DAT on EVERY start** (mtime bumps at launcher check and at client start, with no
   translation loss), so a size+mtime fingerprint would false-positive every session and
-  degenerate Tier 0 into a force-re-patch-per-launch. Detection is a **content sentinel**
+  degenerate Tier 0 into a force-re-patch-per-launch. ~~Detection is a **content sentinel**
   instead: on launch, read a small sample of known-translated artifact fragments via the
   existing datexport READ path (milliseconds); any sampled fragment reverted to English ⇒
-  **force re-patch with a freshly synced artifact even when the translation-file hash
-  matches**. Sample choice: spread across distinct SubFiles (collateral reverts are
-  per-SubFile, so K sampled SubFiles detect a wipe of any of them; full certainty needs the
-  full artifact row-set — sampling breadth is an implementation knob). One-shot guard per
-  detection (no repair loops).
+  force re-patch. Sampling breadth is an implementation knob. One-shot guard per detection.~~
+  **REVISED AGAIN per E5 (2026-08-17, #656): detection is a per-SubFile ITERATION SNAPSHOT,
+  no content reads and no sampling.** E1-F1 killed only the whole-file fingerprint; E5 measured
+  the per-SubFile metadata underneath it and it is exactly the signal we wanted: one
+  non-elevated read-only open + `GetSubfileSizes` (~0.2 s) returns size+iteration for every
+  SubFile; predicate **`iteration moved ∨ FileId vanished` = chunk replaced since our patch**.
+  Proven on a live update (49.1→49.3) and against the 48.8→49.1 ground truth: 1,277/1,277
+  touched SubFiles covered, 0 missed, negative control all-zero (`Version` is dead; `size` a
+  strict subset of `iteration`; our own patch preserves both, so no self-noise; also closes
+  the byte-identical-replacement blind spot a content pair-diff has). The snapshot
+  (FileId → Iteration) is persisted after each successful patch and refreshed after a
+  successful repair — which makes the repair self-limiting, replacing the one-shot marker
+  whose key E1-F1 killed. The diff set doubles as the repair set for free. Coverage is total
+  by construction, so the sampling-breadth knob disappears. Full data:
+  `docs/knowledge-base/update-49/RESULTS.md` §E5; redesigned ticket: #565.
 - **Anti-masking handshake** (revised by **ADR-0045**, 2026-08-06 — the client never reads
   lotro.com): the distribution response carries the GameVersion the artifact was generated for
   **and a server-computed staleness verdict** ("does the TMS know an Unprocessed version newer
@@ -129,6 +141,7 @@ faster repair) — not a correctness or UX requirement.
 | E4 | Is a pre-creds launcher kill clean? | Kill at login screen → relaunch → verify straight-to-login + game boots | Safety of branch B | ✅ **clean, 3× reproduced** — relaunch indistinguishable from a normal start (UAC → DAT check → login); game boots fine |
 | E3 | Full-corpus patch duration | Synthetic ~100k+-row polish.txt → patch a DAT COPY → time it | Repair-set: optional vs required | ✅ **800,864 rows = 14.7 s; 21,660 = 5.6 s ⇒ repair-set optional** |
 | E2 | Handle behavior across a real update cycle (download vs apply bursts; slow-network hour-long updates) | **Forced downgrade** (swap live DAT for the 48.8 backup → launcher replays the real 48.8→49.1 cycle) + probe/writes timeline (`scripts/experiments/e2-dat-handle-monitor.ps1`) | Quiesce windows; whether probe-success can occur mid-update | ✅ **download leaves the DAT free (~11 s window, probe-success mid-update IS possible ⇒ convergent loop required & sufficient); apply = single ~1 s lock burst; post-update login screen free (branch A holds on update day); client holds the DAT for the whole session.** Caveat: ~5 MB delta — big-major burst shape TBD at the next real SSG major |
+| E5 | Does an SSG chunk replacement move per-SubFile size/iteration? (2026-08-17, #656) | Snapshot `(FileId,Size,Iteration,Version)` for all ~310k SubFiles via one `GetSubfileSizes` (`scripts/experiments/e5-subfile-metadata-snapshot.ps1`, non-elevated); diff after-patch vs after-update vs plain-launch; 48.8 backup diffed OFFLINE via `-DatPath` | Tier-0 detection: metadata snapshot vs content sentinel | ✅ **iteration+presence = complete signal: 1,277/1,277 ground-truth coverage (899 iteration + 378 removed, 0 missed); negative control 0/0/0 despite E1-F1; measured live on 49.1→49.3 (57 replaced, all caught); `Version` dead, `size` strict subset; 0.2 s warm / 1.4 s cold ⇒ #565 redesigned around it** |
 
 New lock-anatomy facts (2026-08-02, E1/E4 pass): `LotroLauncher.exe` manifests `asInvoker` and
 the game dir ACL grants Users only RX, but **the launcher prompts UAC and runs elevated on every
@@ -178,8 +191,8 @@ execution order — the real chains are:
 - **#624** UR-23 superseded version stays retirable → **#85** UR-24 forum watcher
 - **#562** UR-22 artifact version + verdict → **#626** UR-25 current-version endpoint + rel →
   **#627** UR-26 patcher drops the forum scrape
-- **#562** UR-22 → **#565** UR-10 Tier-0 content-sentinel → **#566** UR-11 Tier-1 orchestrator →
-  **#567** UR-12 forced-downgrade E2E
+- **#562** UR-22 → **#565** UR-10 Tier-0 wipe detection (iteration snapshot per E5) →
+  **#566** UR-11 Tier-1 orchestrator → **#567** UR-12 forced-downgrade E2E
 - **#563** UR-20 import echo-guard → **#564** UR-21 one-time source repair
 
 First real 49.1 import: **#559** (UR-02) — a manual ops run against a live game install, not a
@@ -188,7 +201,8 @@ code ticket. It carries no milestone and stays that way: the backlog loop must n
 ## Acceptance criteria (final per Q1–Q5)
 
 - [ ] After a simulated chunk-wipe (write-test DAT with a reverted SubFile), the next launch
-      detects the revert via the content sentinel and restores every artifact row (Tier 0).
+      detects the revert via the ~~content sentinel~~ **iteration-snapshot diff (E5 revision)**
+      and restores every artifact row (Tier 0).
 - [ ] Sentinel force-patches only when the server's staleness verdict says the artifact is
       current, and declines on stale/unknown/offline (handshake — ADR-0045; the client never
       reads lotro.com and never compares versions itself).

--- a/scripts/experiments/e5-subfile-metadata-snapshot.ps1
+++ b/scripts/experiments/e5-subfile-metadata-snapshot.ps1
@@ -228,9 +228,14 @@ public static class E5Native
 {
     // Pre-loading by absolute path pins the module the later DllImport("datexport.dll") calls bind
     // to, so the loader never probes the working directory or %PATH% (the DLL-planting guard the
-    // production interop gets from DefaultDllImportSearchPaths).
+    // production interop gets from DefaultDllImportSearchPaths). LOAD_WITH_ALTERED_SEARCH_PATH is
+    // required: datexport.dll's own dependencies (msvcr71, msvcp71/90, zlib1T - committed beside
+    // it) must resolve from ITS directory, not the PowerShell host's, or the load dies with
+    // win32 error 126.
+    public const uint LoadWithAlteredSearchPath = 0x8;
+
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    public static extern IntPtr LoadLibraryW(string lpFileName);
+    public static extern IntPtr LoadLibraryExW(string lpFileName, IntPtr hFile, uint dwFlags);
 
     [DllImport("datexport.dll", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
     public static extern int OpenDatFileEx2(
@@ -265,9 +270,9 @@ public static class E5Native
 }
 '@
 
-if ([E5Native]::LoadLibraryW($resolvedDll) -eq [IntPtr]::Zero)
+if ([E5Native]::LoadLibraryExW($resolvedDll, [IntPtr]::Zero, [E5Native]::LoadWithAlteredSearchPath) -eq [IntPtr]::Zero)
 {
-    throw "LoadLibrary failed for $resolvedDll (win32 error $([Runtime.InteropServices.Marshal]::GetLastWin32Error()))"
+    throw "LoadLibraryExW failed for $resolvedDll (win32 error $([Runtime.InteropServices.Marshal]::GetLastWin32Error()))"
 }
 
 # 2 | ReadOnly(4). Bit 0x4 is what makes the native library ask the OS for GENERIC_READ only, which

--- a/scripts/experiments/e5-subfile-metadata-snapshot.ps1
+++ b/scripts/experiments/e5-subfile-metadata-snapshot.ps1
@@ -1,5 +1,5 @@
 # E5 per-SubFile metadata snapshot (spec 0012 / #656): does an SSG chunk replacement move a
-# SubFile's stored size or iteration number?
+# SubFile's stored size, iteration number or version?
 #
 # Why: the Tier-0 sentinel of #565 samples fragment CONTENT because finding E1-F1 killed the
 # whole-file size+mtime fingerprint. The per-SubFile metadata in between was never measured, and
@@ -22,6 +22,9 @@
 #   4. optional, after logging in and entering the game (the client writes at session start too):
 #                           .\e5-subfile-metadata-snapshot.ps1 -Label after-session
 #
+# Add -IncludeVersion to any snapshot to also record the per-SubFile version (one native call per
+# SubFile, timed separately so the one-call size+iteration cost stays visible).
+#
 # Then diff. Snapshot 2 vs 1 is the negative control and MUST be empty for the signal to be
 # usable; snapshot 3 vs 1 is the measurement:
 #   .\e5-subfile-metadata-snapshot.ps1 -Diff -Baseline <after-patch.csv> -Compare <after-update.csv>
@@ -41,6 +44,9 @@ param(
 
     [Parameter(ParameterSetName = 'Snapshot')]
     [string]$OutDir = (Join-Path $PSScriptRoot '..\..\intel\update-49'),
+
+    [Parameter(ParameterSetName = 'Snapshot')]
+    [switch]$IncludeVersion,
 
     [Parameter(ParameterSetName = 'Diff', Mandatory = $true)]
     [switch]$Diff,
@@ -63,58 +69,72 @@ function Test-IsTextFile([int]$fileId)
     return ($fileId -shr 24) -eq $TextFileMarker
 }
 
+# CSV shape: FileId,Size,Iteration[,Version]. Read by hand instead of Import-Csv - 300k
+# PSCustomObjects per file take minutes in Windows PowerShell 5.1, plain lines take seconds.
+function Read-Snapshot([string]$path)
+{
+    if (-not (Test-Path -LiteralPath $path))
+    {
+        throw "Snapshot not found: $path"
+    }
+
+    $lines = [System.IO.File]::ReadAllLines($path)
+    if ($lines.Length -lt 2)
+    {
+        throw "Snapshot has no rows: $path"
+    }
+
+    $columns = $lines[0].Split(',')
+    $map = [System.Collections.Generic.Dictionary[int, string[]]]::new($lines.Length)
+    for ($i = 1; $i -lt $lines.Length; $i++)
+    {
+        $parts = $lines[$i].Split(',')
+        if ($parts.Length -lt 3)
+        {
+            continue
+        }
+        $map[[int]$parts[0]] = $parts
+    }
+
+    return @{ Columns = $columns; Map = $map }
+}
+
 function Invoke-Diff([string]$baselinePath, [string]$comparePath)
 {
-    foreach ($path in @($baselinePath, $comparePath))
-    {
-        if (-not (Test-Path -LiteralPath $path))
-        {
-            throw "Snapshot not found: $path"
-        }
-    }
-
-    $baselineRows = Import-Csv -LiteralPath $baselinePath
-    $compareRows = Import-Csv -LiteralPath $comparePath
-
-    $baselineMap = @{}
-    foreach ($row in $baselineRows)
-    {
-        $baselineMap[[int]$row.FileId] = @{ Size = [int]$row.Size; Iteration = [int]$row.Iteration }
-    }
-
-    $compareMap = @{}
-    foreach ($row in $compareRows)
-    {
-        $compareMap[[int]$row.FileId] = @{ Size = [int]$row.Size; Iteration = [int]$row.Iteration }
-    }
+    $baseline = Read-Snapshot $baselinePath
+    $compare = Read-Snapshot $comparePath
+    $hasVersion = ($baseline.Columns -contains 'Version') -and ($compare.Columns -contains 'Version')
 
     $sizeChanged = [System.Collections.Generic.List[int]]::new()
     $iterationChanged = [System.Collections.Generic.List[int]]::new()
-    $eitherChanged = [System.Collections.Generic.List[int]]::new()
+    $versionChanged = [System.Collections.Generic.List[int]]::new()
+    $anyChanged = [System.Collections.Generic.List[int]]::new()
     $added = [System.Collections.Generic.List[int]]::new()
     $removed = [System.Collections.Generic.List[int]]::new()
 
-    foreach ($fileId in $compareMap.Keys)
+    foreach ($fileId in $compare.Map.Keys)
     {
-        if (-not $baselineMap.ContainsKey($fileId))
+        if (-not $baseline.Map.ContainsKey($fileId))
         {
             [void]$added.Add($fileId)
             continue
         }
 
-        $before = $baselineMap[$fileId]
-        $after = $compareMap[$fileId]
-        $sizeMoved = $before.Size -ne $after.Size
-        $iterationMoved = $before.Iteration -ne $after.Iteration
+        $before = $baseline.Map[$fileId]
+        $after = $compare.Map[$fileId]
+        $sizeMoved = $before[1] -ne $after[1]
+        $iterationMoved = $before[2] -ne $after[2]
+        $versionMoved = $hasVersion -and ($before[3] -ne $after[3])
 
         if ($sizeMoved) { [void]$sizeChanged.Add($fileId) }
         if ($iterationMoved) { [void]$iterationChanged.Add($fileId) }
-        if ($sizeMoved -or $iterationMoved) { [void]$eitherChanged.Add($fileId) }
+        if ($versionMoved) { [void]$versionChanged.Add($fileId) }
+        if ($sizeMoved -or $iterationMoved -or $versionMoved) { [void]$anyChanged.Add($fileId) }
     }
 
-    foreach ($fileId in $baselineMap.Keys)
+    foreach ($fileId in $baseline.Map.Keys)
     {
-        if (-not $compareMap.ContainsKey($fileId))
+        if (-not $compare.Map.ContainsKey($fileId))
         {
             [void]$removed.Add($fileId)
         }
@@ -124,27 +144,35 @@ function Invoke-Diff([string]$baselinePath, [string]$comparePath)
 
     Write-Host ''
     Write-Host "E5 diff" -ForegroundColor Cyan
-    Write-Host "  baseline : $baselinePath ($($baselineMap.Count) subfiles)"
-    Write-Host "  compare  : $comparePath ($($compareMap.Count) subfiles)"
+    Write-Host "  baseline : $baselinePath ($($baseline.Map.Count) subfiles)"
+    Write-Host "  compare  : $comparePath ($($compare.Map.Count) subfiles)"
     Write-Host ''
     Write-Host "  size changed      : $($sizeChanged.Count)   (text: $(& $textOf $sizeChanged))"
     Write-Host "  iteration changed : $($iterationChanged.Count)   (text: $(& $textOf $iterationChanged))"
-    Write-Host "  either changed    : $($eitherChanged.Count)   (text: $(& $textOf $eitherChanged))"
+    if ($hasVersion)
+    {
+        Write-Host "  version changed   : $($versionChanged.Count)   (text: $(& $textOf $versionChanged))"
+    }
+    else
+    {
+        Write-Host "  version changed   : n/a (take both snapshots with -IncludeVersion to compare it)"
+    }
+    Write-Host "  any changed       : $($anyChanged.Count)   (text: $(& $textOf $anyChanged))"
     Write-Host "  added             : $($added.Count)   (text: $(& $textOf $added))"
     Write-Host "  removed           : $($removed.Count)   (text: $(& $textOf $removed))"
     Write-Host ''
 
-    if ($eitherChanged.Count -eq 0 -and $added.Count -eq 0 -and $removed.Count -eq 0)
+    if ($anyChanged.Count -eq 0 -and $added.Count -eq 0 -and $removed.Count -eq 0)
     {
         Write-Host "  VERDICT: no movement at all between these two snapshots." -ForegroundColor Yellow
         Write-Host "  As a negative control that is the PASS we want. As the post-update measurement" -ForegroundColor Yellow
         Write-Host "  it means the signal is dead and #565 stays a content sentinel." -ForegroundColor Yellow
     }
 
-    $changedTextIds = @($eitherChanged | Where-Object { Test-IsTextFile $_ } | Sort-Object)
+    $changedTextIds = @($anyChanged | Where-Object { Test-IsTextFile $_ } | Sort-Object)
     $compareItem = Get-Item -LiteralPath $comparePath
     $outPath = Join-Path $compareItem.DirectoryName ($compareItem.BaseName + '-changed-text-fileids.txt')
-    Set-Content -LiteralPath $outPath -Value $changedTextIds -Encoding ASCII
+    [System.IO.File]::WriteAllLines($outPath, [string[]]$changedTextIds)
     Write-Host "  changed TEXT FileIds written to: $outPath"
     Write-Host "  Cross-check these against the 1,277 SubFiles the 48.8 vs 49.1 export pair-diff"
     Write-Host "  already knows were touched (update-49/RESULTS.md) - overlap is the real proof."
@@ -168,8 +196,14 @@ if ([Environment]::Is64BitProcess)
     }
 
     Write-Host "64-bit host detected - relaunching in 32-bit PowerShell (datexport.dll is x86)..." -ForegroundColor DarkGray
-    & $wow -ExecutionPolicy Bypass -NoProfile -File $PSCommandPath `
-        -DatPath $DatPath -Label $Label -DllPath $DllPath -OutDir $OutDir
+    $relaunchArgs = @(
+        '-ExecutionPolicy', 'Bypass', '-NoProfile', '-File', $PSCommandPath,
+        '-DatPath', $DatPath, '-Label', $Label, '-DllPath', $DllPath, '-OutDir', $OutDir)
+    if ($IncludeVersion)
+    {
+        $relaunchArgs += '-IncludeVersion'
+    }
+    & $wow @relaunchArgs
     exit $LASTEXITCODE
 }
 
@@ -224,6 +258,9 @@ public static class E5Native
         int count);
 
     [DllImport("datexport.dll", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int GetSubfileVersion(int datFileHandle, int fileId);
+
+    [DllImport("datexport.dll", CallingConvention = CallingConvention.Cdecl)]
     public static extern void CloseDatFile(int datFileHandle);
 }
 '@
@@ -251,7 +288,7 @@ $datFile = Get-Item -LiteralPath $resolvedDat
 $processes = (Get-Process -Name LotroLauncher, lotroclient, lotroclient64 -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }) -join '+'
 if (-not $processes) { $processes = 'none' }
 
-$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+$sizesWatch = [System.Diagnostics.Stopwatch]::StartNew()
 
 $handle = [E5Native]::OpenDatFileEx2(
     $requestedHandle, $resolvedDat, $openFlagsRead,
@@ -262,6 +299,9 @@ if ($handle -ne $requestedHandle)
 {
     throw "OpenDatFileEx2 failed (returned $handle, expected $requestedHandle). Is the client running and holding the DAT?"
 }
+
+$versions = $null
+$versionMs = 0
 
 try
 {
@@ -276,13 +316,24 @@ try
     $iterations = New-Object int[] $count
 
     [E5Native]::GetSubfileSizes($handle, $fileIds, $sizes, $iterations, 0, $count)
+    $sizesWatch.Stop()
+
+    if ($IncludeVersion)
+    {
+        $versionWatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $versions = New-Object int[] $count
+        for ($i = 0; $i -lt $count; $i++)
+        {
+            $versions[$i] = [E5Native]::GetSubfileVersion($handle, $fileIds[$i])
+        }
+        $versionWatch.Stop()
+        $versionMs = $versionWatch.ElapsedMilliseconds
+    }
 }
 finally
 {
     [E5Native]::CloseDatFile($handle)
 }
-
-$stopwatch.Stop()
 
 if (-not (Test-Path -LiteralPath $OutDir))
 {
@@ -293,10 +344,21 @@ $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 $csvPath = Join-Path $OutDir "e5-$Label-$timestamp.csv"
 
 $builder = [System.Text.StringBuilder]::new()
-[void]$builder.AppendLine('FileId,Size,Iteration')
-for ($i = 0; $i -lt $count; $i++)
+if ($IncludeVersion)
 {
-    [void]$builder.AppendLine("$($fileIds[$i]),$($sizes[$i]),$($iterations[$i])")
+    [void]$builder.AppendLine('FileId,Size,Iteration,Version')
+    for ($i = 0; $i -lt $count; $i++)
+    {
+        [void]$builder.AppendLine("$($fileIds[$i]),$($sizes[$i]),$($iterations[$i]),$($versions[$i])")
+    }
+}
+else
+{
+    [void]$builder.AppendLine('FileId,Size,Iteration')
+    for ($i = 0; $i -lt $count; $i++)
+    {
+        [void]$builder.AppendLine("$($fileIds[$i]),$($sizes[$i]),$($iterations[$i])")
+    }
 }
 [System.IO.File]::WriteAllText($csvPath, $builder.ToString())
 
@@ -308,25 +370,30 @@ for ($i = 0; $i -lt $count; $i++)
 
 $metaPath = Join-Path $OutDir "e5-$Label-$timestamp.meta.txt"
 @(
-    "label            : $Label"
-    "taken            : $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
-    "dat              : $resolvedDat"
-    "dat size (B)     : $($datFile.Length)"
-    "dat mtime        : $($datFile.LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss'))"
-    "vnumDatFile      : $vnumDatFile"
-    "vnumGameData     : $vnumGameData"
-    "subfiles total   : $count"
-    "subfiles text    : $textCount"
-    "running procs    : $processes"
-    "read duration ms : $($stopwatch.ElapsedMilliseconds)"
+    "label                 : $Label"
+    "taken                 : $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+    "dat                   : $resolvedDat"
+    "dat size (B)          : $($datFile.Length)"
+    "dat mtime             : $($datFile.LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss'))"
+    "vnumDatFile           : $vnumDatFile"
+    "vnumGameData          : $vnumGameData"
+    "subfiles total        : $count"
+    "subfiles text         : $textCount"
+    "running procs         : $processes"
+    "open+sizes call ms    : $($sizesWatch.ElapsedMilliseconds)"
+    "version loop ms       : $(if ($IncludeVersion) { $versionMs } else { 'skipped' })"
 ) | Set-Content -LiteralPath $metaPath -Encoding UTF8
 
 Write-Host ''
-Write-Host "E5 snapshot '$Label' taken in $($stopwatch.ElapsedMilliseconds) ms" -ForegroundColor Green
-Write-Host "  subfiles : $count total, $textCount text"
-Write-Host "  csv      : $csvPath"
-Write-Host "  meta     : $metaPath"
+Write-Host "E5 snapshot '$Label' taken - open + GetSubfileSizes in $($sizesWatch.ElapsedMilliseconds) ms" -ForegroundColor Green
+if ($IncludeVersion)
+{
+    Write-Host "  version loop : $versionMs ms ($count per-SubFile calls)"
+}
+Write-Host "  subfiles     : $count total, $textCount text"
+Write-Host "  csv          : $csvPath"
+Write-Host "  meta         : $metaPath"
 Write-Host ''
-Write-Host "The read duration above is the cost the whole Tier-0 detector would pay per launch if"
+Write-Host "The open + sizes duration is the cost the whole Tier-0 detector would pay per launch if"
 Write-Host "this signal turns out to work. Note it in the E5 write-up."
 Write-Host ''


### PR DESCRIPTION
Related to #656 (already closed by the tool PR #657 — this PR lands the experiment's RESULTS and the one fix the live run required). Gates the redesign of #565.

## What this delivers

- **Fix:** the E5 snapshot script loads datexport.dll via `LoadLibraryExW` + `LOAD_WITH_ALTERED_SEARCH_PATH` — plain `LoadLibraryW` dies with win32 error 126 because the DLL's beside-it dependencies (msvcr71, msvcp71/90, zlib1T) don't resolve from the PowerShell host's directories.
- **Knowledge base:** `update-49/RESULTS.md` §E5 (full measurement tables + gating conclusions), README index entry, update history (49.3 observed 2026-08-17 mid-experiment).
- **Spec 0012:** Tier-0 detection revised — content sentinel superseded by the iteration snapshot; E5 row added to the experiments table. The handshake/verdict wording is deliberately untouched (PR #661 / ADR-0047 owns that revision).

## The measurement (2026-08-17, live Windows box, non-elevated)

| Diff | size | iteration | version | added | removed |
|---|---|---|---|---|---|
| Negative control (plain launch, no update) | 0 | 0 | 0 | 0 | 0 |
| Real update 49.1→49.3 (hit mid-protocol) | 56 | **57** | 0 | 122 | 9 |
| 48.8 backup ↔ live 49.3 (offline via `-DatPath`) | 725 | **937** | 68 | 2,769 | 385 |

Ground-truth cross-check (export pair-diff 48.8→49.1): **1,277/1,277 touched SubFiles covered** (899 iteration-moved + 378 vanished), **0 missed**. `any changed` = `iteration changed` in every measurement; `Version` never moved on the real update. Cost: 0.21–0.23 s warm / 1.3–1.4 s cold per snapshot.

Ticket follow-through already done: results comment on #656, #565 rewritten (content sampling → snapshot detector; comment documents which prior corrections became obsolete), wrapper-args UAC bug found en route filed as #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHtpfH3FugX3rc28Ammg5K