### PR TITLE
/ticket: optional /buddy step on the plan

### DIFF
--- a/.claude/commands/ticket.md
+++ b/.claude/commands/ticket.md
@@ -66,6 +66,18 @@ Step 0 already left you on a clean, fresh `main`; anything dirty now is this ses
 - **Never work on `main` directly.** If for any reason you find yourself past step 0 with commits
   to make and no ticket branch yet, cut the branch first — nothing is ever committed to `main`.
 
+## 4.5 Buddy the plan — run it when you judge it's worth it
+
+Before writing code, ask whether the approach rests on something you never actually checked. If it
+does, run **`/buddy`** on the plan: a fresh isolated agent that receives your reasoning as numbered
+claims and a mandate to refute them against the code. This is your call — no permission needed,
+just run it and say you did.
+
+Signals it earns its cost: the ticket was spec-worthy, you picked between approaches, you leaned on
+a `docs/knowledge-base/` finding or an ADR ruling, or one load-bearing assumption decides the whole
+slice. A crisp small bug/refactor does not need it — same spirit as "small diff = zero agents".
+Running it here is cheaper than learning the same thing from `code-reviewer` after 250 lines.
+
 ## 5. Implement
 
 Follow the `/feature` discipline: mirror the sibling slice; slim SRP handler (record + handler +


### PR DESCRIPTION
## What
Adds step 4.5 to `.claude/commands/ticket.md`, between "Branch" and "Implement": if the model judges the approach rests on an unchecked assumption, it runs `/buddy` on the plan.

## Why
`/ticket` already has an isolated review gate (`code-reviewer` in step 6), but that runs on the written diff. A wrong approach is found there only after the code exists. `/buddy` spawns a fresh, unnamed agent that gets the reasoning as numbered claims and a mandate to refute them against the code - so the check happens before the slice is built.

## Not a gate
No permission needed, no hard rule. Trivial tickets skip it, same spirit as the existing "small diff = zero agents" house rule in CLAUDE.md. Only `/ticket` changed; the headless loop (`work-ticket.md`) and `qa-ticket.md` are untouched.

Mirrors TheKittySaver PR #499.

## Test
Docs-only change to a slash command; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFwJwbHfxEUtpYcq4wPg3E