### PR TITLE
Loop: gitignore the conductor's lock — the worker preflight has aborted every ticket since #465

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -500,6 +500,10 @@ data/
 
 # Claude lock files
 .claude/scheduled_tasks.lock
+# The backlog conductor's mutex (scripts/claude/backlog-loop.sh). Since #465 it holds a `pid`
+# file, so an unignored lock shows up as `?? .claude/backlog-loop.lock/` and the worker's
+# clean-tree preflight aborts every ticket with "dirty working copy" — the loop could not start.
+.claude/backlog-loop.lock/
 
 # Claude per-user settings
 .claude/settings.local.json


### PR DESCRIPTION
One-line fix to a month-old regression in the autonomous loop.

`scripts/claude/backlog-loop.sh` takes a mutex at `.claude/backlog-loop.lock/` and, since #465 (2026-07-12), writes its `pid` inside. That directory was never gitignored. An empty directory is invisible to `git status`, a directory with a file is not — so every conductor run since then has shown `?? .claude/backlog-loop.lock/` to `work-ticket.sh`, whose clean-tree preflight aborts with **"dirty working copy — commit or stash before running the loop"** before any worker starts. The last successful conductor run (`scheduled-20260712-003115`) predates #465 by hours; nothing ran the conductor afterwards, so nobody saw it.

Reproduced today: `backlog-loop.sh 659` aborted twice on a clean tree; `work-ticket.sh 659` invoked directly passed and is working the ticket.

Fix: ignore `.claude/backlog-loop.lock/` in `.gitignore`, with the why next to it. No script change — the preflight is right to demand a clean tree; the lock just is not user work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)