### PR TITLE
BUG: the prod N-1 gate calls a batch backward-incompatible when the serving release merely fails to restore (CD #236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,16 @@ jobs:
       - name: Hetzner deploy script self-test
         run: ./scripts/tests/hetzner-deploy.tests.sh
 
-      # Same two N-1 promotion gate self-tests as pr-verify (#534) — CD is triggered by THIS workflow
-      # concluding success, so both scripts the prod leg is about to run get checked here too.
+      # Same three N-1 promotion gate self-tests as pr-verify (#534, #679) — CD is triggered by THIS
+      # workflow concluding success, so every script the prod leg is about to run gets checked here too.
       - name: Prod-baseline resolution self-test
         run: ./scripts/tests/resolve-prod-baseline.tests.sh
 
       - name: N-1 promotion gate verdict self-test
         run: ./scripts/tests/n1-promotion-gate.tests.sh
+
+      - name: N-1 proof classification self-test
+        run: ./scripts/tests/n1-compat.tests.sh
 
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -151,6 +151,14 @@ jobs:
       - name: N-1 promotion gate verdict self-test
         run: ./scripts/tests/n1-promotion-gate.tests.sh
 
+      # The proof the gate maps. Its two failures mean opposite things, and only the run itself can
+      # earn exit 1 — a previous release that no longer restores or builds has proven nothing. CD
+      # #236 is what a collapsed mapping costs: an advisory published after the serving release
+      # blocked every promotion under the message "your migrations break prod". Stubs `dotnet`, so
+      # the whole control flow runs here without Docker, .NET or a schema.
+      - name: N-1 proof classification self-test
+        run: ./scripts/tests/n1-compat.tests.sh
+
       # Everything below is the .NET gate: it runs only when the PR can actually affect it. A PR
       # that merely edits a script CI executes (or a Dockerfile) stops here, green, in seconds.
       - name: Setup .NET

--- a/docs/adr/0024-n1-backward-compat-ci-proof.md
+++ b/docs/adr/0024-n1-backward-compat-ci-proof.md
@@ -276,3 +276,51 @@ The PR-time `HEAD^1` job stays exactly as decided above — fast feedback next t
 deploy-time leg is the real guarantee. The staging leg stays ungated: staging deploys every push,
 so `HEAD^1` semantics still match it. Tests: `scripts/tests/resolve-prod-baseline.tests.sh` and
 `scripts/tests/n1-promotion-gate.tests.sh` (guards job, next to the other bash gates).
+
+## Amendment: only a suite that ran can call a batch bad, and the old tree is not re-judged (2026-08-20, #679)
+
+The amendment above named restore under exit 2, but `scripts/n1-compat.sh` never implemented the
+split: it ran `dotnet test` on the old worktree and mapped **any** non-zero exit to 1. A previous
+release that fails to *restore* therefore reported "your migrations are backward-incompatible".
+
+CD #236 is what that costs. The release serving prod (2026-07-27) pinned Testcontainers 4.13.0 →
+SSH.NET 2025.1.0. GHSA-q939-rpr3-3284 landed on that package **after** the release shipped, and with
+`NuGetAudit=all` + `TreatWarningsAsErrors` its restore died on NU1903 "Warning As Error". Not one
+test ran, yet the gate told the approver to split a batch nothing had judged — and pointed at the
+one escape hatch (`image_tag` dispatch) that skips the gate entirely. The PR-time leg never saw it:
+its baseline is `HEAD^1`, always a recent tree.
+
+Three corrections, all in `scripts/n1-compat.sh`:
+
+- **Restore and build are their own phase, and the run is `--no-build`.** Only a suite that compiled
+  and then failed its tests can earn exit 1; a previous release that no longer restores or builds
+  exits 2 as UNJUDGED. Where both happen at once, exit 1 wins — "promote in smaller steps" is the
+  action either way, and the build failure stays in the log.
+- **`TreatWarningsAsErrors` is waived for the previous release.** That tree is built to be
+  *executed*, not re-judged: its own PR already gated its warnings, while what decides them here
+  keeps moving under it. The live advisory feed is the sharp edge — it renders a verdict about a
+  package pinned in the past, not about this batch's schema, and it retro-fails **every** future
+  promotion until the baseline advances past it. Findings stay visible as warnings; the current tree
+  keeps its own audit and zero-warning gate, and nothing from the worktree ships. The same waiver
+  covers analyzer drift, the other way today's toolchain can condemn old code for the wrong reason.
+
+- **Only a suite that EXECUTED tests may report green.** The mirror of the rule above, and the
+  hole the first two corrections would otherwise have left as the last fail-*open* rot mode:
+  `dotnet test` exits **0** when it discovers nothing ("No test is available in ….dll" is a
+  warning — verified on VSTest 18.0.1), so an adapter that stopped resolving in the old tree would
+  have reported GREEN having proven nothing. Each run now writes a trx and the suite counts as
+  judged only when `executed > 0`; zero executed joins the exit-2 bucket. This also catches the run
+  *environment* failing before the first test (Docker down, an image that will not pull), which the
+  old collapsed mapping reported as a confident RED. Once at least one test has executed, a failure
+  is a real verdict — exit 1 — and the RED message says so rather than pretending otherwise.
+
+The trade-off is stated plainly: the proof no longer notices that the serving release depends on a
+vulnerable package. That was never its job — it judges whether old code survives a new schema — and
+`NuGetAudit` on the current tree is where a vulnerable dependency actually gets caught, on the code
+that ships.
+
+Tests: `scripts/tests/n1-compat.tests.sh` (guards job) stubs `dotnet` over a fixture git repo and
+pins both directions — a test failure is RED, a restore/build failure or a run that executed zero
+tests is UNJUDGED, the waiver reaches every compiling phase of the old tree and never leaks onto the
+current tree, and every run is handed the seam dir the HEAD schema was generated into (the one line
+that keeps the whole proof from going vacuous).

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -635,10 +635,13 @@ two different fixes:
 
 - **`RED` — the batch's schema breaks the release prod is running right now. Do not retry:** approve
   a candidate containing only the expand, let it serve, then promote the contract.
-- **`COULD NOT RUN` — the proof itself failed to build, generate or start, so the batch is
-  UNJUDGED,** not proven bad. Fix the infra failure named in the log and re-run the job. Do **not**
-  split the batch, and do not reach for the `image_tag` dispatch: it skips the gate entirely, so
-  nothing would be proven at all.
+- **`COULD NOT RUN` — nothing was executed against the schema, so the batch is UNJUDGED,** not
+  proven bad. That covers the proof's own setup (script generation, the worktree, the seam) *and*
+  a serving release that no longer restores or builds with today's toolchain — an old tree is not
+  re-judged by today's rules, so a warning-shaped failure there is infra, never a schema verdict
+  (#679). Fix the failure named in the log and re-run the job. Do **not** split the batch, and do
+  not reach for the `image_tag` dispatch: it skips the gate entirely, so nothing would be proven
+  at all.
 
 Migration-free promotions skip in seconds. An unresolvable baseline fails closed. The
 nothing-serving-yet skip needs **two agreeing signals** — no `production` deployment on record ever

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -49,8 +49,10 @@ INERT='\.md$|^docs/|^LICENSE$|^\.gitignore$|^\.gitattributes$|\.sh$|\.ps1$|(^|/)
 # deploy.sh is here because it is the script CD runs on a PROD box and its self-test is the only
 # thing that checks it before it gets there (HETZ-04); the two scripts/ci/ halves of the N-1
 # promotion gate for the same reason — CD's prod leg runs them (#534) and their self-tests are the
-# only pre-deploy check they face.
-GUARD_INPUTS='^scripts/check-ssr-purity\.(sh|ps1)$|^scripts/check-client-hypermedia\.(sh|ps1)$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|^scripts/claude/(issue-trust|next-ticket|work-ticket)\.sh$|^scripts/tests/claude-loop-provenance\.tests\.sh$|^scripts/hetzner/deploy\.sh$|^scripts/tests/hetzner-deploy\.tests\.sh$|^scripts/ci/(resolve-prod-baseline|n1-promotion-gate)\.sh$|^scripts/tests/(resolve-prod-baseline|n1-promotion-gate)\.tests\.sh$|(^|/)Dockerfile[^/]*$|^\.github/workflows/(pr-verify|ci)\.yml$'
+# only pre-deploy check they face — and scripts/n1-compat.sh, the proof those halves call, whose
+# verdict classification decides whether a blocked promotion reads as "your migrations break prod"
+# or as "the proof never ran" (#679).
+GUARD_INPUTS='^scripts/check-ssr-purity\.(sh|ps1)$|^scripts/check-client-hypermedia\.(sh|ps1)$|^scripts/check-migration-safety\.(sh|ps1)$|^scripts/tests/check-migration-safety\.tests\.sh$|^scripts/check-dockerfile-restore-graph\.(sh|ps1)$|^scripts/claude/(issue-trust|next-ticket|work-ticket)\.sh$|^scripts/tests/claude-loop-provenance\.tests\.sh$|^scripts/hetzner/deploy\.sh$|^scripts/tests/hetzner-deploy\.tests\.sh$|^scripts/ci/(resolve-prod-baseline|n1-promotion-gate)\.sh$|^scripts/n1-compat\.sh$|^scripts/tests/(resolve-prod-baseline|n1-promotion-gate|n1-compat)\.tests\.sh$|(^|/)Dockerfile[^/]*$|^\.github/workflows/(pr-verify|ci)\.yml$'
 
 # Build-relevant despite matching INERT: the two workflows that DEFINE the .NET gate.
 CODE_INPUTS='^\.github/workflows/(pr-verify|ci)\.yml$'

--- a/scripts/ci/n1-promotion-gate.sh
+++ b/scripts/ci/n1-promotion-gate.sh
@@ -8,9 +8,10 @@
 #            Retrying changes nothing; the resolution is to promote in smaller steps (ADR-0023:
 #            approve a candidate carrying only the expand, let it serve, then promote the contract).
 #   exit 2 — the proof never ran (dotnet tool restore, schema-script generation, the worktree, a
-#            missing seam, no integration suites found). The batch is UNJUDGED, not bad; the fix is
-#            the infra failure in the log, and the promotion is blocked because an unjudged batch
-#            must not ship — not because its migrations are known to break anything.
+#            missing seam, no integration suites found, or a serving release that no longer
+#            restores/builds or that executed zero tests — #679). The batch is UNJUDGED, not bad;
+#            the fix is the infra failure in the log, and the promotion is blocked because an
+#            unjudged batch must not ship — not because its migrations are known to break anything.
 #
 # Collapsing the two sends the approver to split a healthy batch on an infra flake — or worse, to
 # the `image_tag` dispatch, which skips this gate entirely. So the mapping lives here, in a script

--- a/scripts/n1-compat.sh
+++ b/scripts/n1-compat.sh
@@ -14,11 +14,18 @@
 #   2. Check out the previous release (default: HEAD^1 — on a PR merge commit that is the main
 #      tip being merged into, i.e. the deployed release; the repo has no version tags and CD
 #      ships every main commit) into a temporary git worktree.
-#   3. Run every *.Tests.Integration.csproj the OLD checkout discovers (the same convention
-#      pr-verify.yml gates on — no silent narrowing) with N1_COMPAT_SCHEMA_SCRIPTS_DIR pointing
-#      at the generated scripts. Each old test fixture applies the HEAD schema to its container
-#      before its own MigrateAsync (which then no-ops). Red = the old release cannot live on the
-#      new schema = a backward-incompatible migration.
+#   3. Restore and build every *.Tests.Integration.csproj the OLD checkout discovers (the same
+#      convention pr-verify.yml gates on — no silent narrowing), THEN run it with
+#      N1_COMPAT_SCHEMA_SCRIPTS_DIR pointing at the generated scripts. Each old test fixture
+#      applies the HEAD schema to its container before its own MigrateAsync (which then no-ops).
+#      Red = the old release cannot live on the new schema = a backward-incompatible migration.
+#
+# Restore/build is its own phase because only the run after it can produce the exit-1 verdict. A
+# previous release that no longer restores or compiles has proven NOTHING about this batch's
+# schema, and calling that "backward-incompatible" sends the approver to split a healthy batch
+# (ADR-0024's deploy-time amendment lists restore under exit 2 for exactly this reason; CD #236
+# is the run where the collapsed mapping actually misfired). The mirror rule holds on the way up:
+# only a suite that EXECUTED tests may report green, so a run discovering zero tests is exit 2 too.
 #
 # Bootstrap: if the previous release predates the seam (no N1_COMPAT_SCHEMA_SCRIPTS_DIR marker in
 # its tests/), there is nothing it can prove — report loudly and pass. The window closes at the
@@ -33,7 +40,8 @@
 #                                           # deliberate-red experiment from #340's AC)
 #
 # Requires: Docker (Testcontainers), the pinned dotnet-ef tool (dotnet tool restore runs here).
-# Exit codes: 0 = compatible (or bootstrap), 1 = N-1 incompatibility (old suite red), 2 = cannot run.
+# Exit codes: 0 = compatible (or bootstrap), 1 = N-1 incompatibility (old suite's TESTS red),
+# 2 = cannot run (incl. an old suite that no longer restores or builds).
 set -euo pipefail
 
 CODE_REF="${1:-HEAD^1}"
@@ -64,6 +72,7 @@ say() {
 }
 
 schema_dir=""
+results_dir=""
 worktree_parent=""
 worktree_dir=""
 cleanup() {
@@ -76,6 +85,9 @@ cleanup() {
   fi
   if [ -n "$schema_dir" ] && [ -d "$schema_dir" ]; then
     rm -rf "$schema_dir"
+  fi
+  if [ -n "$results_dir" ] && [ -d "$results_dir" ]; then
+    rm -rf "$results_dir"
   fi
 }
 trap cleanup EXIT
@@ -161,15 +173,62 @@ if ! grep -rq "$SEAM_MARKER" "$worktree_dir/tests" --include="*.cs" 2>/dev/null;
 fi
 
 # --- 3. Run the OLD release's integration suites against the NEW schema. ----------------------
+# TreatWarningsAsErrors is deliberately OFF for the previous release. That tree is built to be
+# EXECUTED, not to be re-judged: its own PR already gated its warnings, while everything that
+# decides them here keeps moving underneath it. The live NuGet advisory feed is the sharpest
+# edge — it retro-fails any release pinning a package an advisory has since covered, which is a
+# verdict about the past, not about this batch's schema. CD #236: the serving release pinned
+# Testcontainers 4.13.0 -> SSH.NET 2025.1.0 -> NU1903 "Warning As Error", its restore died, and
+# no promotion could ever run again. Findings stay VISIBLE as warnings in the log; the CURRENT
+# tree keeps its own audit and its own zero-warning gate, and nothing from this worktree ships.
+# WarningsAsErrors is cleared alongside it: an explicit <WarningsAsErrors>NU1903</WarningsAsErrors>
+# promotes a code past TreatWarningsAsErrors and would re-open this hole. No project here carries
+# one today — it is a global property so it wins if one ever appears.
+OLD_TREE_BUILD_ARGS=(-p:TreatWarningsAsErrors=false -p:WarningsAsErrors=)
+
+# How many tests a run actually EXECUTED, from its trx. `dotnet test` exits 0 when it discovers
+# nothing at all ("No test is available in ….dll" is a WARNING — verified on VSTest 18.0.1), so
+# without this floor an adapter that stopped resolving in the old tree would report a confident
+# GREEN having proven exactly nothing. Same reasoning as the suites=0 guard below, one level down.
+trx_executed_count() {
+  local trx="$1"
+  local count=''
+  [ -f "$trx" ] || { echo 0; return; }
+  count="$(grep -o 'executed="[0-9]*"' "$trx" | head -1 | grep -o '[0-9]*' || true)"
+  echo "${count:-0}"
+}
+
+results_dir="$(canonical_tmp_dir)"
 status=0
+unbuildable=0
+unrun=0
 suites=0
 while IFS= read -r proj; do
   suites=$((suites + 1))
+  suite_name="$(basename "$proj" .csproj)"
   echo "::group::$(basename "$proj") (previous release, HEAD schema)"
-  if ! (cd "$worktree_dir" && \
-        N1_COMPAT_SCHEMA_SCRIPTS_DIR="$schema_dir" \
-        dotnet test "$proj" --configuration Release --logger "console;verbosity=minimal"); then
-    status=1
+  # Restore and build BEFORE the run, so the run itself can only fail for one reason: the old
+  # release's tests genuinely reject the new schema. That is the exit-1 verdict; a tree that never
+  # compiled cannot earn it.
+  if ! (cd "$worktree_dir" && dotnet restore "$proj" "${OLD_TREE_BUILD_ARGS[@]}") \
+     || ! (cd "$worktree_dir" && dotnet build "$proj" --configuration Release --no-restore "${OLD_TREE_BUILD_ARGS[@]}"); then
+    echo "ERROR: '$suite_name' from the previous release no longer restores or builds with today's toolchain — it can prove nothing about this schema." >&2
+    unbuildable=$((unbuildable + 1))
+  else
+    test_status=0
+    (cd "$worktree_dir" && \
+      N1_COMPAT_SCHEMA_SCRIPTS_DIR="$schema_dir" \
+      dotnet test "$proj" --configuration Release --no-build \
+        --logger "console;verbosity=minimal" \
+        --logger "trx;LogFileName=$suite_name.trx" \
+        --results-directory "$results_dir") || test_status=$?
+
+    if [ "$(trx_executed_count "$results_dir/$suite_name.trx")" -eq 0 ]; then
+      echo "ERROR: '$suite_name' executed ZERO tests — it proved nothing about this schema. Check the log for a discovery failure or a run that died before the first test." >&2
+      unrun=$((unrun + 1))
+    elif [ "$test_status" -ne 0 ]; then
+      status=1
+    fi
   fi
   echo "::endgroup::"
 done < <(find "$worktree_dir/tests" -name '*.Tests.Integration.csproj' | sort)
@@ -179,9 +238,23 @@ if [ "$suites" -eq 0 ]; then
   exit 2
 fi
 
+unjudged=$((unbuildable + unrun))
+
+# A suite whose tests ran and failed outranks a sibling that never ran: "promote in smaller steps"
+# is the action the operator must take either way. But say so — an approver who splits the batch on
+# this verdict must know the split does not restore the coverage the silent suites never gave.
 if [ "$status" -ne 0 ]; then
-  say "N-1 compat: RED — the previous release ($prev_sha) fails on the current schema. A migration in this change is backward-incompatible (ADR-0023): ship it as expand → backfill → contract, or fix the breaking DDL. (If the old suite failed to build or start rather than failing tests, it's an infra problem — check the log above.)"
+  blind=''
+  if [ "$unjudged" -ne 0 ]; then
+    blind=" NOTE: $unjudged of $suites suite(s) produced no verdict of their own (see the log) — that part of the batch stays UNJUDGED even after you split it."
+  fi
+  say "N-1 compat: RED — the previous release ($prev_sha) fails on the current schema. A migration in this change is backward-incompatible (ADR-0023): ship it as expand → backfill → contract, or fix the breaking DDL.${blind} (A failure of the run ENVIRONMENT — Docker, an image pull, a test host that died mid-run — can also land here once at least one test has executed; read the failures before you split.)"
   exit 1
+fi
+
+if [ "$unjudged" -ne 0 ]; then
+  say "N-1 compat: COULD NOT RUN — $unjudged of $suites integration suite(s) from the previous release ($prev_sha) produced no verdict ($unbuildable did not restore or build, $unrun executed no tests), so this batch is UNJUDGED, not proven bad. Fix the failure in the log above; splitting the batch would only hide the fact that nothing was proven."
+  exit 2
 fi
 
 say "N-1 compat: GREEN — previous release $prev_sha passes all $suites integration suite(s) on the current schema."

--- a/scripts/tests/classify-changes.tests.sh
+++ b/scripts/tests/classify-changes.tests.sh
@@ -87,6 +87,8 @@ expect 'code=false guards=true images=false' 'the prod N-1 promotion gate resolv
 expect 'code=false guards=true images=false' 'the resolver self-test'                     'scripts/tests/resolve-prod-baseline.tests.sh'
 expect 'code=false guards=true images=false' 'the promotion gate verdict mapping'         'scripts/ci/n1-promotion-gate.sh'
 expect 'code=false guards=true images=false' 'the verdict-mapping self-test'              'scripts/tests/n1-promotion-gate.tests.sh'
+expect 'code=false guards=true images=false' 'the N-1 proof the gate calls'               'scripts/n1-compat.sh'
+expect 'code=false guards=true images=false' 'the N-1 proof classification self-test'     'scripts/tests/n1-compat.tests.sh'
 
 echo
 echo '── images ───────────────────────────────────────────────────────────────────────────────────'

--- a/scripts/tests/n1-compat.tests.sh
+++ b/scripts/tests/n1-compat.tests.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# Test suite for the N-1 proof's verdict classification (scripts/n1-compat.sh — ADR-0024, #679).
+#
+# The property here is WHICH failure earns WHICH exit code. ADR-0024's deploy-time amendment gives
+# the two opposite meanings: exit 1 says the serving release cannot live on this schema (do NOT
+# retry — promote in smaller steps), exit 2 says the proof never ran (the batch is UNJUDGED and the
+# fix is the infra). Only a suite that actually BUILT and then failed its tests can earn exit 1; a
+# previous release that no longer restores or compiles has proven nothing at all.
+#
+# CD #236 is why this suite exists. The serving release pinned Testcontainers 4.13.0 -> SSH.NET
+# 2025.1.0, an advisory landed on it after that release shipped, its restore died on NU1903
+# "Warning As Error", and the collapsed mapping reported "your migrations break prod" — telling the
+# approver to split a batch whose migrations were never judged.
+#
+# Every case runs the REAL scripts/n1-compat.sh over a fixture git repo with `dotnet` STUBBED on
+# PATH, so the whole control flow is exercised without Docker, .NET, a schema or a container. git,
+# find and grep stay real — the worktree and the discovery loop are part of what is under test.
+#
+# CI runs this in the `guards` job, next to the other bash gates.
+
+set -euo pipefail
+
+SCRIPT_SH="$(cd "$(dirname "$0")/.." && pwd)/n1-compat.sh"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+cases=0
+CASE=""
+LAST_OUTPUT=""
+LAST_STATUS=0
+STUB_LOG="$TMP_ROOT/dotnet.log"
+
+fail() {
+    printf '✗ [%s] %s\n' "$CASE" "$1"
+    if [ -n "${2:-}" ]; then
+        printf '%s\n' "$2" | sed 's/^/    /'
+    fi
+    printf '  --- n1-compat.sh output ---\n%s\n' "$LAST_OUTPUT" | sed 's/^/    /'
+    printf '  --- dotnet invocations ---\n%s\n' "$(cat "$STUB_LOG" 2>/dev/null)" | sed 's/^/    /'
+    exit 1
+}
+
+pass() {
+    cases=$((cases + 1))
+    printf '✓ [%s] %s\n' "$CASE" "$1"
+}
+
+# --- Fixture: a real git repo carrying the seam, two integration suites and the real script -----
+FIXTURE="$TMP_ROOT/repo"
+SUITES=(
+    'LotroKoniecDev.AuthSystem.API.Tests.Integration:AuthSystemApiFactory'
+    'LotroKoniecDev.TranslationSystem.API.Tests.Integration:TranslationSystemApiFactory'
+)
+
+mkdir -p "$FIXTURE/scripts"
+cp "$SCRIPT_SH" "$FIXTURE/scripts/n1-compat.sh"
+for entry in "${SUITES[@]}"; do
+    suite="${entry%%:*}"
+    factory="${entry##*:}"
+    mkdir -p "$FIXTURE/tests/$suite"
+    # The seam marker and its call site are what the script asserts before it will prove anything.
+    echo 'var dir = Environment.GetEnvironmentVariable("N1_COMPAT_SCHEMA_SCRIPTS_DIR");' \
+        > "$FIXTURE/tests/$suite/N1CompatSchemaSeam.cs"
+    echo 'await N1CompatSchemaSeam.ApplyIfConfiguredAsync(container);' \
+        > "$FIXTURE/tests/$suite/$factory.cs"
+    echo '<Project Sdk="Microsoft.NET.Sdk" />' > "$FIXTURE/tests/$suite/$suite.csproj"
+done
+
+git -C "$FIXTURE" init --quiet --initial-branch=main
+git -C "$FIXTURE" config user.email 'n1-compat-tests@example.invalid'
+git -C "$FIXTURE" config user.name 'n1-compat tests'
+git -C "$FIXTURE" add -A
+git -C "$FIXTURE" commit --quiet -m 'fixture: previous release'
+
+# --- The `dotnet` stub -------------------------------------------------------------------------
+# It logs every invocation (so a case can prove what did and did NOT run) and fails the phase named
+# by STUB_<PHASE>_FAIL_MATCH for the project whose path contains that substring. Restore is asked
+# to tell the two trees apart by cwd: the HEAD-tree restores run in the fixture root, the previous
+# release's run inside the worktree.
+STUB_BIN="$TMP_ROOT/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/dotnet" <<'STUB'
+#!/usr/bin/env bash
+# The seam dir is logged as its own field: it is the single line that makes the whole proof
+# non-vacuous (ADR-0024 §3), so the suite has to be able to assert it reached the run.
+printf '%s|%s|%s\n' "$PWD" "${N1_COMPAT_SCHEMA_SCRIPTS_DIR:-}" "$*" >> "$N1_STUB_LOG"
+
+phase="$1"
+shift
+STUB_ARGV="$*"
+
+matches() {
+    local needle="$1"
+    shift
+    [ -n "$needle" ] && printf '%s\n' "$*" | grep -qF -- "$needle"
+}
+
+case "$phase" in
+    tool)
+        exit 0
+        ;;
+    restore)
+        # The current tree's own restores are not what this proof judges — always fine.
+        [ "$PWD" = "$N1_FIXTURE_ROOT" ] && exit 0
+        matches "${STUB_RESTORE_FAIL_MATCH:-}" "$@" && exit 1
+        exit 0
+        ;;
+    ef)
+        output=''
+        while [ $# -gt 0 ]; do
+            [ "$1" = '--output' ] && output="$2"
+            shift
+        done
+        [ -n "$output" ] || exit 9
+        echo 'INSERT INTO "__EFMigrationsHistory" ("MigrationId") VALUES (N'"'"'20260101_Stub'"'"');' > "$output"
+        exit 0
+        ;;
+    build)
+        matches "${STUB_BUILD_FAIL_MATCH:-}" "$@" && exit 1
+        exit 0
+        ;;
+    test)
+        # Mirror VSTest: write the trx the caller asked for, and report zero executed tests with
+        # exit 0 — "No test is available in ….dll" is a warning, not a failure (VSTest 18.0.1).
+        results_dir='.'
+        log_name='stub.trx'
+        for arg in "$@"; do
+            case "$arg" in
+                trx\;LogFileName=*) log_name="${arg#*LogFileName=}" ;;
+            esac
+        done
+        while [ $# -gt 0 ]; do
+            [ "$1" = '--results-directory' ] && results_dir="$2"
+            shift
+        done
+        executed=2
+        failed=0
+        matches "${STUB_TEST_NO_TESTS_MATCH:-}" "$STUB_ARGV" && executed=0
+        matches "${STUB_TEST_FAIL_MATCH:-}" "$STUB_ARGV" && failed=1
+        mkdir -p "$results_dir"
+        printf '<Counters total="%s" executed="%s" passed="%s" failed="%s" />\n' \
+            "$executed" "$executed" "$((executed - failed))" "$failed" > "$results_dir/$log_name"
+        [ "$failed" -ne 0 ] && exit 1
+        exit 0
+        ;;
+esac
+exit 0
+STUB
+chmod +x "$STUB_BIN/dotnet"
+
+run_proof() {
+    : > "$STUB_LOG"
+    : > "$TMP_ROOT/step_summary"
+    LAST_STATUS=0
+    LAST_OUTPUT="$( (cd "$FIXTURE" && env \
+        PATH="$STUB_BIN:$PATH" \
+        GITHUB_STEP_SUMMARY="$TMP_ROOT/step_summary" \
+        N1_STUB_LOG="$STUB_LOG" \
+        N1_FIXTURE_ROOT="$FIXTURE" \
+        "$@" ./scripts/n1-compat.sh HEAD) 2>&1 )" || LAST_STATUS=$?
+}
+
+# Every dotnet invocation of one phase against one suite, e.g. `dotnet test` on the Auth suite.
+# Log line: <cwd>|<N1_COMPAT_SCHEMA_SCRIPTS_DIR>|<argv>
+invocations_for() {
+    grep -E "\|$1 " "$STUB_LOG" | grep -F "$2" || true
+}
+
+seam_dir_of() {
+    printf '%s\n' "$1" | cut -d'|' -f2
+}
+
+CASE='everything green'
+run_proof
+[ "$LAST_STATUS" -eq 0 ] || fail 'a previous release that builds and passes must exit 0' "status $LAST_STATUS"
+grep -q 'GREEN' <<<"$LAST_OUTPUT" || fail 'the green verdict should be stated'
+[ -n "$(invocations_for test 'AuthSystem')" ] || fail 'both suites must actually run'
+[ -n "$(invocations_for test 'TranslationSystem')" ] || fail 'both suites must actually run'
+pass 'a buildable, passing previous release exits 0 and runs every discovered suite'
+
+CASE='old suite tests fail'
+run_proof STUB_TEST_FAIL_MATCH='AuthSystem'
+[ "$LAST_STATUS" -eq 1 ] || fail 'tests that ran and failed are the exit-1 verdict' "status $LAST_STATUS"
+grep -q 'RED' <<<"$LAST_OUTPUT" || fail 'the red verdict should be stated'
+grep -qi 'backward-incompatible' <<<"$LAST_OUTPUT" || fail 'the red verdict must name the ADR-0023 resolution'
+if grep -qi 'UNJUDGED\|COULD NOT RUN' <<<"$LAST_OUTPUT"; then fail 'a proven incompatibility must not read as an infra failure'; fi
+pass 'a previous release whose TESTS fail on the new schema exits 1 as RED'
+
+CASE='old suite does not restore'
+run_proof STUB_RESTORE_FAIL_MATCH='AuthSystem'
+[ "$LAST_STATUS" -eq 2 ] || fail 'a previous release that cannot restore proves nothing — exit 2' "status $LAST_STATUS"
+grep -q 'COULD NOT RUN' <<<"$LAST_OUTPUT" || fail 'the operator must be told the proof could not run'
+grep -q 'UNJUDGED' <<<"$LAST_OUTPUT" || fail 'the batch must read as unjudged, not proven bad'
+if grep -qw 'RED' <<<"$LAST_OUTPUT"; then fail 'a restore failure must NOT be reported as a schema RED'; fi
+if grep -qi 'backward-incompatible' <<<"$LAST_OUTPUT"; then fail 'a restore failure must not accuse the migrations'; fi
+[ -z "$(invocations_for build 'AuthSystem')" ] || fail 'a suite that failed to restore must not be built'
+[ -z "$(invocations_for test 'AuthSystem')" ] || fail 'a suite that failed to restore must not be tested'
+pass 'a previous release that no longer restores exits 2 as UNJUDGED, and is never tested'
+
+CASE='old suite does not build'
+run_proof STUB_BUILD_FAIL_MATCH='TranslationSystem'
+[ "$LAST_STATUS" -eq 2 ] || fail 'a previous release that cannot build proves nothing — exit 2' "status $LAST_STATUS"
+grep -q 'UNJUDGED' <<<"$LAST_OUTPUT" || fail 'the batch must read as unjudged, not proven bad'
+if grep -qw 'RED' <<<"$LAST_OUTPUT"; then fail 'a build failure must NOT be reported as a schema RED'; fi
+[ -z "$(invocations_for test 'TranslationSystem')" ] || fail 'a suite that failed to build must not be tested'
+[ -n "$(invocations_for test 'AuthSystem')" ] || fail 'one unbuildable suite must not stop the others from being proven'
+pass 'a previous release that no longer builds exits 2 as UNJUDGED, and is never tested'
+
+CASE='a proven incompatibility outranks an unbuildable sibling'
+run_proof STUB_BUILD_FAIL_MATCH='AuthSystem' STUB_TEST_FAIL_MATCH='TranslationSystem'
+[ "$LAST_STATUS" -eq 1 ] || fail 'a suite that ran and failed still proves the schema breaks' "status $LAST_STATUS"
+grep -q 'RED' <<<"$LAST_OUTPUT" || fail 'the proven incompatibility is the verdict the operator must act on'
+pass 'a real test failure wins over an unbuildable sibling suite — the batch IS proven bad'
+
+CASE='the previous release is not re-judged by todays rules'
+run_proof
+# restore and build only: those are the two phases that resolve packages and compile, so they are
+# the two that today's advisory feed and today's analyzers can fail. The run itself is --no-build.
+for phase in restore build; do
+    invocations="$(invocations_for "$phase" 'Tests.Integration')"
+    [ -n "$invocations" ] || fail "the previous release must be ${phase}d at all"
+    while IFS= read -r line; do
+        grep -qF -- '-p:TreatWarningsAsErrors=false' <<<"$line" \
+            || fail "every '$phase' of the previous release must waive TreatWarningsAsErrors — an advisory published after that release must not block a promotion (CD #236)" "$line"
+    done <<<"$invocations"
+done
+pass 'every phase of the previous release waives TreatWarningsAsErrors'
+
+CASE='the current tree keeps its own gate'
+run_proof
+head_restores="$(grep -E "^$FIXTURE\|[^|]*\|restore " "$STUB_LOG" || true)"
+[ -n "$head_restores" ] || fail 'the current tree must still be restored'
+if grep -qF -- '-p:TreatWarningsAsErrors=false' <<<"$head_restores"; then
+    fail 'the waiver is for the previous release only — the CURRENT tree keeps its zero-warning gate' "$head_restores"
+fi
+pass 'the waiver never leaks onto the current tree'
+
+CASE='the built output is reused'
+run_proof
+while IFS= read -r line; do
+    grep -qF -- '--no-build' <<<"$line" || fail 'the run must reuse the build, so a test failure can only mean the tests failed' "$line"
+done <<<"$(invocations_for test 'Tests.Integration')"
+pass 'the suites run with --no-build, so exit 1 can only come from the tests themselves'
+
+CASE='a suite that executed nothing proves nothing'
+run_proof STUB_TEST_NO_TESTS_MATCH='AuthSystem'
+[ "$LAST_STATUS" -eq 2 ] || fail 'a run that discovered zero tests must be UNJUDGED, never green' "status $LAST_STATUS"
+grep -q 'UNJUDGED' <<<"$LAST_OUTPUT" || fail 'zero executed tests is an infra verdict'
+if grep -q 'GREEN' <<<"$LAST_OUTPUT"; then fail 'a suite that ran nothing must NOT report the batch green'; fi
+grep -qi 'ZERO tests' <<<"$LAST_OUTPUT" || fail 'the log must name the suite that executed nothing'
+pass 'a suite discovering zero tests exits 2 — dotnet test alone would have exited 0'
+
+CASE='the run carries the schema seam'
+run_proof
+# The dir the HEAD schema was generated INTO — whatever `dotnet ef migrations script --output` was
+# pointed at. Asserted from the log, not from disk: the script deletes it on the way out.
+generated_into=''
+while IFS= read -r line; do
+    out="$(printf '%s\n' "$line" | grep -o -- '--output [^ ]*' | cut -d' ' -f2)"
+    [ -n "$out" ] || fail 'the schema scripts must be generated to an explicit --output path' "$line"
+    case "$out" in
+        */translation.sql | */auth.sql) ;;
+        *) fail 'both contexts must be generated, one script each' "$out" ;;
+    esac
+    generated_into="$(dirname "$out")"
+done <<<"$(invocations_for ef 'migrations script')"
+[ -n "$generated_into" ] || fail 'the HEAD schema must be generated at all'
+
+while IFS= read -r line; do
+    seam="$(seam_dir_of "$line")"
+    [ -n "$seam" ] || fail 'without N1_COMPAT_SCHEMA_SCRIPTS_DIR the old suite migrates its OWN old schema and every run is vacuous green (ADR-0024 §3)' "$line"
+    [ "$seam" = "$generated_into" ] \
+        || fail 'the run must be handed the very dir the HEAD schema was generated into' "seam=$seam generated=$generated_into"
+done <<<"$(invocations_for test 'Tests.Integration')"
+pass 'every run receives the seam dir the HEAD schema was generated into'
+
+CASE='no suites to discover'
+bare="$TMP_ROOT/bare"
+cp -R "$FIXTURE" "$bare"
+rm -rf "$bare/.git"
+find "$bare/tests" -name '*.Tests.Integration.csproj' -delete
+git -C "$bare" init --quiet --initial-branch=main
+git -C "$bare" config user.email 'n1-compat-tests@example.invalid'
+git -C "$bare" config user.name 'n1-compat tests'
+git -C "$bare" add -A
+git -C "$bare" commit --quiet -m 'fixture: previous release with no integration suites'
+LAST_STATUS=0
+LAST_OUTPUT="$( (cd "$bare" && env \
+    PATH="$STUB_BIN:$PATH" \
+    N1_STUB_LOG="$STUB_LOG" \
+    N1_FIXTURE_ROOT="$bare" \
+    ./scripts/n1-compat.sh HEAD) 2>&1 )" || LAST_STATUS=$?
+[ "$LAST_STATUS" -eq 2 ] || fail 'a previous release with no integration suites must refuse to report green' "status $LAST_STATUS"
+if grep -q 'GREEN' <<<"$LAST_OUTPUT"; then fail 'nothing discovered must never read as proven'; fi
+pass 'a previous release with no integration suites exits 2 instead of a false green'
+
+CASE='step summary'
+run_proof STUB_RESTORE_FAIL_MATCH='AuthSystem'
+grep -q 'UNJUDGED' "$TMP_ROOT/step_summary" || fail 'the approver reads the summary — the verdict must land there too'
+pass 'a blocked proof writes its verdict to the job summary'
+
+printf '\nAll %d n1-compat case(s) passed.\n' "$cases"

--- a/scripts/tests/n1-promotion-gate.tests.sh
+++ b/scripts/tests/n1-promotion-gate.tests.sh
@@ -5,7 +5,8 @@
 # The one property here is the operator instruction attached to each exit code of
 # scripts/n1-compat.sh. That script separates "the serving release cannot live on this schema"
 # (exit 1) from "the proof never ran" (exit 2 — dotnet tool restore, script generation, the
-# worktree, a missing seam, no integration suites found). Both block the promotion, but they demand
+# worktree, a missing seam, no integration suites found, or a serving release that no longer
+# restores/builds or executed zero tests — #679; scripts/tests/n1-compat.tests.sh pins that side). Both block the promotion, but they demand
 # OPPOSITE next actions: exit 1 means do NOT retry, promote in smaller steps; exit 2 means the batch
 # is UNJUDGED and the fix is the infra, not the batch. Collapsing them into one "your migrations
 # break prod" message sends the approver to split a healthy batch — or to the `image_tag` dispatch


### PR DESCRIPTION
## Why

CD #236's prod promotion failed with **"this batch's migrations break the release currently serving on prod — do NOT retry, promote in smaller steps"**. Not one test had run.

The release serving prod (2026-07-27) pins Testcontainers 4.13.0 → SSH.NET 2025.1.0. GHSA-q939-rpr3-3284 landed on that package **after** that release shipped, so with `NuGetAudit=all` + `TreatWarningsAsErrors` its `dotnet restore` now dies on `NU1903: Warning As Error`. `scripts/n1-compat.sh` mapped any non-zero `dotnet test` to exit 1, so it could not tell a restore failure from a real incompatibility — and it pointed the approver at the one escape hatch (`image_tag` dispatch) that skips the gate entirely.

The PR-time leg never saw this: its baseline is `HEAD^1`, always a recent tree. Only the prod gate reaches back far enough, and the problem gets worse the further prod lags.

ADR-0024's deploy-time amendment already listed restore under exit 2. Only the implementation was missing.

## What

**Only a suite that ran can call a batch bad.** Restore and build are their own phase and the run is `--no-build`, so exit 1 can mean exactly one thing: the old tests ran and rejected the new schema. A previous release that no longer restores or builds is exit 2, UNJUDGED.

**Only a suite that ran can call a batch good.** `dotnet test` exits **0** when it discovers nothing — `No test is available in ….dll` is a warning (verified on VSTest 18.0.1). Left alone, that would have been the last fail-*open* rot mode: an adapter that stopped resolving in the old tree reports GREEN having proven nothing. Each run now writes a trx and counts as judged only when `executed > 0`. That also catches a run environment dying before the first test (Docker down, an image that will not pull), which the old mapping reported as a confident RED.

**The previous release is not re-judged by today's rules.** `TreatWarningsAsErrors` (and an explicit `WarningsAsErrors` list) is waived for that tree. It is built to be *executed*: its own PR gated its warnings, while the advisory feed keeps moving under it and retro-fails every future promotion. Findings stay visible as warnings, the current tree keeps its own audit and zero-warning gate, and nothing from the worktree ships.

**Mixed verdicts stay honest.** A real test failure still outranks an unbuildable sibling — "promote in smaller steps" is the action either way — but the RED message now names how many suites stayed blind, so nobody splits a batch believing the split restores that coverage.

## Verification

Reproduced the exact CI failure locally against the real baseline `3875711`, then proved that tree **restores and builds clean** with the waiver — so this unblocks the promotion, it is not just a better error message.

`scripts/tests/n1-compat.tests.sh` (new, 12 cases) stubs `dotnet` on PATH over a fixture git repo; `git`, `find` and `grep` stay real. Mutation-checked — every one of these turns the suite red:

| Mutation | |
|---|---|
| `unbuildable` mapped back to `status=1` (the original bug) | killed |
| trx zero-executed floor removed | killed |
| `N1_COMPAT_SCHEMA_SCRIPTS_DIR` dropped from the run | killed |
| `suites=0` guard removed | killed |
| waiver leaked onto the current tree | killed |
| discovery narrowed to the first suite | killed |

All 7 guards self-tests, shellcheck and actionlint green. No .NET sources touched.

## Notes

- `n1-compat.yml` triggers on `scripts/n1-compat.sh`, so this PR runs the **real** proof against `HEAD^1` end to end.
- The self-test is wired into the guards job of both `pr-verify` and `ci`, and into `GUARD_INPUTS` with cases pinning both directions.
- Re-running CD #236 itself will not help — its checkout is pinned at `12bf4e50`, which predates this fix. Merging creates a fresh CD run whose prod leg carries the fixed gate; that leg still needs an approval.

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgjmRNaJie18RKr2iCyQEL
