### PR TITLE
[BUG] Cookie bar covers the legal footer links on mobile — "Regulamin" and "Polityka prywatności" unreachable

### DIFF
--- a/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
+++ b/src/Frontend/LotroKoniecDev.Frontend/wwwroot/layout.css
@@ -1570,10 +1570,14 @@ code {
 }
 
 /* ───────── Cookie consent bar ───────── */
+/* Sticky, never fixed (#672) — the same idiom as .nav above, at the other edge. Fixed put the bar out
+   of flow, so nothing reserved space for it and it sat on top of the end of the document, burying the
+   footer's legal links at maximum scroll. In flow as the last child of the .app column it reserves
+   exactly the height its copy wraps to, so the footer always comes to rest above it, and it is still
+   pinned to the bottom edge while anything is left to scroll. Accepted means not rendered at all, so
+   nothing is left reserved behind it. */
 .cookie-bar {
-    position: fixed;
-    left: 0;
-    right: 0;
+    position: sticky;
     bottom: 0;
     z-index: 60;
     border-top: 1px solid var(--border-hi);

--- a/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/CookieConsentBannerTests.cs
+++ b/tests/LotroKoniecDev.Frontend.E2E.Tests/Flows/CookieConsentBannerTests.cs
@@ -5,13 +5,21 @@ using Shouldly;
 namespace LotroKoniecDev.Frontend.E2E.Tests.Flows;
 
 /// <summary>
-/// LEGAL-04 — the cookie information banner's acceptance criteria, pinned in a real browser with
-/// <em>JavaScript disabled</em>: a new visitor sees the banner on any page, accepting it (a plain
-/// SSR form post — no script) hides it everywhere, and the consent survives navigation. Needs no
-/// account and no seeded database — the banner is anonymous by design.
+/// LEGAL-04 — the cookie information banner's acceptance criteria, pinned in a real browser: with
+/// <em>JavaScript disabled</em>, a new visitor sees the banner on any page, accepting it (a plain
+/// SSR form post — no script) hides it everywhere, and the consent survives navigation; and on a
+/// phone-sized viewport the bar stays pinned to the bottom edge yet leaves the footer's legal links
+/// reachable (#672). Needs no account and no seeded database — the banner is anonymous by design.
 /// </summary>
 public sealed class CookieConsentBannerTests : E2ETestBase
 {
+    private const string BannerLabel = "Informacja o plikach cookie";
+    private const string AcceptButtonName = "Akceptuję";
+    private const string TermsLinkName = "Regulamin";
+    private const string PrivacyPolicyLinkName = "Polityka prywatności";
+    private const int PhoneViewportWidth = 390;
+    private const int PhoneViewportHeight = 844;
+
     public CookieConsentBannerTests(PlaywrightStackFixture fixture) : base(fixture)
     {
     }
@@ -31,7 +39,7 @@ public sealed class CookieConsentBannerTests : E2ETestBase
 
         // A brand-new visitor sees the banner on the home page…
         await page.GotoAsync($"{Fixture.FrontendBaseUrl}/");
-        ILocator banner = page.GetByRole(AriaRole.Region, new() { Name = "Informacja o plikach cookie" });
+        ILocator banner = page.GetByRole(AriaRole.Region, new() { Name = BannerLabel });
         await banner.WaitForAsync();
 
         // …and on any other page.
@@ -39,7 +47,7 @@ public sealed class CookieConsentBannerTests : E2ETestBase
         (await banner.IsVisibleAsync()).ShouldBeTrue();
 
         // Accepting is a plain form post that works without JavaScript.
-        await page.GetByRole(AriaRole.Button, new() { Name = "Akceptuję", Exact = true }).ClickAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = AcceptButtonName, Exact = true }).ClickAsync();
         await banner.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Detached });
 
         // The accept redirect returns to the page the form was posted from.
@@ -49,4 +57,122 @@ public sealed class CookieConsentBannerTests : E2ETestBase
         await page.GotoAsync($"{Fixture.FrontendBaseUrl}/");
         (await banner.IsVisibleAsync()).ShouldBeFalse();
     }
+
+    /// <summary>
+    /// #672, the half of the trade that is easy to lose: the bar is sticky rather than in normal flow,
+    /// so it is still glued to the bottom edge of the viewport at the top of a long page. A plain
+    /// in-flow bar would satisfy the reachability test below just as well while scrolling the consent
+    /// notice off-screen entirely — which is LEGAL-04's whole point — so it is asserted separately.
+    /// </summary>
+    [Fact]
+    public async Task Banner_on_a_phone_viewport_stays_pinned_to_the_bottom_edge_while_the_page_can_still_scroll()
+    {
+        await using IBrowserContext phoneContext = await NewPhoneContextAsync();
+        IPage page = await OpenTermsPageAsync(phoneContext);
+        ILocator banner = page.GetByRole(AriaRole.Region, new() { Name = BannerLabel });
+        await banner.WaitForAsync();
+
+        // The terms page is far taller than the viewport, so an in-flow bar would be below the fold.
+        LocatorBoundingBoxResult bar = await RequireBoundingBoxAsync(banner);
+
+        (bar.Y + bar.Height).ShouldBe(PhoneViewportHeight, 1d);
+    }
+
+    /// <summary>
+    /// #672 — the bar used to be <c>position: fixed</c>, i.e. out of flow, so at the end of the page it
+    /// sat on top of the last ~165px of the document: exactly where "Regulamin" and "Polityka
+    /// prywatności" live, the two links a visitor who has not consented yet most needs. The invariant
+    /// is stated at <em>maximum scroll</em> on purpose — a bar pinned to the bottom edge passes over
+    /// the footer mid-scroll by design, and it is where the visitor comes to rest that must be clear.
+    /// JavaScript is on here purely as the test's measuring tape (scroll to the end, read boxes); the
+    /// banner's own no-JavaScript contract is pinned by the JS-less test above.
+    /// </summary>
+    [Fact]
+    public async Task Banner_on_a_phone_viewport_leaves_the_legal_footer_links_reachable_at_the_end_of_the_page()
+    {
+        await using IBrowserContext phoneContext = await NewPhoneContextAsync();
+        IPage page = await OpenTermsPageAsync(phoneContext);
+        ILocator banner = page.GetByRole(AriaRole.Region, new() { Name = BannerLabel });
+        await banner.WaitForAsync();
+        ILocator footer = page.GetByRole(AriaRole.Contentinfo);
+        ILocator termsLink = footer.GetByRole(AriaRole.Link, new() { Name = TermsLinkName, Exact = true });
+        ILocator privacyPolicyLink = footer.GetByRole(AriaRole.Link, new() { Name = PrivacyPolicyLinkName, Exact = true });
+
+        // Act — a first-time visitor hunting for the legal texts scrolls to the very end of the page.
+        await ScrollToBottomAsync(page);
+
+        // Assert — the whole footer comes to rest above the bar, which is strictly stronger than the
+        // two links doing so, and both links really take a tap: the trial click runs Playwright's
+        // hit-target check, so an element painted over the link fails it.
+        LocatorBoundingBoxResult bar = await RequireBoundingBoxAsync(banner);
+        LocatorBoundingBoxResult footerBox = await RequireBoundingBoxAsync(footer);
+        LocatorBoundingBoxResult termsBox = await RequireBoundingBoxAsync(termsLink);
+        LocatorBoundingBoxResult privacyPolicyBox = await RequireBoundingBoxAsync(privacyPolicyLink);
+
+        (footerBox.Y + footerBox.Height).ShouldBeLessThanOrEqualTo(bar.Y + 1);
+        (termsBox.Y + termsBox.Height).ShouldBeLessThanOrEqualTo(bar.Y);
+        (privacyPolicyBox.Y + privacyPolicyBox.Height).ShouldBeLessThanOrEqualTo(bar.Y);
+        await termsLink.ClickAsync(new LocatorClickOptions { Trial = true });
+        await privacyPolicyLink.ClickAsync(new LocatorClickOptions { Trial = true });
+    }
+
+    /// <summary>
+    /// #672 — the other end of the same trade: nothing may stay reserved for a bar that is gone. The
+    /// bar reserves its space by being in flow, so consent removing it from the markup is what makes
+    /// the footer flush again; this would fail a re-implementation that padded the footer instead.
+    /// </summary>
+    [Fact]
+    public async Task Accepting_on_a_phone_viewport_leaves_the_footer_flush_with_the_end_of_the_page()
+    {
+        await using IBrowserContext phoneContext = await NewPhoneContextAsync();
+        IPage page = await OpenTermsPageAsync(phoneContext);
+        ILocator banner = page.GetByRole(AriaRole.Region, new() { Name = BannerLabel });
+        await banner.WaitForAsync();
+
+        await page.GetByRole(AriaRole.Button, new() { Name = AcceptButtonName, Exact = true }).ClickAsync();
+        await banner.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Detached });
+        await page.WaitForLoadStateAsync();
+        await WaitForFontsAsync(page);
+        await ScrollToBottomAsync(page);
+
+        LocatorBoundingBoxResult footerBox = await RequireBoundingBoxAsync(page.GetByRole(AriaRole.Contentinfo));
+
+        (footerBox.Y + footerBox.Height).ShouldBe(PhoneViewportHeight, 1d);
+    }
+
+    /// <summary>
+    /// The reporter's viewport size: below 640px the bar stacks and its button goes full width, so it
+    /// is at its tallest exactly where the viewport is shortest. This emulates the size, not the
+    /// device — real iOS Safari is closed out by the ticket's manual retest on staging.
+    /// </summary>
+    private async Task<IBrowserContext> NewPhoneContextAsync()
+    {
+        IBrowserContext phoneContext = await Fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true,
+            ViewportSize = new ViewportSize { Width = PhoneViewportWidth, Height = PhoneViewportHeight }
+        });
+        phoneContext.SetDefaultTimeout(20_000);
+        return phoneContext;
+    }
+
+    private async Task<IPage> OpenTermsPageAsync(IBrowserContext context)
+    {
+        IPage page = await context.NewPageAsync();
+        await page.GotoAsync($"{Fixture.FrontendBaseUrl}/regulamin");
+        await WaitForFontsAsync(page);
+        return page;
+    }
+
+    /// <summary>Every face in <c>fonts.css</c> is <c>font-display: swap</c>, so a late swap would
+    /// reflow the document after it was measured — settle them before reading any box.</summary>
+    private static async Task WaitForFontsAsync(IPage page) =>
+        await page.EvaluateAsync<bool>("document.fonts.ready.then(() => true)");
+
+    private static async Task ScrollToBottomAsync(IPage page) =>
+        await page.EvaluateAsync("window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'instant' })");
+
+    private static async Task<LocatorBoundingBoxResult> RequireBoundingBoxAsync(ILocator locator) =>
+        await locator.BoundingBoxAsync()
+        ?? throw new InvalidOperationException($"'{locator}' has no bounding box — it is not rendered.");
 }


### PR DESCRIPTION
Closes #672

## What

`.cookie-bar` goes from `position: fixed` to `position: sticky; bottom: 0`. That is the whole fix — no C# change, no modifier class, no reserved padding.

A fixed bar is out of flow, so nothing reserved space for it and it sat on top of the end of the document at maximum scroll, burying "Regulamin" and "Polityka prywatności". In flow as the last child of the `.app` flex column, a sticky bar reserves exactly the height its copy wraps to, so the footer always comes to rest above it — while staying pinned to the bottom edge for as long as anything is left to scroll, so the LEGAL-04 notice is no less visible. It also makes the bar structurally symmetric with `.nav`, which is already sticky chrome with the same `backdrop-filter` at the opposite edge.

`left/right` are dropped because they only sized the out-of-flow box; the in-flow bar takes its full width from `.app`'s default `align-items: stretch`.

## Why not the approach the ticket suggested

The ticket proposed hoisting the consent read into `MainLayout` and reserving extra `.foot` padding. The reserve is not one number but a function of viewport width — roughly 170px at 390px, ~190px at 320px, ~76px on desktop — and it rots silently whenever the banner copy, the font stack or iOS Dynamic Type moves it. Sticky needs no number at all, and because the bar is simply not rendered once consent is given, "no leftover gap" holds by construction rather than by remembering to drop a class.

## Three ticket statements that did not survive contact with the code

1. **"Desktop is unaffected in practice… pages are long enough that the footer scrolls clear of it."** False. Page length is irrelevant to a fixed element — it is pinned to the viewport bottom at every offset. Measured at maximum scroll:

   | viewport | bar | `.foot-links` | overlaps |
   |---|---|---|---|
   | 390×844 | 679..844 (165px tall) | 668..685 | yes |
   | 1366×900 | 788..900 (112px tall) | 776..793 | yes |

2. **AC 3, "Desktop (1366×900) is visually unchanged", is knowingly not met** — and should not be. At maximum scroll the desktop bar now settles below the footer instead of covering its last ~76px. That is the desktop half of this same bug being fixed.

3. **AC 1 as worded is a false green.** "First visit: the bounding box of `.foot-links` does not intersect the cookie bar's" is trivially true on the *broken* CSS too, because on an unscrolled long page the footer is far below the fold. The invariant only means anything at maximum scroll, and the test says so.

## Tests

Three new browser tests at 390×844 in `CookieConsentBannerTests`, alongside the existing JS-less banner test, which keeps its own JavaScript-disabled context untouched.

Both failure directions were verified against the real stack, not argued:

- **Reachability test is red on the pre-fix stylesheet** — `footer bottom 843.75 vs bar top 677`, a 167px gap. A real regression guard, not a marginal-pixel one.
- **Pinned-at-scroll-top test is red under `position: static`** — and the other three pass. Every reachability assertion is taken at maximum scroll, where static, relative and sticky are geometrically identical, so without this test the suite would happily accept a bar that scrolls the consent notice off-screen entirely and guts LEGAL-04.

JavaScript is enabled in the three new tests purely as the test's measuring tape (scroll to the end, read boxes). Fonts are settled before every measurement — each face in `fonts.css` is `font-display: swap`, and a late swap would reflow the document after it was measured.

## Verification

Run locally, because **this PR gets no CI coverage**: `e2e.yml` fires only on `workflow_dispatch` or a Dependabot PR touching dependency manifests (CI-03/#405), and no guard script reads `.css`.

```
dotnet build LotroKoniecDev.slnx                  0 warnings, 0 errors
Frontend.E2E.Tests (CookieConsentBanner)          4/4 passed
Frontend.Tests.Unit                               577 passed
Tests.Unit                                        4091 passed
Architecture.Tests.Unit                           21 passed
scripts/check-ssr-purity.sh                       passed
scripts/check-client-hypermedia.sh                passed
```

## Beyond `/regulamin`

Short pages (`/not-found`, `/access-denied`, `LoginUnavailable`, `BadRequest`, the `ErrorBoundary` fallback) use `.status-stage { min-height: 60vh }` and now gain a scrollbar they did not have, because the bar's height joins the flow. That is the same fix working there. `.foot { margin-top: auto }` keeps the bar glued to the bottom on pages that still fit, so it never floats mid-screen.

## Not closed by this PR

The bug was reported on **iPhone 17 / Safari**; the test browser is headless Chromium, and `.app`/`body` use `100vh`, not `100dvh`. iOS Safari resolves "bottom of the viewport" differently for `fixed` and `sticky` while its toolbars animate, so nothing here proves the iOS behaviour. The QA-FE-01 `S01_PUBLIC` retest on a real phone against staging is load-bearing, not ceremonial.

Out of scope, found while reading: the auth origin renders its own footer across ten `.cshtml` pages and shows **no cookie bar at all**, yet both the footer's "Polityka prywatności" link and the banner's own policy link send the visitor there. That belongs on the LEGAL epic.
