### PR TITLE
LEGAL-14: Change e-mail address from "Moje konto" (GDPR right to rectification)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -265,6 +265,7 @@ cancellation link's landing page — LEGAL-01).
 | `POST` | `auth/change-password` | bearer token | `ChangePasswordRequest { currentPassword, newPassword }` |
 | `POST` | `auth/account/delete` | bearer token | `DeleteAccountRequest { password }` — **schedules** GDPR deletion (ADR-0031): 14-day grace window, account locked for the window, sessions + refresh tokens revoked, one-time cancellation link emailed → **204** + `X-Deletion-Scheduled-At` / `X-Deletion-Finalizes-At` headers; erasure runs in the finalizer only after the window elapses |
 | `POST` | `auth/account/cancel-deletion` | anonymous (emailed one-time token), rate-limited | `CancelAccountDeletionRequest { email, token }` → **200** `CancelAccountDeletionResponse { passwordResetToken }` — unlocks the account and forces a password reset (the pre-deletion password may be the attacker's) |
+| `POST` | `auth/account/change-email` | bearer token, `change-email-limit` (3/h per IP) | `ChangeEmailRequest { newEmail, currentPassword }` — **starts** an e-mail change (ADR-0048). Nothing on the account moves: a verification link goes to the new address (24 h) and a warning to the old one. Confirming happens on the auth pages `/Account/ConfirmEmailChange` (GET form, POST applies), after which the old address receives a 14-day link to `/Account/RevertEmailChange` that restores the address and clears the password |
 | `GET` | `auth/account/data-export` | bearer token | `AccountDataExportResponse` — GDPR export |
 | `GET` | `/` | anonymous | discovery document (links into the auth flows) |
 
@@ -514,7 +515,7 @@ Sent only with `Accept: application/vnd.dev-lotrokoniecdev.hateoas.json`.
 ### 10.2 `auth-api` rels (`AuthSystem.Contracts/Hateoas/Rels.cs`)
 
 `self`, `register`, `forgot-password`, `export-account-data` (discovery); `change-password`,
-`delete-account`, `resend-email-confirmation` (account aggregate). While a deletion is scheduled
+`change-email`, `delete-account`, `resend-email-confirmation` (account aggregate). While a deletion is scheduled
 the account aggregate suppresses the normal rels and emits only `cancel-deletion`
 (POST `auth/account/cancel-deletion`) — every other transition is a dead end on a locked account.
 

--- a/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
+++ b/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
@@ -76,29 +76,41 @@ legitimate e-mail change, and null the password, seconds after the notice arrive
 
 **The revert token is deliberately not bound to the security stamp.**
 `EmailChangeRevertTokenProvider` is our own `IUserTwoFactorTokenProvider<ApplicationUser>` over an
-`IDataProtector`, protecting `(createdAt, userId, purpose)` and nothing else. Its purpose embeds
-both addresses (`RevertEmailChange:{previous}->{new}`).
+`IDataProtector`, protecting `(createdAt, userId, revertStamp, purpose)`. Its purpose embeds both
+addresses (`RevertEmailChange:{previous}->{new}`).
 
-**Two guards, because one is not enough — and this is where the "no schema change" version of this
-ADR failed twice.**
+**Three rules, because the first two were each defeated in review.**
 
-1. *Restore from wherever the account sits.* Refuse only when the account is **already back** on
-   `previous`. Requiring it to still sit on the address the token names is the trap: an attacker
-   who knows the password changes the address twice, A→B then B→C, and the owner's A→B link matches
-   nothing while the fresh revert offer for B→C is delivered to B, which the attacker owns.
-2. *Rotate `ApplicationUser.EmailChangeRevertStamp` on a successful revert, and bake it into every
-   revert token.* Guard 1 alone opens the mirror attack: after that same chain the attacker holds
-   `Rev(B→C)` in **their** mailbox, so once the owner reverts and resets their password, the
-   attacker fires their own token, the account moves back to B, the password is cleared again and
-   the page hands them a live reset link — silently, because the revert leg sends no e-mail. Every
-   revert token is a bearer credential to move the account to its previous address, and nothing on
-   the row distinguishes the owner's from the attacker's. Rotating retires the whole chain at once
-   and is what actually makes a link single-use.
+1. *Arm at most one undo per chain, at the address the chain started from.*
+   `ApplicationUser.EmailChangeRevertTo` is set by the first change since the last revert and never
+   overwritten. Only the change that armed it carries a link. This is what makes a second change
+   worthless to an attacker: after A→B→C nothing is mailed to B, so there is no token in their
+   hands at all.
+2. *The row decides the destination, never the link.* A revert restores `EmailChangeRevertTo`, not
+   the address the presented token names. Even a leaked token can only put the account back where
+   the owner started.
+3. *Rotate `EmailChangeRevertStamp` on a successful revert, and bake it into every token.* This is
+   what makes a link single-use, together with the refusal when the account is already back on the
+   armed address.
 
-The stamp is a **new nullable column**, so this ADR no longer ships without a migration. It is
-additive and expand-only, which is the cheapest shape ADR-0023 allows, and it buys the guarantee
-the rest of this decision only claimed. It is deliberately **not** the security stamp: a password
-change rotates that, and surviving a password change is the one thing a revert token must do.
+The two rejected shapes, kept because each looks correct until it is attacked:
+
+- *"Refuse unless the account still sits on the address the token names."* An attacker chains
+  A→B then B→C, and the owner's A→B link matches nothing.
+- *"Restore from wherever the account sits, and rotate a stamp for single use."* Rotation is
+  symmetric and the attacker held `Rev(B→C)` in their own mailbox, so they simply clicked first:
+  the stamp rotated, the owner's link died, and the account was theirs at B with a password they
+  chose. Whoever clicks first wins, and the attacker is not waiting for an e-mail.
+
+Both fell to the same thing — a token that names its own destination is a bearer credential, and
+after a chain of changes the attacker holds one. Rule 1 stops one being issued to them; rule 2
+makes it useless if one ever is.
+
+The two columns are **new nullable fields**, so this ADR no longer ships without a migration. They
+are additive and expand-only, which is the cheapest shape ADR-0023 allows, and they buy the
+guarantee the rest of this decision only claimed. The revert stamp is deliberately **not** the
+security stamp: a password change rotates that, and surviving a password change is the one thing a
+revert token must do.
 
 ## Consequences
 
@@ -122,8 +134,12 @@ change rotates that, and surviving a password change is the one thing a revert t
 - **A revert token outlives a password change by design.** That is the whole point, and it means
   the token cannot be cancelled by rotating the stamp — the usual lever in this codebase. Anyone
   touching `EmailChangeRevertTokenProvider` must understand that omitting the stamp is the
-  requirement, not an oversight, and the guard that replaces it is the not-already-back check on
-  the revert page.
+  requirement, not an oversight. What replaces it is `EmailChangeRevertStamp`, rotated on revert
+  and only on revert.
+- **A second change in a chain gets no undo link.** If the *owner* legitimately changes twice, the
+  second change sends its notices without one, and their outstanding link still restores to where
+  the chain started rather than to the intermediate address. Slightly surprising, and the safe way
+  round: the alternative hands a working link to whoever holds the intermediate mailbox.
 - **Unused tokens from before the last revert are dead, including ones their owner still wanted.**
   Rotating on revert is deliberately blunt: it cannot tell the attacker's token from a second
   legitimate one. A user who had two changes in flight and reverts one loses the other's link and
@@ -202,8 +218,11 @@ change rotates that, and surviving a password change is the one thing a revert t
   14 days, carrying `(createdAt, userId, revertStamp, purpose)`. Its unit tests must pin **both**
   halves: a *security* stamp rotation does not invalidate it, and a *revert* stamp rotation does.
   Those two assertions are this ADR, executable.
-- `EmailChangeCompletedProcessor` skips a redelivery whose account has already moved on, so a
-  dead-lettered replay cannot mint a fresh token and restart the fourteen days.
+- `EmailChangeCompletedProcessor` mints and sends a revert link only when `EmailChangeRevertTo`
+  still names the address this message came from. A redelivery therefore cannot arm a second link,
+  and a later change in the chain cannot arm one at all. Its unit tests must stub
+  `UserManager.NormalizeEmail`: an unstubbed substitute returns null on both sides and
+  `string.Equals(null, null)` is true, which silently walks every test past that branch.
 - Every value that arrives in one of these links is checked for shape before the page prints it or
   acts on it. The user id must parse as a `Guid` — Identity converts it to the key type before it
   queries, so a non-GUID throws inside the store and a bad link becomes a 500 on a page somebody

--- a/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
+++ b/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
@@ -1,0 +1,183 @@
+# ADR-0048: An E-mail Change Is Undone From the Old Mailbox, With a Token No Stamp Rotation Can Kill
+
+**Status:** Accepted
+**Date:** 2026-08-20
+**Decision-makers:** Solo maintainer (ticket #671, LEGAL-14, legal & GDPR pack #459)
+**Related:** ADR-0031 (the same threat, answered for deletion), ADR-0038 (the one dispatch
+pipeline every e-mail here rides), ADR-0046 (what may be said behind a verified password),
+spec 0013, `Features/Auth/RequestEmailChange`, `Pages/Account/ConfirmEmailChange`,
+`Pages/Account/RevertEmailChange`, `Persistence/Identity/EmailChangeRevertTokenProvider`
+
+## Context
+
+The e-mail address is the login identifier: `LoginModel` resolves the account with
+`FindByEmailAsync`. So "change your e-mail" is really "change the credential you sign in with",
+and LEGAL-14 asks us to expose it as self-service, because the privacy policy §06 already promises
+rectification "w ustawieniach konta".
+
+The obvious flow — current password, then a verification link clicked in the new mailbox — has a
+hole the maintainer named directly: **the password is the only barrier, and the password is
+exactly what gets stolen.** An attacker who credential-stuffs their way in changes the address to
+one they own, clicks their own link, and the real owner is locked out permanently. They cannot log
+in (wrong address), cannot reset a password (the reset link goes to the attacker), and cannot use
+the deletion-cancel path (nothing was deleted). Support e-mail is the only way back, which is what
+the ticket set out to remove.
+
+This is not a new problem in this repo. ADR-0031 hit the identical shape — "a single
+credential-stuffing hit could erase an entire account with zero recovery window" — and answered
+it without adding a second factor the product does not have: **do not block the action, give the
+mailbox the attacker does not control a single-use way to undo it, and destroy the stolen
+credential on the way out.** `CancelAccountDeletion` nulls `PasswordHash` for exactly that reason.
+
+Requiring the *old* mailbox to approve before anything moves would close the hole completely, and
+was rejected: "I no longer have access to my old mailbox" is the single most common legitimate
+reason to change an e-mail address, and gating on that mailbox turns the feature back into a
+support ticket for the people who need it most.
+
+One detail decides whether the undo pattern actually works here. Identity's
+`DataProtectorTokenProvider` writes the user's security stamp into every token and refuses it once
+the stamp moves. Changing the password rotates the stamp — and changing the password is precisely
+the attacker's next move after taking over the address. A stamp-bound revert token is dead by the
+time the victim reads their mail.
+
+## Decision
+
+**An e-mail change proceeds on password + a click in the new mailbox, and the old mailbox holds a
+14-day, single-use revert link that restores the address and destroys the password.**
+
+1. **Request** (`POST auth/account/change-email`, authorized, 3/hour per IP). Password verified,
+   new address checked free, a scheduled deletion refuses the whole thing (ADR-0031's lockout must
+   stay reachable). Nothing on the user row changes, so the handler saves the outbox row itself —
+   `ForgotPassword` is the shape to copy, not `DeleteAccount`. One `EmailChangeRequested` row,
+   carrying **both** the current and the target address. Its processor sends **two** e-mails: the
+   verification link to the new address, and a warning to the old one naming the target, so the
+   owner learns of an attack while the link is still unclicked.
+2. **Confirm** (`/Account/ConfirmEmailChange`, anonymous, token-authorized). **GET renders a
+   confirmation form; the POST does the work.** The token is a stamp-bound
+   `EmailChangeTokenProvider` whose purpose embeds the target address, so editing the address in
+   the URL fails verification. The POST verifies the token *first*, then in **one** save: new
+   address, `EmailConfirmed = true`, security stamp rotated, and an `EmailChangeCompleted` outbox
+   row. Then `IUserSessionRevoker` revokes the OpenIddict tokens and authorizations.
+3. **Notify + arm the undo.** `EmailChangeCompleted` carries both addresses. Its processor sends a
+   notice to the new address and, to the **old** address, a notice carrying the revert link.
+4. **Revert** (`/Account/RevertEmailChange`, anonymous, token-authorized, 14 days). **GET renders a
+   confirmation form; the POST does the work.** It restores the previous address, sets
+   `PasswordHash = null`, rotates the stamp, revokes sessions and hands the visitor into the
+   password-reset flow — `CancelAccountDeletion`'s playbook, verbatim. The stolen password stops
+   working at that moment.
+
+**Neither page may mutate on `GET`.** `CancelDeletion.cshtml.cs` states the reason in its own doc
+comment: *"A GET only shows a confirmation form, so a mail scanner that opens the link cancels
+nothing."* The revert link lands in a **live** mailbox, and corporate mail security (SafeLinks,
+Proofpoint, Mimecast) fetches every URL it sees. A GET-mutating revert page would undo every
+legitimate e-mail change, and null the password, seconds after the notice arrived.
+`ConfirmEmail.cshtml.cs` does mutate on `GET`; it is the older outlier, not the pattern to copy.
+
+**The revert token is deliberately not bound to the security stamp.**
+`EmailChangeRevertTokenProvider` is our own `IUserTwoFactorTokenProvider<ApplicationUser>` over an
+`IDataProtector`, protecting `(createdAt, userId, purpose)` and nothing else. Its purpose embeds
+both addresses (`RevertEmailChange:{previous}->{new}`). It is single-use in effect, not by stamp
+rotation: the page refuses unless the account currently sits on the address the token was issued
+against, so a second click, or a token issued for an older change, changes nothing.
+
+## Consequences
+
+**Good**
+
+- The threat the ticket could not otherwise answer is answered: an attacker with the password but
+  not the old mailbox holds the account for at most 14 days, and loses the password when the owner
+  clicks. Two e-mails have to be missed for the takeover to stick.
+- The legitimate "I lost my old mailbox" case still self-serves. Nothing in the flow requires
+  reading the old inbox.
+- No new factor, no new infrastructure, no schema change: no `PendingEmail` column, no audit table,
+  **no EF migration**, so ADR-0023 has nothing to weigh in on. Pending state lives in the token.
+- It mirrors ADR-0031, so a reader who understands deletion already understands this.
+
+**Bad / accepted**
+
+- **The window is not a lock.** For up to 14 days the attacker really does control the account and
+  can read and write translations. We accept it: the alternative locks out the users the feature
+  exists for. Deletion could afford the lockout because the account was on its way out anyway.
+- **A revert token outlives a password change by design.** That is the whole point, and it means
+  the token cannot be cancelled by rotating the stamp — the usual lever in this codebase. Anyone
+  touching `EmailChangeRevertTokenProvider` must understand that omitting the stamp is the
+  requirement, not an oversight, and the guard that replaces it is the current-address check on the
+  revert page.
+- **The old address learns the new one.** The warning and the notice both name it in full. In the
+  attack case the recipient is the legitimate owner and needs it to act; in the normal case the
+  recipient is the user themselves.
+- **At-least-once delivery can double a send.** `EmailChangeRequested` sends two e-mails from one
+  message, so a failure on the second retries the first. Duplicated warnings and duplicated
+  verification links are harmless — a resent link is the same link — which is the bar ADR-0038's
+  registry sets for any new message type.
+- **A password change kills a *pending* change**, because the confirm token is stamp-bound. The
+  user simply asks again. Only the revert token is exempt.
+- **A lost data-protection keyring kills a revert link with no way to reissue it.** The runbook
+  already notes that losing the auth keyring breaks antiforgery plus the password-reset and
+  confirmation links — but those live 24 h, so the damage self-heals in a day. A revert token lives
+  14 days and, because this ADR deliberately persists nothing, there is no server-side record from
+  which to mint a replacement. The keyring volume (M6-04 / ADR-0005) is now load-bearing for two
+  weeks instead of one day.
+- **The uniqueness check is application-level and racy.** `UserManager.UpdateAsync` validates with
+  `FindByEmailAsync` *before* the write, so the unique index from `UniqueEmailIndex` is the only
+  real arbiter. `UserStore.UpdateAsync` catches only `DbUpdateConcurrencyException`, so a Postgres
+  `23505` surfaces as an unhandled `DbUpdateException`. Both write legs therefore carry
+  `RegisterUser`'s `catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)`
+  and turn the race into a `Result` failure instead of a 500.
+
+## Alternatives Considered
+
+- **Old address approves first, then the new one confirms.** Closes the hole outright. Rejected:
+  it makes the feature unusable for anyone who lost the old mailbox, which is the main reason
+  people change an address at all. It would trade one support-ticket-only population for another,
+  larger one.
+- **Notify the old address and offer nothing to click.** The smallest diff and what GitHub-class
+  products do. Rejected on the maintainer's own objection: a notice the owner misses, or cannot
+  read, leaves no way back, and this repo already refused that trade for deletion.
+- **A revert link built on `DataProtectorTokenProvider` like every other token here.** Rejected on
+  a mechanism check, not on taste: it embeds the security stamp, and the attacker rotates the stamp
+  by changing the password. The link would be dead before it was useful.
+- **Persist the pending change and the revert secret in columns** (`PendingEmail`,
+  `EmailRevertTokenHash`, `EmailRevertUntil`). Robust and inspectable, and it would give a real
+  audit row. Rejected as YAGNI for now: it buys nothing the token does not already give, and it
+  costs a migration plus expand/backfill discipline on a ~zero-user table. Revisit if we ever need
+  to *show* a pending change in the UI or to cancel one administratively.
+- **Step up with a second factor.** There is no second factor in the product. Out of scope.
+- **Use Identity's built-in `GenerateChangeEmailTokenAsync` / `ChangeEmailAsync` for the confirm
+  leg.** Both are public, and `ChangeEmailAsync` sets the address, sets `EmailConfirmed`, rotates
+  the stamp and saves **once** — so it does *not* split the mutation from the outbox row, and an
+  earlier draft of this ADR was wrong to say it did. Rejected for one narrower reason:
+  `ChangeEmailAsync` verifies the token *inside* itself, and Identity's purpose string
+  (`"ChangeEmail:" + newEmail`) is a `private static` a caller cannot reproduce. So the only
+  available order is enqueue-then-call, and an invalid token returns before saving — leaving a
+  tracked `EmailChangeCompleted` row in a request-scoped `AuthDbContext` that OpenIddict also
+  writes through, where a later flush can send a "your address changed" e-mail for a change that
+  never happened. Owning the provider lets the handler verify first, then commit the row and the
+  mutation together, which is the `DeleteAccount` / `CancelAccountDeletion` shape this repo already
+  uses for exactly this problem.
+
+## Implementation Notes
+
+- `EmailChangeTokenProvider` (confirm leg) is an ordinary `DataProtectorTokenProvider`, registered
+  like `AccountDeletionCancellationTokenProvider`, lifespan 24 h to match the activation link the
+  users already know. It exists so the handler can call `VerifyUserTokenAsync` **before** it
+  enqueues anything — see the rejected alternative above, not because Identity's own API is
+  unavailable or transactionally worse.
+- Do **not** set `NormalizedEmail` by hand. `UserManager.UpdateAsync` runs
+  `UpdateNormalizedEmailAsync` after validation and before the write, so a hand-set value is
+  overwritten either way.
+- `EmailChangeRevertTokenProvider` (revert leg) is hand-written over `IDataProtector`, lifespan
+  14 days, **no stamp**. Its unit tests must pin that a stamp rotation does *not* invalidate it —
+  that assertion is the ADR, executable.
+- Both new outbox types get a `RabbitMqTopology` routing key under `email.*`. The queue binds
+  `email.#`, so no binding or queue-argument change and no `PRECONDITION_FAILED` risk (ADR-0036).
+- Neither leg may call SMTP on a request path; both go through the outbox (ADR-0038).
+  `ResendEmailConfirmation` stays the one deliberate exception in this system.
+
+## References
+
+- Ticket #671 (LEGAL-14), spec 0013
+- ADR-0031 (deletion grace period — the same threat, the same answer)
+- ADR-0038 (one dispatch pipeline for every transactional e-mail)
+- Google's 7-day "recover your account" window and Apple's rescue-address pattern are the
+  consumer-scale precedents for undo-from-the-old-mailbox.

--- a/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
+++ b/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
@@ -61,7 +61,8 @@ time the victim reads their mail.
 3. **Notify + arm the undo.** `EmailChangeCompleted` carries both addresses. Its processor sends a
    notice to the new address and, to the **old** address, a notice carrying the revert link.
 4. **Revert** (`/Account/RevertEmailChange`, anonymous, token-authorized, 14 days). **GET renders a
-   confirmation form; the POST does the work.** It restores the previous address, sets
+   confirmation form; the POST does the work.** It restores the previous address *from wherever the
+   account currently sits*, sets
    `PasswordHash = null`, rotates the stamp, revokes sessions and hands the visitor into the
    password-reset flow — `CancelAccountDeletion`'s playbook, verbatim. The stolen password stops
    working at that moment.
@@ -76,9 +77,16 @@ legitimate e-mail change, and null the password, seconds after the notice arrive
 **The revert token is deliberately not bound to the security stamp.**
 `EmailChangeRevertTokenProvider` is our own `IUserTwoFactorTokenProvider<ApplicationUser>` over an
 `IDataProtector`, protecting `(createdAt, userId, purpose)` and nothing else. Its purpose embeds
-both addresses (`RevertEmailChange:{previous}->{new}`). It is single-use in effect, not by stamp
-rotation: the page refuses unless the account currently sits on the address the token was issued
-against, so a second click, or a token issued for an older change, changes nothing.
+both addresses (`RevertEmailChange:{previous}->{new}`).
+
+**The single-use guard is "the account is not already back on the previous address" — not "the
+account still sits on the address the token names".** The stricter-looking version is the one that
+fails: an attacker who knows the password simply changes the address twice, A→B then B→C. The
+owner's A→B link would then match nothing, while the fresh revert offer for B→C is delivered to B,
+which the attacker owns. Two API calls inside the hour's rate budget, and the guarantee above is
+gone. Restoring `previous` from wherever the account has been dragged is what makes the promise
+true. The second click is still refused, because by then the account *is* back on the previous
+address, so a revert cannot run twice and clear a password the owner has since reset.
 
 ## Consequences
 
@@ -101,8 +109,15 @@ against, so a second click, or a token issued for an older change, changes nothi
 - **A revert token outlives a password change by design.** That is the whole point, and it means
   the token cannot be cancelled by rotating the stamp — the usual lever in this codebase. Anyone
   touching `EmailChangeRevertTokenProvider` must understand that omitting the stamp is the
-  requirement, not an oversight, and the guard that replaces it is the current-address check on the
-  revert page.
+  requirement, not an oversight, and the guard that replaces it is the not-already-back check on
+  the revert page.
+- **A revert token revives if the account legitimately returns to the same pair.** Because the
+  guard is stateless, an A→B token that was never used starts working again if the user later moves
+  A→B once more within its 14 days. The holder of mailbox A could then undo that later, wanted
+  change and clear the password. We accept it: the power is bounded by the same 14 days, and it
+  belongs to whoever controls the address the account itself came from — the same party the token
+  was issued to. Persisting the pending change would close it, at the cost of the columns this ADR
+  rejected.
 - **The old address learns the new one.** The warning and the notice both name it in full. In the
   attack case the recipient is the legitimate owner and needs it to act; in the normal case the
   recipient is the user themselves.
@@ -169,6 +184,11 @@ against, so a second click, or a token issued for an older change, changes nothi
 - `EmailChangeRevertTokenProvider` (revert leg) is hand-written over `IDataProtector`, lifespan
   14 days, **no stamp**. Its unit tests must pin that a stamp rotation does *not* invalidate it —
   that assertion is the ADR, executable.
+- Every value that arrives in one of these links is checked for shape before the page prints it or
+  acts on it. The user id must parse as a `Guid` — Identity converts it to the key type before it
+  queries, so a non-GUID throws inside the store and a bad link becomes a 500 on a page somebody
+  opened from their inbox — and the addresses must match `EmailConstants.RegexPattern`, which also
+  keeps arbitrary text off a branded page that carries a password-clearing button.
 - Both new outbox types get a `RabbitMqTopology` routing key under `email.*`. The queue binds
   `email.#`, so no binding or queue-argument change and no `PRECONDITION_FAILED` risk (ADR-0036).
 - Neither leg may call SMTP on a request path; both go through the outbox (ADR-0038).

--- a/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
+++ b/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
@@ -79,14 +79,26 @@ legitimate e-mail change, and null the password, seconds after the notice arrive
 `IDataProtector`, protecting `(createdAt, userId, purpose)` and nothing else. Its purpose embeds
 both addresses (`RevertEmailChange:{previous}->{new}`).
 
-**The single-use guard is "the account is not already back on the previous address" — not "the
-account still sits on the address the token names".** The stricter-looking version is the one that
-fails: an attacker who knows the password simply changes the address twice, A→B then B→C. The
-owner's A→B link would then match nothing, while the fresh revert offer for B→C is delivered to B,
-which the attacker owns. Two API calls inside the hour's rate budget, and the guarantee above is
-gone. Restoring `previous` from wherever the account has been dragged is what makes the promise
-true. The second click is still refused, because by then the account *is* back on the previous
-address, so a revert cannot run twice and clear a password the owner has since reset.
+**Two guards, because one is not enough — and this is where the "no schema change" version of this
+ADR failed twice.**
+
+1. *Restore from wherever the account sits.* Refuse only when the account is **already back** on
+   `previous`. Requiring it to still sit on the address the token names is the trap: an attacker
+   who knows the password changes the address twice, A→B then B→C, and the owner's A→B link matches
+   nothing while the fresh revert offer for B→C is delivered to B, which the attacker owns.
+2. *Rotate `ApplicationUser.EmailChangeRevertStamp` on a successful revert, and bake it into every
+   revert token.* Guard 1 alone opens the mirror attack: after that same chain the attacker holds
+   `Rev(B→C)` in **their** mailbox, so once the owner reverts and resets their password, the
+   attacker fires their own token, the account moves back to B, the password is cleared again and
+   the page hands them a live reset link — silently, because the revert leg sends no e-mail. Every
+   revert token is a bearer credential to move the account to its previous address, and nothing on
+   the row distinguishes the owner's from the attacker's. Rotating retires the whole chain at once
+   and is what actually makes a link single-use.
+
+The stamp is a **new nullable column**, so this ADR no longer ships without a migration. It is
+additive and expand-only, which is the cheapest shape ADR-0023 allows, and it buys the guarantee
+the rest of this decision only claimed. It is deliberately **not** the security stamp: a password
+change rotates that, and surviving a password change is the one thing a revert token must do.
 
 ## Consequences
 
@@ -97,8 +109,9 @@ address, so a revert cannot run twice and clear a password the owner has since r
   clicks. Two e-mails have to be missed for the takeover to stick.
 - The legitimate "I lost my old mailbox" case still self-serves. Nothing in the flow requires
   reading the old inbox.
-- No new factor, no new infrastructure, no schema change: no `PendingEmail` column, no audit table,
-  **no EF migration**, so ADR-0023 has nothing to weigh in on. Pending state lives in the token.
+- No new factor and no new infrastructure. The pending change itself still lives in the token — no
+  `PendingEmail` column, no audit table. The one schema cost is a single nullable
+  `EmailChangeRevertStamp`, additive and expand-only (ADR-0023's cheapest shape).
 - It mirrors ADR-0031, so a reader who understands deletion already understands this.
 
 **Bad / accepted**
@@ -111,13 +124,17 @@ address, so a revert cannot run twice and clear a password the owner has since r
   touching `EmailChangeRevertTokenProvider` must understand that omitting the stamp is the
   requirement, not an oversight, and the guard that replaces it is the not-already-back check on
   the revert page.
-- **A revert token revives if the account legitimately returns to the same pair.** Because the
-  guard is stateless, an A→B token that was never used starts working again if the user later moves
-  A→B once more within its 14 days. The holder of mailbox A could then undo that later, wanted
-  change and clear the password. We accept it: the power is bounded by the same 14 days, and it
-  belongs to whoever controls the address the account itself came from — the same party the token
-  was issued to. Persisting the pending change would close it, at the cost of the columns this ADR
-  rejected.
+- **Unused tokens from before the last revert are dead, including ones their owner still wanted.**
+  Rotating on revert is deliberately blunt: it cannot tell the attacker's token from a second
+  legitimate one. A user who had two changes in flight and reverts one loses the other's link and
+  must ask again. That is the right way round — a stale link that still works is what the second
+  review found, twice.
+- **The revert also cancels a scheduled deletion.** It has to: rotating the security stamp kills
+  ADR-0031's cancel token, and after an address change that cancel link was mailed to the address
+  the account was moved to. Refusing the revert instead would leave the account locked, unable to
+  log in or reset, and hard-erased by the finalizer — data loss reachable from one ordinary click.
+  So this is a second, deliberate way back into a locked account, and it is exactly as strong as
+  the first: proof of control over the mailbox the account came from.
 - **The old address learns the new one.** The warning and the notice both name it in full. In the
   attack case the recipient is the legitimate owner and needs it to act; in the normal case the
   recipient is the user themselves.
@@ -182,8 +199,11 @@ address, so a revert cannot run twice and clear a password the owner has since r
   `UpdateNormalizedEmailAsync` after validation and before the write, so a hand-set value is
   overwritten either way.
 - `EmailChangeRevertTokenProvider` (revert leg) is hand-written over `IDataProtector`, lifespan
-  14 days, **no stamp**. Its unit tests must pin that a stamp rotation does *not* invalidate it —
-  that assertion is the ADR, executable.
+  14 days, carrying `(createdAt, userId, revertStamp, purpose)`. Its unit tests must pin **both**
+  halves: a *security* stamp rotation does not invalidate it, and a *revert* stamp rotation does.
+  Those two assertions are this ADR, executable.
+- `EmailChangeCompletedProcessor` skips a redelivery whose account has already moved on, so a
+  dead-lettered replay cannot mint a fresh token and restart the fourteen days.
 - Every value that arrives in one of these links is checked for shape before the page prints it or
   acts on it. The user id must parse as a `Guid` — Identity converts it to the key type before it
   queries, so a non-GUID throws inside the store and a bad link becomes a 500 on a page somebody

--- a/docs/specs/0013-self-service-email-change.md
+++ b/docs/specs/0013-self-service-email-change.md
@@ -1,0 +1,343 @@
+# Spec 0013: Self-service e-mail change from "Moje konto"
+
+- **Status:** Agreed
+- **Date:** 2026-08-20
+- **Author:** koniecdev
+- **Ticket:** #671 (LEGAL-14)
+- **Related:** **ADR-0048** (the guard decision: undo from the old mailbox, with a token no stamp
+  rotation can kill), spec 0009 (Moje konto GDPR self-service — this is its explicit "e-mail
+  change" out-of-scope item), ADR-0031 (two-phase deletion — the same threat, answered first),
+  ADR-0035/0036/0037/0038 (the outbox → broker → processor e-mail pipeline), ADR-0040
+  (authorization-aware HATEOAS links), ADR-0044 (frontend owns Polish copy), ADR-0046 (what may be
+  said behind a verified password).
+  Siblings to mirror: `Features/Auth/ChangePassword.cs` (the authorized command),
+  `Features/Auth/ForgotPassword.cs` (a pure-send handler that saves its own outbox row),
+  `Features/Auth/CancelAccountDeletion.cs` (verify token → mutate → outbox in one save),
+  `Pages/Account/CancelDeletion.cshtml(.cs)` (**the page shape: GET form, POST action**),
+  `Components/Pages/Account/ChangePassword.razor`,
+  `Persistence/Identity/AccountDeletionCancellationTokenProvider.cs`.
+
+## Business context
+
+The privacy policy already promises rectification as self-service: §06 says *"Prawo do
+sprostowania — poprawisz nieaktualne lub błędne dane w ustawieniach konta."* Today nothing in
+"Moje konto" is editable, so that sentence is false and art. 16 RODO is only reachable by
+e-mailing the owner. The e-mail address is also the **login identifier** (`LoginModel` looks the
+user up with `FindByEmailAsync`), so a translator who loses access to their mailbox loses access
+to the account with no way back that does not involve a human.
+
+Spec 0009 deliberately parked "e-mail change" as out of scope when it built the account section.
+This spec is that follow-up: the last self-service GDPR right the policy claims and the product
+does not deliver.
+
+The naive flow — password plus a click in the new mailbox — hands the account to anyone who steals
+the password, permanently. ADR-0048 records why we answer that with an undo from the old mailbox
+rather than with an approval gate on it.
+
+## Goal
+
+A signed-in translator can change the e-mail address they log in with, from "Moje konto", proving
+it with their current password and with a click on a link sent to the **new** address. The old
+mailbox is told before and after, and holds a 14-day single-use link that undoes the change and
+destroys the password that authorised it.
+
+## In scope
+
+### The four legs
+
+```
+REQUEST   POST auth/account/change-email      password + new address, authorized, 3/h per IP
+          → warning e-mail        → OLD inbox (names the target address)
+          → verification link     → NEW inbox (24 h)
+
+CONFIRM   GET  /Account/ConfirmEmailChange    renders a confirmation form — MUTATES NOTHING
+          POST /Account/ConfirmEmailChange    token verified first, then ONE save:
+          address moves · EmailConfirmed = true · stamp rotated · outbox row
+          → sessions revoked
+          → notice                → NEW inbox
+          → notice + REVERT link  → OLD inbox (14 days)
+
+REVERT    GET  /Account/RevertEmailChange     renders a confirmation form — MUTATES NOTHING
+          POST /Account/RevertEmailChange     address restored · PasswordHash = null
+          → stamp rotated · sessions revoked · password-reset flow
+```
+
+**Neither page may mutate on `GET`.** `Pages/Account/CancelDeletion.cshtml.cs` says why in its own
+doc comment: *"A GET only shows a confirmation form, so a mail scanner that opens the link cancels
+nothing."* The revert link lands in a **live** mailbox, and corporate mail security fetches every
+URL it sees — a GET-mutating revert page would undo every legitimate change and null the password
+seconds after the notice arrived. `ConfirmEmail.cshtml.cs` mutates on `GET`; it is the older
+outlier and explicitly **not** the pattern here.
+
+### Auth API (`LotroKoniecDev.AuthSystem.API`)
+
+- **`Features/Auth/RequestEmailChange.cs`** — `POST auth/account/change-email`,
+  `RequireAuthorization()`, mirroring `ChangePassword`. Command
+  `(UserId, NewEmail, CurrentPassword, IpAddress, UserAgent)`; FluentValidation validator for the
+  command (`EmailConstants` rules on `NewEmail`, non-empty password). The handler verifies the
+  password, refuses while a deletion is scheduled, refuses the caller's own current address,
+  refuses an address another account holds, and enqueues one outbox row. It **does not mutate the
+  user**, so — like `ForgotPassword.cs:90-91` and unlike `DeleteAccount` — it injects
+  `AuthDbContext` and calls `SaveChangesAsync` itself before `NotifyEnqueuedCommitted()`.
+  `OutboxWriter.Enqueue` only `Add`s; a handler that forgets the save sends nothing.
+- **`Features/Auth/ConfirmEmailChange.cs`** and **`Features/Auth/RevertEmailChange.cs`** — the two
+  page legs as `ICommandHandler` slices, so the PageModels stay thin (CLAUDE.md: "handlers are
+  orchestrators"). `CancelDeletion.cshtml.cs` + `CancelAccountDeletion.cs` is the exact pair to
+  mirror; `ConfirmEmail.cshtml.cs`, which inlines its logic, is not.
+- **`Persistence/Identity/EmailChangeTokenProvider.cs`** — our own
+  `DataProtectorTokenProvider<ApplicationUser>` + options class, exactly like
+  `AccountDeletionCancellationTokenProvider`. `ProviderName = "EmailChange"`,
+  `PurposeFor(newEmail) => $"ChangeEmail:{newEmail}"`, lifespan **24 h**. It exists so the handler
+  can `VerifyUserTokenAsync` **before** it enqueues anything: Identity's own `ChangeEmailAsync`
+  verifies internally against a `private static` purpose string, forcing an enqueue-then-call
+  order that leaves a tracked outbox row behind on a bad token (ADR-0048 §Alternatives). It is
+  *not* because Identity's API is unavailable — `GenerateChangeEmailTokenAsync` and
+  `ChangeEmailAsync` are both public and both save exactly once.
+- **`Persistence/Identity/EmailChangeRevertTokenProvider.cs`** — hand-written
+  `IUserTwoFactorTokenProvider<ApplicationUser>` over `IDataProtector`, protecting
+  `(createdAt, userId, purpose)` and **no security stamp**, lifespan **14 days**,
+  `PurposeFor(previous, next) => $"RevertEmailChange:{previous}->{next}"`. ADR-0048 §Decision
+  explains why the stamp must be left out; a unit test pins that a stamp rotation does not kill it.
+  `AddTokenProvider` type-checks `IUserTwoFactorTokenProvider<TUser>`, not
+  `DataProtectorTokenProvider`, so it registers exactly like the existing one.
+- **Outbox contracts** `Outbox/EmailChangeRequested.cs`
+  (`Guid IdentityUserId, string CurrentEmail, string NewEmail`) and `Outbox/EmailChangeCompleted.cs`
+  (`Guid IdentityUserId, string PreviousEmail, string NewEmail`). Both carry addresses because —
+  unlike `EmailConfirmationRequested` — reading them off the user row at send time is wrong: after
+  a delayed or dead-lettered redelivery the row already holds the **new** address, and a warning
+  meant for the old mailbox would go to the attacker. The **tokens** are still created by the
+  processor at send time, so "the link expires 24 h from when you receive this" stays true.
+- **Routing** — two entries in `OutboxMessageRouting` and two routing keys in `RabbitMqTopology`
+  (`email.change-requested`, `email.change-completed`). The queue binds `email.#`, so no binding
+  or queue-argument change, hence no `PRECONDITION_FAILED` risk (ADR-0036).
+- **Processors** `Services/Emails/EmailChangeRequestProcessor.cs` (verification link → new,
+  warning → old; skips when `user.Email` no longer equals `CurrentEmail`, because the request is
+  already resolved) and `EmailChangeCompletedProcessor.cs` (notice → new, notice + revert link →
+  old), registered as keyed `IEmailMessageProcessor` (ADR-0038). Both are safe to run twice.
+- **Sender + link factories** `Services/Emails/IEmailChangeEmailSender` + `EmailChangeEmailSender`
+  (four templates), `EmailChangeVerificationLinkFactory`, `EmailChangeRevertLinkFactory` — scheme
+  and host from the configured issuer, never the `Host` header (copied from
+  `EmailVerificationLinkFactory`).
+- **`Pages/Account/ConfirmEmailChange.cshtml(.cs)`** — `?userId=&email=&token=` on the GET, the
+  same values posted back from a hidden form. `[EnableRateLimiting("auth-endpoint-limit")]`, like
+  every sibling page.
+- **`Pages/Account/RevertEmailChange.cshtml(.cs)`** — `?userId=&from=&to=&token=`, same shape. The
+  POST refuses unless the account currently sits on `to`, restores `from`, nulls `PasswordHash`,
+  rotates the stamp, revokes sessions and hands the visitor a password-reset token, exactly as
+  `CancelAccountDeletion` does.
+- **`ApiErrors/AuthErrors`** += `InvalidEmailChangeToken`, `EmailChangeSameAddress`,
+  `EmailChangeFailed(details)`. `UserAlreadyExistsByEmail`, `InvalidCurrentPassword` and
+  `DeletionAlreadyScheduled` are reused.
+- **Rate limiting** — a new `change-email-limit` policy in `Program.cs`: **3 per hour partitioned
+  by remote IP**, copying `forgot-password-limit`, which guards the same abuse (flooding a
+  stranger's inbox). It cannot be partitioned by user: `app.UseRateLimiter()` sits at
+  `Program.cs:380`, deliberately **before** `app.UseAuthentication()` at `:383`, so
+  `httpContext.User` is still the anonymous default when the partition key is computed — a
+  "user id" key would collapse to one global bucket any anonymous caller could exhaust.
+- **Contracts** — `Features/Auth/Account/ChangeEmailRequest.cs`
+  (`string NewEmail, string CurrentPassword`), and `Rels.ChangeEmail = "change-email"` advertised
+  by `AccountAggregateLinkFactory` for an active (non-deletion-scheduled) account.
+
+### Frontend (`LotroKoniecDev.Frontend`)
+
+- **`Components/Pages/Account/ChangeEmail.razor`** — `/account/change-email`, `[Authorize]`,
+  static SSR, mirroring `ChangePassword.razor`: new address + repeat + current password, follows
+  the `change-email` rel from the account export envelope, renders API `ProblemDetails`, and on
+  success shows "sprawdź nową skrzynkę" instead of claiming the address already changed. The copy
+  states plainly that the address is also the login, and that the old mailbox gets a way to undo.
+- **`AccountLoader.RequestEmailChangeAsync(href, newEmail, currentPassword, ct)`**.
+- **`Account.razor`** — a "Zmień e-mail" action row in "Operacje", gated on
+  `Links.HasLink(Rels.ChangeEmail)`, plus a "Zmień" link next to the e-mail value in "Dane konta".
+
+### Docs & legal copy
+
+- `Pages/Account/PrivacyPolicy.cshtml` — the "Realizacja praw bez formalności" card names only
+  export and deletion today; it gains the e-mail change (owner decision). §06's rectification
+  promise needs no edit — this ticket is what makes it true.
+- `docs/API.md` — the auth endpoint list and the account-aggregate rel table both need the new
+  entries.
+
+### Tests
+
+- `AuthSystem.API.Tests.Unit` — the `RequestEmailChange` handler across every branch; the confirm
+  and revert handlers; both processors, including repeat-safety and the stale-request skip; both
+  token providers, including the stamp-rotation assertion that is ADR-0048 made executable.
+- `AuthSystem.API.Tests.Integration` — the endpoint (401 / 400 / 422 / happy), the confirm page
+  (GET mutates nothing, valid POST, tampered address, expired, replayed, address taken meanwhile)
+  and the revert page (GET mutates nothing, valid POST, wrong current address, after a password
+  change, replayed). The 429 case needs its own factory with `RateLimiting:ForceEnable`, mirroring
+  `Tests/RateLimiting/ResendConfirmationRateLimitingTests` — the limiter is off in Testing.
+- `Frontend.Tests.Unit` — loader + bUnit render tests, mirroring the `ChangePassword.razor` tests.
+
+## Out of scope
+
+- **Recovering an account whose registration address was mistyped** (owner decision). With
+  `RequireConfirmedEmail = true` such a user cannot log in, so an authorized endpoint can never
+  reach them. Fixing that needs an anonymous, password-verified flow with a different threat model
+  — a separate ticket.
+- **Blocking the attacker during the revert window.** ADR-0048 accepts that the account is really
+  taken over for up to 14 days; a lockout would break the users the feature exists for.
+- **Changing the username.** `UserName` is separate from `Email` here (`RegisterUser` takes both),
+  and nothing in the ticket asks for it.
+- **A `PendingEmail` column, a revert-secret column or an audit table.** The tokens carry the
+  pending state, so **this ticket ships no EF migration**. The audit trail the ticket asks for is
+  structured logging with masked addresses + IP + user agent, which is what `DeleteAccount` and
+  `CancelAccountDeletion` already do.
+- **Two-factor / step-up auth** on the change. The password is the factor the product has.
+- **Security headers on the auth origin.** The CSP of bug #670 is emitted only by the frontend's
+  `SecurityHeadersMiddleware`; the auth origin ships none, so the new pages' inline `<style>` is
+  unaffected. That the auth origin has no security headers at all is a real pre-existing gap and a
+  separate ticket.
+
+## Business rules & edge cases
+
+- **The address moves only at confirmation.** Until the form in the new mailbox's link is
+  submitted, the account keeps the old address and the old login. An unconfirmed request expires.
+- **`RequireConfirmedEmail = true`** (`PersistenceDependencyInjection.cs:50`) makes the single-write
+  confirm mandatory: address and `EmailConfirmed = true` must land in one `Store.UpdateAsync`, or a
+  crash between two writes locks the user out of their own account. Revert obeys the same rule.
+- **Uniqueness is checked twice, and neither check is airtight.** `UserManager.UpdateAsync`
+  validates with an application-level `FindByEmailAsync` *before* the write, so it is TOCTOU; the
+  `UniqueEmailIndex` migration is the real arbiter. `UserStore.UpdateAsync` catches only
+  `DbUpdateConcurrencyException`, so a Postgres `23505` escapes as `DbUpdateException`. Both write
+  legs wrap the save in `RegisterUser`'s
+  `catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)` and return a
+  `Result` failure — never a 500 on a page a user reached from an e-mail.
+- **Do not set `NormalizedEmail` by hand.** `UpdateAsync` recomputes it after validation and before
+  the write, so a hand-set value is dead code.
+- **The revert can find its old address taken.** Between the change and the click, somebody may
+  have registered the freed address. The revert then fails with the generic invalid-link state; the
+  account stays where it is and the password is **not** nulled.
+- **"Already in use" is said out loud.** `RegisterUser.RegisterAsync` already returns
+  `UserAlreadyExistsByEmail` to an *anonymous* caller, so telling an authenticated,
+  password-verified, rate-limited caller the same thing adds no exposure the product does not
+  already accept.
+- **A scheduled deletion blocks the change**, for ADR-0031's reason: the account is locked and the
+  emailed cancel link is the only way back in; a stamp rotation here would break it.
+- **Confirming and reverting both rotate the security stamp**, which makes each link single-use,
+  ends every cookie session via `SecurityStampCookieValidator` and — with `IUserSessionRevoker` —
+  revokes the OpenIddict tokens and authorizations. Same treatment as `ChangePassword`.
+- **A password change invalidates a pending e-mail change** (same stamp) but **not** a revert link
+  (ADR-0048 — that is the point). The user simply requests the change again.
+- **The revert link is single-use in effect, not by stamp.** The POST refuses unless the account
+  currently sits on the address the token was issued against, so a second submit, or a token from
+  an older change, changes nothing.
+- **Requesting a second change does not kill the first link.** Each token is bound to its own
+  target address, so two outstanding links can only ever land on the address their own e-mail was
+  sent to. Whichever is confirmed first wins; the other dies with the stamp rotation.
+- **The links are tamper-evident.** Addresses travel in the query string but are baked into the
+  token purpose, so editing them fails verification. `userId` is only a lookup key.
+- **The old mailbox is told the full new address**, in both the warning and the notice. The only
+  recipient is whoever controls the old mailbox: the legitimate owner, who needs it to act.
+- **A stale request warning is dropped, not sent.** If `EmailChangeRequested` is delivered after
+  the change already completed, `user.Email` no longer equals its `CurrentEmail`; the processor
+  acknowledges and sends nothing, so the warning can never reach the new (possibly attacker's)
+  mailbox.
+- **Case and whitespace.** Addresses are trimmed before use, like `LoginModel` does, and compared
+  through `UserManager.NormalizeEmail`, so `Jan@X.pl` is "the same address" as `jan@x.pl`.
+- **At-least-once delivery can double a send.** `EmailDeliveryProcessor` writes the inbox row only
+  *after* `ProcessAsync` succeeds, so a failure on the second of two e-mails resends both. A
+  duplicated warning and a resent (identical) link are harmless — the bar ADR-0038's registry sets.
+- **The TMS translator profile follows automatically.** `Translator.Email` is a `ComplexProperty`
+  with no unique index, and `TranslatorProvisioner` refreshes it whenever the claims fingerprint
+  moves — so the new address propagates on the next authenticated TMS request with no work here.
+  `Translation.SubmittedById` is an `IdentityId`, never an address.
+
+## Contract
+
+- **Trigger:** `POST auth/account/change-email` (authorized), then
+  `GET`+`POST /Account/ConfirmEmailChange` (anonymous, token-authorized), then optionally
+  `GET`+`POST /Account/RevertEmailChange` (anonymous, token-authorized).
+- **Input:** `ChangeEmailRequest(string NewEmail, string CurrentPassword)` →
+  `RequestEmailChange.Command(UserId, NewEmail, CurrentPassword, IpAddress, UserAgent)`.
+- **Output:** `200 OK` with no body on the request leg, mirroring its nearest sibling
+  `ChangePassword` (`DeleteAccount`'s 204 carries headers this endpoint has none of); an HTML
+  form, then a success or error state, on the two page legs.
+- **Errors:** `401` no subject claim · `422` validation ·
+  `400 Auth.InvalidCurrentPassword` · `400 Auth.EmailChangeSameAddress` ·
+  `400 Auth.UserAlreadyExistsByEmail` · `400 Auth.DeletionAlreadyScheduled` · `429` rate limit.
+  Both pages render `Auth.InvalidEmailChangeToken` as "link wygasł lub jest nieprawidłowy".
+- **Files touched:** none — no DAT, no translation artifact, **no EF migration**.
+
+## Acceptance criteria
+
+- [ ] A signed-in user sees a "Zmień e-mail" entry in "Moje konto" whenever the account export
+      envelope advertises the `change-email` rel, and does not see it while a deletion is scheduled.
+- [ ] `POST auth/account/change-email` with a wrong current password returns
+      `Auth.InvalidCurrentPassword` and enqueues nothing.
+- [ ] A request for an address another account holds returns `Auth.UserAlreadyExistsByEmail`;
+      a request for the caller's own current address returns `Auth.EmailChangeSameAddress`.
+- [ ] A valid request **commits** exactly one `EmailChangeRequested` row (asserted against the DB,
+      not against the writer), and its processor sends the verification link to the **new** address
+      and a warning naming that address to the **old** one.
+- [ ] The account's e-mail is unchanged until the confirmation is submitted; the user can still log
+      in with the old address in the meantime.
+- [ ] **A `GET` of either the confirm or the revert URL changes nothing** — it only renders a form.
+      This is the mail-scanner guard and it is asserted directly.
+- [ ] Submitting the confirmation sets the new address with `EmailConfirmed = true`, rotates the
+      security stamp, revokes the user's sessions, and commits one `EmailChangeCompleted` row in the
+      same save as the address change.
+- [ ] `EmailChangeCompleted` produces a notice to the new address and a notice **carrying the
+      revert link** to the previous one.
+- [ ] Submitting the confirmation a second time fails with the invalid/expired state and changes
+      nothing; editing its `email` query parameter fails verification and changes nothing.
+- [ ] The revert restores the previous address, sets `PasswordHash = null`, rotates the stamp and
+      sends the visitor into the password-reset flow.
+- [ ] **The revert link still works after the password has been changed** — the stamp rotation does
+      not invalidate it (ADR-0048).
+- [ ] The revert refuses when the account no longer sits on the address it was issued against, and
+      refuses when the previous address has been taken meanwhile — without nulling the password.
+- [ ] A uniqueness race on either write leg renders the error state, not a 500.
+- [ ] After the change the user logs in with the new address, and the old address is rejected.
+- [ ] The 4th request within an hour is answered `429` (own factory, `RateLimiting:ForceEnable`).
+- [ ] Every form works with JavaScript disabled (`scripts/check-ssr-purity.sh` stays green) and
+      `scripts/check-client-hypermedia.sh` stays green — the frontend resolves the endpoint by rel.
+- [ ] The privacy policy's self-service card names the e-mail change, and `docs/API.md` lists the
+      new endpoint and rel.
+- [ ] `dotnet build` green with zero warnings; unit + integration suites green.
+
+## Open questions
+
+**Empirical — answered from the code (buddy pass, 2026-08-20):**
+
+- *Is the e-mail the login identifier?* Yes — `Pages/Account/Login.cshtml.cs` resolves the user
+  with `FindByEmailAsync(Email.Trim())`. The UI copy must say the login changes with it.
+- *Does `CancelDeletion` mutate on `GET`?* **No** — `CancelDeletion.cshtml.cs:11-15` renders a form
+  precisely so mail scanners cancel nothing. An earlier draft claimed the opposite and would have
+  shipped a self-triggering revert link.
+- *Can a rate-limit partition read the authenticated user?* **No** — `UseRateLimiter` at
+  `Program.cs:380` runs before `UseAuthentication` at `:383`, deliberately.
+- *Does `Enqueue` alone commit?* **No** — `OutboxWriter.Enqueue` only calls `Add`; a handler that
+  mutates nothing must save explicitly, as `ForgotPassword` does.
+- *Are Identity's `GenerateChangeEmailTokenAsync` / `ChangeEmailAsync` public, and does the latter
+  save twice?* Public, and it saves **once**. The custom provider is justified by verify-before-
+  enqueue only.
+- *Would a `DataProtectorTokenProvider` revert token survive the attacker's password change?* No —
+  it embeds the security stamp (the store implements `IUserSecurityStampStore`) and rejects the
+  token once the stamp moves. Hence the hand-written revert provider.
+- *Does the repo accept e-mail enumeration on an authenticated, password-gated endpoint?*
+  `RegisterUser.RegisterAsync` already returns `UserAlreadyExistsByEmail` to an anonymous caller.
+- *Does a new routing key need a broker topology change?* No — `EmailQueue` binds `email.#` and
+  queue arguments are untouched (ADR-0036).
+- *Is a DB migration needed?* No — tokens are stateless DataProtector payloads, and the TMS side
+  has no unique index on `Translator.Email`.
+- *Does #670's CSP affect the new auth pages?* No — the CSP comes only from the frontend's
+  `SecurityHeadersMiddleware`; the auth origin emits none.
+
+**Business decisions — answered by the owner, 2026-08-20:**
+
+- **Guard level** → the old mailbox gets a 14-day single-use revert link that also destroys the
+  password; the old mailbox does **not** gate the change. Recorded as ADR-0048.
+- **Old-address warning at request time** → yes, in addition to the notice after completion.
+- **Verification link lifetime** → 24 h, matching the activation link.
+- **The mistyped-registration-address lockout** → out of scope for LEGAL-14.
+- **Privacy policy** → extend the "Realizacja praw bez formalności" card to name the e-mail change.
+
+## Assumptions
+
+- The e-mail pipeline (outbox → relay → broker → processor) is the delivery mechanism for both new
+  message types; no direct SMTP call on a request path (ADR-0038; `ResendEmailConfirmation` stays
+  the single deliberate exception).
+- Polish copy for every user-facing string lives in the frontend and in the auth Razor pages
+  (ADR-0044); the API returns `Error` codes, not sentences for the end user.
+- No real users yet, so the new rel and the new endpoints ship without any back-compat shim.

--- a/docs/specs/0013-self-service-email-change.md
+++ b/docs/specs/0013-self-service-email-change.md
@@ -219,14 +219,22 @@ outlier and explicitly **not** the pattern here.
   revokes the OpenIddict tokens and authorizations. Same treatment as `ChangePassword`.
 - **A password change invalidates a pending e-mail change** (same stamp) but **not** a revert link
   (ADR-0048 — that is the point). The user simply requests the change again.
-- **The revert link is single-use in effect, not by stamp.** The POST refuses unless the account
-  currently sits on the address the token was issued against, so a second submit, or a token from
-  an older change, changes nothing.
+- **The revert restores the previous address from wherever the account currently sits.** Requiring
+  it to still sit on the address the token names is the trap: an attacker with the password changes
+  the address twice (A→B→C) and the owner's A→B link matches nothing, while the new revert offer
+  goes to the attacker's B. What makes the link single-use instead is the reverse check — the POST
+  refuses when the account is **already back** on the previous address, so a second submit cannot
+  clear a password the owner has since reset. An unused token does revive if the account
+  legitimately returns to the same pair inside its 14 days; ADR-0048 accepts that.
 - **Requesting a second change does not kill the first link.** Each token is bound to its own
   target address, so two outstanding links can only ever land on the address their own e-mail was
   sent to. Whichever is confirmed first wins; the other dies with the stamp rotation.
-- **The links are tamper-evident.** Addresses travel in the query string but are baked into the
-  token purpose, so editing them fails verification. `userId` is only a lookup key.
+- **The links are tamper-evident, and their values are checked for shape first.** Addresses travel
+  in the query string but are baked into the token purpose, so editing them fails verification. The
+  `userId` must parse as a `Guid` before it reaches Identity, which converts it to the key type and
+  throws on anything else, and the addresses must match `EmailConstants.RegexPattern` before the
+  page prints them — otherwise both pages become a place to put arbitrary text next to a real
+  button.
 - **The old mailbox is told the full new address**, in both the warning and the notice. The only
   recipient is whoever controls the old mailbox: the legitimate owner, who needs it to act.
 - **A stale request warning is dropped, not sent.** If `EmailChangeRequested` is delivered after
@@ -253,9 +261,10 @@ outlier and explicitly **not** the pattern here.
 - **Output:** `200 OK` with no body on the request leg, mirroring its nearest sibling
   `ChangePassword` (`DeleteAccount`'s 204 carries headers this endpoint has none of); an HTML
   form, then a success or error state, on the two page legs.
-- **Errors:** `401` no subject claim · `422` validation ·
+- **Errors:** `401` no subject claim · `400` validation ·
   `400 Auth.InvalidCurrentPassword` · `400 Auth.EmailChangeSameAddress` ·
-  `400 Auth.UserAlreadyExistsByEmail` · `400 Auth.DeletionAlreadyScheduled` · `429` rate limit.
+  `422 Auth.UserAlreadyExistsByEmail` · `422 Auth.DeletionAlreadyScheduled` · `429` rate limit.
+  (`ErrorExtensions` maps `Validation` → 400 and `DataConflict` → 422 repo-wide.)
   Both pages render `Auth.InvalidEmailChangeToken` as "link wygasł lub jest nieprawidłowy".
 - **Files touched:** none — no DAT, no translation artifact, **no EF migration**.
 

--- a/docs/specs/0013-self-service-email-change.md
+++ b/docs/specs/0013-self-service-email-change.md
@@ -95,7 +95,7 @@ outlier and explicitly **not** the pattern here.
   `ChangeEmailAsync` are both public and both save exactly once.
 - **`Persistence/Identity/EmailChangeRevertTokenProvider.cs`** — hand-written
   `IUserTwoFactorTokenProvider<ApplicationUser>` over `IDataProtector`, protecting
-  `(createdAt, userId, purpose)` and **no security stamp**, lifespan **14 days**,
+  `(createdAt, userId, revertStamp, purpose)` and **no security stamp**, lifespan **14 days**,
   `PurposeFor(previous, next) => $"RevertEmailChange:{previous}->{next}"`. ADR-0048 §Decision
   explains why the stamp must be left out; a unit test pins that a stamp rotation does not kill it.
   `AddTokenProvider` type-checks `IUserTwoFactorTokenProvider<TUser>`, not
@@ -179,10 +179,11 @@ outlier and explicitly **not** the pattern here.
   taken over for up to 14 days; a lockout would break the users the feature exists for.
 - **Changing the username.** `UserName` is separate from `Email` here (`RegisterUser` takes both),
   and nothing in the ticket asks for it.
-- **A `PendingEmail` column, a revert-secret column or an audit table.** The tokens carry the
-  pending state, so **this ticket ships no EF migration**. The audit trail the ticket asks for is
-  structured logging with masked addresses + IP + user agent, which is what `DeleteAccount` and
-  `CancelAccountDeletion` already do.
+- **A `PendingEmail` column or an audit table.** The pending change itself lives in the token. The
+  one schema change is a single nullable `EmailChangeRevertStamp` (additive, expand-only —
+  ADR-0023's cheapest shape), which is what makes a revert link single-use. The audit trail the
+  ticket asks for is structured logging with masked addresses + IP + user agent, which is what
+  `DeleteAccount` and `CancelAccountDeletion` already do.
 - **Two-factor / step-up auth** on the change. The password is the factor the product has.
 - **Security headers on the auth origin.** The CSP of bug #670 is emitted only by the frontend's
   `SecurityHeadersMiddleware`; the auth origin ships none, so the new pages' inline `<style>` is
@@ -219,13 +220,17 @@ outlier and explicitly **not** the pattern here.
   revokes the OpenIddict tokens and authorizations. Same treatment as `ChangePassword`.
 - **A password change invalidates a pending e-mail change** (same stamp) but **not** a revert link
   (ADR-0048 — that is the point). The user simply requests the change again.
-- **The revert restores the previous address from wherever the account currently sits.** Requiring
-  it to still sit on the address the token names is the trap: an attacker with the password changes
-  the address twice (A→B→C) and the owner's A→B link matches nothing, while the new revert offer
-  goes to the attacker's B. What makes the link single-use instead is the reverse check — the POST
-  refuses when the account is **already back** on the previous address, so a second submit cannot
-  clear a password the owner has since reset. An unused token does revive if the account
-  legitimately returns to the same pair inside its 14 days; ADR-0048 accepts that.
+- **The revert restores the previous address from wherever the account currently sits**, and
+  rotates `ApplicationUser.EmailChangeRevertStamp`, which every revert token carries. Both halves
+  are load-bearing (ADR-0048): requiring the account to still sit on the address the token names
+  lets an attacker chain A→B→C and orphan the owner's link, while omitting the stamp lets the
+  attacker's own `B→C` token — mailed to the mailbox they control — undo the owner's recovery
+  afterwards and hand them a fresh reset link. Rotating retires the whole chain, which is what
+  makes a link single-use.
+- **The revert cancels a scheduled deletion too.** Rotating the security stamp kills ADR-0031's
+  cancel token, and after an address change that cancel link went to the address the account was
+  moved to. Refusing instead would leave the account locked, unable to log in or reset, and erased
+  by the finalizer.
 - **Requesting a second change does not kill the first link.** Each token is bound to its own
   target address, so two outstanding links can only ever land on the address their own e-mail was
   sent to. Whichever is confirmed first wins; the other dies with the stamp rotation.
@@ -266,7 +271,8 @@ outlier and explicitly **not** the pattern here.
   `422 Auth.UserAlreadyExistsByEmail` · `422 Auth.DeletionAlreadyScheduled` · `429` rate limit.
   (`ErrorExtensions` maps `Validation` → 400 and `DataConflict` → 422 repo-wide.)
   Both pages render `Auth.InvalidEmailChangeToken` as "link wygasł lub jest nieprawidłowy".
-- **Files touched:** none — no DAT, no translation artifact, **no EF migration**.
+- **Files touched:** no DAT and no translation artifact. One EF migration,
+  `AddEmailChangeRevertStampToUsers` — a nullable `uuid` column, additive and N-1 safe.
 
 ## Acceptance criteria
 
@@ -303,6 +309,12 @@ outlier and explicitly **not** the pattern here.
       `scripts/check-client-hypermedia.sh` stays green — the frontend resolves the endpoint by rel.
 - [ ] The privacy policy's self-service card names the e-mail change, and `docs/API.md` lists the
       new endpoint and rel.
+- [ ] A revert token minted before an earlier successful revert is refused, so an attacker who
+      chained a second change cannot undo the owner's recovery with the link sent to their mailbox.
+- [ ] A revert on an account with a scheduled deletion cancels the deletion instead of leaving it
+      to be erased.
+- [ ] A malformed `userId` or address in either link renders the error state, never a 500, and is
+      never printed on the page.
 - [ ] `dotnet build` green with zero warnings; unit + integration suites green.
 
 ## Open questions
@@ -328,8 +340,10 @@ outlier and explicitly **not** the pattern here.
   `RegisterUser.RegisterAsync` already returns `UserAlreadyExistsByEmail` to an anonymous caller.
 - *Does a new routing key need a broker topology change?* No — `EmailQueue` binds `email.#` and
   queue arguments are untouched (ADR-0036).
-- *Is a DB migration needed?* No — tokens are stateless DataProtector payloads, and the TMS side
-  has no unique index on `Translator.Email`.
+- *Is a DB migration needed?* One, and only for the revert stamp — the pending change itself is
+  stateless. Two review passes proved a stateless single-use guard cannot exist here: the owner's
+  token and the attacker's are structurally identical, so only server state can retire one. The TMS
+  side needs nothing (no unique index on `Translator.Email`).
 - *Does #670's CSP affect the new auth pages?* No — the CSP comes only from the frontend's
   `SecurityHeadersMiddleware`; the auth origin emits none.
 

--- a/docs/specs/0013-self-service-email-change.md
+++ b/docs/specs/0013-self-service-email-change.md
@@ -180,8 +180,9 @@ outlier and explicitly **not** the pattern here.
 - **Changing the username.** `UserName` is separate from `Email` here (`RegisterUser` takes both),
   and nothing in the ticket asks for it.
 - **A `PendingEmail` column or an audit table.** The pending change itself lives in the token. The
-  one schema change is a single nullable `EmailChangeRevertStamp` (additive, expand-only —
-  ADR-0023's cheapest shape), which is what makes a revert link single-use. The audit trail the
+  schema change is two nullable columns, `EmailChangeRevertStamp` and `EmailChangeRevertTo`
+  (additive, expand-only — ADR-0023's cheapest shape), which are what make a revert link both
+  single-use and impossible to point somewhere the owner did not start from. The audit trail the
   ticket asks for is structured logging with masked addresses + IP + user agent, which is what
   `DeleteAccount` and `CancelAccountDeletion` already do.
 - **Two-factor / step-up auth** on the change. The password is the factor the product has.
@@ -220,13 +221,12 @@ outlier and explicitly **not** the pattern here.
   revokes the OpenIddict tokens and authorizations. Same treatment as `ChangePassword`.
 - **A password change invalidates a pending e-mail change** (same stamp) but **not** a revert link
   (ADR-0048 — that is the point). The user simply requests the change again.
-- **The revert restores the previous address from wherever the account currently sits**, and
-  rotates `ApplicationUser.EmailChangeRevertStamp`, which every revert token carries. Both halves
-  are load-bearing (ADR-0048): requiring the account to still sit on the address the token names
-  lets an attacker chain A→B→C and orphan the owner's link, while omitting the stamp lets the
-  attacker's own `B→C` token — mailed to the mailbox they control — undo the owner's recovery
-  afterwards and hand them a fresh reset link. Rotating retires the whole chain, which is what
-  makes a link single-use.
+- **Only the first change since the last revert arms an undo, and it arms
+  `ApplicationUser.EmailChangeRevertTo` at the address the chain started from.** A later change in
+  the same chain sends its notices without a link. A revert restores that armed address — never the
+  one its link names — and clears it, rotating `EmailChangeRevertStamp` so every issued token dies.
+  All three parts are load-bearing; ADR-0048 records the two shapes that looked sufficient and were
+  each defeated.
 - **The revert cancels a scheduled deletion too.** Rotating the security stamp kills ADR-0031's
   cancel token, and after an address change that cancel link went to the address the account was
   moved to. Refusing instead would leave the account locked, unable to log in or reset, and erased
@@ -272,7 +272,7 @@ outlier and explicitly **not** the pattern here.
   (`ErrorExtensions` maps `Validation` → 400 and `DataConflict` → 422 repo-wide.)
   Both pages render `Auth.InvalidEmailChangeToken` as "link wygasł lub jest nieprawidłowy".
 - **Files touched:** no DAT and no translation artifact. One EF migration,
-  `AddEmailChangeRevertStampToUsers` — a nullable `uuid` column, additive and N-1 safe.
+  `AddEmailChangeRevertFieldsToUsers` — two nullable columns, additive and N-1 safe.
 
 ## Acceptance criteria
 
@@ -300,8 +300,9 @@ outlier and explicitly **not** the pattern here.
       sends the visitor into the password-reset flow.
 - [ ] **The revert link still works after the password has been changed** — the stamp rotation does
       not invalidate it (ADR-0048).
-- [ ] The revert refuses when the account no longer sits on the address it was issued against, and
-      refuses when the previous address has been taken meanwhile — without nulling the password.
+- [ ] The revert refuses when the account is already back on the armed address, when nothing is
+      armed, and when the armed address has been taken meanwhile — the last without nulling the
+      password.
 - [ ] A uniqueness race on either write leg renders the error state, not a 500.
 - [ ] After the change the user logs in with the new address, and the old address is rejected.
 - [ ] The 4th request within an hour is answered `429` (own factory, `RateLimiting:ForceEnable`).
@@ -340,9 +341,10 @@ outlier and explicitly **not** the pattern here.
   `RegisterUser.RegisterAsync` already returns `UserAlreadyExistsByEmail` to an anonymous caller.
 - *Does a new routing key need a broker topology change?* No — `EmailQueue` binds `email.#` and
   queue arguments are untouched (ADR-0036).
-- *Is a DB migration needed?* One, and only for the revert stamp — the pending change itself is
-  stateless. Two review passes proved a stateless single-use guard cannot exist here: the owner's
-  token and the attacker's are structurally identical, so only server state can retire one. The TMS
+- *Is a DB migration needed?* One, for the two revert fields — the pending change itself is still
+  stateless. Three review passes proved a stateless guard cannot exist here: the owner's token and
+  the attacker's are structurally identical, so only server state can say which address is a legal
+  destination and which links are spent. The TMS
   side needs nothing (no unique index on `Translator.Email`).
 - *Does #670's CSP affect the new auth pages?* No — the CSP comes only from the frontend's
   `SecurityHeadersMiddleware`; the auth origin emits none.

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiDependencyInjection.cs
@@ -70,20 +70,27 @@ internal static class ApiDependencyInjection
             services.AddScoped<ICommandHandler<CancelAccountDeletion.Command, Result<CancelAccountDeletion.CancelledDeletion>>, CancelAccountDeletion.Handler>();
             services.AddScoped<ICommandHandler<ChangePassword.Command, Result>, ChangePassword.Handler>();
             services.AddScoped<ICommandHandler<ConfirmEmail.Command, Result>, ConfirmEmail.Handler>();
+            services.AddScoped<ICommandHandler<ConfirmEmailChange.Command, Result>, ConfirmEmailChange.Handler>();
             services.AddScoped<ICommandHandler<DeleteAccount.Command, Result<DeleteAccount.ScheduledDeletion>>, DeleteAccount.Handler>();
             services.AddScoped<IQueryHandler<ExportAccountData.Query, Result<AccountDataExportResponse>>, ExportAccountData.Handler>();
             services.AddScoped<ICommandHandler<ForgotPassword.Command, Result>, ForgotPassword.Handler>();
             services.AddScoped<ICommandHandler<RegisterUser.Command, Result<IdentityId>>, RegisterUser.Handler>();
+            services.AddScoped<ICommandHandler<RequestEmailChange.Command, Result>, RequestEmailChange.Handler>();
+            services.AddScoped<ICommandHandler<RevertEmailChange.Command, Result<RevertEmailChange.RevertedEmailChange>>, RevertEmailChange.Handler>();
             services.AddScoped<ICommandHandler<ResendEmailConfirmation.Command, Result>, ResendEmailConfirmation.Handler>();
             services.AddScoped<ICommandHandler<ResetPassword.Command, Result>, ResetPassword.Handler>();
 
             services.AddScoped<IEmailVerificationLinkFactory, EmailVerificationLinkFactory>();
             services.AddScoped<IPasswordResetLinkFactory, PasswordResetLinkFactory>();
             services.AddScoped<ICancelDeletionLinkFactory, CancelDeletionLinkFactory>();
+            services.AddScoped<EmailChangeLinkFactory>();
+            services.AddScoped<IEmailChangeVerificationLinkFactory>(sp => sp.GetRequiredService<EmailChangeLinkFactory>());
+            services.AddScoped<IEmailChangeRevertLinkFactory>(sp => sp.GetRequiredService<EmailChangeLinkFactory>());
             services.AddSingleton<IEmailTemplateRenderer, EmailTemplateRenderer>();
             services.AddScoped<IPasswordResetEmailSender, PasswordResetEmailSender>();
             services.AddScoped<IAccountConfirmationEmailSender, AccountConfirmationEmailSender>();
             services.AddScoped<IAccountDeletionEmailSender, AccountDeletionEmailSender>();
+            services.AddScoped<IEmailChangeEmailSender, EmailChangeEmailSender>();
 
             services.AddScoped<IAccountErasureService, AccountErasureService>();
             services.AddScoped<IAccountDeletionFinalizer, AccountDeletionFinalizer>();
@@ -112,6 +119,10 @@ internal static class ApiDependencyInjection
                 nameof(AccountDeletionScheduled));
             services.AddKeyedScoped<IEmailMessageProcessor, AccountDeletionCancelledProcessor>(
                 nameof(AccountDeletionCancelled));
+            services.AddKeyedScoped<IEmailMessageProcessor, EmailChangeRequestProcessor>(
+                nameof(EmailChangeRequested));
+            services.AddKeyedScoped<IEmailMessageProcessor, EmailChangeCompletedProcessor>(
+                nameof(EmailChangeCompleted));
             services.AddScoped<EmailDeliveryProcessor>();
             services.AddHostedService<EmailDispatchConsumer>();
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiErrors/AuthErrors.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/ApiErrors/AuthErrors.cs
@@ -80,4 +80,19 @@ internal static class AuthErrors
         new("Auth.CancelDeletionFailed",
             details,
             TypeOfError.Failure);
+
+    public static Error InvalidEmailChangeToken =>
+        new("Auth.InvalidEmailChangeToken",
+            "The email change link is invalid or has expired.",
+            TypeOfError.Validation);
+
+    public static Error EmailChangeSameAddress =>
+        new("Auth.EmailChangeSameAddress",
+            "The new email address is the same as the current one.",
+            TypeOfError.Validation);
+
+    public static Error EmailChangeFailed(string details) =>
+        new("Auth.EmailChangeFailed",
+            details,
+            TypeOfError.Failure);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/EventIds.cs
@@ -114,6 +114,27 @@ internal static class EventIds
     public const int DeletionCancelledRescheduled = 2381;
     public const int DeletionCancelledAddressMissing = 2382;
 
+    // Change E-mail request / confirm / revert (2500-2519)
+    public const int EmailChangeRequested = 2500;
+    public const int EmailChangeSameAddress = 2501;
+    public const int EmailChangeAddressTaken = 2502;
+    public const int EmailChangeTokenInvalid = 2503;
+    public const int EmailChangeApplied = 2504;
+    public const int EmailChangeUpdateFailed = 2505;
+    public const int EmailChangeConfirmRace = 2506;
+    public const int EmailChangeRevertTokenInvalid = 2510;
+    public const int EmailChangeReverted = 2511;
+    public const int EmailChangeRevertFailed = 2512;
+    public const int EmailChangeRevertAddressTaken = 2513;
+    public const int EmailChangeRevertAlreadySettled = 2514;
+    public const int EmailChangeRevertRace = 2515;
+
+    // Change E-mail dispatch (2520-2529)
+    public const int EmailChangeDispatchUserGone = 2520;
+    public const int EmailChangeDispatchStaleRequest = 2521;
+    public const int EmailChangeDispatchAddressMissing = 2522;
+    public const int EmailChangeDispatchWarningFailed = 2523;
+
     // Middleware (2400-2499)
     public const int UnauthorizedAccessAttempt = 2400;
     public const int ForbiddenAccessAttempt = 2401;
@@ -131,6 +152,8 @@ internal static class EventIds
     public const int PasswordResetCompletedViaUi = 2630;
     public const int RegisterCompletedViaUi = 2640;
     public const int DeletionCancelledViaUi = 2650;
+    public const int EmailChangeConfirmedViaUi = 2660;
+    public const int EmailChangeRevertedViaUi = 2661;
 
     // GDPR Deletion Scheduling internals (2700-2709). 2701-2703 and 2705 are no longer used: the undo
     // step is gone (ADR-0038 decision 5), and both deletion flows now change the security stamp inside

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ConfirmEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ConfirmEmailChange.cs
@@ -2,7 +2,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using LotroKoniecDev.AuthSystem.API.ApiErrors;
 using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.API.Outbox;
@@ -10,7 +9,6 @@ using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using LotroKoniecDev.AuthSystem.Persistence.Identity;
-using LotroKoniecDev.AuthSystem.Persistence.Outbox;
 using LotroKoniecDev.SharedKernel.Constants;
 using LotroKoniecDev.SharedKernel.Messaging;
 using LotroKoniecDev.SharedKernel.Monads;
@@ -43,6 +41,13 @@ internal sealed partial class ConfirmEmailChange
         {
             RuleFor(x => x.UserId)
                 .NotEmpty().WithMessage("User ID is required.");
+
+            // The id arrives from a query string, and Identity converts it to the key type before it
+            // queries. A value that is not a GUID throws inside the store, which would turn a bad link
+            // into a crash on a page somebody opened from their inbox.
+            RuleFor(x => x.UserId)
+                .Must(userId => Guid.TryParse(userId, out _))
+                    .WithMessage("User ID must be a GUID.");
 
             RuleFor(x => x.NewEmail)
                 .NotEmpty().WithMessage("A valid email address is required.")
@@ -89,7 +94,7 @@ internal sealed partial class ConfirmEmailChange
                 return Result.Failure(AuthErrors.InvalidEmailChangeToken);
             }
 
-            string newEmail = command.NewEmail.Trim();
+            string newEmail = command.NewEmail;
 
             ApplicationUser? user = await _userManager.FindByIdAsync(command.UserId);
 
@@ -99,11 +104,6 @@ internal sealed partial class ConfirmEmailChange
             {
                 LogTokenInvalid(_logger, newEmail.MaskEmail(), command.IpAddress, command.UserAgent);
                 return Result.Failure(AuthErrors.InvalidEmailChangeToken);
-            }
-
-            if (user.DeletionScheduledAt is not null)
-            {
-                return Result.Failure(AuthErrors.DeletionAlreadyScheduled);
             }
 
             // The target address is baked into the purpose, so editing it in the link fails here.
@@ -119,13 +119,27 @@ internal sealed partial class ConfirmEmailChange
                 return Result.Failure(AuthErrors.InvalidEmailChangeToken);
             }
 
+            // Checked only after the token, so a caller without one cannot tell this state apart from
+            // any other refusal.
+            if (user.DeletionScheduledAt is not null)
+            {
+                return Result.Failure(AuthErrors.DeletionAlreadyScheduled);
+            }
+
             ApplicationUser? addressOwner = await _userManager.FindByEmailAsync(newEmail);
             if (addressOwner is not null)
             {
                 return Result.Failure(AuthErrors.UserAlreadyExistsByEmail);
             }
 
-            string previousEmail = user.Email ?? string.Empty;
+            // The notice and the revert token are both built from this address, and an empty one would
+            // produce a message its own processor refuses to read. Refuse here instead.
+            if (string.IsNullOrWhiteSpace(user.Email))
+            {
+                return Result.Failure(AuthErrors.InvalidEmailChangeToken);
+            }
+
+            string previousEmail = user.Email;
 
             user.Email = newEmail;
 
@@ -144,13 +158,13 @@ internal sealed partial class ConfirmEmailChange
             Result<IdentityResult> updateResult = await TryUpdateAsync(user);
             if (updateResult.IsFailure)
             {
-                DiscardPendingOutboxMessages();
+                DiscardPendingChanges();
                 return Result.Failure(updateResult.Error);
             }
 
             if (!updateResult.Value.Succeeded)
             {
-                DiscardPendingOutboxMessages();
+                DiscardPendingChanges();
 
                 string errors = string.Join(", ", updateResult.Value.Errors.Select(e => e.Description));
                 LogUpdateFailed(_logger, user.Id, errors);
@@ -188,17 +202,16 @@ internal sealed partial class ConfirmEmailChange
         }
 
         /// <summary>
-        /// A failed update never reaches the store, so the outbox row it was meant to travel with is
-        /// still sitting in the change tracker. Detaching it keeps a later save in this same request
-        /// from announcing a change that did not happen.
+        /// A failed update never reaches the store, so both halves of this unit of work are still
+        /// sitting in the change tracker: the outbox row as Added, and the user as Modified with the
+        /// new address already on it. This context is shared with OpenIddict for the rest of the
+        /// request, so a later save there would commit the change we just reported as failed, or
+        /// announce one that never happened. Dropping the whole unit of work is the only version that
+        /// leaves neither half behind.
         /// </summary>
-        private void DiscardPendingOutboxMessages()
+        private void DiscardPendingChanges()
         {
-            foreach (EntityEntry<OutboxMessage> entry in
-                     _db.ChangeTracker.Entries<OutboxMessage>().Where(e => e.State is EntityState.Added))
-            {
-                entry.State = EntityState.Detached;
-            }
+            _db.ChangeTracker.Clear();
         }
 
         [LoggerMessage(EventId = EventIds.EmailChangeTokenInvalid, Level = LogLevel.Warning, Message = "Invalid e-mail change token presented for {NewEmail}. IP: {IpAddress}, UserAgent: {UserAgent}")]

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ConfirmEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ConfirmEmailChange.cs
@@ -153,6 +153,11 @@ internal sealed partial class ConfirmEmailChange
             // processor creates moments later is built from the stamp that was actually stored.
             user.SecurityStamp = Guid.NewGuid().ToString();
 
+            // Only the first change since the last revert arms the undo, and it arms it at the address
+            // the chain started from. A second change must not make itself a target: after A to B to C
+            // that would hand an undo link to B, which is whoever took the account over (ADR-0048).
+            user.EmailChangeRevertTo ??= previousEmail;
+
             _outboxWriter.Enqueue(new EmailChangeCompleted(user.Id, previousEmail, newEmail));
 
             Result<IdentityResult> updateResult = await TryUpdateAsync(user);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ConfirmEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/ConfirmEmailChange.cs
@@ -1,0 +1,216 @@
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using LotroKoniecDev.AuthSystem.API.ApiErrors;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Sessions;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+using LotroKoniecDev.SharedKernel.Constants;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Features.Auth;
+
+/// <summary>
+/// Applies an e-mail change once the owner of the new mailbox follows the link. The address,
+/// <see cref="ApplicationUser.EmailConfirmed"/> and the new security stamp land in one save, together
+/// with the outbox row that notifies both mailboxes and arms the revert link (ADR-0048).
+/// </summary>
+/// <remarks>
+/// The single save is not a style choice. Identity runs with <c>RequireConfirmedEmail</c>, so an
+/// address that lands without its confirmation flag would lock the user out of their own account.
+/// The token is checked before anything is enqueued, which is why this flow uses its own token
+/// provider instead of <c>UserManager.ChangeEmailAsync</c>.
+/// </remarks>
+internal sealed partial class ConfirmEmailChange
+{
+    internal sealed record Command(
+        string UserId,
+        string NewEmail,
+        string Token,
+        string? IpAddress,
+        string? UserAgent) : ICommand<Result>;
+
+    internal sealed class CommandValidator : AbstractValidator<Command>
+    {
+        public CommandValidator()
+        {
+            RuleFor(x => x.UserId)
+                .NotEmpty().WithMessage("User ID is required.");
+
+            RuleFor(x => x.NewEmail)
+                .NotEmpty().WithMessage("A valid email address is required.")
+                .MaximumLength(EmailConstants.MaxLength)
+                    .WithMessage($"Email must not exceed {EmailConstants.MaxLength} characters.")
+                .Matches(EmailConstants.RegexPattern)
+                    .WithMessage("A valid email address is required.");
+
+            RuleFor(x => x.Token)
+                .NotEmpty().WithMessage("Confirmation token is required.");
+        }
+    }
+
+    internal sealed partial class Handler : ICommandHandler<Command, Result>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly AuthDbContext _db;
+        private readonly OutboxWriter _outboxWriter;
+        private readonly IUserSessionRevoker _sessionRevoker;
+        private readonly IValidator<Command> _validator;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(
+            UserManager<ApplicationUser> userManager,
+            AuthDbContext db,
+            OutboxWriter outboxWriter,
+            IUserSessionRevoker sessionRevoker,
+            IValidator<Command> validator,
+            ILogger<Handler> logger)
+        {
+            _userManager = userManager;
+            _db = db;
+            _outboxWriter = outboxWriter;
+            _sessionRevoker = sessionRevoker;
+            _validator = validator;
+            _logger = logger;
+        }
+
+        public async ValueTask<Result> Handle(Command command, CancellationToken cancellationToken)
+        {
+            ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                return Result.Failure(AuthErrors.InvalidEmailChangeToken);
+            }
+
+            string newEmail = command.NewEmail.Trim();
+
+            ApplicationUser? user = await _userManager.FindByIdAsync(command.UserId);
+
+            // An unknown user, a tampered address and an expired token all answer the same way, so the
+            // page cannot be used to learn anything about an account.
+            if (user is null)
+            {
+                LogTokenInvalid(_logger, newEmail.MaskEmail(), command.IpAddress, command.UserAgent);
+                return Result.Failure(AuthErrors.InvalidEmailChangeToken);
+            }
+
+            if (user.DeletionScheduledAt is not null)
+            {
+                return Result.Failure(AuthErrors.DeletionAlreadyScheduled);
+            }
+
+            // The target address is baked into the purpose, so editing it in the link fails here.
+            bool tokenValid = await _userManager.VerifyUserTokenAsync(
+                user,
+                EmailChangeTokenProvider.ProviderName,
+                EmailChangeTokenProvider.PurposeFor(newEmail),
+                command.Token);
+
+            if (!tokenValid)
+            {
+                LogTokenInvalid(_logger, newEmail.MaskEmail(), command.IpAddress, command.UserAgent);
+                return Result.Failure(AuthErrors.InvalidEmailChangeToken);
+            }
+
+            ApplicationUser? addressOwner = await _userManager.FindByEmailAsync(newEmail);
+            if (addressOwner is not null)
+            {
+                return Result.Failure(AuthErrors.UserAlreadyExistsByEmail);
+            }
+
+            string previousEmail = user.Email ?? string.Empty;
+
+            user.Email = newEmail;
+
+            // The address and its confirmation flag have to move together. NormalizedEmail is left
+            // alone on purpose: UpdateAsync recomputes it after validation and before the write, so
+            // setting it here would only be overwritten.
+            user.EmailConfirmed = true;
+
+            // A new stamp ends every session and makes this link single-use. It is set inside the same
+            // save that commits the outbox row (ADR-0038 decision 2), so the revert token the dispatch
+            // processor creates moments later is built from the stamp that was actually stored.
+            user.SecurityStamp = Guid.NewGuid().ToString();
+
+            _outboxWriter.Enqueue(new EmailChangeCompleted(user.Id, previousEmail, newEmail));
+
+            Result<IdentityResult> updateResult = await TryUpdateAsync(user);
+            if (updateResult.IsFailure)
+            {
+                DiscardPendingOutboxMessages();
+                return Result.Failure(updateResult.Error);
+            }
+
+            if (!updateResult.Value.Succeeded)
+            {
+                DiscardPendingOutboxMessages();
+
+                string errors = string.Join(", ", updateResult.Value.Errors.Select(e => e.Description));
+                LogUpdateFailed(_logger, user.Id, errors);
+                return Result.Failure(AuthErrors.EmailChangeFailed(errors));
+            }
+
+            _outboxWriter.NotifyEnqueuedCommitted();
+
+            await _sessionRevoker.RevokeAllAsync(user.Id.ToString(), cancellationToken);
+
+            LogChangeApplied(
+                _logger, user.Id, previousEmail.MaskEmail(), newEmail.MaskEmail(), command.IpAddress, command.UserAgent);
+
+            return Result.Success();
+        }
+
+        /// <summary>
+        /// The uniqueness check above is an ordinary query, so two requests can pass it at the same
+        /// time. The unique index is what really decides, and <c>UserStore.UpdateAsync</c> only handles
+        /// concurrency conflicts, so the duplicate-key error arrives here as a raw
+        /// <see cref="DbUpdateException"/>. It is caught for the same reason registration catches it:
+        /// a person who followed a link from their inbox must see an error page, not a crash.
+        /// </summary>
+        private async Task<Result<IdentityResult>> TryUpdateAsync(ApplicationUser user)
+        {
+            try
+            {
+                return Result.Success(await _userManager.UpdateAsync(user));
+            }
+            catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
+            {
+                LogUpdateRace(_logger, ex, user.Id);
+                return Result.Failure<IdentityResult>(AuthErrors.UserAlreadyExistsByEmail);
+            }
+        }
+
+        /// <summary>
+        /// A failed update never reaches the store, so the outbox row it was meant to travel with is
+        /// still sitting in the change tracker. Detaching it keeps a later save in this same request
+        /// from announcing a change that did not happen.
+        /// </summary>
+        private void DiscardPendingOutboxMessages()
+        {
+            foreach (EntityEntry<OutboxMessage> entry in
+                     _db.ChangeTracker.Entries<OutboxMessage>().Where(e => e.State is EntityState.Added))
+            {
+                entry.State = EntityState.Detached;
+            }
+        }
+
+        [LoggerMessage(EventId = EventIds.EmailChangeTokenInvalid, Level = LogLevel.Warning, Message = "Invalid e-mail change token presented for {NewEmail}. IP: {IpAddress}, UserAgent: {UserAgent}")]
+        private static partial void LogTokenInvalid(ILogger logger, string newEmail, string? ipAddress, string? userAgent);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeApplied, Level = LogLevel.Information, Message = "E-mail change applied for user {UserId}: {PreviousEmail} -> {NewEmail}. IP: {IpAddress}, UserAgent: {UserAgent}")]
+        private static partial void LogChangeApplied(ILogger logger, Guid userId, string previousEmail, string newEmail, string? ipAddress, string? userAgent);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeUpdateFailed, Level = LogLevel.Error, Message = "Failed to persist the e-mail change for user {UserId}: {Errors}")]
+        private static partial void LogUpdateFailed(ILogger logger, Guid userId, string errors);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeConfirmRace, Level = LogLevel.Warning, Message = "E-mail change for user {UserId} lost a race for the new address")]
+        private static partial void LogUpdateRace(ILogger logger, Exception exception, Guid userId);
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RequestEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RequestEmailChange.cs
@@ -90,9 +90,7 @@ internal sealed partial class RequestEmailChange : IApiEndpoint
                 return Result.Failure(AuthErrors.UserNotFound);
             }
 
-            // A trailing space from a paste or from autofill must not become part of the address, the
-            // same reason the login page trims.
-            string newEmail = command.NewEmail.Trim();
+            string newEmail = command.NewEmail;
 
             // The account is locked for the whole grace period and the cancel link in the e-mail is the
             // only way back into it. Rotating the security stamp later in this flow would break that
@@ -108,7 +106,12 @@ internal sealed partial class RequestEmailChange : IApiEndpoint
                 return Result.Failure(AuthErrors.InvalidCurrentPassword);
             }
 
-            string currentEmail = user.Email ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(user.Email))
+            {
+                return Result.Failure(AuthErrors.UserNotFound);
+            }
+
+            string currentEmail = user.Email;
 
             if (string.Equals(
                     _userManager.NormalizeEmail(newEmail),
@@ -170,7 +173,9 @@ internal sealed partial class RequestEmailChange : IApiEndpoint
 
                 Command command = new(
                     userId,
-                    request.NewEmail,
+                    // Trimmed before validation, not after: the address rule rejects any whitespace, so
+                    // a trailing space from a paste would otherwise fail instead of being cleaned up.
+                    request.NewEmail.Trim(),
                     request.CurrentPassword,
                     httpContext.Connection.RemoteIpAddress?.ToString(),
                     httpContext.Request.Headers.UserAgent.ToString());

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RequestEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RequestEmailChange.cs
@@ -1,0 +1,194 @@
+using System.Security.Claims;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Identity;
+using OpenIddict.Abstractions;
+using LotroKoniecDev.AuthSystem.API.ApiErrors;
+using LotroKoniecDev.AuthSystem.API.Common;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.SharedKernel.Constants;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Features.Auth;
+
+/// <summary>
+/// Starts an e-mail change. The address only moves when the link sent to the new mailbox is used, so
+/// nothing on the account changes here (ADR-0048).
+/// </summary>
+/// <remarks>
+/// Because there is no change to the user row, this handler has to save the outbox row itself:
+/// <c>OutboxWriter.Enqueue</c> only adds it to the unit of work. <see cref="ForgotPassword"/> is the
+/// shape to copy here, not <see cref="DeleteAccount"/>, which gets its save for free from
+/// <c>UserManager.UpdateAsync</c>.
+/// </remarks>
+internal sealed partial class RequestEmailChange : IApiEndpoint
+{
+    internal sealed record Command(
+        string UserId,
+        string NewEmail,
+        string CurrentPassword,
+        string? IpAddress,
+        string? UserAgent) : ICommand<Result>;
+
+    internal sealed class CommandValidator : AbstractValidator<Command>
+    {
+        public CommandValidator()
+        {
+            RuleFor(x => x.UserId)
+                .NotEmpty().WithMessage("User ID is required.");
+
+            RuleFor(x => x.NewEmail)
+                .NotEmpty().WithMessage("A valid email address is required.")
+                .MaximumLength(EmailConstants.MaxLength)
+                    .WithMessage($"Email must not exceed {EmailConstants.MaxLength} characters.")
+                .Matches(EmailConstants.RegexPattern)
+                    .WithMessage("A valid email address is required.");
+
+            RuleFor(x => x.CurrentPassword)
+                .NotEmpty().WithMessage("Current password is required.");
+        }
+    }
+
+    internal sealed partial class Handler : ICommandHandler<Command, Result>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly AuthDbContext _db;
+        private readonly OutboxWriter _outboxWriter;
+        private readonly IValidator<Command> _validator;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(
+            UserManager<ApplicationUser> userManager,
+            AuthDbContext db,
+            OutboxWriter outboxWriter,
+            IValidator<Command> validator,
+            ILogger<Handler> logger)
+        {
+            _userManager = userManager;
+            _db = db;
+            _outboxWriter = outboxWriter;
+            _validator = validator;
+            _logger = logger;
+        }
+
+        public async ValueTask<Result> Handle(Command command, CancellationToken cancellationToken)
+        {
+            ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                return Result.Failure(validationResult.ToValidationError(nameof(RequestEmailChange)));
+            }
+
+            ApplicationUser? user = await _userManager.FindByIdAsync(command.UserId);
+            if (user is null)
+            {
+                return Result.Failure(AuthErrors.UserNotFound);
+            }
+
+            // A trailing space from a paste or from autofill must not become part of the address, the
+            // same reason the login page trims.
+            string newEmail = command.NewEmail.Trim();
+
+            // The account is locked for the whole grace period and the cancel link in the e-mail is the
+            // only way back into it. Rotating the security stamp later in this flow would break that
+            // link, so the change is refused while a deletion is pending (ADR-0031).
+            if (user.DeletionScheduledAt is not null)
+            {
+                return Result.Failure(AuthErrors.DeletionAlreadyScheduled);
+            }
+
+            bool passwordValid = await _userManager.CheckPasswordAsync(user, command.CurrentPassword);
+            if (!passwordValid)
+            {
+                return Result.Failure(AuthErrors.InvalidCurrentPassword);
+            }
+
+            string currentEmail = user.Email ?? string.Empty;
+
+            if (string.Equals(
+                    _userManager.NormalizeEmail(newEmail),
+                    _userManager.NormalizeEmail(currentEmail),
+                    StringComparison.Ordinal))
+            {
+                LogSameAddress(_logger, user.Id);
+                return Result.Failure(AuthErrors.EmailChangeSameAddress);
+            }
+
+            // Registration already tells an anonymous caller that an address is taken, so saying it to
+            // a caller who just proved they know this account's password reveals nothing new.
+            ApplicationUser? addressOwner = await _userManager.FindByEmailAsync(newEmail);
+            if (addressOwner is not null)
+            {
+                LogAddressTaken(_logger, user.Id, newEmail.MaskEmail());
+                return Result.Failure(AuthErrors.UserAlreadyExistsByEmail);
+            }
+
+            _outboxWriter.Enqueue(new EmailChangeRequested(user.Id, currentEmail, newEmail));
+            await _db.SaveChangesAsync(cancellationToken);
+
+            // Only after the commit. The relay reads committed rows, so a signal sent earlier could
+            // arrive while there is still nothing to see (ADR-0035).
+            _outboxWriter.NotifyEnqueuedCommitted();
+
+            LogChangeRequested(
+                _logger, user.Id, currentEmail.MaskEmail(), newEmail.MaskEmail(), command.IpAddress, command.UserAgent);
+
+            return Result.Success();
+        }
+
+        [LoggerMessage(EventId = EventIds.EmailChangeRequested, Level = LogLevel.Information, Message = "E-mail change requested for user {UserId}: {CurrentEmail} -> {NewEmail}. IP: {IpAddress}, UserAgent: {UserAgent}")]
+        private static partial void LogChangeRequested(ILogger logger, Guid userId, string currentEmail, string newEmail, string? ipAddress, string? userAgent);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeSameAddress, Level = LogLevel.Information, Message = "E-mail change refused for user {UserId}: the new address is the current one")]
+        private static partial void LogSameAddress(ILogger logger, Guid userId);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeAddressTaken, Level = LogLevel.Information, Message = "E-mail change refused for user {UserId}: {NewEmail} belongs to another account")]
+        private static partial void LogAddressTaken(ILogger logger, Guid userId, string newEmail);
+    }
+
+    public void MapEndpoint(IEndpointRouteBuilder endpointRouteBuilder)
+    {
+        endpointRouteBuilder.MapPost("auth/account/change-email", async (
+                ChangeEmailRequest request,
+                ClaimsPrincipal user,
+                HttpContext httpContext,
+                ICommandHandler<Command, Result> handler,
+                CancellationToken cancellationToken) =>
+            {
+                string? userId = user.FindFirstValue(ClaimTypes.NameIdentifier)
+                    ?? user.FindFirstValue(OpenIddictConstants.Claims.Subject);
+
+                if (string.IsNullOrEmpty(userId))
+                {
+                    return Results.Unauthorized();
+                }
+
+                Command command = new(
+                    userId,
+                    request.NewEmail,
+                    request.CurrentPassword,
+                    httpContext.Connection.RemoteIpAddress?.ToString(),
+                    httpContext.Request.Headers.UserAgent.ToString());
+
+                Result commandResult = await handler.Handle(command, cancellationToken);
+
+                return commandResult.IsFailure
+                    ? Results.Problem(commandResult.Error.ToProblemDetails())
+                    : Results.Ok();
+            })
+            .RequireAuthorization()
+            .RequireRateLimiting("change-email-limit")
+            .WithName(nameof(RequestEmailChange))
+            .WithTags("Account")
+            .Produces(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RequestEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RequestEmailChange.cs
@@ -175,7 +175,10 @@ internal sealed partial class RequestEmailChange : IApiEndpoint
                     userId,
                     // Trimmed before validation, not after: the address rule rejects any whitespace, so
                     // a trailing space from a paste would otherwise fail instead of being cleaned up.
-                    request.NewEmail.Trim(),
+                    // The null coalesce is not decoration: the record's non-nullable string does not
+                    // stop System.Text.Json from binding a JSON null, and the validator is what should
+                    // answer for it, not a NullReferenceException.
+                    (request.NewEmail ?? string.Empty).Trim(),
                     request.CurrentPassword,
                     httpContext.Connection.RemoteIpAddress?.ToString(),
                     httpContext.Request.Headers.UserAgent.ToString());

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RevertEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RevertEmailChange.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using LotroKoniecDev.AuthSystem.API.ApiErrors;
 using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
@@ -78,6 +79,7 @@ internal sealed partial class RevertEmailChange
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly AuthDbContext _db;
+        private readonly OutboxWriter _outboxWriter;
         private readonly IUserSessionRevoker _sessionRevoker;
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
@@ -85,12 +87,14 @@ internal sealed partial class RevertEmailChange
         public Handler(
             UserManager<ApplicationUser> userManager,
             AuthDbContext db,
+            OutboxWriter outboxWriter,
             IUserSessionRevoker sessionRevoker,
             IValidator<Command> validator,
             ILogger<Handler> logger)
         {
             _userManager = userManager;
             _db = db;
+            _outboxWriter = outboxWriter;
             _sessionRevoker = sessionRevoker;
             _validator = validator;
             _logger = logger;
@@ -127,17 +131,22 @@ internal sealed partial class RevertEmailChange
                 return Result.Failure<RevertedEmailChange>(AuthErrors.InvalidEmailChangeToken);
             }
 
-            // The guard is "the account is not already back on the previous address", NOT "the account
-            // still sits on the address the token names". The stricter version looks safer and is the
-            // opposite: an attacker who knows the password just changes the address twice, A to B then
-            // B to C, and the owner's A-to-B link no longer matches anything — while the new revert
-            // offer goes to B, which the attacker owns. This way the link keeps working from wherever
-            // the account has been dragged, which is the whole promise of ADR-0048.
-            // It still refuses the second click, because by then the account IS back on the previous
-            // address, so a revert cannot run twice and clear a freshly reset password.
+            // Where the account goes is decided by the row, never by the link. The token proves who is
+            // asking; the armed target says where they may put it. That is what makes a second change
+            // useless to an attacker: it cannot arm a target of its own, so there is no link to hand
+            // them and no way for one to move the account somewhere the owner did not start from.
+            string? revertTarget = user.EmailChangeRevertTo;
+            if (string.IsNullOrWhiteSpace(revertTarget))
+            {
+                LogAlreadySettled(_logger, user.Id);
+                return Result.Failure<RevertedEmailChange>(AuthErrors.InvalidEmailChangeToken);
+            }
+
+            // Already back where it started, so there is nothing to undo. This is what stops a second
+            // click clearing a password the owner has since reset.
             if (string.Equals(
                     _userManager.NormalizeEmail(user.Email),
-                    _userManager.NormalizeEmail(previousEmail),
+                    _userManager.NormalizeEmail(revertTarget),
                     StringComparison.Ordinal))
             {
                 LogAlreadySettled(_logger, user.Id);
@@ -147,14 +156,14 @@ internal sealed partial class RevertEmailChange
             // Somebody may have registered the freed address in the meantime. Then there is nothing to
             // go back to, and the password must stay as it is: clearing it would lock the account out
             // of both addresses at once.
-            ApplicationUser? previousAddressOwner = await _userManager.FindByEmailAsync(previousEmail);
+            ApplicationUser? previousAddressOwner = await _userManager.FindByEmailAsync(revertTarget);
             if (previousAddressOwner is not null)
             {
                 LogPreviousAddressTaken(_logger, user.Id);
                 return Result.Failure<RevertedEmailChange>(AuthErrors.UserAlreadyExistsByEmail);
             }
 
-            user.Email = previousEmail;
+            user.Email = revertTarget;
             user.EmailConfirmed = true;
 
             // Whoever moved the address knew the password, so the password goes. Only the reset flow
@@ -163,17 +172,26 @@ internal sealed partial class RevertEmailChange
 
             user.SecurityStamp = Guid.NewGuid().ToString();
 
-            // Retires every revert link issued so far, including the ones further up a chain of
-            // changes. Without it the attacker's own token, mailed to an address they controlled,
-            // still works and simply undoes this recovery (ADR-0048).
+            // Retires every revert link issued so far and disarms the chain, so the next change starts
+            // a fresh one from here.
             user.EmailChangeRevertStamp = Guid.NewGuid();
+            user.EmailChangeRevertTo = null;
 
             // A deletion the same person may have scheduled is called off here. Its cancel link went to
             // the address the account was moved to, so leaving the schedule in place would hand the
             // erasure to whoever took the account over.
+            bool cancelledADeletion = user.DeletionScheduledAt is not null;
             user.DeletionScheduledAt = null;
             user.LockoutEnd = null;
             user.AccessFailedCount = 0;
+
+            // ADR-0031 wants every cancellation announced, and this is one. The notice rides the same
+            // save as the change, so "cancelled but nobody told" cannot happen, and it reaches the
+            // restored address rather than the one it was taken to.
+            if (cancelledADeletion)
+            {
+                _outboxWriter.Enqueue(new AccountDeletionCancelled(user.Id));
+            }
 
             Result<IdentityResult> updateResult = await TryUpdateAsync(user);
             if (updateResult.IsFailure)
@@ -191,6 +209,11 @@ internal sealed partial class RevertEmailChange
                 return Result.Failure<RevertedEmailChange>(AuthErrors.EmailChangeFailed(errors));
             }
 
+            if (cancelledADeletion)
+            {
+                _outboxWriter.NotifyEnqueuedCommitted();
+            }
+
             await _sessionRevoker.RevokeAllAsync(user.Id.ToString(), cancellationToken);
 
             // Created after the save, from the stored stamp. A token made before it would be
@@ -198,9 +221,9 @@ internal sealed partial class RevertEmailChange
             string passwordResetToken = await _userManager.GeneratePasswordResetTokenAsync(user);
 
             LogReverted(
-                _logger, user.Id, currentEmail.MaskEmail(), previousEmail.MaskEmail(), command.IpAddress, command.UserAgent);
+                _logger, user.Id, currentEmail.MaskEmail(), revertTarget.MaskEmail(), command.IpAddress, command.UserAgent);
 
-            return Result.Success(new RevertedEmailChange(previousEmail, passwordResetToken));
+            return Result.Success(new RevertedEmailChange(revertTarget, passwordResetToken));
         }
 
         /// <summary>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RevertEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RevertEmailChange.cs
@@ -1,0 +1,208 @@
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using LotroKoniecDev.AuthSystem.API.ApiErrors;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Services.Sessions;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.SharedKernel.Constants;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Features.Auth;
+
+/// <summary>
+/// Undoes an e-mail change from the old mailbox (ADR-0048). It exists for one case: somebody who knew
+/// the password moved the account to an address they own, and the real owner still reads the address
+/// it came from.
+/// </summary>
+/// <remarks>
+/// It also clears the password, because the password is what let the change happen in the first
+/// place, and returns a fresh reset token that sends the visitor into the reset flow.
+/// <see cref="CancelAccountDeletion"/> answers the same problem the same way.
+/// No e-mail goes out afterwards. The person who needs to know is reading the page, and telling the
+/// address the account was just taken from would only warn an attacker.
+/// </remarks>
+internal sealed partial class RevertEmailChange
+{
+    internal sealed record Command(
+        string UserId,
+        string PreviousEmail,
+        string CurrentEmail,
+        string Token,
+        string? IpAddress,
+        string? UserAgent) : ICommand<Result<RevertedEmailChange>>;
+
+    internal sealed record RevertedEmailChange(string RestoredEmail, string PasswordResetToken);
+
+    internal sealed class CommandValidator : AbstractValidator<Command>
+    {
+        public CommandValidator()
+        {
+            RuleFor(x => x.UserId)
+                .NotEmpty().WithMessage("User ID is required.");
+
+            RuleFor(x => x.PreviousEmail)
+                .NotEmpty().WithMessage("A valid email address is required.")
+                .MaximumLength(EmailConstants.MaxLength)
+                    .WithMessage($"Email must not exceed {EmailConstants.MaxLength} characters.")
+                .Matches(EmailConstants.RegexPattern)
+                    .WithMessage("A valid email address is required.");
+
+            RuleFor(x => x.CurrentEmail)
+                .NotEmpty().WithMessage("A valid email address is required.")
+                .MaximumLength(EmailConstants.MaxLength)
+                    .WithMessage($"Email must not exceed {EmailConstants.MaxLength} characters.")
+                .Matches(EmailConstants.RegexPattern)
+                    .WithMessage("A valid email address is required.");
+
+            RuleFor(x => x.Token)
+                .NotEmpty().WithMessage("Revert token is required.");
+        }
+    }
+
+    internal sealed partial class Handler : ICommandHandler<Command, Result<RevertedEmailChange>>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IUserSessionRevoker _sessionRevoker;
+        private readonly IValidator<Command> _validator;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(
+            UserManager<ApplicationUser> userManager,
+            IUserSessionRevoker sessionRevoker,
+            IValidator<Command> validator,
+            ILogger<Handler> logger)
+        {
+            _userManager = userManager;
+            _sessionRevoker = sessionRevoker;
+            _validator = validator;
+            _logger = logger;
+        }
+
+        public async ValueTask<Result<RevertedEmailChange>> Handle(
+            Command command, CancellationToken cancellationToken)
+        {
+            ValidationResult validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                return Result.Failure<RevertedEmailChange>(AuthErrors.InvalidEmailChangeToken);
+            }
+
+            string previousEmail = command.PreviousEmail.Trim();
+            string currentEmail = command.CurrentEmail.Trim();
+
+            ApplicationUser? user = await _userManager.FindByIdAsync(command.UserId);
+            if (user is null)
+            {
+                LogTokenInvalid(_logger, previousEmail.MaskEmail(), command.IpAddress, command.UserAgent);
+                return Result.Failure<RevertedEmailChange>(AuthErrors.InvalidEmailChangeToken);
+            }
+
+            bool tokenValid = await _userManager.VerifyUserTokenAsync(
+                user,
+                EmailChangeRevertTokenProvider.ProviderName,
+                EmailChangeRevertTokenProvider.PurposeFor(previousEmail, currentEmail),
+                command.Token);
+
+            if (!tokenValid)
+            {
+                LogTokenInvalid(_logger, previousEmail.MaskEmail(), command.IpAddress, command.UserAgent);
+                return Result.Failure<RevertedEmailChange>(AuthErrors.InvalidEmailChangeToken);
+            }
+
+            // This is what makes the link single-use, since the token deliberately carries no security
+            // stamp. The account has to still sit where the token said it did, so a second visit, or a
+            // link from an older change, does nothing.
+            if (!string.Equals(
+                    _userManager.NormalizeEmail(user.Email),
+                    _userManager.NormalizeEmail(currentEmail),
+                    StringComparison.Ordinal))
+            {
+                LogAlreadySettled(_logger, user.Id);
+                return Result.Failure<RevertedEmailChange>(AuthErrors.InvalidEmailChangeToken);
+            }
+
+            // Somebody may have registered the freed address in the meantime. Then there is nothing to
+            // go back to, and the password must stay as it is: clearing it would lock the account out
+            // of both addresses at once.
+            ApplicationUser? previousAddressOwner = await _userManager.FindByEmailAsync(previousEmail);
+            if (previousAddressOwner is not null)
+            {
+                LogPreviousAddressTaken(_logger, user.Id);
+                return Result.Failure<RevertedEmailChange>(AuthErrors.UserAlreadyExistsByEmail);
+            }
+
+            user.Email = previousEmail;
+            user.EmailConfirmed = true;
+
+            // Whoever moved the address knew the password, so the password goes. Only the reset flow
+            // brings the account back, and it now runs through the mailbox that just proved ownership.
+            user.PasswordHash = null;
+
+            user.SecurityStamp = Guid.NewGuid().ToString();
+
+            Result<IdentityResult> updateResult = await TryUpdateAsync(user);
+            if (updateResult.IsFailure)
+            {
+                return Result.Failure<RevertedEmailChange>(updateResult.Error);
+            }
+
+            if (!updateResult.Value.Succeeded)
+            {
+                string errors = string.Join(", ", updateResult.Value.Errors.Select(e => e.Description));
+                LogRevertFailed(_logger, user.Id, errors);
+                return Result.Failure<RevertedEmailChange>(AuthErrors.EmailChangeFailed(errors));
+            }
+
+            await _sessionRevoker.RevokeAllAsync(user.Id.ToString(), cancellationToken);
+
+            // Created after the save, from the stored stamp. A token made before it would be
+            // invalidated by the very stamp change it travels with.
+            string passwordResetToken = await _userManager.GeneratePasswordResetTokenAsync(user);
+
+            LogReverted(
+                _logger, user.Id, currentEmail.MaskEmail(), previousEmail.MaskEmail(), command.IpAddress, command.UserAgent);
+
+            return Result.Success(new RevertedEmailChange(previousEmail, passwordResetToken));
+        }
+
+        /// <summary>
+        /// Same reasoning as the confirm leg: the uniqueness check is a plain query, the unique index
+        /// is the real arbiter, and its duplicate-key error is not one <c>UserStore.UpdateAsync</c>
+        /// handles.
+        /// </summary>
+        private async Task<Result<IdentityResult>> TryUpdateAsync(ApplicationUser user)
+        {
+            try
+            {
+                return Result.Success(await _userManager.UpdateAsync(user));
+            }
+            catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
+            {
+                LogRevertRace(_logger, ex, user.Id);
+                return Result.Failure<IdentityResult>(AuthErrors.UserAlreadyExistsByEmail);
+            }
+        }
+
+        [LoggerMessage(EventId = EventIds.EmailChangeRevertTokenInvalid, Level = LogLevel.Warning, Message = "Invalid e-mail change revert token presented for {PreviousEmail}. IP: {IpAddress}, UserAgent: {UserAgent}")]
+        private static partial void LogTokenInvalid(ILogger logger, string previousEmail, string? ipAddress, string? userAgent);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeRevertAlreadySettled, Level = LogLevel.Information, Message = "Revert link for user {UserId} refused: the account no longer sits on the address it was issued against")]
+        private static partial void LogAlreadySettled(ILogger logger, Guid userId);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeRevertAddressTaken, Level = LogLevel.Warning, Message = "Revert link for user {UserId} refused: the previous address now belongs to another account")]
+        private static partial void LogPreviousAddressTaken(ILogger logger, Guid userId);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeReverted, Level = LogLevel.Information, Message = "E-mail change reverted for user {UserId}: {CurrentEmail} -> {PreviousEmail}. IP: {IpAddress}, UserAgent: {UserAgent}")]
+        private static partial void LogReverted(ILogger logger, Guid userId, string currentEmail, string previousEmail, string? ipAddress, string? userAgent);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeRevertFailed, Level = LogLevel.Error, Message = "Failed to revert the e-mail change for user {UserId}: {Errors}")]
+        private static partial void LogRevertFailed(ILogger logger, Guid userId, string errors);
+
+        [LoggerMessage(EventId = EventIds.EmailChangeRevertRace, Level = LogLevel.Warning, Message = "Revert for user {UserId} lost a race for the previous address")]
+        private static partial void LogRevertRace(ILogger logger, Exception exception, Guid userId);
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RevertEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RevertEmailChange.cs
@@ -44,6 +44,13 @@ internal sealed partial class RevertEmailChange
             RuleFor(x => x.UserId)
                 .NotEmpty().WithMessage("User ID is required.");
 
+            // The id arrives from a query string, and Identity converts it to the key type before it
+            // queries. A value that is not a GUID throws inside the store, which would turn a bad link
+            // into a crash on a page somebody opened from their inbox.
+            RuleFor(x => x.UserId)
+                .Must(userId => Guid.TryParse(userId, out _))
+                    .WithMessage("User ID must be a GUID.");
+
             RuleFor(x => x.PreviousEmail)
                 .NotEmpty().WithMessage("A valid email address is required.")
                 .MaximumLength(EmailConstants.MaxLength)
@@ -91,8 +98,8 @@ internal sealed partial class RevertEmailChange
                 return Result.Failure<RevertedEmailChange>(AuthErrors.InvalidEmailChangeToken);
             }
 
-            string previousEmail = command.PreviousEmail.Trim();
-            string currentEmail = command.CurrentEmail.Trim();
+            string previousEmail = command.PreviousEmail;
+            string currentEmail = command.CurrentEmail;
 
             ApplicationUser? user = await _userManager.FindByIdAsync(command.UserId);
             if (user is null)
@@ -113,12 +120,17 @@ internal sealed partial class RevertEmailChange
                 return Result.Failure<RevertedEmailChange>(AuthErrors.InvalidEmailChangeToken);
             }
 
-            // This is what makes the link single-use, since the token deliberately carries no security
-            // stamp. The account has to still sit where the token said it did, so a second visit, or a
-            // link from an older change, does nothing.
-            if (!string.Equals(
+            // The guard is "the account is not already back on the previous address", NOT "the account
+            // still sits on the address the token names". The stricter version looks safer and is the
+            // opposite: an attacker who knows the password just changes the address twice, A to B then
+            // B to C, and the owner's A-to-B link no longer matches anything — while the new revert
+            // offer goes to B, which the attacker owns. This way the link keeps working from wherever
+            // the account has been dragged, which is the whole promise of ADR-0048.
+            // It still refuses the second click, because by then the account IS back on the previous
+            // address, so a revert cannot run twice and clear a freshly reset password.
+            if (string.Equals(
                     _userManager.NormalizeEmail(user.Email),
-                    _userManager.NormalizeEmail(currentEmail),
+                    _userManager.NormalizeEmail(previousEmail),
                     StringComparison.Ordinal))
             {
                 LogAlreadySettled(_logger, user.Id);
@@ -129,7 +141,7 @@ internal sealed partial class RevertEmailChange
             // go back to, and the password must stay as it is: clearing it would lock the account out
             // of both addresses at once.
             ApplicationUser? previousAddressOwner = await _userManager.FindByEmailAsync(previousEmail);
-            if (previousAddressOwner is not null)
+            if (previousAddressOwner is not null && previousAddressOwner.Id != user.Id)
             {
                 LogPreviousAddressTaken(_logger, user.Id);
                 return Result.Failure<RevertedEmailChange>(AuthErrors.UserAlreadyExistsByEmail);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RevertEmailChange.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/RevertEmailChange.cs
@@ -6,6 +6,7 @@ using LotroKoniecDev.AuthSystem.API.ApiErrors;
 using LotroKoniecDev.AuthSystem.API.Extensions;
 using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using LotroKoniecDev.AuthSystem.Persistence.Identity;
 using LotroKoniecDev.SharedKernel.Constants;
 using LotroKoniecDev.SharedKernel.Messaging;
@@ -24,6 +25,9 @@ namespace LotroKoniecDev.AuthSystem.API.Features.Auth;
 /// <see cref="CancelAccountDeletion"/> answers the same problem the same way.
 /// No e-mail goes out afterwards. The person who needs to know is reading the page, and telling the
 /// address the account was just taken from would only warn an attacker.
+/// It also cancels a scheduled deletion. After an address change the cancel link of ADR-0031 was sent
+/// to a mailbox the owner may no longer control, so refusing here would leave the account to be erased
+/// by the very person it was taken from.
 /// </remarks>
 internal sealed partial class RevertEmailChange
 {
@@ -73,17 +77,20 @@ internal sealed partial class RevertEmailChange
     internal sealed partial class Handler : ICommandHandler<Command, Result<RevertedEmailChange>>
     {
         private readonly UserManager<ApplicationUser> _userManager;
+        private readonly AuthDbContext _db;
         private readonly IUserSessionRevoker _sessionRevoker;
         private readonly IValidator<Command> _validator;
         private readonly ILogger<Handler> _logger;
 
         public Handler(
             UserManager<ApplicationUser> userManager,
+            AuthDbContext db,
             IUserSessionRevoker sessionRevoker,
             IValidator<Command> validator,
             ILogger<Handler> logger)
         {
             _userManager = userManager;
+            _db = db;
             _sessionRevoker = sessionRevoker;
             _validator = validator;
             _logger = logger;
@@ -141,7 +148,7 @@ internal sealed partial class RevertEmailChange
             // go back to, and the password must stay as it is: clearing it would lock the account out
             // of both addresses at once.
             ApplicationUser? previousAddressOwner = await _userManager.FindByEmailAsync(previousEmail);
-            if (previousAddressOwner is not null && previousAddressOwner.Id != user.Id)
+            if (previousAddressOwner is not null)
             {
                 LogPreviousAddressTaken(_logger, user.Id);
                 return Result.Failure<RevertedEmailChange>(AuthErrors.UserAlreadyExistsByEmail);
@@ -156,14 +163,29 @@ internal sealed partial class RevertEmailChange
 
             user.SecurityStamp = Guid.NewGuid().ToString();
 
+            // Retires every revert link issued so far, including the ones further up a chain of
+            // changes. Without it the attacker's own token, mailed to an address they controlled,
+            // still works and simply undoes this recovery (ADR-0048).
+            user.EmailChangeRevertStamp = Guid.NewGuid();
+
+            // A deletion the same person may have scheduled is called off here. Its cancel link went to
+            // the address the account was moved to, so leaving the schedule in place would hand the
+            // erasure to whoever took the account over.
+            user.DeletionScheduledAt = null;
+            user.LockoutEnd = null;
+            user.AccessFailedCount = 0;
+
             Result<IdentityResult> updateResult = await TryUpdateAsync(user);
             if (updateResult.IsFailure)
             {
+                DiscardPendingChanges();
                 return Result.Failure<RevertedEmailChange>(updateResult.Error);
             }
 
             if (!updateResult.Value.Succeeded)
             {
+                DiscardPendingChanges();
+
                 string errors = string.Join(", ", updateResult.Value.Errors.Select(e => e.Description));
                 LogRevertFailed(_logger, user.Id, errors);
                 return Result.Failure<RevertedEmailChange>(AuthErrors.EmailChangeFailed(errors));
@@ -179,6 +201,17 @@ internal sealed partial class RevertEmailChange
                 _logger, user.Id, currentEmail.MaskEmail(), previousEmail.MaskEmail(), command.IpAddress, command.UserAgent);
 
             return Result.Success(new RevertedEmailChange(previousEmail, passwordResetToken));
+        }
+
+        /// <summary>
+        /// A failed update never reaches the store, so this unit of work is still in the change
+        /// tracker with the restored address and a cleared password on it. The context is shared with
+        /// OpenIddict for the rest of the request, so a later save there would commit a revert this
+        /// handler just reported as failed.
+        /// </summary>
+        private void DiscardPendingChanges()
+        {
+            _db.ChangeTracker.Clear();
         }
 
         /// <summary>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/AccountAggregateLinkFactory.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Hateoas/AccountAggregateFactories/AccountAggregateLinkFactory.cs
@@ -44,6 +44,11 @@ internal sealed class AccountAggregateLinkFactory : IAccountAggregateLinkFactory
             method: HttpMethods.Post));
 
         links.AddIfPresent(await _linkFactory.CreateAsync(
+            endpoint: nameof(RequestEmailChange),
+            rel: Rels.ChangeEmail,
+            method: HttpMethods.Post));
+
+        links.AddIfPresent(await _linkFactory.CreateAsync(
             endpoint: nameof(DeleteAccount),
             rel: Rels.DeleteAccount,
             method: HttpMethods.Post));

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/EmailChangeCompleted.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/EmailChangeCompleted.cs
@@ -1,0 +1,12 @@
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// The outbox payload for "this account has moved to a new address". It tells the new mailbox the
+/// change is done and gives the old one the link that undoes it (ADR-0048).
+/// </summary>
+/// <remarks>
+/// <see cref="PreviousEmail"/> is only in this payload. By the time the processor runs, the user row
+/// no longer holds it, and it is both the address the notice goes to and half of the revert token's
+/// purpose.
+/// </remarks>
+public sealed record EmailChangeCompleted(Guid IdentityUserId, string PreviousEmail, string NewEmail);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/EmailChangeRequested.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/EmailChangeRequested.cs
@@ -1,0 +1,16 @@
+namespace LotroKoniecDev.AuthSystem.API.Outbox;
+
+/// <summary>
+/// The outbox payload for "someone asked to move this account to another address". The producer
+/// serializes it, and the relay and the consumer read it back.
+/// </summary>
+/// <remarks>
+/// It carries both addresses, unlike <see cref="EmailConfirmationRequested"/>, which carries only the
+/// id. Reading the current address off the user row at send time would be wrong here: after a delayed
+/// or dead-lettered redelivery the row already holds the new address, and the warning meant for the
+/// old mailbox would go to the very address the attacker chose. <c>CurrentEmail</c> also tells the
+/// processor whether the request is still open at all.
+/// The confirmation token still belongs to the sending step, so the processor creates it, and the
+/// "the link expires in 24 hours" sentence stays true no matter how long the message waited.
+/// </remarks>
+public sealed record EmailChangeRequested(Guid IdentityUserId, string CurrentEmail, string NewEmail);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxMessageRouting.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Outbox/OutboxMessageRouting.cs
@@ -16,7 +16,9 @@ internal static class OutboxMessageRouting
         [nameof(EmailConfirmationRequested)] = RabbitMqTopology.EmailConfirmationRoutingKey,
         [nameof(PasswordResetRequested)] = RabbitMqTopology.PasswordResetRoutingKey,
         [nameof(AccountDeletionScheduled)] = RabbitMqTopology.DeletionScheduledRoutingKey,
-        [nameof(AccountDeletionCancelled)] = RabbitMqTopology.DeletionCancelledRoutingKey
+        [nameof(AccountDeletionCancelled)] = RabbitMqTopology.DeletionCancelledRoutingKey,
+        [nameof(EmailChangeRequested)] = RabbitMqTopology.EmailChangeRequestedRoutingKey,
+        [nameof(EmailChangeCompleted)] = RabbitMqTopology.EmailChangeCompletedRoutingKey
     };
 
     public static bool TryGetRoutingKey(string type, [NotNullWhen(true)] out string? routingKey)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmailChange.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmailChange.cshtml
@@ -1,0 +1,391 @@
+@page
+@model LotroKoniecDev.AuthSystem.API.Pages.Account.ConfirmEmailChangeModel
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Potwierdzenie nowego adresu e-mail — lotro-translator.pl</title>
+    <link rel="stylesheet" href="/fonts.css" />
+    <style>
+        :root {
+            --bg:        oklch(0.16 0.011 80);
+            --bg-2:      oklch(0.20 0.013 80);
+            --surface:   oklch(0.23 0.014 80);
+            --surface-hi:oklch(0.28 0.016 80);
+            --border:    oklch(0.34 0.016 80);
+            --border-hi: oklch(0.44 0.020 80);
+
+            --text:      oklch(0.96 0.008 85);
+            --text-mute: oklch(0.80 0.012 85);
+            --text-dim:  oklch(0.68 0.014 85);
+
+            --accent:     oklch(0.78 0.11 84);
+            --accent-hi:  oklch(0.85 0.12 84);
+            --accent-dim: oklch(0.48 0.07 84);
+            --accent-soft:oklch(0.32 0.05 84);
+
+            --danger:      oklch(0.68 0.16 25);
+            --danger-hi:   oklch(0.76 0.18 25);
+            --danger-dim:  oklch(0.42 0.10 25);
+            --danger-soft: oklch(0.30 0.07 25);
+
+            --radius: 14px;
+            --radius-sm: 8px;
+            --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
+
+            --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
+            --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        }
+
+        * { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; }
+        body {
+            background: var(--bg);
+            color: var(--text);
+            font-family: var(--font-sans);
+            font-size: 15px;
+            line-height: 1.55;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            min-height: 100vh;
+        }
+        a { color: inherit; text-decoration: none; }
+        button { font-family: inherit; cursor: pointer; }
+
+        .app {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            background:
+                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
+        }
+
+        .auth-top {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            padding: 16px 28px;
+            border-bottom: 1px solid var(--border);
+            background: oklch(0.15 0.011 80 / 0.7);
+            backdrop-filter: blur(10px);
+        }
+        .brand {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            color: var(--text);
+            font-weight: 700;
+            font-size: 16px;
+            letter-spacing: -0.01em;
+        }
+        .brand-mark {
+            width: 30px; height: 30px;
+            border-radius: 8px;
+            background: linear-gradient(160deg, var(--accent), var(--accent-dim));
+            color: oklch(0.16 0.012 80);
+            display: grid;
+            place-items: center;
+            box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
+        }
+        .brand-mark svg { width: 17px; height: 17px; }
+        .brand-accent { color: var(--accent-hi); }
+        .auth-top .top-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 7px;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--text-mute);
+            padding: 7px 13px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-2);
+            transition: color .15s, border-color .15s, background .15s;
+        }
+        .auth-top .top-link:hover { color: var(--text); border-color: var(--border-hi); background: var(--surface-hi); }
+        .auth-top .top-link svg { width: 13px; height: 13px; }
+
+        .auth-main {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 48px 24px 56px;
+        }
+        .auth-stack { width: 100%; max-width: 416px; }
+
+        .auth-eyebrow {
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.18em;
+            color: var(--accent);
+            text-align: center;
+            margin: 0 0 16px;
+            text-transform: uppercase;
+        }
+        .auth-eyebrow.danger { color: var(--danger-hi); }
+
+        .auth-panel {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            overflow: hidden;
+            width: 100%;
+        }
+        .auth-panel-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 18px 24px;
+            border-bottom: 1px solid var(--border);
+            background: linear-gradient(to bottom,
+                oklch(0.25 0.016 80 / 0.6),
+                oklch(0.22 0.014 80 / 0));
+        }
+        .auth-panel-head h2 {
+            margin: 0;
+            font-size: 16px;
+            font-weight: 700;
+            letter-spacing: -0.005em;
+            color: var(--text);
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .auth-panel-head .panel-icon {
+            width: 30px; height: 30px;
+            border-radius: 8px;
+            background: var(--bg-2);
+            border: 1px solid var(--border);
+            color: var(--accent-hi);
+            display: grid;
+            place-items: center;
+            flex: 0 0 30px;
+        }
+        .auth-panel-head .panel-icon svg { width: 16px; height: 16px; }
+        .auth-panel-head .panel-aside {
+            font-family: var(--font-mono);
+            font-size: 10.5px;
+            color: var(--text-mute);
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+        .auth-panel-body {
+            padding: 22px 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+        .auth-lead {
+            margin: -2px 0 0;
+            font-size: 13.5px;
+            color: var(--text-mute);
+            line-height: 1.5;
+        }
+
+        .auth-alert {
+            display: flex;
+            align-items: flex-start;
+            gap: 10px;
+            padding: 13px 15px;
+            background: oklch(0.30 0.07 25 / 0.4);
+            border: 1px solid var(--danger-dim);
+            border-radius: var(--radius-sm);
+            color: oklch(0.92 0.04 25);
+            font-size: 13px;
+            line-height: 1.45;
+        }
+        .auth-alert > svg { width: 18px; height: 18px; flex: 0 0 18px; color: var(--danger-hi); margin-top: 1px; }
+        .auth-alert .t { font-weight: 600; display: block; }
+        .auth-alert .s {
+            display: block;
+            margin-top: 3px;
+            color: oklch(0.82 0.06 25);
+            font-size: 12.5px;
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            padding: 13px 20px;
+            border-radius: var(--radius-sm);
+            border: 1px solid transparent;
+            font-weight: 600;
+            font-size: 14.5px;
+            transition: transform .08s, background .15s, border-color .15s, color .15s;
+        }
+        .btn:active { transform: translateY(1px); }
+        .btn svg { width: 16px; height: 16px; flex: 0 0 16px; }
+        .btn-primary {
+            background: var(--accent);
+            color: oklch(0.16 0.012 80);
+            border-color: oklch(0.62 0.09 84);
+        }
+        .btn-primary:hover { background: var(--accent-hi); }
+        .btn-ghost {
+            background: transparent;
+            color: var(--text-mute);
+            border-color: var(--border);
+        }
+        .btn-ghost:hover { color: var(--text); border-color: var(--border-hi); background: var(--surface-hi); }
+        .btn-block { width: 100%; }
+
+        .auth-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 2px; }
+
+        .auth-meta {
+            margin-top: 16px;
+            font-family: var(--font-mono);
+            font-size: 10.5px;
+            letter-spacing: 0.08em;
+            color: var(--text-dim);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            text-transform: uppercase;
+        }
+        .auth-meta svg { width: 12px; height: 12px; color: var(--accent-hi); }
+
+        .foot {
+            padding: 22px 28px 26px;
+            border-top: 1px solid var(--border);
+            text-align: center;
+        }
+        .foot p {
+            margin: 0;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            color: var(--text-mute);
+        }
+
+        @@media (max-width: 640px) {
+            .auth-top { padding: 14px 18px; }
+            .auth-top .top-link span { display: none; }
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <div class="auth-top">
+            <a href="https://lotro-translator.pl" class="brand">
+                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="1.1" fill="currentColor"/></svg></span>
+                <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
+            </a>
+            <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
+        </div>
+
+        <div class="auth-main">
+            <div class="auth-stack">
+                @if (Model.IsCompleted)
+                {
+                    <p class="auth-eyebrow">Dostęp do konta</p>
+                    <section class="auth-panel" aria-labelledby="confirm-change-h">
+                        <header class="auth-panel-head">
+                            <h2 id="confirm-change-h">
+                                <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 8 9 6 9-6"/></svg></span>
+                                Nowy adres e-mail
+                            </h2>
+                            <span class="panel-aside">Gotowe</span>
+                        </header>
+                        <div class="auth-panel-body">
+                            <div class="auth-alert success" role="status" data-testid="confirm-email-change-success">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+                                <div>
+                                    <span class="t">Adres e-mail Twojego konta został zmieniony</span>
+                                    <span class="s">Od teraz logujesz się adresem <strong>@Model.Email</strong>. Ze względów bezpieczeństwa zakończyliśmy wszystkie sesje — zaloguj się ponownie.</span>
+                                </div>
+                            </div>
+                            <div class="auth-actions">
+                                <a href="/Account/Login" class="btn btn-primary btn-block">
+                                    Zaloguj się
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m13 5 7 7-7 7"/></svg>
+                                </a>
+                            </div>
+                        </div>
+                    </section>
+                }
+                else if (!string.IsNullOrEmpty(Model.ErrorMessage))
+                {
+                    <p class="auth-eyebrow danger">Dostęp do konta</p>
+                    <section class="auth-panel" aria-labelledby="confirm-change-h">
+                        <header class="auth-panel-head">
+                            <h2 id="confirm-change-h">
+                                <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 8 9 6 9-6"/></svg></span>
+                                Nowy adres e-mail
+                            </h2>
+                            <span class="panel-aside">Błąd</span>
+                        </header>
+                        <div class="auth-panel-body">
+                            <div class="auth-alert" role="alert" data-testid="confirm-email-change-error">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.7 3h16.94a2 2 0 0 0 1.7-3L13.69 3.86a2 2 0 0 0-3.4 0z"/></svg>
+                                <div>
+                                    <span class="t">Link wygasł lub jest nieprawidłowy</span>
+                                    <span class="s">@Model.ErrorMessage Link jest ważny 24 godziny i można go użyć tylko raz. Zaloguj się i poproś o zmianę adresu jeszcze raz.</span>
+                                </div>
+                            </div>
+                            <div class="auth-actions">
+                                <a href="/Account/Login" class="btn btn-ghost btn-block">
+                                    Powrót do logowania
+                                </a>
+                            </div>
+                        </div>
+                    </section>
+                }
+                else
+                {
+                    <p class="auth-eyebrow">Dostęp do konta</p>
+                    <section class="auth-panel" aria-labelledby="confirm-change-h">
+                        <header class="auth-panel-head">
+                            <h2 id="confirm-change-h">
+                                <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 8 9 6 9-6"/></svg></span>
+                                Potwierdź nowy adres e-mail
+                            </h2>
+                            <span class="panel-aside">Krok 2/2</span>
+                        </header>
+                        <div class="auth-panel-body">
+                            <p class="auth-lead">
+                                Twoje konto ma od teraz działać na adresie <strong>@Model.Email</strong>.
+                                Adres e-mail jest jednocześnie loginem, więc kolejne logowanie wykonasz już tym adresem.
+                            </p>
+                            <p class="auth-lead">
+                                Na dotychczasowy adres wyślemy wiadomość z linkiem, którym w razie potrzeby cofniesz tę zmianę.
+                            </p>
+                            <form method="post" data-testid="confirm-email-change-form">
+                                <input type="hidden" asp-for="UserId" />
+                                <input type="hidden" asp-for="Email" />
+                                <input type="hidden" asp-for="Token" />
+                                <div class="auth-actions">
+                                    <button type="submit" class="btn btn-primary btn-block" data-testid="confirm-email-change-submit">
+                                        Potwierdź nowy adres
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m13 5 7 7-7 7"/></svg>
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </section>
+                }
+                <p class="auth-meta"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg> Połączenie szyfrowane · TLS 1.3</p>
+            </div>
+        </div>
+
+        <footer class="foot">
+            <p>lotro-translator.pl — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmailChange.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmailChange.cshtml.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.RateLimiting;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Features.Auth;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
+
+/// <summary>
+/// The page the "confirm your new address" link leads to. A GET only shows a confirmation form, so a
+/// mail scanner that opens the link changes no address. The POST applies the change.
+/// </summary>
+[EnableRateLimiting("auth-endpoint-limit")]
+internal sealed partial class ConfirmEmailChangeModel : PageModel
+{
+    private readonly ICommandHandler<ConfirmEmailChange.Command, Result> _handler;
+    private readonly ILogger<ConfirmEmailChangeModel> _logger;
+
+    public ConfirmEmailChangeModel(
+        ICommandHandler<ConfirmEmailChange.Command, Result> handler,
+        ILogger<ConfirmEmailChangeModel> logger)
+    {
+        _handler = handler;
+        _logger = logger;
+    }
+
+    [BindProperty]
+    public string UserId { get; set; } = string.Empty;
+
+    [BindProperty]
+    public string Email { get; set; } = string.Empty;
+
+    [BindProperty]
+    public string Token { get; set; } = string.Empty;
+
+    public bool IsCompleted { get; set; }
+
+    public string? ErrorMessage { get; set; }
+
+    public void OnGet(string? userId = null, string? email = null, string? token = null)
+    {
+        UserId = userId ?? string.Empty;
+        Email = email ?? string.Empty;
+        Token = token ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(UserId) || string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Token))
+        {
+            ErrorMessage = "Link potwierdzający zmianę adresu jest nieprawidłowy.";
+        }
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (string.IsNullOrWhiteSpace(UserId) || string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Token))
+        {
+            ErrorMessage = "Link potwierdzający zmianę adresu jest nieprawidłowy.";
+            return Page();
+        }
+
+        ConfirmEmailChange.Command command = new(
+            UserId,
+            Email,
+            Token,
+            HttpContext.Connection.RemoteIpAddress?.ToString(),
+            HttpContext.Request.Headers.UserAgent.ToString());
+
+        Result commandResult = await _handler.Handle(command, HttpContext.RequestAborted);
+
+        if (commandResult.IsFailure)
+        {
+            ErrorMessage = "Link potwierdzający zmianę adresu jest nieprawidłowy lub wygasł.";
+            return Page();
+        }
+
+        LogEmailChangeConfirmedViaUi(_logger, Email.MaskEmail());
+
+        IsCompleted = true;
+        return Page();
+    }
+
+    [LoggerMessage(EventId = EventIds.EmailChangeConfirmedViaUi, Level = LogLevel.Information, Message = "E-mail change confirmed via UI for {MaskedEmail}.")]
+    private static partial void LogEmailChangeConfirmedViaUi(ILogger logger, string maskedEmail);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmailChange.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmailChange.cshtml.cs
@@ -45,7 +45,7 @@ internal sealed partial class ConfirmEmailChangeModel : PageModel
         Email = email ?? string.Empty;
         Token = token ?? string.Empty;
 
-        if (string.IsNullOrWhiteSpace(UserId) || string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Token))
+        if (!HasUsableLinkValues())
         {
             ErrorMessage = "Link potwierdzający zmianę adresu jest nieprawidłowy.";
         }
@@ -53,7 +53,7 @@ internal sealed partial class ConfirmEmailChangeModel : PageModel
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (string.IsNullOrWhiteSpace(UserId) || string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Token))
+        if (!HasUsableLinkValues())
         {
             ErrorMessage = "Link potwierdzający zmianę adresu jest nieprawidłowy.";
             return Page();
@@ -79,6 +79,16 @@ internal sealed partial class ConfirmEmailChangeModel : PageModel
         IsCompleted = true;
         return Page();
     }
+
+    /// <summary>
+    /// The link's values are printed on this page and then acted on, so they are checked for shape
+    /// before either happens. It keeps arbitrary text off a branded page that carries a real button,
+    /// and it keeps a non-GUID id out of Identity's key conversion, which would throw.
+    /// </summary>
+    private bool HasUsableLinkValues() =>
+        Guid.TryParse(UserId, out _)
+        && !string.IsNullOrWhiteSpace(Token)
+        && EmailLinkValue.LooksLikeAnAddress(Email);
 
     [LoggerMessage(EventId = EventIds.EmailChangeConfirmedViaUi, Level = LogLevel.Information, Message = "E-mail change confirmed via UI for {MaskedEmail}.")]
     private static partial void LogEmailChangeConfirmedViaUi(ILogger logger, string maskedEmail);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/EmailLinkValue.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/EmailLinkValue.cs
@@ -1,0 +1,19 @@
+using System.Text.RegularExpressions;
+using LotroKoniecDev.SharedKernel.Constants;
+
+namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
+
+/// <summary>
+/// Shape check for an e-mail address that arrived in a link's query string, before a page prints it
+/// or acts on it.
+/// </summary>
+internal static partial class EmailLinkValue
+{
+    public static bool LooksLikeAnAddress(string? value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && value.Length <= EmailConstants.MaxLength
+        && AddressRegex().IsMatch(value);
+
+    [GeneratedRegex(EmailConstants.RegexPattern, RegexOptions.None, matchTimeoutMilliseconds: 250)]
+    private static partial Regex AddressRegex();
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/PrivacyPolicy.cshtml
@@ -287,7 +287,7 @@
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
                 <div>
                     <div class="pc-t">Realizacja praw bez formalności</div>
-                    <div class="pc-s">Eksport oraz usunięcie konta uruchomisz samodzielnie w sekcji „Moje konto" — bez konieczności kontaktu mailowego.</div>
+                    <div class="pc-s">Eksport, zmianę adresu e-mail oraz usunięcie konta uruchomisz samodzielnie w sekcji „Moje konto" — bez konieczności kontaktu mailowego.</div>
                 </div>
             </div>
         </div>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/RevertEmailChange.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/RevertEmailChange.cshtml
@@ -1,0 +1,364 @@
+@page
+@model LotroKoniecDev.AuthSystem.API.Pages.Account.RevertEmailChangeModel
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cofnięcie zmiany adresu e-mail — lotro-translator.pl</title>
+    <link rel="stylesheet" href="/fonts.css" />
+    <style>
+        :root {
+            --bg:        oklch(0.16 0.011 80);
+            --bg-2:      oklch(0.20 0.013 80);
+            --surface:   oklch(0.23 0.014 80);
+            --surface-hi:oklch(0.28 0.016 80);
+            --border:    oklch(0.34 0.016 80);
+            --border-hi: oklch(0.44 0.020 80);
+
+            --text:      oklch(0.96 0.008 85);
+            --text-mute: oklch(0.80 0.012 85);
+            --text-dim:  oklch(0.68 0.014 85);
+
+            --accent:     oklch(0.78 0.11 84);
+            --accent-hi:  oklch(0.85 0.12 84);
+            --accent-dim: oklch(0.48 0.07 84);
+            --accent-soft:oklch(0.32 0.05 84);
+
+            --danger:      oklch(0.68 0.16 25);
+            --danger-hi:   oklch(0.76 0.18 25);
+            --danger-dim:  oklch(0.42 0.10 25);
+            --danger-soft: oklch(0.30 0.07 25);
+
+            --radius: 14px;
+            --radius-sm: 8px;
+            --shadow: 0 1px 0 oklch(0.38 0.013 80 / 0.5) inset, 0 8px 24px -12px rgba(0,0,0,0.55);
+
+            --font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
+            --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+        }
+
+        * { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; }
+        body {
+            background: var(--bg);
+            color: var(--text);
+            font-family: var(--font-sans);
+            font-size: 15px;
+            line-height: 1.55;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            min-height: 100vh;
+        }
+        a { color: inherit; text-decoration: none; }
+        button { font-family: inherit; cursor: pointer; }
+
+        .app {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            background:
+                radial-gradient(1200px 600px at 80% -200px, oklch(0.28 0.055 84 / 0.35), transparent 60%),
+                radial-gradient(900px 500px at -100px 100px, oklch(0.22 0.025 80 / 0.5), transparent 60%);
+        }
+
+        .auth-top {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            padding: 16px 28px;
+            border-bottom: 1px solid var(--border);
+            background: oklch(0.15 0.011 80 / 0.7);
+            backdrop-filter: blur(10px);
+        }
+        .brand {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            color: var(--text);
+            font-weight: 700;
+            font-size: 16px;
+            letter-spacing: -0.01em;
+        }
+        .brand-mark {
+            width: 30px; height: 30px;
+            border-radius: 8px;
+            background: linear-gradient(160deg, var(--accent), var(--accent-dim));
+            color: oklch(0.16 0.012 80);
+            display: grid;
+            place-items: center;
+            box-shadow: 0 0 0 1px oklch(0.60 0.07 84 / 0.5) inset;
+        }
+        .brand-mark svg { width: 17px; height: 17px; }
+        .brand-accent { color: var(--accent-hi); }
+        .auth-top .top-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 7px;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--text-mute);
+            padding: 7px 13px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-2);
+            transition: color .15s, border-color .15s, background .15s;
+        }
+        .auth-top .top-link:hover { color: var(--text); border-color: var(--border-hi); background: var(--surface-hi); }
+        .auth-top .top-link svg { width: 13px; height: 13px; }
+
+        .auth-main {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 48px 24px 56px;
+        }
+        .auth-stack { width: 100%; max-width: 416px; }
+
+        .auth-eyebrow {
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.18em;
+            color: var(--accent);
+            text-align: center;
+            margin: 0 0 16px;
+            text-transform: uppercase;
+        }
+        .auth-eyebrow.danger { color: var(--danger-hi); }
+
+        .auth-panel {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            overflow: hidden;
+            width: 100%;
+        }
+        .auth-panel-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 18px 24px;
+            border-bottom: 1px solid var(--border);
+            background: linear-gradient(to bottom,
+                oklch(0.25 0.016 80 / 0.6),
+                oklch(0.22 0.014 80 / 0));
+        }
+        .auth-panel-head h2 {
+            margin: 0;
+            font-size: 16px;
+            font-weight: 700;
+            letter-spacing: -0.005em;
+            color: var(--text);
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .auth-panel-head .panel-icon {
+            width: 30px; height: 30px;
+            border-radius: 8px;
+            background: var(--bg-2);
+            border: 1px solid var(--border);
+            color: var(--accent-hi);
+            display: grid;
+            place-items: center;
+            flex: 0 0 30px;
+        }
+        .auth-panel-head .panel-icon svg { width: 16px; height: 16px; }
+        .auth-panel-head .panel-aside {
+            font-family: var(--font-mono);
+            font-size: 10.5px;
+            color: var(--text-mute);
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+        .auth-panel-body {
+            padding: 22px 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+        .auth-lead {
+            margin: -2px 0 0;
+            font-size: 13.5px;
+            color: var(--text-mute);
+            line-height: 1.5;
+        }
+
+        .auth-alert {
+            display: flex;
+            align-items: flex-start;
+            gap: 10px;
+            padding: 13px 15px;
+            background: oklch(0.30 0.07 25 / 0.4);
+            border: 1px solid var(--danger-dim);
+            border-radius: var(--radius-sm);
+            color: oklch(0.92 0.04 25);
+            font-size: 13px;
+            line-height: 1.45;
+        }
+        .auth-alert > svg { width: 18px; height: 18px; flex: 0 0 18px; color: var(--danger-hi); margin-top: 1px; }
+        .auth-alert .t { font-weight: 600; display: block; }
+        .auth-alert .s {
+            display: block;
+            margin-top: 3px;
+            color: oklch(0.82 0.06 25);
+            font-size: 12.5px;
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            padding: 13px 20px;
+            border-radius: var(--radius-sm);
+            border: 1px solid transparent;
+            font-weight: 600;
+            font-size: 14.5px;
+            transition: transform .08s, background .15s, border-color .15s, color .15s;
+        }
+        .btn:active { transform: translateY(1px); }
+        .btn svg { width: 16px; height: 16px; flex: 0 0 16px; }
+        .btn-primary {
+            background: var(--accent);
+            color: oklch(0.16 0.012 80);
+            border-color: oklch(0.62 0.09 84);
+        }
+        .btn-primary:hover { background: var(--accent-hi); }
+        .btn-ghost {
+            background: transparent;
+            color: var(--text-mute);
+            border-color: var(--border);
+        }
+        .btn-ghost:hover { color: var(--text); border-color: var(--border-hi); background: var(--surface-hi); }
+        .btn-block { width: 100%; }
+
+        .auth-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 2px; }
+
+        .auth-meta {
+            margin-top: 16px;
+            font-family: var(--font-mono);
+            font-size: 10.5px;
+            letter-spacing: 0.08em;
+            color: var(--text-dim);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            text-transform: uppercase;
+        }
+        .auth-meta svg { width: 12px; height: 12px; color: var(--accent-hi); }
+
+        .foot {
+            padding: 22px 28px 26px;
+            border-top: 1px solid var(--border);
+            text-align: center;
+        }
+        .foot p {
+            margin: 0;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            color: var(--text-mute);
+        }
+
+        @@media (max-width: 640px) {
+            .auth-top { padding: 14px 18px; }
+            .auth-top .top-link span { display: none; }
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <div class="auth-top">
+            <a href="https://lotro-translator.pl" class="brand">
+                <span class="brand-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="1.1" fill="currentColor"/></svg></span>
+                <span class="brand-text">lotro-<span class="brand-accent">translator</span>.pl</span>
+            </a>
+            <a href="/Account/Login" class="top-link"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/></svg><span>Zaloguj się</span></a>
+        </div>
+
+        <div class="auth-main">
+            <div class="auth-stack">
+                @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+                {
+                    <p class="auth-eyebrow danger">Bezpieczeństwo konta</p>
+                    <section class="auth-panel" aria-labelledby="revert-h">
+                        <header class="auth-panel-head">
+                            <h2 id="revert-h">
+                                <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></span>
+                                Cofnięcie zmiany adresu
+                            </h2>
+                            <span class="panel-aside">Błąd</span>
+                        </header>
+                        <div class="auth-panel-body">
+                            <div class="auth-alert" role="alert" data-testid="revert-email-change-error">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.7 3h16.94a2 2 0 0 0 1.7-3L13.69 3.86a2 2 0 0 0-3.4 0z"/></svg>
+                                <div>
+                                    <span class="t">Link wygasł lub jest nieprawidłowy</span>
+                                    <span class="s">@Model.ErrorMessage Linku można użyć tylko raz i działa przez 14 dni od zmiany adresu. Jeśli nadal nie masz dostępu do konta, skontaktuj się z nami.</span>
+                                </div>
+                            </div>
+                            <div class="auth-actions">
+                                <a href="/Account/Login" class="btn btn-ghost btn-block">
+                                    Powrót do logowania
+                                </a>
+                            </div>
+                        </div>
+                    </section>
+                }
+                else
+                {
+                    <p class="auth-eyebrow danger">Bezpieczeństwo konta</p>
+                    <section class="auth-panel" aria-labelledby="revert-h">
+                        <header class="auth-panel-head">
+                            <h2 id="revert-h">
+                                <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></span>
+                                Cofnij zmianę adresu e-mail
+                            </h2>
+                            <span class="panel-aside">To nie ja</span>
+                        </header>
+                        <div class="auth-panel-body">
+                            <p class="auth-lead">
+                                Konto, które działało na adresie <strong>@Model.From</strong>, zostało przeniesione na adres <strong>@Model.To</strong>.
+                            </p>
+                            <p class="auth-lead">
+                                Jeśli to nie Ty, cofnij zmianę. Przywrócimy poprzedni adres i unieważnimy obecne hasło —
+                                osoba, która je zna, straci dostęp do konta. Zaraz potem ustawisz nowe hasło.
+                            </p>
+                            <form method="post" data-testid="revert-email-change-form">
+                                <input type="hidden" asp-for="UserId" />
+                                <input type="hidden" asp-for="From" />
+                                <input type="hidden" asp-for="To" />
+                                <input type="hidden" asp-for="Token" />
+                                <div class="auth-actions">
+                                    <button type="submit" class="btn btn-primary btn-block" data-testid="revert-email-change-submit">
+                                        Cofnij zmianę i ustaw nowe hasło
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m13 5 7 7-7 7"/></svg>
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </section>
+                }
+                <p class="auth-meta"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg> Połączenie szyfrowane · TLS 1.3</p>
+            </div>
+        </div>
+
+        <footer class="foot">
+            <p>lotro-translator.pl — niekomercyjny projekt społeczności polskich graczy LOTRO</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/RevertEmailChange.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/RevertEmailChange.cshtml.cs
@@ -93,11 +93,17 @@ internal sealed partial class RevertEmailChangeModel : PageModel
         });
     }
 
+    /// <summary>
+    /// The link's values are printed on this page and then acted on, so they are checked for shape
+    /// before either happens. It keeps arbitrary text off a branded page that carries a button which
+    /// clears a password, and it keeps a non-GUID id out of Identity's key conversion, which would
+    /// throw.
+    /// </summary>
     private bool HasEveryValue() =>
-        !string.IsNullOrWhiteSpace(UserId)
-        && !string.IsNullOrWhiteSpace(From)
-        && !string.IsNullOrWhiteSpace(To)
-        && !string.IsNullOrWhiteSpace(Token);
+        Guid.TryParse(UserId, out _)
+        && !string.IsNullOrWhiteSpace(Token)
+        && EmailLinkValue.LooksLikeAnAddress(From)
+        && EmailLinkValue.LooksLikeAnAddress(To);
 
     [LoggerMessage(EventId = EventIds.EmailChangeRevertedViaUi, Level = LogLevel.Information, Message = "E-mail change reverted via UI for {MaskedEmail}. Redirecting to the forced password reset.")]
     private static partial void LogEmailChangeRevertedViaUi(ILogger logger, string maskedEmail);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/RevertEmailChange.cshtml.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/RevertEmailChange.cshtml.cs
@@ -1,0 +1,104 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.RateLimiting;
+using LotroKoniecDev.AuthSystem.API.Extensions;
+using LotroKoniecDev.AuthSystem.API.Features.Auth;
+using LotroKoniecDev.SharedKernel.Messaging;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Pages.Account;
+
+/// <summary>
+/// The page the "to nie ja" link in the old mailbox leads to (ADR-0048). A GET only shows a
+/// confirmation form. That is not decoration: this link lands in a live inbox, corporate mail
+/// security opens every URL it sees, and a GET that reverted would undo every legitimate e-mail
+/// change and clear the password seconds after the notice arrived.
+/// </summary>
+[EnableRateLimiting("auth-endpoint-limit")]
+internal sealed partial class RevertEmailChangeModel : PageModel
+{
+    private readonly ICommandHandler<RevertEmailChange.Command, Result<RevertEmailChange.RevertedEmailChange>> _handler;
+    private readonly ILogger<RevertEmailChangeModel> _logger;
+
+    public RevertEmailChangeModel(
+        ICommandHandler<RevertEmailChange.Command, Result<RevertEmailChange.RevertedEmailChange>> handler,
+        ILogger<RevertEmailChangeModel> logger)
+    {
+        _handler = handler;
+        _logger = logger;
+    }
+
+    [BindProperty]
+    public string UserId { get; set; } = string.Empty;
+
+    /// <summary>The address the account is going back to.</summary>
+    [BindProperty]
+    public string From { get; set; } = string.Empty;
+
+    /// <summary>The address the account was moved to, and where it has to still be for this to work.</summary>
+    [BindProperty]
+    public string To { get; set; } = string.Empty;
+
+    [BindProperty]
+    public string Token { get; set; } = string.Empty;
+
+    public string? ErrorMessage { get; set; }
+
+    public void OnGet(string? userId = null, string? from = null, string? to = null, string? token = null)
+    {
+        UserId = userId ?? string.Empty;
+        From = from ?? string.Empty;
+        To = to ?? string.Empty;
+        Token = token ?? string.Empty;
+
+        if (!HasEveryValue())
+        {
+            ErrorMessage = "Link cofający zmianę adresu jest nieprawidłowy.";
+        }
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!HasEveryValue())
+        {
+            ErrorMessage = "Link cofający zmianę adresu jest nieprawidłowy.";
+            return Page();
+        }
+
+        RevertEmailChange.Command command = new(
+            UserId,
+            From,
+            To,
+            Token,
+            HttpContext.Connection.RemoteIpAddress?.ToString(),
+            HttpContext.Request.Headers.UserAgent.ToString());
+
+        Result<RevertEmailChange.RevertedEmailChange> commandResult =
+            await _handler.Handle(command, HttpContext.RequestAborted);
+
+        if (commandResult.IsFailure)
+        {
+            ErrorMessage = "Link cofający zmianę adresu jest nieprawidłowy lub wygasł.";
+            return Page();
+        }
+
+        LogEmailChangeRevertedViaUi(_logger, From.MaskEmail());
+
+        // The password is gone now, so the only way back into the account is the reset flow. Same
+        // ending as cancelling a scheduled deletion.
+        return RedirectToPage("/Account/ResetPassword", new
+        {
+            email = commandResult.Value.RestoredEmail,
+            token = commandResult.Value.PasswordResetToken
+        });
+    }
+
+    private bool HasEveryValue() =>
+        !string.IsNullOrWhiteSpace(UserId)
+        && !string.IsNullOrWhiteSpace(From)
+        && !string.IsNullOrWhiteSpace(To)
+        && !string.IsNullOrWhiteSpace(Token);
+
+    [LoggerMessage(EventId = EventIds.EmailChangeRevertedViaUi, Level = LogLevel.Information, Message = "E-mail change reverted via UI for {MaskedEmail}. Redirecting to the forced password reset.")]
+    private static partial void LogEmailChangeRevertedViaUi(ILogger logger, string maskedEmail);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Program.cs
@@ -260,6 +260,7 @@ try
     const string authEndpointRateLimitPolicy = "auth-endpoint-limit";
     const string forgotPasswordRateLimitPolicy = "forgot-password-limit";
     const string resendConfirmationRateLimitPolicy = "resend-confirmation-limit";
+    const string changeEmailRateLimitPolicy = "change-email-limit";
     const string resendConfirmationPageViewPartition = "resend-confirmation-page-view";
 
     builder.Services.AddRateLimiter(options =>
@@ -293,6 +294,20 @@ try
                 {
                     PermitLimit = 3,
                     Window = TimeSpan.FromMinutes(15)
+                }));
+
+        // The e-mail change request sends mail to an address the caller typed in, so it can be used to
+        // flood a stranger's inbox. Same threat as forgot-password, same budget.
+        // The key is the IP and not the user: UseRateLimiter runs before UseAuthentication on purpose
+        // (see below), so httpContext.User is still anonymous here and a "per user" key would collapse
+        // into one bucket shared by everybody.
+        options.AddPolicy(changeEmailRateLimitPolicy, httpContext =>
+            RateLimitPartition.GetFixedWindowLimiter(
+                partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                factory: _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = 3,
+                    Window = TimeSpan.FromHours(1)
                 }));
 
         // A separate rate limit for resending the confirmation e-mail. The limit belongs to the send,

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeCompletedProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeCompletedProcessor.cs
@@ -17,9 +17,12 @@ namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
 /// The revert token is created here, at send time, like every other token in this pipeline. It can be
 /// built from the payload alone, which matters: by now the user row no longer holds the previous
 /// address, and that address is half of the token's purpose.
+/// Only the change that armed the undo carries a link. A later change in the same chain sends the
+/// notices without one, so an attacker who moved the account on a second time gets nothing they could
+/// use to undo the owner's recovery.
 /// A message may arrive more than once (ADR-0035), so this has to be safe to run twice. It is: a
-/// repeat sends the same two notices with a fresh revert token that opens the same page and reaches
-/// the same decision.
+/// repeat sends the same notices with a fresh revert token that opens the same page and reaches the
+/// same decision, and the armed target it reads does not move.
 /// </remarks>
 internal sealed partial class EmailChangeCompletedProcessor : IEmailMessageProcessor
 {
@@ -84,35 +87,39 @@ internal sealed partial class EmailChangeCompletedProcessor : IEmailMessageProce
             return Result.Success();
         }
 
-        // A redelivery that arrives after the account moved on, or after the revert already ran, would
-        // otherwise mint a brand-new token and start its fourteen days again from today.
-        if (!string.Equals(
-                _userManager.NormalizeEmail(user.Email),
-                _userManager.NormalizeEmail(message.NewEmail),
-                StringComparison.Ordinal))
+        // Only the change that armed the undo may carry its link. After A to B to C the armed target
+        // is still A, so the B-to-C message sends no link at all — there is nothing to hand whoever
+        // took the account over, and nothing for them to burn before the owner clicks (ADR-0048).
+        bool armedByThisChange = string.Equals(
+            _userManager.NormalizeEmail(user.EmailChangeRevertTo),
+            _userManager.NormalizeEmail(message.PreviousEmail),
+            StringComparison.Ordinal);
+
+        if (armedByThisChange)
         {
-            LogStaleChange(_logger, message.IdentityUserId);
-            return Result.Success();
+            string revertToken = await _userManager.GenerateUserTokenAsync(
+                user,
+                EmailChangeRevertTokenProvider.ProviderName,
+                EmailChangeRevertTokenProvider.PurposeFor(message.PreviousEmail, message.NewEmail));
+
+            // The old address goes first. It is the one that can still undo this, so if only one of
+            // the two messages ever gets through, it has to be that one.
+            Result revertOfferResult = await _emailChangeEmailSender.SendChangedNoticeWithRevertAsync(
+                user.Id,
+                message.PreviousEmail,
+                message.NewEmail,
+                revertToken,
+                _revertTokenOptions.TokenLifespan,
+                cancellationToken);
+
+            if (revertOfferResult.IsFailure)
+            {
+                return revertOfferResult;
+            }
         }
-
-        string revertToken = await _userManager.GenerateUserTokenAsync(
-            user,
-            EmailChangeRevertTokenProvider.ProviderName,
-            EmailChangeRevertTokenProvider.PurposeFor(message.PreviousEmail, message.NewEmail));
-
-        // The old address goes first. It is the one that can still undo this, so if only one of the
-        // two messages ever gets through, it has to be that one.
-        Result revertOfferResult = await _emailChangeEmailSender.SendChangedNoticeWithRevertAsync(
-            user.Id,
-            message.PreviousEmail,
-            message.NewEmail,
-            revertToken,
-            _revertTokenOptions.TokenLifespan,
-            cancellationToken);
-
-        if (revertOfferResult.IsFailure)
+        else
         {
-            return revertOfferResult;
+            LogNoUndoArmed(_logger, message.IdentityUserId);
         }
 
         return await _emailChangeEmailSender.SendChangedNoticeAsync(
@@ -122,8 +129,8 @@ internal sealed partial class EmailChangeCompletedProcessor : IEmailMessageProce
     [LoggerMessage(
         EventId = EventIds.EmailChangeDispatchStaleRequest,
         Level = LogLevel.Information,
-        Message = "Skipping e-mail change notices for user {UserId}: the account no longer sits on the new address")]
-    private static partial void LogStaleChange(ILogger logger, Guid userId);
+        Message = "No undo link for user {UserId}: an earlier change in the chain already armed one")]
+    private static partial void LogNoUndoArmed(ILogger logger, Guid userId);
 
     [LoggerMessage(
         EventId = EventIds.EmailChangeDispatchUserGone,

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeCompletedProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeCompletedProcessor.cs
@@ -84,6 +84,17 @@ internal sealed partial class EmailChangeCompletedProcessor : IEmailMessageProce
             return Result.Success();
         }
 
+        // A redelivery that arrives after the account moved on, or after the revert already ran, would
+        // otherwise mint a brand-new token and start its fourteen days again from today.
+        if (!string.Equals(
+                _userManager.NormalizeEmail(user.Email),
+                _userManager.NormalizeEmail(message.NewEmail),
+                StringComparison.Ordinal))
+        {
+            LogStaleChange(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
         string revertToken = await _userManager.GenerateUserTokenAsync(
             user,
             EmailChangeRevertTokenProvider.ProviderName,
@@ -107,6 +118,12 @@ internal sealed partial class EmailChangeCompletedProcessor : IEmailMessageProce
         return await _emailChangeEmailSender.SendChangedNoticeAsync(
             user.Id, message.NewEmail, message.PreviousEmail, cancellationToken);
     }
+
+    [LoggerMessage(
+        EventId = EventIds.EmailChangeDispatchStaleRequest,
+        Level = LogLevel.Information,
+        Message = "Skipping e-mail change notices for user {UserId}: the account no longer sits on the new address")]
+    private static partial void LogStaleChange(ILogger logger, Guid userId);
 
     [LoggerMessage(
         EventId = EventIds.EmailChangeDispatchUserGone,

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeCompletedProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeCompletedProcessor.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// What happens when an <see cref="EmailChangeCompleted"/> message arrives: tell the new address it
+/// is now the login, and tell the old one what happened while handing it the link that undoes it
+/// (ADR-0048).
+/// </summary>
+/// <remarks>
+/// The revert token is created here, at send time, like every other token in this pipeline. It can be
+/// built from the payload alone, which matters: by now the user row no longer holds the previous
+/// address, and that address is half of the token's purpose.
+/// A message may arrive more than once (ADR-0035), so this has to be safe to run twice. It is: a
+/// repeat sends the same two notices with a fresh revert token that opens the same page and reaches
+/// the same decision.
+/// </remarks>
+internal sealed partial class EmailChangeCompletedProcessor : IEmailMessageProcessor
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IEmailChangeEmailSender _emailChangeEmailSender;
+    private readonly EmailChangeRevertTokenProviderOptions _revertTokenOptions;
+    private readonly ILogger<EmailChangeCompletedProcessor> _logger;
+
+    public EmailChangeCompletedProcessor(
+        UserManager<ApplicationUser> userManager,
+        IEmailChangeEmailSender emailChangeEmailSender,
+        IOptions<EmailChangeRevertTokenProviderOptions> revertTokenOptions,
+        ILogger<EmailChangeCompletedProcessor> logger)
+    {
+        _userManager = userManager;
+        _emailChangeEmailSender = emailChangeEmailSender;
+        _revertTokenOptions = revertTokenOptions.Value;
+        _logger = logger;
+    }
+
+    public object? TryDeserialize(ReadOnlySpan<byte> body)
+    {
+        try
+        {
+            EmailChangeCompleted? message = JsonSerializer.Deserialize<EmailChangeCompleted>(body);
+
+            return message is null
+                   || message.IdentityUserId == Guid.Empty
+                   || string.IsNullOrWhiteSpace(message.PreviousEmail)
+                   || string.IsNullOrWhiteSpace(message.NewEmail)
+                ? null
+                : message;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public Task<Result> ProcessAsync(object message, CancellationToken cancellationToken)
+    {
+        return ProcessAsync((EmailChangeCompleted)message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Handles one message from start to finish and says whether it may be acknowledged.
+    /// </summary>
+    /// <returns>
+    /// This is not a business result. Success means "acknowledge it and drop it from the queue",
+    /// either because both notices went out or because the account is gone and sending again could
+    /// never change anything. Failure means "worth another try", for example when the SMTP relay is
+    /// down.
+    /// </returns>
+    public async Task<Result> ProcessAsync(EmailChangeCompleted message, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationUser? user = await _userManager.FindByIdAsync(message.IdentityUserId.ToString());
+        if (user is null)
+        {
+            LogUserGone(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        string revertToken = await _userManager.GenerateUserTokenAsync(
+            user,
+            EmailChangeRevertTokenProvider.ProviderName,
+            EmailChangeRevertTokenProvider.PurposeFor(message.PreviousEmail, message.NewEmail));
+
+        // The old address goes first. It is the one that can still undo this, so if only one of the
+        // two messages ever gets through, it has to be that one.
+        Result revertOfferResult = await _emailChangeEmailSender.SendChangedNoticeWithRevertAsync(
+            user.Id,
+            message.PreviousEmail,
+            message.NewEmail,
+            revertToken,
+            _revertTokenOptions.TokenLifespan,
+            cancellationToken);
+
+        if (revertOfferResult.IsFailure)
+        {
+            return revertOfferResult;
+        }
+
+        return await _emailChangeEmailSender.SendChangedNoticeAsync(
+            user.Id, message.NewEmail, message.PreviousEmail, cancellationToken);
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.EmailChangeDispatchUserGone,
+        Level = LogLevel.Information,
+        Message = "Skipping e-mail change notices for user {UserId}: the account no longer exists")]
+    private static partial void LogUserGone(ILogger logger, Guid userId);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeEmailSender.cs
@@ -1,0 +1,181 @@
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Services.Emails.Templates;
+using LotroKoniecDev.AuthSystem.Infrastructure.Emails;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+internal sealed class EmailChangeEmailSender : IEmailChangeEmailSender
+{
+    private readonly IEmailService _emailService;
+    private readonly IEmailChangeVerificationLinkFactory _verificationLinkFactory;
+    private readonly IEmailChangeRevertLinkFactory _revertLinkFactory;
+    private readonly IEmailTemplateRenderer _templateRenderer;
+    private readonly TimeSpan _verificationLinkLifespan;
+    private readonly ILogger<EmailChangeEmailSender> _logger;
+
+    public EmailChangeEmailSender(
+        IEmailService emailService,
+        IEmailChangeVerificationLinkFactory verificationLinkFactory,
+        IEmailChangeRevertLinkFactory revertLinkFactory,
+        IEmailTemplateRenderer templateRenderer,
+        IOptions<EmailChangeTokenProviderOptions> tokenProviderOptions,
+        ILogger<EmailChangeEmailSender> logger)
+    {
+        _emailService = emailService;
+        _verificationLinkFactory = verificationLinkFactory;
+        _revertLinkFactory = revertLinkFactory;
+        _templateRenderer = templateRenderer;
+        _verificationLinkLifespan = tokenProviderOptions.Value.TokenLifespan;
+        _logger = logger;
+    }
+
+    public Task<Result> SendVerificationAsync(
+        Guid userId,
+        string newEmail,
+        string verificationToken,
+        CancellationToken cancellationToken)
+    {
+        string link = _verificationLinkFactory.Create(userId, newEmail, verificationToken);
+
+        EmailTemplateModel template = new()
+        {
+            Preheader = "Potwierdź nowy adres e-mail swojego konta.",
+            Heading = "Potwierdź nowy adres e-mail",
+            Paragraphs =
+            [
+                $"Na tym adresie ma działać Twoje konto w {EmailBranding.Name}.",
+                "Adres e-mail jest jednocześnie loginem, więc po potwierdzeniu będziesz logować się właśnie tym adresem.",
+                $"Link wygasa po {EmailDurationText.Describe(_verificationLinkLifespan)} od wysłania tej wiadomości."
+            ],
+            CallToAction = new EmailCallToAction("Potwierdź nowy adres", link),
+            SecurityNote =
+                "Jeśli to nie Ty prosiłeś(-aś) o zmianę adresu, zignoruj tę wiadomość — bez kliknięcia w link nic się nie zmieni."
+        };
+
+        return SendAsync(
+            userId,
+            operation: "EmailChangeVerification",
+            recipient: newEmail,
+            subject: $"Potwierdź nowy adres e-mail — {EmailBranding.Name}",
+            template: template,
+            cancellationToken: cancellationToken);
+    }
+
+    public Task<Result> SendChangeRequestedWarningAsync(
+        Guid userId,
+        string currentEmail,
+        string newEmail,
+        CancellationToken cancellationToken)
+    {
+        EmailTemplateModel template = new()
+        {
+            Preheader = "Ktoś poprosił o zmianę adresu e-mail Twojego konta.",
+            Heading = "Prośba o zmianę adresu e-mail",
+            Paragraphs =
+            [
+                $"Ktoś, kto zna hasło do Twojego konta w {EmailBranding.Name}, poprosił o przeniesienie go na adres {newEmail}.",
+                "Nic jeszcze się nie zmieniło. Adres zmieni się dopiero wtedy, gdy ktoś kliknie link wysłany na tamten adres.",
+                "Jeśli to Ty — nie musisz nic robić z tą wiadomością."
+            ],
+            SecurityNote =
+                "Jeśli to nie Ty — natychmiast zmień hasło. Ktoś inny je zna. Gdy zmiana adresu jednak dojdzie do skutku, "
+                + "wyślemy tu link, którym cofniesz ją i unieważnisz to hasło."
+        };
+
+        return SendAsync(
+            userId,
+            operation: "EmailChangeRequestedWarning",
+            recipient: currentEmail,
+            subject: $"Prośba o zmianę adresu e-mail — {EmailBranding.Name}",
+            template: template,
+            cancellationToken: cancellationToken);
+    }
+
+    public Task<Result> SendChangedNoticeAsync(
+        Guid userId,
+        string newEmail,
+        string previousEmail,
+        CancellationToken cancellationToken)
+    {
+        EmailTemplateModel template = new()
+        {
+            Preheader = "Ten adres jest teraz Twoim loginem.",
+            Heading = "Adres e-mail został zmieniony",
+            Paragraphs =
+            [
+                $"Konto w {EmailBranding.Name} korzysta od teraz z tego adresu. Poprzedni adres to {previousEmail}.",
+                "Adres e-mail jest jednocześnie loginem, więc następne logowanie wykonaj już tym adresem.",
+                "Ze względów bezpieczeństwa wszystkie sesje zostały zakończone — zaloguj się ponownie."
+            ],
+            SecurityNote =
+                "Jeśli to nie Ty zmieniałeś(-aś) adres, skorzystaj z linku wysłanego na poprzedni adres, aby cofnąć zmianę."
+        };
+
+        return SendAsync(
+            userId,
+            operation: "EmailChanged",
+            recipient: newEmail,
+            subject: $"Adres e-mail został zmieniony — {EmailBranding.Name}",
+            template: template,
+            cancellationToken: cancellationToken);
+    }
+
+    public Task<Result> SendChangedNoticeWithRevertAsync(
+        Guid userId,
+        string previousEmail,
+        string newEmail,
+        string revertToken,
+        TimeSpan revertWindow,
+        CancellationToken cancellationToken)
+    {
+        string link = _revertLinkFactory.Create(userId, previousEmail, newEmail, revertToken);
+
+        EmailTemplateModel template = new()
+        {
+            Preheader = "Konto przeniesiono na inny adres. Jeśli to nie Ty — cofnij zmianę.",
+            Heading = "Adres e-mail Twojego konta został zmieniony",
+            Paragraphs =
+            [
+                $"Konto w {EmailBranding.Name}, które działało na tym adresie, korzysta od teraz z adresu {newEmail}.",
+                "Jeśli to Ty — nie musisz nic robić.",
+                $"Jeśli to nie Ty, użyj przycisku poniżej. Cofnie on zmianę, przywróci ten adres i unieważni obecne hasło, "
+                + $"a następnie pozwoli Ci ustawić nowe. Link działa przez {EmailDurationText.Describe(revertWindow)} od wysłania tej wiadomości."
+            ],
+            CallToAction = new EmailCallToAction("To nie ja — cofnij zmianę", link),
+            SecurityNote =
+                "Po upływie tego czasu odzyskanie konta będzie wymagało kontaktu z administratorem."
+        };
+
+        return SendAsync(
+            userId,
+            operation: "EmailChangedRevertOffer",
+            recipient: previousEmail,
+            subject: $"Adres e-mail Twojego konta został zmieniony — {EmailBranding.Name}",
+            template: template,
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task<Result> SendAsync(
+        Guid userId,
+        string operation,
+        string recipient,
+        string subject,
+        EmailTemplateModel template,
+        CancellationToken cancellationToken)
+    {
+        using IDisposable? scope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["EmailOperation"] = operation,
+            ["RecipientUserId"] = userId
+        });
+
+        return await _emailService
+            .SendAsync(
+                receiverEmail: recipient,
+                subject: subject,
+                body: _templateRenderer.Render(template),
+                cancellationToken: cancellationToken);
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeLinkFactories.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeLinkFactories.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.API.Settings;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+internal interface IEmailChangeVerificationLinkFactory
+{
+    string Create(Guid userId, string newEmail, string token);
+}
+
+internal interface IEmailChangeRevertLinkFactory
+{
+    string Create(Guid userId, string previousEmail, string newEmail, string token);
+}
+
+/// <summary>
+/// Builds the two links of the e-mail change flow. Both take their scheme and host from the
+/// configured issuer and never from the request's Host header, so a faked Host cannot redirect a link
+/// we send to a mailbox.
+/// </summary>
+internal sealed class EmailChangeLinkFactory : IEmailChangeVerificationLinkFactory, IEmailChangeRevertLinkFactory
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly string _scheme;
+    private readonly HostString _host;
+
+    public EmailChangeLinkFactory(
+        LinkGenerator linkGenerator,
+        IOptions<OpenIddictSettings> openIddictSettings)
+    {
+        _linkGenerator = linkGenerator;
+
+        Uri issuer = new(openIddictSettings.Value.Issuer, UriKind.Absolute);
+        _scheme = issuer.Scheme;
+        _host = HostString.FromUriComponent(issuer);
+    }
+
+    public string Create(Guid userId, string newEmail, string token)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(newEmail);
+        ArgumentException.ThrowIfNullOrWhiteSpace(token);
+
+        return Build(
+            "/Account/ConfirmEmailChange",
+            new { userId = userId.ToString(), email = newEmail, token });
+    }
+
+    public string Create(Guid userId, string previousEmail, string newEmail, string token)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(previousEmail);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newEmail);
+        ArgumentException.ThrowIfNullOrWhiteSpace(token);
+
+        return Build(
+            "/Account/RevertEmailChange",
+            new { userId = userId.ToString(), from = previousEmail, to = newEmail, token });
+    }
+
+    private string Build(string page, object values)
+    {
+        string? link = _linkGenerator.GetUriByPage(
+            page: page,
+            handler: null,
+            values: values,
+            scheme: _scheme,
+            host: _host);
+
+        return link
+            ?? throw new InvalidOperationException(
+                $"Could not create the '{page}' link. Ensure the Razor Page is registered.");
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeRequestProcessor.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/EmailChangeRequestProcessor.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// What happens when an <see cref="EmailChangeRequested"/> message arrives: create the confirmation
+/// token now rather than earlier, send the link to the new address, and warn the old one that
+/// somebody asked to move the account (ADR-0048).
+/// </summary>
+/// <remarks>
+/// A message may arrive more than once (ADR-0035), so this has to be safe to run twice. It is: a
+/// repeat re-sends the same two messages with a fresh but equally valid token, which is annoying and
+/// nothing worse.
+/// The stale check matters more than it looks. The payload carries the address the account had when
+/// the request was made, and a delivery that arrives after the change already happened would
+/// otherwise read the new address off the row and send the "somebody wants to move your account"
+/// warning to the very mailbox that asked for it.
+/// </remarks>
+internal sealed partial class EmailChangeRequestProcessor : IEmailMessageProcessor
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IEmailChangeEmailSender _emailChangeEmailSender;
+    private readonly ILogger<EmailChangeRequestProcessor> _logger;
+
+    public EmailChangeRequestProcessor(
+        UserManager<ApplicationUser> userManager,
+        IEmailChangeEmailSender emailChangeEmailSender,
+        ILogger<EmailChangeRequestProcessor> logger)
+    {
+        _userManager = userManager;
+        _emailChangeEmailSender = emailChangeEmailSender;
+        _logger = logger;
+    }
+
+    public object? TryDeserialize(ReadOnlySpan<byte> body)
+    {
+        try
+        {
+            EmailChangeRequested? message = JsonSerializer.Deserialize<EmailChangeRequested>(body);
+
+            return message is null
+                   || message.IdentityUserId == Guid.Empty
+                   || string.IsNullOrWhiteSpace(message.CurrentEmail)
+                   || string.IsNullOrWhiteSpace(message.NewEmail)
+                ? null
+                : message;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public Task<Result> ProcessAsync(object message, CancellationToken cancellationToken)
+    {
+        return ProcessAsync((EmailChangeRequested)message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Handles one message from start to finish and says whether it may be acknowledged.
+    /// </summary>
+    /// <returns>
+    /// This is not a business result. Success means "acknowledge it and drop it from the queue",
+    /// either because both e-mails went out or because sending again could never change anything: the
+    /// user is gone, or the request is out of date because the address already moved. Failure means
+    /// "worth another try", for example when the SMTP relay is down.
+    /// </returns>
+    public async Task<Result> ProcessAsync(EmailChangeRequested message, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationUser? user = await _userManager.FindByIdAsync(message.IdentityUserId.ToString());
+        if (user is null)
+        {
+            LogUserGone(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            LogAddressMissing(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        if (!string.Equals(
+                _userManager.NormalizeEmail(user.Email),
+                _userManager.NormalizeEmail(message.CurrentEmail),
+                StringComparison.Ordinal))
+        {
+            LogStaleRequest(_logger, message.IdentityUserId);
+            return Result.Success();
+        }
+
+        string verificationToken = await _userManager.GenerateUserTokenAsync(
+            user,
+            EmailChangeTokenProvider.ProviderName,
+            EmailChangeTokenProvider.PurposeFor(message.NewEmail));
+
+        Result verificationResult = await _emailChangeEmailSender.SendVerificationAsync(
+            user.Id, message.NewEmail, verificationToken, cancellationToken);
+
+        if (verificationResult.IsFailure)
+        {
+            return verificationResult;
+        }
+
+        Result warningResult = await _emailChangeEmailSender.SendChangeRequestedWarningAsync(
+            user.Id, message.CurrentEmail, message.NewEmail, cancellationToken);
+
+        if (warningResult.IsFailure)
+        {
+            // Retrying re-sends the verification link too. A second copy of the same link is harmless,
+            // and the warning is the message this flow cannot afford to lose.
+            LogWarningFailed(_logger, user.Id, warningResult.Error.Message);
+        }
+
+        return warningResult;
+    }
+
+    [LoggerMessage(
+        EventId = EventIds.EmailChangeDispatchUserGone,
+        Level = LogLevel.Information,
+        Message = "Skipping e-mail change messages for user {UserId}: the account no longer exists")]
+    private static partial void LogUserGone(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailChangeDispatchStaleRequest,
+        Level = LogLevel.Information,
+        Message = "Skipping e-mail change messages for user {UserId}: the account already moved to another address")]
+    private static partial void LogStaleRequest(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailChangeDispatchAddressMissing,
+        Level = LogLevel.Warning,
+        Message = "Skipping e-mail change messages for user {UserId}: the account carries no e-mail address")]
+    private static partial void LogAddressMissing(ILogger logger, Guid userId);
+
+    [LoggerMessage(
+        EventId = EventIds.EmailChangeDispatchWarningFailed,
+        Level = LogLevel.Error,
+        Message = "Failed to warn the previous address of user {UserId} about a pending e-mail change: {Error}")]
+    private static partial void LogWarningFailed(ILogger logger, Guid userId, string error);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IEmailChangeEmailSender.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Services/Emails/IEmailChangeEmailSender.cs
@@ -1,0 +1,44 @@
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Services.Emails;
+
+/// <summary>
+/// The four messages of the e-mail change flow. Two go to the old mailbox, and they are what makes a
+/// stolen password recoverable (ADR-0048), so neither is optional.
+/// </summary>
+internal interface IEmailChangeEmailSender
+{
+    /// <summary>To the new address: the link that applies the change.</summary>
+    Task<Result> SendVerificationAsync(
+        Guid userId,
+        string newEmail,
+        string verificationToken,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// To the old address, while the change is still pending: somebody asked to move this account.
+    /// </summary>
+    Task<Result> SendChangeRequestedWarningAsync(
+        Guid userId,
+        string currentEmail,
+        string newEmail,
+        CancellationToken cancellationToken);
+
+    /// <summary>To the new address, after the change: this is now your login.</summary>
+    Task<Result> SendChangedNoticeAsync(
+        Guid userId,
+        string newEmail,
+        string previousEmail,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// To the old address, after the change: it happened, and here is the link that undoes it.
+    /// </summary>
+    Task<Result> SendChangedNoticeWithRevertAsync(
+        Guid userId,
+        string previousEmail,
+        string newEmail,
+        string revertToken,
+        TimeSpan revertWindow,
+        CancellationToken cancellationToken);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/ChangeEmailRequest.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Features/Auth/Account/ChangeEmailRequest.cs
@@ -1,0 +1,3 @@
+namespace LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+
+public sealed record ChangeEmailRequest(string NewEmail, string CurrentPassword);

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Hateoas/Rels.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Contracts/Hateoas/Rels.cs
@@ -6,6 +6,7 @@ public static class Rels
 
     // Account aggregate
     public const string ChangePassword = "change-password";
+    public const string ChangeEmail = "change-email";
     public const string DeleteAccount = "delete-account";
     public const string CancelDeletion = "cancel-deletion";
     public const string ResendEmailConfirmation = "resend-email-confirmation";

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Domain/Aggregates/ApplicationUsers/Entities/ApplicationUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Domain/Aggregates/ApplicationUsers/Entities/ApplicationUser.cs
@@ -18,4 +18,12 @@ public sealed class ApplicationUser : IdentityUser<Guid>
     /// thing a revert token has to do.
     /// </summary>
     public Guid? EmailChangeRevertStamp { get; set; }
+
+    /// <summary>
+    /// The address a revert puts the account back on: the one it had before the first change since
+    /// the last revert. It is set once per chain and never overwritten, so a second change cannot make
+    /// itself an undo target, and it is what a revert restores — never the address the presented link
+    /// happens to name (ADR-0048).
+    /// </summary>
+    public string? EmailChangeRevertTo { get; set; }
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Domain/Aggregates/ApplicationUsers/Entities/ApplicationUser.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Domain/Aggregates/ApplicationUsers/Entities/ApplicationUser.cs
@@ -11,4 +11,11 @@ public sealed class ApplicationUser : IdentityUser<Guid>
     public bool TermsOfServiceAccepted { get; set; }
     public DateTimeOffset? TermsOfServiceAcceptedDate { get; set; }
     public DateTimeOffset? DeletionScheduledAt { get; set; }
+
+    /// <summary>
+    /// Invalidates every revert link issued before the last successful revert (ADR-0048). It cannot be
+    /// the security stamp: a password change rotates that, and surviving a password change is the one
+    /// thing a revert token has to do.
+    /// </summary>
+    public Guid? EmailChangeRevertStamp { get; set; }
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Infrastructure/Messaging/RabbitMqTopology.cs
@@ -48,6 +48,17 @@ public static class RabbitMqTopology
     public const string DeletionCancelledRoutingKey = "email.deletion-cancelled";
 
     /// <summary>
+    /// Routing key of the e-mail change request: the verification link for the new address and the
+    /// warning for the old one.
+    /// </summary>
+    public const string EmailChangeRequestedRoutingKey = "email.change-requested";
+
+    /// <summary>
+    /// Routing key of the e-mail change notice, which also carries the revert link to the old address.
+    /// </summary>
+    public const string EmailChangeCompletedRoutingKey = "email.change-completed";
+
+    /// <summary>
     /// The dead-letter exchange. The broker sends here every message <see cref="EmailQueue"/> gives up
     /// on, either because the consumer rejected it or because it passed
     /// <see cref="EmailDeliveryLimit"/>. It is a fanout, because everything that fails goes to the same

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
@@ -37,6 +37,8 @@ internal sealed class ApplicationUserConfiguration : IEntityTypeConfiguration<Ap
 
         builder.Property(u => u.DeletionScheduledAt);
 
+        builder.Property(u => u.EmailChangeRevertStamp);
+
         // A partial index. The deletion job only looks at the few rows that have a date set.
         builder.HasIndex(u => u.DeletionScheduledAt)
             .HasFilter($"\"{nameof(ApplicationUser.DeletionScheduledAt)}\" IS NOT NULL");

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Configurations/ApplicationUserConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.SharedKernel.Constants;
 
 namespace LotroKoniecDev.AuthSystem.Persistence.Configurations;
 
@@ -38,6 +39,9 @@ internal sealed class ApplicationUserConfiguration : IEntityTypeConfiguration<Ap
         builder.Property(u => u.DeletionScheduledAt);
 
         builder.Property(u => u.EmailChangeRevertStamp);
+
+        builder.Property(u => u.EmailChangeRevertTo)
+            .HasMaxLength(EmailConstants.MaxLength);
 
         // A partial index. The deletion job only looks at the few rows that have a date set.
         builder.HasIndex(u => u.DeletionScheduledAt)

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/EmailChangeRevertTokenProvider.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/EmailChangeRevertTokenProvider.cs
@@ -130,16 +130,16 @@ public sealed class EmailChangeRevertTokenProvider : IUserTwoFactorTokenProvider
     }
 
     /// <summary>
-    /// Never a two-factor option. This provider only backs a link we e-mail, so nothing may offer it
-    /// as a login step.
-    /// </summary>
-    /// <summary>
     /// An account that has never been reverted has no stamp yet, and every token it issues shares that
     /// same empty value. The first successful revert sets one, which is what retires them all.
     /// </summary>
     private static string StampOf(ApplicationUser user) =>
         user.EmailChangeRevertStamp?.ToString() ?? string.Empty;
 
+    /// <summary>
+    /// Never a two-factor option. This provider only backs a link we e-mail, so nothing may offer it
+    /// as a login step.
+    /// </summary>
     public Task<bool> CanGenerateTwoFactorTokenAsync(UserManager<ApplicationUser> manager, ApplicationUser user) =>
         Task.FromResult(false);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/EmailChangeRevertTokenProvider.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/EmailChangeRevertTokenProvider.cs
@@ -1,0 +1,133 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Identity;
+
+/// <summary>
+/// Options for the revert token. Fourteen days is long on purpose: the person who needs this link is
+/// someone who has just been locked out of their own account and may not read that mailbox daily.
+/// </summary>
+public sealed class EmailChangeRevertTokenProviderOptions
+{
+    public TimeSpan TokenLifespan { get; set; } = TimeSpan.FromDays(14);
+}
+
+/// <summary>
+/// Creates the token behind the "to nie ja" link sent to the old address after an e-mail change
+/// (ADR-0048). Following it restores the previous address and clears the password.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It does <b>not</b> extend <see cref="DataProtectorTokenProvider{TUser}"/>, and that is the whole
+/// point. That provider writes the user's security stamp into the token and refuses the token once
+/// the stamp moves. Changing the password rotates the stamp, and changing the password is exactly
+/// what an attacker does after taking over the address — so a stamp-bound revert link would already
+/// be dead by the time the real owner read their mail. This one protects the creation time, the user
+/// id and the purpose, and nothing else.
+/// </para>
+/// <para>
+/// Leaving the stamp out also removes what normally makes these links single-use, so the revert page
+/// replaces it: it refuses unless the account still sits on the address the token was issued against.
+/// A second visit, or a token from an older change, therefore changes nothing.
+/// </para>
+/// </remarks>
+public sealed class EmailChangeRevertTokenProvider : IUserTwoFactorTokenProvider<ApplicationUser>
+{
+    public const string ProviderName = "EmailChangeRevert";
+
+    private const string ProtectorPurpose = "LotroKoniecDev.AuthSystem.EmailChangeRevert.v1";
+
+    private readonly IDataProtector _protector;
+    private readonly TimeProvider _timeProvider;
+    private readonly EmailChangeRevertTokenProviderOptions _options;
+
+    public EmailChangeRevertTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        TimeProvider timeProvider,
+        IOptions<EmailChangeRevertTokenProviderOptions> options)
+    {
+        _protector = dataProtectionProvider.CreateProtector(ProtectorPurpose);
+        _timeProvider = timeProvider;
+        _options = options.Value;
+    }
+
+    public static string PurposeFor(string previousEmail, string newEmail) =>
+        $"RevertEmailChange:{previousEmail}->{newEmail}";
+
+    public Task<string> GenerateAsync(string purpose, UserManager<ApplicationUser> manager, ApplicationUser user)
+    {
+        ArgumentNullException.ThrowIfNull(manager);
+        ArgumentNullException.ThrowIfNull(user);
+
+        string payload = string.Join(
+            '|',
+            _timeProvider.GetUtcNow().UtcTicks.ToString(CultureInfo.InvariantCulture),
+            user.Id.ToString(),
+            purpose ?? string.Empty);
+
+        // Base64, like every Identity-issued token here. The link factory runs it through
+        // LinkGenerator, which escapes it for the query string.
+        return Task.FromResult(Convert.ToBase64String(_protector.Protect(Encoding.UTF8.GetBytes(payload))));
+    }
+
+    public Task<bool> ValidateAsync(
+        string purpose,
+        string token,
+        UserManager<ApplicationUser> manager,
+        ApplicationUser user)
+    {
+        ArgumentNullException.ThrowIfNull(manager);
+        ArgumentNullException.ThrowIfNull(user);
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return Task.FromResult(false);
+        }
+
+        byte[] payload;
+        try
+        {
+            payload = _protector.Unprotect(Convert.FromBase64String(token));
+        }
+        catch (Exception exception) when (exception is CryptographicException or FormatException)
+        {
+            // A token that was tampered with, or was signed by a key ring we no longer hold, is simply
+            // not a token. Both look the same from here and both mean "refuse".
+            return Task.FromResult(false);
+        }
+
+        string[] parts = Encoding.UTF8.GetString(payload).Split('|', 3);
+        if (parts.Length != 3)
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out long createdAtTicks))
+        {
+            return Task.FromResult(false);
+        }
+
+        DateTimeOffset createdAt = new(createdAtTicks, TimeSpan.Zero);
+        if (createdAt + _options.TokenLifespan < _timeProvider.GetUtcNow())
+        {
+            return Task.FromResult(false);
+        }
+
+        bool matches = string.Equals(parts[1], user.Id.ToString(), StringComparison.Ordinal)
+                       && string.Equals(parts[2], purpose ?? string.Empty, StringComparison.Ordinal);
+
+        return Task.FromResult(matches);
+    }
+
+    /// <summary>
+    /// Never a two-factor option. This provider only backs a link we e-mail, so nothing may offer it
+    /// as a login step.
+    /// </summary>
+    public Task<bool> CanGenerateTwoFactorTokenAsync(UserManager<ApplicationUser> manager, ApplicationUser user) =>
+        Task.FromResult(false);
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/EmailChangeRevertTokenProvider.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/EmailChangeRevertTokenProvider.cs
@@ -31,9 +31,12 @@ public sealed class EmailChangeRevertTokenProviderOptions
 /// id and the purpose, and nothing else.
 /// </para>
 /// <para>
-/// Leaving the stamp out also removes what normally makes these links single-use, so the revert page
-/// replaces it: it refuses unless the account still sits on the address the token was issued against.
-/// A second visit, or a token from an older change, therefore changes nothing.
+/// What it does carry instead is
+/// <see cref="ApplicationUser.EmailChangeRevertStamp"/>, which rotates on a successful revert and on
+/// nothing else. That is what makes these links single-use, and it is not optional: every revert
+/// token is a bearer credential to move the account to its previous address, and after a chain of
+/// changes an attacker holds one too. Without this field their token stays live and they simply undo
+/// the owner's recovery. Rotating on revert kills every token in the chain at once.
 /// </para>
 /// </remarks>
 public sealed class EmailChangeRevertTokenProvider : IUserTwoFactorTokenProvider<ApplicationUser>
@@ -68,6 +71,7 @@ public sealed class EmailChangeRevertTokenProvider : IUserTwoFactorTokenProvider
             '|',
             _timeProvider.GetUtcNow().UtcTicks.ToString(CultureInfo.InvariantCulture),
             user.Id.ToString(),
+            StampOf(user),
             purpose ?? string.Empty);
 
         // Base64, like every Identity-issued token here. The link factory runs it through
@@ -101,8 +105,8 @@ public sealed class EmailChangeRevertTokenProvider : IUserTwoFactorTokenProvider
             return Task.FromResult(false);
         }
 
-        string[] parts = Encoding.UTF8.GetString(payload).Split('|', 3);
-        if (parts.Length != 3)
+        string[] parts = Encoding.UTF8.GetString(payload).Split('|', 4);
+        if (parts.Length != 4)
         {
             return Task.FromResult(false);
         }
@@ -119,7 +123,8 @@ public sealed class EmailChangeRevertTokenProvider : IUserTwoFactorTokenProvider
         }
 
         bool matches = string.Equals(parts[1], user.Id.ToString(), StringComparison.Ordinal)
-                       && string.Equals(parts[2], purpose ?? string.Empty, StringComparison.Ordinal);
+                       && string.Equals(parts[2], StampOf(user), StringComparison.Ordinal)
+                       && string.Equals(parts[3], purpose ?? string.Empty, StringComparison.Ordinal);
 
         return Task.FromResult(matches);
     }
@@ -128,6 +133,13 @@ public sealed class EmailChangeRevertTokenProvider : IUserTwoFactorTokenProvider
     /// Never a two-factor option. This provider only backs a link we e-mail, so nothing may offer it
     /// as a login step.
     /// </summary>
+    /// <summary>
+    /// An account that has never been reverted has no stamp yet, and every token it issues shares that
+    /// same empty value. The first successful revert sets one, which is what retires them all.
+    /// </summary>
+    private static string StampOf(ApplicationUser user) =>
+        user.EmailChangeRevertStamp?.ToString() ?? string.Empty;
+
     public Task<bool> CanGenerateTwoFactorTokenAsync(UserManager<ApplicationUser> manager, ApplicationUser user) =>
         Task.FromResult(false);
 }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/EmailChangeTokenProvider.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Identity/EmailChangeTokenProvider.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Identity;
+
+/// <summary>
+/// Options for the e-mail change token provider. The link lives 24 hours, the same as the activation
+/// link users already know.
+/// </summary>
+public sealed class EmailChangeTokenProviderOptions : DataProtectionTokenProviderOptions
+{
+    public EmailChangeTokenProviderOptions()
+    {
+        Name = EmailChangeTokenProvider.ProviderName;
+        TokenLifespan = TimeSpan.FromHours(24);
+    }
+}
+
+/// <summary>
+/// Creates the token behind the "confirm your new address" link. The purpose carries the target
+/// address, so a token made for one address cannot confirm another, and the token is tied to the
+/// user's security stamp, which makes it single-use: applying the change rotates the stamp.
+/// </summary>
+/// <remarks>
+/// Identity ships <c>GenerateChangeEmailTokenAsync</c> and <c>ChangeEmailAsync</c> and both are
+/// public, so this provider does not exist because that API is missing. It exists because
+/// <c>ChangeEmailAsync</c> checks the token inside itself against a purpose string Identity keeps
+/// private. A caller could then only enqueue its outbox row first and call afterwards, and a bad
+/// token returns before the save, leaving that row tracked in a context something else may still
+/// flush. Owning the purpose lets the handler check the token first and then commit the row and the
+/// address change together (ADR-0048).
+/// </remarks>
+public sealed class EmailChangeTokenProvider : DataProtectorTokenProvider<ApplicationUser>
+{
+    public const string ProviderName = "EmailChange";
+
+    public EmailChangeTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<EmailChangeTokenProviderOptions> options,
+        ILogger<EmailChangeTokenProvider> logger)
+        : base(dataProtectionProvider, options, logger)
+    {
+    }
+
+    public static string PurposeFor(string newEmail) => $"ChangeEmail:{newEmail}";
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260820162701_AddEmailChangeRevertStampToUsers.Designer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260820162701_AddEmailChangeRevertStampToUsers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820162701_AddEmailChangeRevertStampToUsers")]
+    partial class AddEmailChangeRevertStampToUsers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260820162701_AddEmailChangeRevertStampToUsers.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260820162701_AddEmailChangeRevertStampToUsers.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailChangeRevertStampToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "EmailChangeRevertStamp",
+                schema: "authsystem",
+                table: "Users",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailChangeRevertStamp",
+                schema: "authsystem",
+                table: "Users");
+        }
+    }
+}

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260820164716_AddEmailChangeRevertFieldsToUsers.Designer.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260820164716_AddEmailChangeRevertFieldsToUsers.Designer.cs
@@ -12,8 +12,8 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    [Migration("20260820162701_AddEmailChangeRevertStampToUsers")]
-    partial class AddEmailChangeRevertStampToUsers
+    [Migration("20260820164716_AddEmailChangeRevertFieldsToUsers")]
+    partial class AddEmailChangeRevertFieldsToUsers
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -86,6 +86,10 @@ namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
 
                     b.Property<Guid?>("EmailChangeRevertStamp")
                         .HasColumnType("uuid");
+
+                    b.Property<string>("EmailChangeRevertTo")
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)");
 
                     b.Property<bool>("EmailConfirmed")
                         .HasColumnType("boolean");

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260820164716_AddEmailChangeRevertFieldsToUsers.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/20260820164716_AddEmailChangeRevertFieldsToUsers.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
 {
     /// <inheritdoc />
-    public partial class AddEmailChangeRevertStampToUsers : Migration
+    public partial class AddEmailChangeRevertFieldsToUsers : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -17,6 +17,14 @@ namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
                 table: "Users",
                 type: "uuid",
                 nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EmailChangeRevertTo",
+                schema: "authsystem",
+                table: "Users",
+                type: "character varying(250)",
+                maxLength: 250,
+                nullable: true);
         }
 
         /// <inheritdoc />
@@ -24,6 +32,11 @@ namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "EmailChangeRevertStamp",
+                schema: "authsystem",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "EmailChangeRevertTo",
                 schema: "authsystem",
                 table: "Users");
         }

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/AuthDbContextModelSnapshot.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/Migrations/AuthDbContextModelSnapshot.cs
@@ -84,6 +84,10 @@ namespace LotroKoniecDev.AuthSystem.Persistence.Migrations
                     b.Property<Guid?>("EmailChangeRevertStamp")
                         .HasColumnType("uuid");
 
+                    b.Property<string>("EmailChangeRevertTo")
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)");
+
                     b.Property<bool>("EmailConfirmed")
                         .HasColumnType("boolean");
 

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/PersistenceDependencyInjection.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.Persistence/PersistenceDependencyInjection.cs
@@ -56,7 +56,17 @@ public static class PersistenceDependencyInjection
                 .AddDefaultTokenProviders()
                 .AddTokenProvider<AccountDeletionCancellationTokenProvider>(
                     AccountDeletionCancellationTokenProvider.ProviderName)
+                .AddTokenProvider<EmailChangeTokenProvider>(
+                    EmailChangeTokenProvider.ProviderName)
+                // AddTokenProvider checks for IUserTwoFactorTokenProvider<TUser>, not for
+                // DataProtectorTokenProvider, so the hand-written revert provider registers the same
+                // way the others do (ADR-0048).
+                .AddTokenProvider<EmailChangeRevertTokenProvider>(
+                    EmailChangeRevertTokenProvider.ProviderName)
                 .AddEntityFrameworkStores<AuthDbContext>();
+
+            services.AddOptions<EmailChangeTokenProviderOptions>();
+            services.AddOptions<EmailChangeRevertTokenProviderOptions>();
 
             services.Configure<DataProtectionTokenProviderOptions>(options =>
             {

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/Account.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/Account.razor
@@ -75,6 +75,10 @@
                         <dt>E-mail</dt>
                         <dd>
                             <span class="mono">@auth.Email</span>
+                            @if (_result.Value.Links.HasLink(Rels.ChangeEmail))
+                            {
+                                <a href="/account/change-email" data-testid="account-change-email-inline">Zmień</a>
+                            }
                             @if (auth.EmailConfirmed)
                             {
                                 <span class="badge badge-success"><span class="dot"></span>Potwierdzony</span>
@@ -180,6 +184,17 @@
                             <span class="copy">
                                 <span class="t">Zmień hasło</span>
                                 <span class="s">Ustaw nowe hasło, podając obecne.</span>
+                            </span>
+                            <span class="chev" aria-hidden="true">›</span>
+                        </a>
+                    }
+
+                    @if (_result.Value.Links.HasLink(Rels.ChangeEmail))
+                    {
+                        <a class="action-row" href="/account/change-email" data-testid="account-change-email">
+                            <span class="copy">
+                                <span class="t">Zmień e-mail</span>
+                                <span class="s">Adres e-mail jest też Twoim loginem.</span>
                             </span>
                             <span class="chev" aria-hidden="true">›</span>
                         </a>

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountLoader.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/AccountLoader.cs
@@ -77,6 +77,22 @@ internal sealed class AccountLoader
             cancellationToken);
     }
 
+    /// <summary>
+    /// Starts an e-mail change. Nothing on the account moves yet: the address changes only when the
+    /// link sent to the new mailbox is used (ADR-0048).
+    /// </summary>
+    public Task<ApiResult> RequestEmailChangeAsync(
+        string href,
+        string newEmail,
+        string currentPassword,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.PostApiResultAsync(
+            href,
+            new ChangeEmailRequest(newEmail, currentPassword),
+            cancellationToken);
+    }
+
     public Task<ApiResult> ChangePasswordAsync(
         string href,
         string currentPassword,

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/ChangeEmail.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/ChangeEmail.razor
@@ -1,0 +1,218 @@
+@page "/account/change-email"
+@attribute [Authorize]
+@attribute [StreamRendering]
+@using Microsoft.AspNetCore.Authorization
+@using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account
+@using LotroKoniecDev.AuthSystem.Contracts.Hateoas
+@using LotroKoniecDev.Frontend.Infrastructure.Hateoas
+@using LotroKoniecDev.Frontend.Infrastructure.HttpClients
+@using LotroKoniecDev.Hateoas.Abstractions
+@using LotroKoniecDev.Frontend.Infrastructure.Errors
+@inject AccountLoader Loader
+
+<PageTitle>Zmień e-mail — lotro-translator.pl</PageTitle>
+
+<section class="container page-head">
+    <div>
+        <h1>Zmień e-mail</h1>
+        <p class="lede">Adres e-mail jest też Twoim loginem — zmiana wymaga potwierdzenia z nowej skrzynki.</p>
+    </div>
+</section>
+
+<section class="container content-wrap">
+    @if (_requested)
+    {
+        <div class="status-message status-success" role="status">
+            <p>
+                Wysłaliśmy link potwierdzający na adres <strong>@_submittedEmail</strong>.
+                Adres zmieni się dopiero po kliknięciu w ten link. Link jest ważny 24 godziny.
+            </p>
+        </div>
+        <div class="status-message status-warning" role="status">
+            <p>
+                Na dotychczasowy adres wysłaliśmy ostrzeżenie o tej prośbie. Gdy zmiana dojdzie do skutku,
+                trafi tam także link, którym możesz ją cofnąć w ciągu 14 dni.
+            </p>
+        </div>
+        <a class="btn btn-primary" href="/account">Wróć do konta</a>
+    }
+    else if (_loadResult is null)
+    {
+        <div class="loading-indicator">
+            <span class="li-spin"></span> Wczytywanie…
+        </div>
+    }
+    else if (_loadResult.IsUnauthorized)
+    {
+        <RedirectToLogin/>
+    }
+    else if (_loadResult.IsFailure)
+    {
+        <div class="error-message" role="alert">
+            <span class="em-ico" aria-hidden="true">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
+                    <path d="M12 9v4"/><path d="M12 17h.01"/>
+                </svg>
+            </span>
+            <div class="em-body">
+                <ApiProblemAlert Problem="@_loadResult.ProblemDetails"
+                                 Fallback="Nie udało się wczytać danych konta."
+                                 HeadlineClass="t"/>
+            </div>
+        </div>
+    }
+    else if (_changeEmailLink is null)
+    {
+        <div class="status-message status-warning" role="status">
+            <p>Zmiana adresu e-mail jest w tej chwili niedostępna. Spróbuj ponownie później.</p>
+        </div>
+        <a class="btn btn-ghost" href="/account">Wróć do konta</a>
+    }
+    else
+    {
+        <section class="panel">
+            <header class="panel-head">
+                <h2>Nowy adres e-mail</h2>
+                <span class="panel-aside">Obecny: @_currentEmail</span>
+            </header>
+            <div class="panel-body">
+                @if (_submitProblem is not null)
+                {
+                    <div class="error-message" role="alert">
+                        <span class="em-ico" aria-hidden="true">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/>
+                                <path d="M12 9v4"/><path d="M12 17h.01"/>
+                            </svg>
+                        </span>
+                        <div class="em-body">
+                            <ApiProblemAlert Problem="@_submitProblem"
+                                             Fallback="Nie udało się rozpocząć zmiany adresu."
+                                             HeadlineClass="t"/>
+                        </div>
+                    </div>
+                }
+
+                <form method="post" @formname="change-email" @onsubmit="RequestChangeAsync" class="stacked-form">
+                    <AntiforgeryToken/>
+                    <div class="field">
+                        <label for="new-email">
+                            Nowy adres e-mail
+                        </label>
+                        <input id="new-email" name="EmailInput.NewEmail" type="email"
+                               autocomplete="email"/>
+                        <p class="field-hint">Musisz mieć dostęp do tej skrzynki — wyślemy na nią link potwierdzający.</p>
+                    </div>
+                    <div class="field">
+                        <label for="repeat-email">
+                            Powtórz nowy adres e-mail
+                        </label>
+                        <input id="repeat-email" name="EmailInput.RepeatEmail" type="email"
+                               autocomplete="email"/>
+                    </div>
+                    <div class="field">
+                        <label for="current-password">
+                            Obecne hasło
+                        </label>
+                        <input id="current-password" name="EmailInput.CurrentPassword" type="password"
+                               autocomplete="current-password"/>
+                    </div>
+                    <div class="form-actions">
+                        <a class="btn btn-ghost" href="/account">Anuluj</a>
+                        <button type="submit" class="btn btn-primary" data-testid="change-email-submit">Wyślij link potwierdzający</button>
+                    </div>
+                </form>
+            </div>
+        </section>
+    }
+</section>
+
+@code
+{
+    [SupplyParameterFromForm(FormName = "change-email")]
+    private ChangeEmailFormModel? EmailInput { get; set; }
+
+    private ApiResult<AccountDataExportResponse>? _loadResult;
+    private LinkDto? _changeEmailLink;
+    private string _currentEmail = string.Empty;
+    private string _submittedEmail = string.Empty;
+    private Microsoft.AspNetCore.Mvc.ProblemDetails? _submitProblem;
+    private bool _requested;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // A property initializer is rejected for a [SupplyParameterFromForm] model (BL0008), so seed it
+        // here instead.
+        EmailInput ??= new ChangeEmailFormModel();
+
+        _loadResult = await Loader.LoadExportAsync(CancellationToken.None);
+        if (_loadResult.IsSuccess)
+        {
+            _changeEmailLink = _loadResult.Value.Links.FindLink(Rels.ChangeEmail);
+            _currentEmail = _loadResult.Value.AuthData.Email;
+        }
+    }
+
+    private async Task RequestChangeAsync()
+    {
+        _submitProblem = null;
+
+        if (_changeEmailLink is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(EmailInput?.NewEmail)
+            || string.IsNullOrWhiteSpace(EmailInput.CurrentPassword))
+        {
+            _submitProblem = ApiProblemCopy.FrontendAuthored(
+                "Wypełnij wszystkie pola",
+                "Nowy adres e-mail i obecne hasło są wymagane.");
+            return;
+        }
+
+        if (!string.Equals(EmailInput.NewEmail.Trim(), EmailInput.RepeatEmail?.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            _submitProblem = ApiProblemCopy.FrontendAuthored(
+                "Adresy nie są zgodne",
+                "Nowy adres i jego powtórzenie muszą być identyczne.");
+            return;
+        }
+
+        string newEmail = EmailInput.NewEmail.Trim();
+
+        ApiResult result = await Loader.RequestEmailChangeAsync(
+            _changeEmailLink.Href,
+            newEmail,
+            EmailInput.CurrentPassword,
+            CancellationToken.None);
+
+        if (result.IsSuccess)
+        {
+            _submittedEmail = newEmail;
+            _requested = true;
+            return;
+        }
+
+        if (result.IsUnauthorized)
+        {
+            _submitProblem = ApiProblemCopy.FrontendAuthored(
+                "Sesja wygasła",
+                "Zaloguj się ponownie, aby zmienić adres e-mail.");
+            return;
+        }
+
+        _submitProblem = result.ProblemDetails
+                         ?? ApiProblemCopy.FrontendAuthored("Nie udało się rozpocząć zmiany adresu.");
+    }
+
+    public sealed class ChangeEmailFormModel
+    {
+        public string? NewEmail { get; set; }
+
+        public string? RepeatEmail { get; set; }
+
+        public string? CurrentPassword { get; set; }
+    }
+}

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
@@ -51,19 +51,17 @@ public sealed class GameVersion : AggregateRoot<GameVersionId>
     /// A processed version cannot be deleted. An import ran against it and translations point at it
     /// (spec 0001). Any other version was never imported into, so nothing references it and deleting
     /// it frees its version number again (#624).
-    /// The delete handler still checks that no translation points at the version. This aggregate only
-    /// owns the status rule.
+    /// This aggregate only owns the status rule.
     /// </summary>
     public Result EnsureCanBeDeleted()
     {
         // Written as "these statuses may be deleted", not as "anything except Processed", so a new
         // status is never deletable by accident.
-        if (Status is not (GameVersionStatus.Unprocessed or GameVersionStatus.Superseded))
-        {
-            return Result.Failure(DomainErrors.GameVersionEntity.ProcessedCannotBeDeleted(Id));
-        }
-
-        return Result.Success();
+        Result ensureCanBeDeletedResult = Status is not (GameVersionStatus.Unprocessed or GameVersionStatus.Superseded) 
+            ? Result.Failure(DomainErrors.GameVersionEntity.ProcessedCannotBeDeleted(Id)) 
+            : Result.Success();
+        
+        return ensureCanBeDeletedResult;
     }
 
     public static Result<GameVersion> Create(

--- a/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
+++ b/src/TranslationSystem/LotroKoniecDev.TranslationSystem.Domain/Aggregates/GameVersionAggregate/Entities/GameVersion.cs
@@ -51,17 +51,19 @@ public sealed class GameVersion : AggregateRoot<GameVersionId>
     /// A processed version cannot be deleted. An import ran against it and translations point at it
     /// (spec 0001). Any other version was never imported into, so nothing references it and deleting
     /// it frees its version number again (#624).
-    /// This aggregate only owns the status rule.
+    /// The delete handler still checks that no translation points at the version. This aggregate only
+    /// owns the status rule.
     /// </summary>
     public Result EnsureCanBeDeleted()
     {
         // Written as "these statuses may be deleted", not as "anything except Processed", so a new
         // status is never deletable by accident.
-        Result ensureCanBeDeletedResult = Status is not (GameVersionStatus.Unprocessed or GameVersionStatus.Superseded) 
-            ? Result.Failure(DomainErrors.GameVersionEntity.ProcessedCannotBeDeleted(Id)) 
-            : Result.Success();
-        
-        return ensureCanBeDeletedResult;
+        if (Status is not (GameVersionStatus.Unprocessed or GameVersionStatus.Superseded))
+        {
+            return Result.Failure(DomainErrors.GameVersionEntity.ProcessedCannotBeDeleted(Id));
+        }
+
+        return Result.Success();
     }
 
     public static Result<GameVersion> Create(

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -119,6 +119,19 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
             services.AddSingleton<IAccountDeletionEmailSender>(sp =>
                 sp.GetRequiredService<SpyAccountDeletionEmailSender>());
 
+            // Replace the e-mail change sender with a spy, for capturing the confirmation and revert
+            // tokens in tests
+            ServiceDescriptor? existingEmailChangeSender = services
+                .FirstOrDefault(d => d.ServiceType == typeof(IEmailChangeEmailSender));
+            if (existingEmailChangeSender is not null)
+            {
+                services.Remove(existingEmailChangeSender);
+            }
+
+            services.AddSingleton<SpyEmailChangeEmailSender>();
+            services.AddSingleton<IEmailChangeEmailSender>(sp =>
+                sp.GetRequiredService<SpyEmailChangeEmailSender>());
+
             // This suite runs without a broker. The consumer would keep retrying the connection and
             // filling the log with warnings, so it is removed. Its logic has its own unit tests through
             // EmailConfirmationRequestProcessor.

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Bases/AsyncLifetimeTestBase.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/Bases/AsyncLifetimeTestBase.cs
@@ -12,6 +12,7 @@ public abstract class AsyncLifetimeTestBase : IAsyncLifetime
     protected SpyAccountConfirmationEmailSender AccountConfirmationEmailSpy { get; }
     protected SpyPasswordResetEmailSender PasswordResetEmailSpy { get; }
     protected SpyAccountDeletionEmailSender AccountDeletionEmailSpy { get; }
+    protected SpyEmailChangeEmailSender EmailChangeEmailSpy { get; }
 
     protected AsyncLifetimeTestBase(AuthSystemApiFactory factory)
     {
@@ -19,11 +20,13 @@ public abstract class AsyncLifetimeTestBase : IAsyncLifetime
         AccountConfirmationEmailSpy = factory.Services.GetRequiredService<SpyAccountConfirmationEmailSender>();
         PasswordResetEmailSpy = factory.Services.GetRequiredService<SpyPasswordResetEmailSender>();
         AccountDeletionEmailSpy = factory.Services.GetRequiredService<SpyAccountDeletionEmailSender>();
+        EmailChangeEmailSpy = factory.Services.GetRequiredService<SpyEmailChangeEmailSender>();
     }
 
     public virtual async Task InitializeAsync()
     {
         AccountDeletionEmailSpy.Reset();
+        EmailChangeEmailSpy.Reset();
 
         await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
         CleanerService cleaner = scope.ServiceProvider.GetRequiredService<CleanerService>();

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyEmailChangeEmailSender.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyEmailChangeEmailSender.cs
@@ -82,6 +82,13 @@ public sealed class SpyEmailChangeEmailSender : IEmailChangeEmailSender
     public Task WaitForRevertOfferCaptureAsync(TimeSpan? timeout = null) =>
         WaitForAsync(() => LastRevertToken is not null, timeout);
 
+    /// <summary>
+    /// Waits for the notice sent to the new address. A change that arms no undo link sends only this
+    /// one, so it is the signal that the dispatch finished at all.
+    /// </summary>
+    public Task WaitForChangedNoticeCaptureAsync(TimeSpan? timeout = null) =>
+        WaitForAsync(() => LastNoticeRecipient is not null, timeout);
+
     private static async Task WaitForAsync(Func<bool> arrived, TimeSpan? timeout)
     {
         using CancellationTokenSource waitWindow = new(timeout ?? TimeSpan.FromSeconds(15));

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyEmailChangeEmailSender.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Shared/SpyEmailChangeEmailSender.cs
@@ -1,0 +1,110 @@
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.SharedKernel.Monads;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+
+/// <summary>
+/// Captures the two tokens of the e-mail change flow, so tests can follow the links a real user would
+/// receive. It also records which address each message went to: half of ADR-0048 is about the old
+/// mailbox getting told, and a test that only checked the token would not notice if it stopped.
+/// </summary>
+#pragma warning disable CA1515
+public sealed class SpyEmailChangeEmailSender : IEmailChangeEmailSender
+#pragma warning restore CA1515
+{
+    private int _verificationCallCount;
+    private int _warningCallCount;
+    private int _noticeCallCount;
+    private int _revertOfferCallCount;
+
+    public string? LastVerificationRecipient { get; private set; }
+    public string? LastVerificationToken { get; private set; }
+    public string? LastWarningRecipient { get; private set; }
+    public string? LastWarningTargetAddress { get; private set; }
+    public string? LastNoticeRecipient { get; private set; }
+    public string? LastRevertOfferRecipient { get; private set; }
+    public string? LastRevertOfferTargetAddress { get; private set; }
+    public string? LastRevertToken { get; private set; }
+
+    public int VerificationCallCount => Volatile.Read(ref _verificationCallCount);
+    public int WarningCallCount => Volatile.Read(ref _warningCallCount);
+    public int NoticeCallCount => Volatile.Read(ref _noticeCallCount);
+    public int RevertOfferCallCount => Volatile.Read(ref _revertOfferCallCount);
+
+    public Task<Result> SendVerificationAsync(
+        Guid userId, string newEmail, string verificationToken, CancellationToken cancellationToken)
+    {
+        LastVerificationRecipient = newEmail;
+        LastVerificationToken = verificationToken;
+        Interlocked.Increment(ref _verificationCallCount);
+        return Task.FromResult(Result.Success());
+    }
+
+    public Task<Result> SendChangeRequestedWarningAsync(
+        Guid userId, string currentEmail, string newEmail, CancellationToken cancellationToken)
+    {
+        LastWarningRecipient = currentEmail;
+        LastWarningTargetAddress = newEmail;
+        Interlocked.Increment(ref _warningCallCount);
+        return Task.FromResult(Result.Success());
+    }
+
+    public Task<Result> SendChangedNoticeAsync(
+        Guid userId, string newEmail, string previousEmail, CancellationToken cancellationToken)
+    {
+        LastNoticeRecipient = newEmail;
+        Interlocked.Increment(ref _noticeCallCount);
+        return Task.FromResult(Result.Success());
+    }
+
+    public Task<Result> SendChangedNoticeWithRevertAsync(
+        Guid userId,
+        string previousEmail,
+        string newEmail,
+        string revertToken,
+        TimeSpan revertWindow,
+        CancellationToken cancellationToken)
+    {
+        LastRevertOfferRecipient = previousEmail;
+        LastRevertOfferTargetAddress = newEmail;
+        LastRevertToken = revertToken;
+        Interlocked.Increment(ref _revertOfferCallCount);
+        return Task.FromResult(Result.Success());
+    }
+
+    /// <summary>
+    /// Waits for the verification link to arrive. The request only commits an outbox row (ADR-0038),
+    /// so everything after it — relay, delivery, this spy — has to be waited for, never assumed.
+    /// </summary>
+    public Task WaitForVerificationCaptureAsync(TimeSpan? timeout = null) =>
+        WaitForAsync(() => LastVerificationToken is not null, timeout);
+
+    public Task WaitForRevertOfferCaptureAsync(TimeSpan? timeout = null) =>
+        WaitForAsync(() => LastRevertToken is not null, timeout);
+
+    private static async Task WaitForAsync(Func<bool> arrived, TimeSpan? timeout)
+    {
+        using CancellationTokenSource waitWindow = new(timeout ?? TimeSpan.FromSeconds(15));
+
+        while (!arrived() && !waitWindow.IsCancellationRequested)
+        {
+            await Task.Delay(50);
+        }
+    }
+
+    public void Reset()
+    {
+        LastVerificationRecipient = null;
+        LastVerificationToken = null;
+        LastWarningRecipient = null;
+        LastWarningTargetAddress = null;
+        LastNoticeRecipient = null;
+        LastRevertOfferRecipient = null;
+        LastRevertOfferTargetAddress = null;
+        LastRevertToken = null;
+        Interlocked.Exchange(ref _verificationCallCount, 0);
+        Interlocked.Exchange(ref _warningCallCount, 0);
+        Interlocked.Exchange(ref _noticeCallCount, 0);
+        Interlocked.Exchange(ref _revertOfferCallCount, 0);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangeEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangeEndpointTests.cs
@@ -1,0 +1,181 @@
+using System.Net.Http.Headers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+using LotroKoniecDev.AuthSystem.Persistence.Outbox;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+/// <summary>
+/// The request leg of the e-mail change: what it refuses, and what it commits when it accepts
+/// (spec 0013 / ADR-0048).
+/// </summary>
+public sealed class EmailChangeEndpointTests : EndpointsTestBase
+{
+    private const string Password = "TestPass1!";
+
+    public EmailChangeEndpointTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public async Task RequestEmailChange_ShouldReturnOkAndCommitOneOutboxRow_WhenTheRequestIsValid()
+    {
+        RegisterRequest registerRequest = await RegisterAsync();
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, Password);
+        string newEmail = Faker.Internet.Email();
+
+        HttpResponseMessage response = await RequestChangeAsync(accessToken, newEmail, Password);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Enqueue only adds the row to the unit of work; a handler that forgot to save would answer
+        // 200 and send nothing at all.
+        OutboxMessage? row = await OutboxAssertions.WaitForOutboxRowAsync(
+            Factory,
+            message => message.Type == nameof(EmailChangeRequested) && message.Payload.Contains(newEmail, StringComparison.Ordinal));
+
+        row.ShouldNotBeNull();
+        row.Payload.ShouldContain(registerRequest.Email);
+    }
+
+    [Fact]
+    public async Task RequestEmailChange_ShouldSendTheLinkToTheNewAddressAndWarnTheOldOne()
+    {
+        RegisterRequest registerRequest = await RegisterAsync();
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, Password);
+        string newEmail = Faker.Internet.Email();
+
+        await RequestChangeAsync(accessToken, newEmail, Password);
+        await EmailChangeEmailSpy.WaitForVerificationCaptureAsync();
+
+        EmailChangeEmailSpy.LastVerificationRecipient.ShouldBe(newEmail);
+        EmailChangeEmailSpy.LastWarningRecipient.ShouldBe(registerRequest.Email);
+        EmailChangeEmailSpy.LastWarningTargetAddress.ShouldBe(newEmail);
+    }
+
+    [Fact]
+    public async Task RequestEmailChange_ShouldLeaveTheAccountOnTheOldAddress_UntilTheLinkIsUsed()
+    {
+        RegisterRequest registerRequest = await RegisterAsync();
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, Password);
+
+        await RequestChangeAsync(accessToken, Faker.Internet.Email(), Password);
+        await EmailChangeEmailSpy.WaitForVerificationCaptureAsync();
+
+        ApplicationUser user = await LoadUserAsync(registerRequest.Email);
+        user.Email.ShouldBe(registerRequest.Email);
+
+        // And the old address still logs in, which is the point of not moving anything yet.
+        string tokenAfterRequest = await GetAccessTokenAsync(registerRequest.Email, Password);
+        tokenAfterRequest.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task RequestEmailChange_ShouldReturnProblemAndEnqueueNothing_WhenThePasswordIsWrong()
+    {
+        RegisterRequest registerRequest = await RegisterAsync();
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, Password);
+
+        HttpResponseMessage response = await RequestChangeAsync(
+            accessToken, Faker.Internet.Email(), "TotallyWrong9!");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).ShouldContain("Auth.InvalidCurrentPassword");
+        (await CountOutboxRowsAsync(nameof(EmailChangeRequested))).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RequestEmailChange_ShouldReturnProblem_WhenTheAddressBelongsToAnotherAccount()
+    {
+        RegisterRequest registerRequest = await RegisterAsync();
+        RegisterRequest otherUser = await RegisterAsync();
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, Password);
+
+        HttpResponseMessage response = await RequestChangeAsync(accessToken, otherUser.Email, Password);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        (await response.Content.ReadAsStringAsync()).ShouldContain("Auth.UserAlreadyExistsByEmail");
+    }
+
+    [Fact]
+    public async Task RequestEmailChange_ShouldReturnProblem_WhenTheAddressIsTheCallersOwn()
+    {
+        RegisterRequest registerRequest = await RegisterAsync();
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, Password);
+
+        HttpResponseMessage response = await RequestChangeAsync(
+            accessToken, registerRequest.Email.ToUpperInvariant(), Password);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).ShouldContain("Auth.EmailChangeSameAddress");
+    }
+
+    [Fact]
+    public async Task RequestEmailChange_ShouldReturnUnauthorized_WhenNoTokenIsPresented()
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/change-email")
+        {
+            Content = JsonContent.Create(new ChangeEmailRequest(Faker.Internet.Email(), Password))
+        };
+
+        HttpResponseMessage response = await ApiClient.Http.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-an-email")]
+    [InlineData("spaces in@address.pl")]
+    public async Task RequestEmailChange_ShouldReturnValidationProblem_WhenTheAddressIsMalformed(string newEmail)
+    {
+        RegisterRequest registerRequest = await RegisterAsync();
+        string accessToken = await GetAccessTokenAsync(registerRequest.Email, Password);
+
+        HttpResponseMessage response = await RequestChangeAsync(accessToken, newEmail, Password);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        (await CountOutboxRowsAsync(nameof(EmailChangeRequested))).ShouldBe(0);
+    }
+
+    private async Task<RegisterRequest> RegisterAsync()
+    {
+        (RegisterRequest request, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy, Password);
+        return request;
+    }
+
+    private async Task<HttpResponseMessage> RequestChangeAsync(
+        string accessToken, string newEmail, string password)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/change-email");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Content = JsonContent.Create(new ChangeEmailRequest(newEmail, password));
+
+        return await ApiClient.Http.SendAsync(request);
+    }
+
+    private async Task<ApplicationUser> LoadUserAsync(string email)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        return await db.Set<ApplicationUser>()
+            .AsNoTracking()
+            .SingleAsync(user => user.NormalizedEmail == email.ToUpperInvariant());
+    }
+
+    private async Task<int> CountOutboxRowsAsync(string type)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        return await db.OutboxMessages.AsNoTracking().CountAsync(row => row.Type == type);
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangeEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangeEndpointTests.cs
@@ -42,6 +42,7 @@ public sealed class EmailChangeEndpointTests : EndpointsTestBase
 
         row.ShouldNotBeNull();
         row.Payload.ShouldContain(registerRequest.Email);
+        (await CountOutboxRowsAsync(nameof(EmailChangeRequested))).ShouldBe(1);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
@@ -146,8 +146,11 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
             RevertUrl(userId, user.Email, newEmail, revertToken),
             RevertForm(userId, user.Email, newEmail, revertToken));
 
-        // The password is gone, so the page hands the visitor straight to the reset flow.
-        response.StatusCode.ShouldBeOneOf(HttpStatusCode.Redirect, HttpStatusCode.Found, HttpStatusCode.OK);
+        // The password is gone, so the page has to hand the visitor straight to the reset flow. The
+        // test client follows redirects, so the landing URL is what proves it — accepting a bare 200
+        // would also accept the failure rendering.
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.RequestMessage!.RequestUri!.ToString().ShouldContain("/Account/ResetPassword");
 
         ApplicationUser restored = await LoadUserByIdAsync(userId);
         restored.Email.ShouldBe(user.Email);
@@ -183,6 +186,71 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
     }
 
     [Fact]
+    public async Task RevertPage_Post_ShouldStillWorkAfterTheAddressWasChangedAgain()
+    {
+        // The takeover an earlier draft of this guard let through: whoever holds the password moves the
+        // account A -> B, confirms from B, then immediately B -> C. If the revert insisted the account
+        // still sat on B, the owner's A -> B link would match nothing, and the fresh revert offer for
+        // B -> C would be posted to B, which the attacker owns. The owner has to be able to pull the
+        // account back from wherever it has been dragged.
+        (RegisterRequest user, string firstNewEmail, Guid userId) = await CompleteChangeAsync();
+        string revertToken = EmailChangeEmailSpy.LastRevertToken!;
+
+        string secondNewEmail = Faker.Internet.Email();
+        EmailChangeEmailSpy.Reset();
+        string accessToken = await GetAccessTokenAsync(firstNewEmail, Password);
+        using HttpRequestMessage secondRequest = new(HttpMethod.Post, "auth/account/change-email");
+        secondRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        secondRequest.Content = JsonContent.Create(new ChangeEmailRequest(secondNewEmail, Password));
+        (await ApiClient.Http.SendAsync(secondRequest)).StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await EmailChangeEmailSpy.WaitForVerificationCaptureAsync();
+        await ConfirmAsync(userId, secondNewEmail, EmailChangeEmailSpy.LastVerificationToken!);
+        (await LoadUserByIdAsync(userId)).Email.ShouldBe(secondNewEmail);
+
+        await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, firstNewEmail, revertToken),
+            RevertForm(userId, user.Email, firstNewEmail, revertToken));
+
+        ApplicationUser restored = await LoadUserByIdAsync(userId);
+        restored.Email.ShouldBe(user.Email);
+        restored.PasswordHash.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RevertPage_Post_ShouldRefuseAndKeepThePassword_WhenThePreviousAddressWasTaken()
+    {
+        // Nothing to go back to. Clearing the password here would lock the account out of both
+        // addresses at once.
+        (RegisterRequest user, string newEmail, Guid userId) = await CompleteChangeAsync();
+        string revertToken = EmailChangeEmailSpy.LastRevertToken!;
+
+        // The address was freed by the change, so somebody else can claim it. They do not need to
+        // confirm it — occupying the row is enough to make the revert impossible.
+        await ApiClient.Http.PostAsJsonAsync(
+            new Uri("auth/register", UriKind.Relative),
+            new RegisterRequest(
+                Faker.Random.AlphaNumeric(16),
+                user.Email,
+                Password,
+                AcceptedPrivacyPolicy: true,
+                AcceptedDataProcessingConsent: true,
+                AcceptedTermsOfService: true));
+
+        HttpResponseMessage response = await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, newEmail, revertToken),
+            RevertForm(userId, user.Email, newEmail, revertToken));
+
+        (await response.Content.ReadAsStringAsync()).ShouldContain("nieprawidłowy");
+
+        ApplicationUser untouched = await LoadUserByIdAsync(userId);
+        untouched.Email.ShouldBe(newEmail);
+        untouched.PasswordHash.ShouldNotBeNull();
+    }
+
+    [Fact]
     public async Task RevertPage_PostTwice_ShouldRefuseTheSecondTime()
     {
         // The token carries no security stamp, so what makes it single-use is the check that the
@@ -202,6 +270,29 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
 
         (await replay.Content.ReadAsStringAsync()).ShouldContain("nieprawidłowy");
         (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
+    }
+
+    [Theory]
+    [InlineData("not-a-guid")]
+    [InlineData("../../etc/passwd")]
+    public async Task RevertPage_PostWithAMalformedUserId_ShouldRenderTheErrorState(string userIdInput)
+    {
+        // Identity converts the id string to the key type, so a value that is not a Guid throws deep
+        // in the store. A person who followed a link from their inbox has to see the invalid-link
+        // page, never a crash.
+        (RegisterRequest user, string newEmail, Guid userId) = await CompleteChangeAsync();
+        string revertToken = EmailChangeEmailSpy.LastRevertToken!;
+
+        Dictionary<string, string> form = RevertForm(userId, user.Email, newEmail, revertToken);
+        form["UserId"] = userIdInput;
+
+        HttpResponseMessage response = await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, newEmail, revertToken),
+            form);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldContain("nieprawidłowy");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
@@ -255,12 +255,39 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
     }
 
     [Fact]
-    public async Task RevertPage_Post_ShouldNotLetAnOlderRevertTokenRepossessTheAccount()
+    public async Task ConfirmPage_Post_ShouldArmNoUndoLink_ForASecondChangeInTheSameChain()
     {
-        // The counter-takeover. The attacker chains A -> B -> C, so the revert offer for B -> C lands
-        // in B, which is theirs. The owner reverts with their A -> B link and resets the password. If
-        // the attacker's older token still works, they fire it afterwards and take the account back
-        // for good, with no e-mail warning anybody.
+        // Only the change that moved the account away from its starting address may arm an undo. A
+        // second change would otherwise mail a working link to the address the attacker just took
+        // over, and they would use it to reverse the owner's recovery.
+        (RegisterRequest user, string firstNewEmail, Guid userId) = await CompleteChangeAsync();
+
+        string secondNewEmail = Faker.Internet.Email();
+        EmailChangeEmailSpy.Reset();
+        string accessToken = await GetAccessTokenAsync(firstNewEmail, Password);
+        using HttpRequestMessage secondRequest = new(HttpMethod.Post, "auth/account/change-email");
+        secondRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        secondRequest.Content = JsonContent.Create(new ChangeEmailRequest(secondNewEmail, Password));
+        (await ApiClient.Http.SendAsync(secondRequest)).StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await EmailChangeEmailSpy.WaitForVerificationCaptureAsync();
+        await ConfirmAsync(userId, secondNewEmail, EmailChangeEmailSpy.LastVerificationToken!);
+
+        // The plain notice still goes out; the one carrying a link does not.
+        await EmailChangeEmailSpy.WaitForChangedNoticeCaptureAsync();
+        EmailChangeEmailSpy.RevertOfferCallCount.ShouldBe(0);
+
+        // And the account still points home, so the owner's link from the first change works.
+        (await LoadUserByIdAsync(userId)).EmailChangeRevertTo.ShouldBe(user.Email);
+    }
+
+    [Fact]
+    public async Task RevertPage_Post_ShouldKeepTheOwnersLinkAlive_WhenTheAttackerRevertsFirst()
+    {
+        // The attacker does not have to beat the owner to the inbox, only to the click. They chain
+        // A -> B -> C, then immediately fire whatever undo the chain handed them, so that by the time
+        // the owner opens their own e-mail the account is already the attacker's with a password they
+        // chose. Only the address the chain STARTED from may ever be an undo target.
         (RegisterRequest user, string attackerFirstEmail, Guid userId) = await CompleteChangeAsync();
         string ownerRevertToken = EmailChangeEmailSpy.LastRevertToken!;
 
@@ -274,23 +301,28 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
 
         await EmailChangeEmailSpy.WaitForVerificationCaptureAsync();
         await ConfirmAsync(userId, attackerSecondEmail, EmailChangeEmailSpy.LastVerificationToken!);
-        await EmailChangeEmailSpy.WaitForRevertOfferCaptureAsync();
-        string attackerRevertToken = EmailChangeEmailSpy.LastRevertToken!;
 
-        // The owner takes the account back.
+        // Whatever the second change handed the attacker, they fire it at once - before the owner has
+        // even opened their mail.
+        await EmailChangeEmailSpy.WaitForRevertOfferCaptureAsync(TimeSpan.FromSeconds(3));
+        string? attackerRevertToken = EmailChangeEmailSpy.LastRevertToken;
+        if (attackerRevertToken is not null)
+        {
+            await PostToPageAsync(
+                "/Account/RevertEmailChange",
+                RevertUrl(userId, attackerFirstEmail, attackerSecondEmail, attackerRevertToken),
+                RevertForm(userId, attackerFirstEmail, attackerSecondEmail, attackerRevertToken));
+        }
+
+        // The owner opens their link afterwards and still gets the account back.
         await PostToPageAsync(
             "/Account/RevertEmailChange",
             RevertUrl(userId, user.Email, attackerFirstEmail, ownerRevertToken),
             RevertForm(userId, user.Email, attackerFirstEmail, ownerRevertToken));
-        (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
 
-        // The attacker fires the token that was mailed to the address they controlled.
-        await PostToPageAsync(
-            "/Account/RevertEmailChange",
-            RevertUrl(userId, attackerFirstEmail, attackerSecondEmail, attackerRevertToken),
-            RevertForm(userId, attackerFirstEmail, attackerSecondEmail, attackerRevertToken));
-
-        (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
+        ApplicationUser restored = await LoadUserByIdAsync(userId);
+        restored.Email.ShouldBe(user.Email);
+        restored.PasswordHash.ShouldBeNull();
     }
 
     [Fact]
@@ -328,8 +360,8 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
     [Fact]
     public async Task RevertPage_PostTwice_ShouldRefuseTheSecondTime()
     {
-        // The token carries no security stamp, so what makes it single-use is the check that the
-        // account still sits on the address the token was issued against.
+        // The token carries no security stamp, so what makes it single-use is that a successful revert
+        // rotates the revert stamp and disarms the chain.
         (RegisterRequest user, string newEmail, Guid userId) = await CompleteChangeAsync();
         string revertToken = EmailChangeEmailSpy.LastRevertToken!;
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
@@ -117,6 +117,42 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
         (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
     }
 
+    [Theory]
+    [InlineData("not-a-guid")]
+    [InlineData("Twoje konto zostało przejęte")]
+    public async Task ConfirmPage_GetWithAMalformedUserId_RendersTheErrorStateNotACrash(string userIdInput)
+    {
+        (RegisterRequest user, string newEmail, string token) = await RequestChangeAsync();
+
+        HttpResponseMessage response = await ApiClient.Http.GetAsync(new Uri(
+            $"/Account/ConfirmEmailChange?userId={Uri.EscapeDataString(userIdInput)}"
+            + $"&email={Uri.EscapeDataString(newEmail)}&token={Uri.EscapeDataString(token)}",
+            UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldContain("nieprawidłowy");
+        (await LoadUserByIdAsync(await UserIdOfAsync(user.Email))).Email.ShouldBe(user.Email);
+    }
+
+    [Fact]
+    public async Task ConfirmPage_GetWithATextInsteadOfAnAddress_DoesNotPrintItOnThePage()
+    {
+        // The page is on the auth origin and carries a real button, so it must not become a place to
+        // put a sentence of somebody else's choosing.
+        (RegisterRequest user, _, string token) = await RequestChangeAsync();
+        Guid userId = await UserIdOfAsync(user.Email);
+        const string injected = "Twoje konto zostalo przejete - zadzwon pod numer 500600700";
+
+        HttpResponseMessage response = await ApiClient.Http.GetAsync(new Uri(
+            $"/Account/ConfirmEmailChange?userId={userId}&email={Uri.EscapeDataString(injected)}"
+            + $"&token={Uri.EscapeDataString(token)}",
+            UriKind.Relative));
+
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldNotContain(injected);
+        html.ShouldContain("nieprawidłowy");
+    }
+
     [Fact]
     public async Task RevertPage_Get_ShouldChangeNothing()
     {
@@ -216,6 +252,45 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
         ApplicationUser restored = await LoadUserByIdAsync(userId);
         restored.Email.ShouldBe(user.Email);
         restored.PasswordHash.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RevertPage_Post_ShouldNotLetAnOlderRevertTokenRepossessTheAccount()
+    {
+        // The counter-takeover. The attacker chains A -> B -> C, so the revert offer for B -> C lands
+        // in B, which is theirs. The owner reverts with their A -> B link and resets the password. If
+        // the attacker's older token still works, they fire it afterwards and take the account back
+        // for good, with no e-mail warning anybody.
+        (RegisterRequest user, string attackerFirstEmail, Guid userId) = await CompleteChangeAsync();
+        string ownerRevertToken = EmailChangeEmailSpy.LastRevertToken!;
+
+        string attackerSecondEmail = Faker.Internet.Email();
+        EmailChangeEmailSpy.Reset();
+        string accessToken = await GetAccessTokenAsync(attackerFirstEmail, Password);
+        using HttpRequestMessage secondRequest = new(HttpMethod.Post, "auth/account/change-email");
+        secondRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        secondRequest.Content = JsonContent.Create(new ChangeEmailRequest(attackerSecondEmail, Password));
+        (await ApiClient.Http.SendAsync(secondRequest)).StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await EmailChangeEmailSpy.WaitForVerificationCaptureAsync();
+        await ConfirmAsync(userId, attackerSecondEmail, EmailChangeEmailSpy.LastVerificationToken!);
+        await EmailChangeEmailSpy.WaitForRevertOfferCaptureAsync();
+        string attackerRevertToken = EmailChangeEmailSpy.LastRevertToken!;
+
+        // The owner takes the account back.
+        await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, attackerFirstEmail, ownerRevertToken),
+            RevertForm(userId, user.Email, attackerFirstEmail, ownerRevertToken));
+        (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
+
+        // The attacker fires the token that was mailed to the address they controlled.
+        await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, attackerFirstEmail, attackerSecondEmail, attackerRevertToken),
+            RevertForm(userId, attackerFirstEmail, attackerSecondEmail, attackerRevertToken));
+
+        (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
@@ -1,0 +1,337 @@
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Factories;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Register;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.Auth;
+
+/// <summary>
+/// The two page legs of the e-mail change: the confirmation the new mailbox follows, and the undo the
+/// old mailbox holds for 14 days (ADR-0048).
+/// </summary>
+public sealed partial class EmailChangePageTests : EndpointsTestBase
+{
+    private const string Password = "TestPass1!";
+
+    public EmailChangePageTests(AuthSystemApiFactory appFactory) : base(appFactory) { }
+
+    [Fact]
+    public async Task ConfirmPage_Get_ShouldChangeNothing()
+    {
+        // The mail-scanner guard. Corporate mail security opens every link it sees, so a GET that
+        // applied the change would move addresses nobody clicked on.
+        (RegisterRequest user, string newEmail, string token) = await RequestChangeAsync();
+        Guid userId = await UserIdOfAsync(user.Email);
+
+        HttpResponseMessage response = await ApiClient.Http.GetAsync(
+            new Uri(ConfirmUrl(userId, newEmail, token), UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
+    }
+
+    [Fact]
+    public async Task ConfirmPage_Post_ShouldMoveTheAddressAndKeepItConfirmed()
+    {
+        (RegisterRequest user, string newEmail, string token) = await RequestChangeAsync();
+        Guid userId = await UserIdOfAsync(user.Email);
+
+        HttpResponseMessage response = await PostToPageAsync(
+            "/Account/ConfirmEmailChange",
+            ConfirmUrl(userId, newEmail, token),
+            new Dictionary<string, string>
+            {
+                ["UserId"] = userId.ToString(),
+                ["Email"] = newEmail,
+                ["Token"] = token
+            });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        ApplicationUser moved = await LoadUserByIdAsync(userId);
+        moved.Email.ShouldBe(newEmail);
+
+        // RequireConfirmedEmail is on, so an address that landed unconfirmed would lock the user out
+        // of their own account.
+        moved.EmailConfirmed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ConfirmPage_Post_ShouldMakeTheNewAddressTheLogin()
+    {
+        (RegisterRequest user, string newEmail, string token) = await RequestChangeAsync();
+        Guid userId = await UserIdOfAsync(user.Email);
+        await ConfirmAsync(userId, newEmail, token);
+
+        string accessToken = await GetAccessTokenAsync(newEmail, Password);
+
+        accessToken.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task ConfirmPage_PostTwice_ShouldRefuseTheSecondTime()
+    {
+        (RegisterRequest user, string newEmail, string token) = await RequestChangeAsync();
+        Guid userId = await UserIdOfAsync(user.Email);
+        await ConfirmAsync(userId, newEmail, token);
+
+        HttpResponseMessage replay = await PostToPageAsync(
+            "/Account/ConfirmEmailChange",
+            ConfirmUrl(userId, newEmail, token),
+            new Dictionary<string, string>
+            {
+                ["UserId"] = userId.ToString(),
+                ["Email"] = newEmail,
+                ["Token"] = token
+            });
+
+        (await replay.Content.ReadAsStringAsync()).ShouldContain("nieprawidłowy");
+        (await LoadUserByIdAsync(userId)).Email.ShouldBe(newEmail);
+    }
+
+    [Fact]
+    public async Task ConfirmPage_PostWithATamperedAddress_ShouldChangeNothing()
+    {
+        // The address is baked into the token's purpose, so editing it in the link has to fail.
+        (RegisterRequest user, string newEmail, string token) = await RequestChangeAsync();
+        Guid userId = await UserIdOfAsync(user.Email);
+
+        HttpResponseMessage response = await PostToPageAsync(
+            "/Account/ConfirmEmailChange",
+            ConfirmUrl(userId, newEmail, token),
+            new Dictionary<string, string>
+            {
+                ["UserId"] = userId.ToString(),
+                ["Email"] = "attacker@mordor.example",
+                ["Token"] = token
+            });
+
+        (await response.Content.ReadAsStringAsync()).ShouldContain("nieprawidłowy");
+        (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
+    }
+
+    [Fact]
+    public async Task RevertPage_Get_ShouldChangeNothing()
+    {
+        // The most important instance of the guard: this link arrives in a mailbox the user actually
+        // reads, so a GET that reverted would undo every legitimate change automatically.
+        (RegisterRequest user, string newEmail, Guid userId) = await CompleteChangeAsync();
+        string revertToken = EmailChangeEmailSpy.LastRevertToken!;
+
+        HttpResponseMessage response = await ApiClient.Http.GetAsync(
+            new Uri(RevertUrl(userId, user.Email, newEmail, revertToken), UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        ApplicationUser untouched = await LoadUserByIdAsync(userId);
+        untouched.Email.ShouldBe(newEmail);
+        untouched.PasswordHash.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task RevertPage_Post_ShouldRestoreTheAddressAndClearThePassword()
+    {
+        (RegisterRequest user, string newEmail, Guid userId) = await CompleteChangeAsync();
+        string revertToken = EmailChangeEmailSpy.LastRevertToken!;
+
+        HttpResponseMessage response = await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, newEmail, revertToken),
+            RevertForm(userId, user.Email, newEmail, revertToken));
+
+        // The password is gone, so the page hands the visitor straight to the reset flow.
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.Redirect, HttpStatusCode.Found, HttpStatusCode.OK);
+
+        ApplicationUser restored = await LoadUserByIdAsync(userId);
+        restored.Email.ShouldBe(user.Email);
+        restored.EmailConfirmed.ShouldBeTrue();
+        restored.PasswordHash.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RevertPage_Post_ShouldStillWorkAfterThePasswordWasChanged()
+    {
+        // This is ADR-0048's whole reason for a hand-written token provider. Whoever took the account
+        // over changes the password next, which rotates the security stamp — and every other token in
+        // this system dies with that rotation. This one must not.
+        (RegisterRequest user, string newEmail, Guid userId) = await CompleteChangeAsync();
+        string revertToken = EmailChangeEmailSpy.LastRevertToken!;
+
+        const string attackerPassword = "Attacker99!";
+        string accessToken = await GetAccessTokenAsync(newEmail, Password);
+        using HttpRequestMessage changePassword = new(HttpMethod.Post, "auth/change-password");
+        changePassword.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        changePassword.Content = JsonContent.Create(
+            new Contracts.Features.Auth.Password.ChangePasswordRequest(Password, attackerPassword));
+        (await ApiClient.Http.SendAsync(changePassword)).StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, newEmail, revertToken),
+            RevertForm(userId, user.Email, newEmail, revertToken));
+
+        ApplicationUser restored = await LoadUserByIdAsync(userId);
+        restored.Email.ShouldBe(user.Email);
+        restored.PasswordHash.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RevertPage_PostTwice_ShouldRefuseTheSecondTime()
+    {
+        // The token carries no security stamp, so what makes it single-use is the check that the
+        // account still sits on the address the token was issued against.
+        (RegisterRequest user, string newEmail, Guid userId) = await CompleteChangeAsync();
+        string revertToken = EmailChangeEmailSpy.LastRevertToken!;
+
+        await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, newEmail, revertToken),
+            RevertForm(userId, user.Email, newEmail, revertToken));
+
+        HttpResponseMessage replay = await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, newEmail, revertToken),
+            RevertForm(userId, user.Email, newEmail, revertToken));
+
+        (await replay.Content.ReadAsStringAsync()).ShouldContain("nieprawidłowy");
+        (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
+    }
+
+    [Fact]
+    public async Task RevertPage_PostWithAForeignToken_ShouldChangeNothing()
+    {
+        (RegisterRequest user, string newEmail, Guid userId) = await CompleteChangeAsync();
+
+        HttpResponseMessage response = await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, newEmail, "not-a-real-token"),
+            RevertForm(userId, user.Email, newEmail, "not-a-real-token"));
+
+        (await response.Content.ReadAsStringAsync()).ShouldContain("nieprawidłowy");
+
+        ApplicationUser untouched = await LoadUserByIdAsync(userId);
+        untouched.Email.ShouldBe(newEmail);
+        untouched.PasswordHash.ShouldNotBeNull();
+    }
+
+    private async Task<(RegisterRequest User, string NewEmail, string Token)> RequestChangeAsync()
+    {
+        (RegisterRequest user, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
+            ApiClient, Faker, AccountConfirmationEmailSpy, Password);
+
+        string accessToken = await GetAccessTokenAsync(user.Email, Password);
+        string newEmail = Faker.Internet.Email();
+
+        using HttpRequestMessage request = new(HttpMethod.Post, "auth/account/change-email");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Content = JsonContent.Create(new ChangeEmailRequest(newEmail, Password));
+        (await ApiClient.Http.SendAsync(request)).StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await EmailChangeEmailSpy.WaitForVerificationCaptureAsync();
+
+        return (user, newEmail, EmailChangeEmailSpy.LastVerificationToken!);
+    }
+
+    private async Task<(RegisterRequest User, string NewEmail, Guid UserId)> CompleteChangeAsync()
+    {
+        (RegisterRequest user, string newEmail, string token) = await RequestChangeAsync();
+        Guid userId = await UserIdOfAsync(user.Email);
+
+        await ConfirmAsync(userId, newEmail, token);
+        await EmailChangeEmailSpy.WaitForRevertOfferCaptureAsync();
+
+        EmailChangeEmailSpy.LastRevertOfferRecipient.ShouldBe(user.Email);
+        EmailChangeEmailSpy.LastNoticeRecipient.ShouldBe(newEmail);
+
+        return (user, newEmail, userId);
+    }
+
+    private async Task ConfirmAsync(Guid userId, string newEmail, string token)
+    {
+        HttpResponseMessage response = await PostToPageAsync(
+            "/Account/ConfirmEmailChange",
+            ConfirmUrl(userId, newEmail, token),
+            new Dictionary<string, string>
+            {
+                ["UserId"] = userId.ToString(),
+                ["Email"] = newEmail,
+                ["Token"] = token
+            });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private static Dictionary<string, string> RevertForm(Guid userId, string from, string to, string token) =>
+        new()
+        {
+            ["UserId"] = userId.ToString(),
+            ["From"] = from,
+            ["To"] = to,
+            ["Token"] = token
+        };
+
+    private static string ConfirmUrl(Guid userId, string newEmail, string token) =>
+        $"/Account/ConfirmEmailChange?userId={userId}&email={Uri.EscapeDataString(newEmail)}"
+        + $"&token={Uri.EscapeDataString(token)}";
+
+    private static string RevertUrl(Guid userId, string from, string to, string token) =>
+        $"/Account/RevertEmailChange?userId={userId}&from={Uri.EscapeDataString(from)}"
+        + $"&to={Uri.EscapeDataString(to)}&token={Uri.EscapeDataString(token)}";
+
+    private async Task<Guid> UserIdOfAsync(string email)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        return await db.Set<ApplicationUser>()
+            .AsNoTracking()
+            .Where(user => user.NormalizedEmail == email.ToUpperInvariant())
+            .Select(user => user.Id)
+            .SingleAsync();
+    }
+
+    private async Task<ApplicationUser> LoadUserByIdAsync(Guid userId)
+    {
+        await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
+        AuthDbContext db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        return await db.Set<ApplicationUser>().AsNoTracking().SingleAsync(user => user.Id == userId);
+    }
+
+    private async Task<HttpResponseMessage> PostToPageAsync(
+        string pagePath, string getUrl, Dictionary<string, string> formFields)
+    {
+        HttpResponseMessage pageResponse = await ApiClient.Http.GetAsync(new Uri(getUrl, UriKind.Relative));
+        pageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string html = await pageResponse.Content.ReadAsStringAsync();
+        Match match = AntiForgeryTokenRegex().Match(html);
+        if (match.Success)
+        {
+            formFields["__RequestVerificationToken"] = match.Groups[1].Value;
+        }
+
+        using FormUrlEncodedContent content = new(formFields);
+        using HttpRequestMessage request = new(HttpMethod.Post, pagePath) { Content = content };
+
+        if (pageResponse.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
+        {
+            foreach (string cookie in cookies)
+            {
+                request.Headers.Add("Cookie", cookie.Split(';')[0]);
+            }
+        }
+
+        return await ApiClient.Http.SendAsync(request);
+    }
+
+    [GeneratedRegex("""name="__RequestVerificationToken".*?value="([^"]+)""")]
+    private static partial Regex AntiForgeryTokenRegex();
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Hateoas/AccountAggregateHateoasTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Hateoas/AccountAggregateHateoasTests.cs
@@ -32,7 +32,7 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
     [Fact]
     public async Task ExportAccountData_ShouldReturnBaseLinksOnly_WhenEmailIsConfirmed()
     {
-        // Arrange - confirmed users see self, change-password, delete-account only
+        // Arrange - confirmed users see self, change-password, change-email, delete-account only
         (RegisterRequest registerRequest, _) = await UserFactory.RegisterRandomUserWithRequestAsync(
             ApiClient, Faker, AccountConfirmationEmailSpy, TestPassword);
         string accessToken = await GetAccessTokenAsync(registerRequest.Email, TestPassword);
@@ -41,9 +41,10 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
         AccountDataExportResponse response = await RequestHateoasResponseAsync(accessToken);
 
         // Assert
-        response.Links.Count.ShouldBe(3);
+        response.Links.Count.ShouldBe(4);
         response.Links.ShouldContain(l => l.Rel == Rels.Self && l.Method == "GET");
         response.Links.ShouldContain(l => l.Rel == Rels.ChangePassword && l.Method == "POST");
+        response.Links.ShouldContain(l => l.Rel == Rels.ChangeEmail && l.Method == "POST");
         response.Links.ShouldContain(l => l.Rel == Rels.DeleteAccount && l.Method == "POST");
         response.Links.ShouldNotContain(
             l => l.Rel == Rels.ResendEmailConfirmation,
@@ -68,9 +69,10 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
         AccountDataExportResponse response = await RequestHateoasResponseAsync(accessToken);
 
         // Assert
-        response.Links.Count.ShouldBe(4);
+        response.Links.Count.ShouldBe(5);
         response.Links.ShouldContain(l => l.Rel == Rels.Self && l.Method == "GET");
         response.Links.ShouldContain(l => l.Rel == Rels.ChangePassword && l.Method == "POST");
+        response.Links.ShouldContain(l => l.Rel == Rels.ChangeEmail && l.Method == "POST");
         response.Links.ShouldContain(l => l.Rel == Rels.DeleteAccount && l.Method == "POST");
         response.Links.ShouldContain(l => l.Rel == Rels.ResendEmailConfirmation && l.Method == "POST");
     }
@@ -100,7 +102,7 @@ public sealed class AccountAggregateHateoasTests : EndpointsTestBase
         response.Links.ShouldContain(l => l.Rel == Rels.Self && l.Method == "GET");
         response.Links.ShouldContain(l => l.Rel == Rels.CancelDeletion && l.Method == "POST");
         response.Links.ShouldNotContain(
-            l => l.Rel == Rels.ChangePassword || l.Rel == Rels.DeleteAccount,
+            l => l.Rel == Rels.ChangePassword || l.Rel == Rels.ChangeEmail || l.Rel == Rels.DeleteAccount,
             "a deletion-scheduled account must not advertise dead transitions");
     }
 

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/RateLimiting/ChangeEmailRateLimitingTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/RateLimiting/ChangeEmailRateLimitingTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using LotroKoniecDev.AuthSystem.API.Tests.Integration.Shared.Bases;
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Integration.Tests.RateLimiting;
+
+/// <summary>
+/// The e-mail change endpoint sends mail to an address the caller types in, so it can be pointed at a
+/// stranger's inbox. Its budget is the same as forgot-password's, and the key is the client IP.
+/// The suite's Testing host keeps the limiter off; these tests turn it on for a derived host, like
+/// <see cref="ResendConfirmationRateLimitingTests"/>.
+/// </summary>
+public sealed class ChangeEmailRateLimitingTests : EndpointsTestBase
+{
+    /// <summary>Mirrors the change-email-limit policy: 3 permits per hour per client IP.</summary>
+    private const int ChangeEmailPermitLimit = 3;
+
+    private static readonly Uri ChangeEmailEndpoint = new("auth/account/change-email", UriKind.Relative);
+
+    public ChangeEmailRateLimitingTests(AuthSystemApiFactory appFactory) : base(appFactory)
+    {
+    }
+
+    [Fact]
+    public async Task ChangeEmail_ShouldThrottleTheFourthAttemptWithinTheHour()
+    {
+        // The requests are unauthenticated on purpose. UseRateLimiter runs before UseAuthentication,
+        // so the limiter never sees a principal — which is both why the key is the IP and why an
+        // anonymous caller shares the same bucket. Asserting it here keeps that property visible
+        // instead of leaving it to the pipeline order to imply.
+        using WebApplicationFactory<Program> limitedHost = CreateRateLimitedHost();
+        using HttpClient client = limitedHost.CreateClient();
+
+        HttpStatusCode[] statusCodes = new HttpStatusCode[ChangeEmailPermitLimit + 1];
+
+        for (int i = 0; i < statusCodes.Length; i++)
+        {
+            using HttpResponseMessage response = await client.PostAsJsonAsync(
+                ChangeEmailEndpoint,
+                new ChangeEmailRequest($"burst-{i}@lotro-translator.pl", "TestPass1!"));
+            statusCodes[i] = response.StatusCode;
+        }
+
+        statusCodes.Take(ChangeEmailPermitLimit)
+            .ShouldAllBe(statusCode => statusCode != HttpStatusCode.TooManyRequests);
+        statusCodes[ChangeEmailPermitLimit].ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    private WebApplicationFactory<Program> CreateRateLimitedHost()
+    {
+        return Factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "RateLimiting:ForceEnable", "true" }
+                });
+            });
+        });
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Features/Auth/RevertEmailChangeHandlerTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Features/Auth/RevertEmailChangeHandlerTests.cs
@@ -1,9 +1,10 @@
-using FluentValidation;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using LotroKoniecDev.AuthSystem.API.Features.Auth;
 using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
 using LotroKoniecDev.AuthSystem.Persistence.Identity;
 using NSubstitute;
 using Shouldly;
@@ -20,6 +21,7 @@ public sealed class RevertEmailChangeHandlerTests
     private const string CurrentEmail = "attacker@mordor.example";
 
     private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
+    private readonly AuthDbContext _db = CreateDetachedDbContext();
     private readonly IUserSessionRevoker _sessionRevoker = Substitute.For<IUserSessionRevoker>();
 
     public RevertEmailChangeHandlerTests()
@@ -143,6 +145,10 @@ public sealed class RevertEmailChangeHandlerTests
         user.PasswordHash.ShouldBeNull();
         user.SecurityStamp.ShouldNotBe(stampBefore);
 
+        // Retires every revert link issued so far, including the attacker's own further up a chain of
+        // changes. Without it their token still works and undoes this recovery.
+        user.EmailChangeRevertStamp.ShouldNotBeNull();
+
         // Revoking the OpenIddict artifacts leaves no trace in the return value, so it is asserted here.
         await _sessionRevoker.Received(1).RevokeAllAsync(user.Id.ToString(), Arg.Any<CancellationToken>());
     }
@@ -166,6 +172,29 @@ public sealed class RevertEmailChangeHandlerTests
         result.Error.Code.ShouldBe("Auth.EmailChangeFailed");
     }
 
+    [Fact]
+    public async Task Handle_AccountHasADeletionScheduled_CancelsItInsteadOfLeavingTheAccountToBeErased()
+    {
+        // Rotating the security stamp kills the ADR-0031 cancel token, and that link went to the
+        // address the account was moved to. Refusing here, or reverting without cancelling, would hand
+        // the erasure to whoever took the account over.
+        ApplicationUser user = CreateUser();
+        user.DeletionScheduledAt = new DateTimeOffset(2026, 8, 20, 12, 0, 0, TimeSpan.Zero);
+        user.LockoutEnd = new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+        user.AccessFailedCount = 4;
+        StubUser(user, tokenValid: true);
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(user.Id.ToString()), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        user.Email.ShouldBe(PreviousEmail);
+        user.DeletionScheduledAt.ShouldBeNull();
+        user.LockoutEnd.ShouldBeNull();
+        user.AccessFailedCount.ShouldBe(0);
+    }
+
     private static RevertEmailChange.Command CommandFor(string userId) =>
         new(userId, PreviousEmail, CurrentEmail, "revert-token", "203.0.113.7", "xunit");
 
@@ -186,6 +215,7 @@ public sealed class RevertEmailChangeHandlerTests
     private RevertEmailChange.Handler CreateSut() =>
         new(
             _userManager,
+            _db,
             _sessionRevoker,
             new RevertEmailChange.CommandValidator(),
             NullLogger<RevertEmailChange.Handler>.Instance);
@@ -199,6 +229,15 @@ public sealed class RevertEmailChangeHandlerTests
             PasswordHash = "hashed",
             SecurityStamp = Guid.NewGuid().ToString()
         };
+
+    /// <summary>
+    /// The handler only ever calls <c>ChangeTracker.Clear()</c> on this, which needs no connection, so
+    /// the suite stays pure: nothing here opens a socket or a file.
+    /// </summary>
+    private static AuthDbContext CreateDetachedDbContext() =>
+        new(new DbContextOptionsBuilder<AuthDbContext>()
+            .UseNpgsql("Host=unit-test;Database=none;Username=none;Password=none")
+            .Options);
 
     private static UserManager<ApplicationUser> CreateUserManager() =>
         Substitute.For<UserManager<ApplicationUser>>(

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Features/Auth/RevertEmailChangeHandlerTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Features/Auth/RevertEmailChangeHandlerTests.cs
@@ -1,0 +1,207 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using LotroKoniecDev.AuthSystem.API.Features.Auth;
+using LotroKoniecDev.AuthSystem.API.Services.Sessions;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using NSubstitute;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Features.Auth;
+
+/// <summary>
+/// The revert handler decides whether a stolen account can be taken back, so every refusal it makes is
+/// pinned here. It is the one leg of the flow with no database dependency, which keeps these pure.
+/// </summary>
+public sealed class RevertEmailChangeHandlerTests
+{
+    private const string PreviousEmail = "frodo@shire.me";
+    private const string CurrentEmail = "attacker@mordor.example";
+
+    private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
+    private readonly IUserSessionRevoker _sessionRevoker = Substitute.For<IUserSessionRevoker>();
+
+    public RevertEmailChangeHandlerTests()
+    {
+        _userManager.NormalizeEmail(Arg.Any<string?>())
+            .Returns(callInfo => callInfo.Arg<string?>()?.ToUpperInvariant());
+    }
+
+    [Fact]
+    public async Task Handle_MalformedUserId_RefusesWithoutTouchingTheStore()
+    {
+        // Identity converts the id to the key type before it queries, so a non-GUID would throw inside
+        // the store. The validator has to stop it first.
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor("not-a-guid"), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        await _userManager.DidNotReceiveWithAnyArgs().FindByIdAsync(default!);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownUser_RefusesWithTheSameErrorAsABadToken()
+    {
+        Guid userId = Guid.NewGuid();
+        _userManager.FindByIdAsync(userId.ToString()).Returns((ApplicationUser?)null);
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(userId.ToString()), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Auth.InvalidEmailChangeToken");
+    }
+
+    [Fact]
+    public async Task Handle_InvalidToken_RefusesAndLeavesTheAccountAlone()
+    {
+        ApplicationUser user = CreateUser();
+        StubUser(user, tokenValid: false);
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(user.Id.ToString()), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        user.Email.ShouldBe(CurrentEmail);
+        user.PasswordHash.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_AccountAlreadyBackOnThePreviousAddress_RefusesSoASecondClickDoesNothing()
+    {
+        // The token carries no security stamp, so this check is what stops a replay from clearing a
+        // password the owner has already reset.
+        ApplicationUser user = CreateUser();
+        user.Email = PreviousEmail;
+        StubUser(user, tokenValid: true);
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(user.Id.ToString()), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        user.PasswordHash.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_AccountMovedOnAgain_StillRevertsToThePreviousAddress()
+    {
+        // The takeover this guard exists for: the attacker changes the address twice, so the account no
+        // longer sits where the token was issued against. The link still has to work.
+        ApplicationUser user = CreateUser();
+        user.Email = "third@example.com";
+        StubUser(user, tokenValid: true);
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(user.Id.ToString()), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        user.Email.ShouldBe(PreviousEmail);
+        user.PasswordHash.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_PreviousAddressTakenByAnotherAccount_RefusesAndKeepsThePassword()
+    {
+        // There is nowhere to go back to. Clearing the password anyway would lock the account out of
+        // both addresses at once.
+        ApplicationUser user = CreateUser();
+        StubUser(user, tokenValid: true);
+        _userManager.FindByEmailAsync(PreviousEmail).Returns(CreateUser());
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(user.Id.ToString()), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Auth.UserAlreadyExistsByEmail");
+        user.Email.ShouldBe(CurrentEmail);
+        user.PasswordHash.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ValidToken_RestoresTheAddressConfirmsItAndEndsEverySession()
+    {
+        ApplicationUser user = CreateUser();
+        StubUser(user, tokenValid: true);
+        string stampBefore = user.SecurityStamp!;
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(user.Id.ToString()), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.RestoredEmail.ShouldBe(PreviousEmail);
+        user.Email.ShouldBe(PreviousEmail);
+        user.EmailConfirmed.ShouldBeTrue();
+        user.PasswordHash.ShouldBeNull();
+        user.SecurityStamp.ShouldNotBe(stampBefore);
+
+        // Revoking the OpenIddict artifacts leaves no trace in the return value, so it is asserted here.
+        await _sessionRevoker.Received(1).RevokeAllAsync(user.Id.ToString(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PersistenceRefusesTheUpdate_ReportsFailure()
+    {
+        ApplicationUser user = CreateUser();
+        StubUser(user, tokenValid: true);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Failed(new IdentityError
+        {
+            Code = "ConcurrencyFailure",
+            Description = "Optimistic concurrency failure."
+        }));
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(user.Id.ToString()), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.Code.ShouldBe("Auth.EmailChangeFailed");
+    }
+
+    private static RevertEmailChange.Command CommandFor(string userId) =>
+        new(userId, PreviousEmail, CurrentEmail, "revert-token", "203.0.113.7", "xunit");
+
+    private void StubUser(ApplicationUser user, bool tokenValid)
+    {
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.FindByEmailAsync(PreviousEmail).Returns((ApplicationUser?)null);
+        _userManager.VerifyUserTokenAsync(
+                user,
+                EmailChangeRevertTokenProvider.ProviderName,
+                EmailChangeRevertTokenProvider.PurposeFor(PreviousEmail, CurrentEmail),
+                Arg.Any<string>())
+            .Returns(tokenValid);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        _userManager.GeneratePasswordResetTokenAsync(user).Returns("reset-token");
+    }
+
+    private RevertEmailChange.Handler CreateSut() =>
+        new(
+            _userManager,
+            _sessionRevoker,
+            new RevertEmailChange.CommandValidator(),
+            NullLogger<RevertEmailChange.Handler>.Instance);
+
+    private static ApplicationUser CreateUser() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserName = "frodo",
+            Email = CurrentEmail,
+            PasswordHash = "hashed",
+            SecurityStamp = Guid.NewGuid().ToString()
+        };
+
+    private static UserManager<ApplicationUser> CreateUserManager() =>
+        Substitute.For<UserManager<ApplicationUser>>(
+            Substitute.For<IUserStore<ApplicationUser>>(),
+            null!, null!, null!, null!, null!, null!, null!, null!);
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Features/Auth/RevertEmailChangeHandlerTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Features/Auth/RevertEmailChangeHandlerTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using LotroKoniecDev.AuthSystem.API.Features.Auth;
+using LotroKoniecDev.AuthSystem.API.Outbox;
 using LotroKoniecDev.AuthSystem.API.Services.Sessions;
 using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
 using LotroKoniecDev.AuthSystem.Persistence.DbContexts;
@@ -74,7 +75,44 @@ public sealed class RevertEmailChangeHandlerTests
     }
 
     [Fact]
-    public async Task Handle_AccountAlreadyBackOnThePreviousAddress_RefusesSoASecondClickDoesNothing()
+    public async Task Handle_NothingArmed_RefusesEvenWithAValidToken()
+    {
+        // A revert may only put the account where an earlier change armed it. With nothing armed there
+        // is no target, and a token alone must not be able to invent one.
+        ApplicationUser user = CreateUser();
+        user.EmailChangeRevertTo = null;
+        StubUser(user, tokenValid: true);
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(user.Id.ToString()), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        user.Email.ShouldBe(CurrentEmail);
+        user.PasswordHash.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_LinkNamesADifferentAddressThanTheArmedOne_RestoresTheArmedOne()
+    {
+        // The link says where it came from; the row says where the account may go. If a token could
+        // choose the destination, a second change in a chain would become an undo target of its own.
+        ApplicationUser user = CreateUser();
+        user.EmailChangeRevertTo = "chain-start@shire.me";
+        StubUser(user, tokenValid: true);
+        _userManager.FindByEmailAsync("chain-start@shire.me").Returns((ApplicationUser?)null);
+        RevertEmailChange.Handler sut = CreateSut();
+
+        SharedKernel.Monads.Result<RevertEmailChange.RevertedEmailChange> result = await sut.Handle(
+            CommandFor(user.Id.ToString()), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        user.Email.ShouldBe("chain-start@shire.me");
+        result.Value.RestoredEmail.ShouldBe("chain-start@shire.me");
+    }
+
+    [Fact]
+    public async Task Handle_AccountAlreadyBackOnTheArmedAddress_RefusesSoASecondClickDoesNothing()
     {
         // The token carries no security stamp, so this check is what stops a replay from clearing a
         // password the owner has already reset.
@@ -145,9 +183,10 @@ public sealed class RevertEmailChangeHandlerTests
         user.PasswordHash.ShouldBeNull();
         user.SecurityStamp.ShouldNotBe(stampBefore);
 
-        // Retires every revert link issued so far, including the attacker's own further up a chain of
-        // changes. Without it their token still works and undoes this recovery.
+        // Retires every link issued so far and disarms the chain, so the next change starts a fresh
+        // one from here.
         user.EmailChangeRevertStamp.ShouldNotBeNull();
+        user.EmailChangeRevertTo.ShouldBeNull();
 
         // Revoking the OpenIddict artifacts leaves no trace in the return value, so it is asserted here.
         await _sessionRevoker.Received(1).RevokeAllAsync(user.Id.ToString(), Arg.Any<CancellationToken>());
@@ -193,6 +232,11 @@ public sealed class RevertEmailChangeHandlerTests
         user.DeletionScheduledAt.ShouldBeNull();
         user.LockoutEnd.ShouldBeNull();
         user.AccessFailedCount.ShouldBe(0);
+
+        // ADR-0031 wants every cancellation announced, and the notice has to ride the same save.
+        _db.ChangeTracker.Entries<Persistence.Outbox.OutboxMessage>()
+            .Count(entry => entry.Entity.Type == nameof(AccountDeletionCancelled))
+            .ShouldBe(1);
     }
 
     private static RevertEmailChange.Command CommandFor(string userId) =>
@@ -216,6 +260,7 @@ public sealed class RevertEmailChangeHandlerTests
         new(
             _userManager,
             _db,
+            new OutboxWriter(_db, new OutboxSignal(), TimeProvider.System),
             _sessionRevoker,
             new RevertEmailChange.CommandValidator(),
             NullLogger<RevertEmailChange.Handler>.Instance);
@@ -227,7 +272,8 @@ public sealed class RevertEmailChangeHandlerTests
             UserName = "frodo",
             Email = CurrentEmail,
             PasswordHash = "hashed",
-            SecurityStamp = Guid.NewGuid().ToString()
+            SecurityStamp = Guid.NewGuid().ToString(),
+            EmailChangeRevertTo = PreviousEmail
         };
 
     /// <summary>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Identity/EmailChangeRevertTokenProviderTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Identity/EmailChangeRevertTokenProviderTests.cs
@@ -51,6 +51,38 @@ public sealed class EmailChangeRevertTokenProviderTests
     }
 
     [Fact]
+    public async Task ValidateAsync_RevertStampRotatedAfterIssuing_Refuses()
+    {
+        // The counter-takeover this field exists for. Every revert token is a bearer credential to move
+        // the account to its previous address, and after a chain of changes the attacker holds one too.
+        // A successful revert rotates the stamp, which has to retire theirs along with the one just
+        // used.
+        ApplicationUser user = CreateUser();
+        EmailChangeRevertTokenProvider sut = CreateSut(Now);
+        string token = await sut.GenerateAsync(Purpose, _userManager, user);
+
+        user.EmailChangeRevertStamp = Guid.NewGuid();
+        bool valid = await sut.ValidateAsync(Purpose, token, _userManager, user);
+
+        valid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_TokenIssuedAfterAnEarlierRevert_StillAccepts()
+    {
+        // Rotating retires the old tokens, it does not disable the feature: the next change mints a
+        // token against the new stamp and that one has to work.
+        ApplicationUser user = CreateUser();
+        user.EmailChangeRevertStamp = Guid.NewGuid();
+        EmailChangeRevertTokenProvider sut = CreateSut(Now);
+
+        string token = await sut.GenerateAsync(Purpose, _userManager, user);
+        bool valid = await sut.ValidateAsync(Purpose, token, _userManager, user);
+
+        valid.ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task ValidateAsync_TokenOlderThanTheWindow_Refuses()
     {
         ApplicationUser user = CreateUser();

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Identity/EmailChangeRevertTokenProviderTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Identity/EmailChangeRevertTokenProviderTests.cs
@@ -64,7 +64,7 @@ public sealed class EmailChangeRevertTokenProviderTests
     }
 
     [Fact]
-    public async Task ValidateAsync_OnTheLastDayOfTheWindow_Accepts()
+    public async Task ValidateAsync_OneMinuteBeforeExpiry_Accepts()
     {
         ApplicationUser user = CreateUser();
         EmailChangeRevertTokenProvider issuer = CreateSut(Now);

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Identity/EmailChangeRevertTokenProviderTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Identity/EmailChangeRevertTokenProviderTests.cs
@@ -1,0 +1,193 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using NSubstitute;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Identity;
+
+/// <summary>
+/// The revert token is the only thing standing between a stolen password and a permanently lost
+/// account (ADR-0048), so its rules are pinned here rather than left to the page that uses it.
+/// </summary>
+public sealed class EmailChangeRevertTokenProviderTests
+{
+    private const string PreviousEmail = "frodo@shire.me";
+    private const string NewEmail = "attacker@mordor.example";
+
+    private static readonly DateTimeOffset Now = new(2026, 8, 20, 12, 0, 0, TimeSpan.Zero);
+    private static readonly string Purpose = EmailChangeRevertTokenProvider.PurposeFor(PreviousEmail, NewEmail);
+
+    private readonly IDataProtectionProvider _dataProtectionProvider = new EphemeralDataProtectionProvider();
+    private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
+
+    [Fact]
+    public async Task ValidateAsync_TokenItJustIssued_Accepts()
+    {
+        ApplicationUser user = CreateUser();
+        EmailChangeRevertTokenProvider sut = CreateSut(Now);
+
+        string token = await sut.GenerateAsync(Purpose, _userManager, user);
+        bool valid = await sut.ValidateAsync(Purpose, token, _userManager, user);
+
+        valid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_SecurityStampChangedAfterIssuing_StillAccepts()
+    {
+        // This assertion IS ADR-0048. Changing the password rotates the security stamp, and that is the
+        // first thing whoever took the account over will do. A stamp-bound token, which is what every
+        // other token in this system uses, would be dead here — and the owner would have no way back.
+        ApplicationUser user = CreateUser();
+        EmailChangeRevertTokenProvider sut = CreateSut(Now);
+        string token = await sut.GenerateAsync(Purpose, _userManager, user);
+
+        user.SecurityStamp = Guid.NewGuid().ToString();
+        bool valid = await sut.ValidateAsync(Purpose, token, _userManager, user);
+
+        valid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_TokenOlderThanTheWindow_Refuses()
+    {
+        ApplicationUser user = CreateUser();
+        EmailChangeRevertTokenProvider issuer = CreateSut(Now);
+        string token = await issuer.GenerateAsync(Purpose, _userManager, user);
+
+        EmailChangeRevertTokenProvider later = CreateSut(Now + TimeSpan.FromDays(14) + TimeSpan.FromMinutes(1));
+        bool valid = await later.ValidateAsync(Purpose, token, _userManager, user);
+
+        valid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_OnTheLastDayOfTheWindow_Accepts()
+    {
+        ApplicationUser user = CreateUser();
+        EmailChangeRevertTokenProvider issuer = CreateSut(Now);
+        string token = await issuer.GenerateAsync(Purpose, _userManager, user);
+
+        EmailChangeRevertTokenProvider later = CreateSut(Now + TimeSpan.FromDays(14) - TimeSpan.FromMinutes(1));
+        bool valid = await later.ValidateAsync(Purpose, token, _userManager, user);
+
+        valid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_PurposeNamesADifferentTargetAddress_Refuses()
+    {
+        // The addresses travel in the link's query string, so editing either of them has to fail.
+        ApplicationUser user = CreateUser();
+        EmailChangeRevertTokenProvider sut = CreateSut(Now);
+        string token = await sut.GenerateAsync(Purpose, _userManager, user);
+
+        bool valid = await sut.ValidateAsync(
+            EmailChangeRevertTokenProvider.PurposeFor(PreviousEmail, "somebody-else@example.com"),
+            token,
+            _userManager,
+            user);
+
+        valid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_PurposeNamesADifferentPreviousAddress_Refuses()
+    {
+        ApplicationUser user = CreateUser();
+        EmailChangeRevertTokenProvider sut = CreateSut(Now);
+        string token = await sut.GenerateAsync(Purpose, _userManager, user);
+
+        bool valid = await sut.ValidateAsync(
+            EmailChangeRevertTokenProvider.PurposeFor("someone@example.com", NewEmail),
+            token,
+            _userManager,
+            user);
+
+        valid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_TokenIssuedForAnotherUser_Refuses()
+    {
+        EmailChangeRevertTokenProvider sut = CreateSut(Now);
+        string token = await sut.GenerateAsync(Purpose, _userManager, CreateUser());
+
+        bool valid = await sut.ValidateAsync(Purpose, token, _userManager, CreateUser());
+
+        valid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_TokenProtectedByAnotherKeyRing_Refuses()
+    {
+        // What a lost data-protection keyring looks like from here. It has to read as "no token", not
+        // as a crash on a page a person reached from their inbox.
+        ApplicationUser user = CreateUser();
+        string token = await CreateSut(Now).GenerateAsync(Purpose, _userManager, user);
+
+        EmailChangeRevertTokenProvider otherDeployment = new(
+            new EphemeralDataProtectionProvider(),
+            CreateTimeProvider(Now),
+            Microsoft.Extensions.Options.Options.Create(new EmailChangeRevertTokenProviderOptions()));
+
+        bool valid = await otherDeployment.ValidateAsync(Purpose, token, _userManager, user);
+
+        valid.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-base64-at-all!!")]
+    [InlineData("Zm9vYmFy")]
+    public async Task ValidateAsync_MalformedToken_Refuses(string token)
+    {
+        EmailChangeRevertTokenProvider sut = CreateSut(Now);
+
+        bool valid = await sut.ValidateAsync(Purpose, token, _userManager, CreateUser());
+
+        valid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CanGenerateTwoFactorTokenAsync_Always_SaysNo()
+    {
+        // It backs an e-mailed link and nothing else. Offering it as a login step would turn a
+        // 14-day recovery token into a second factor.
+        EmailChangeRevertTokenProvider sut = CreateSut(Now);
+
+        bool canGenerate = await sut.CanGenerateTwoFactorTokenAsync(_userManager, CreateUser());
+
+        canGenerate.ShouldBeFalse();
+    }
+
+    private EmailChangeRevertTokenProvider CreateSut(DateTimeOffset now) =>
+        new(
+            _dataProtectionProvider,
+            CreateTimeProvider(now),
+            Microsoft.Extensions.Options.Options.Create(new EmailChangeRevertTokenProviderOptions()));
+
+    private static ApplicationUser CreateUser() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserName = "frodo",
+            Email = NewEmail,
+            SecurityStamp = Guid.NewGuid().ToString()
+        };
+
+    private static TimeProvider CreateTimeProvider(DateTimeOffset now)
+    {
+        TimeProvider timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(now);
+        return timeProvider;
+    }
+
+    private static UserManager<ApplicationUser> CreateUserManager() =>
+        Substitute.For<UserManager<ApplicationUser>>(
+            Substitute.For<IUserStore<ApplicationUser>>(),
+            null!, null!, null!, null!, null!, null!, null!, null!);
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxMessageRoutingTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Outbox/OutboxMessageRoutingTests.cs
@@ -45,6 +45,46 @@ public sealed class OutboxMessageRoutingTests
         routingKey.ShouldBe(RabbitMqTopology.DeletionCancelledRoutingKey);
     }
 
+    [Fact]
+    public void TryGetRoutingKey_EmailChangeRequested_MapsToChangeRequestedRoutingKey()
+    {
+        bool found = OutboxMessageRouting.TryGetRoutingKey(
+            nameof(EmailChangeRequested), out string? routingKey);
+
+        found.ShouldBeTrue();
+        routingKey.ShouldBe(RabbitMqTopology.EmailChangeRequestedRoutingKey);
+    }
+
+    [Fact]
+    public void TryGetRoutingKey_EmailChangeCompleted_MapsToChangeCompletedRoutingKey()
+    {
+        bool found = OutboxMessageRouting.TryGetRoutingKey(
+            nameof(EmailChangeCompleted), out string? routingKey);
+
+        found.ShouldBeTrue();
+        routingKey.ShouldBe(RabbitMqTopology.EmailChangeCompletedRoutingKey);
+    }
+
+    [Fact]
+    public void EveryRoutingKey_MatchesTheQueueBindingPattern()
+    {
+        // The queue binds "email.#", so a key that does not start with "email." would publish into a
+        // topic exchange with nothing bound to it — and a topic exchange drops those without a word.
+        string[] routingKeys =
+        [
+            RabbitMqTopology.EmailConfirmationRoutingKey,
+            RabbitMqTopology.PasswordResetRoutingKey,
+            RabbitMqTopology.DeletionScheduledRoutingKey,
+            RabbitMqTopology.DeletionCancelledRoutingKey,
+            RabbitMqTopology.EmailChangeRequestedRoutingKey,
+            RabbitMqTopology.EmailChangeCompletedRoutingKey
+        ];
+
+        string bindingPrefix = RabbitMqTopology.EmailBindingPattern.TrimEnd('#');
+
+        routingKeys.ShouldAllBe(routingKey => routingKey.StartsWith(bindingPrefix, StringComparison.Ordinal));
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("emailconfirmationrequested")]
@@ -55,6 +95,10 @@ public sealed class OutboxMessageRoutingTests
     [InlineData("email.deletion-scheduled")]
     [InlineData("accountdeletioncancelled")]
     [InlineData("email.deletion-cancelled")]
+    [InlineData("emailchangerequested")]
+    [InlineData("email.change-requested")]
+    [InlineData("emailchangecompleted")]
+    [InlineData("email.change-completed")]
     [InlineData("SomeFutureUnmappedEvent")]
     public void TryGetRoutingKey_UnknownOrMiscasedType_ReturnsFalse(string type)
     {

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Pages/Account/EmailLinkValueTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Pages/Account/EmailLinkValueTests.cs
@@ -1,0 +1,74 @@
+using LotroKoniecDev.AuthSystem.API.Pages.Account;
+using LotroKoniecDev.SharedKernel.Constants;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Pages.Account;
+
+/// <summary>
+/// The shape check the two e-mail-change pages run before they print a link's value or act on it. It
+/// keeps arbitrary text off a branded page that carries a password-clearing button, and it is what
+/// stops a malformed address reaching code that assumes one.
+/// </summary>
+public sealed class EmailLinkValueTests
+{
+    [Theory]
+    [InlineData("frodo@shire.me")]
+    [InlineData("frodo.baggins@shire.me")]
+    [InlineData("frodo+bag@shire.me")]
+    [InlineData("frodo_b@sub.shire.co.uk")]
+    [InlineData("f@x.pl")]
+    public void LooksLikeAnAddress_RealAddress_Accepts(string value)
+    {
+        EmailLinkValue.LooksLikeAnAddress(value).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-an-address")]
+    [InlineData("no@tld")]
+    [InlineData("two@@at.pl")]
+    [InlineData("spaces in@address.pl")]
+    [InlineData("trailing@space.pl ")]
+    [InlineData("<script>alert(1)</script>@x.pl")]
+    [InlineData("Twoje konto zostało przejęte — kliknij tutaj")]
+    public void LooksLikeAnAddress_AnythingElse_Refuses(string? value)
+    {
+        EmailLinkValue.LooksLikeAnAddress(value).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LooksLikeAnAddress_AtTheLengthCeiling_Accepts()
+    {
+        string local = new('a', EmailConstants.MaxLength - "@shire.me".Length);
+        string value = $"{local}@shire.me";
+
+        value.Length.ShouldBe(EmailConstants.MaxLength);
+        EmailLinkValue.LooksLikeAnAddress(value).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LooksLikeAnAddress_OneCharacterOverTheCeiling_Refuses()
+    {
+        // The length check runs before the regex on purpose, so an over-long value never reaches it.
+        string local = new('a', EmailConstants.MaxLength - "@shire.me".Length + 1);
+        string value = $"{local}@shire.me";
+
+        value.Length.ShouldBe(EmailConstants.MaxLength + 1);
+        EmailLinkValue.LooksLikeAnAddress(value).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    [InlineData("a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-a-")]
+    [InlineData("a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.")]
+    public void LooksLikeAnAddress_HostileInputThatNeverMatches_ReturnsQuicklyInsteadOfHanging(string seed)
+    {
+        // The classic backtracking bait for an address pattern: a long run that almost matches and then
+        // fails. It has to answer, not spin.
+        string value = string.Concat(Enumerable.Repeat(seed, 5))[..EmailConstants.MaxLength];
+
+        EmailLinkValue.LooksLikeAnAddress(value).ShouldBeFalse();
+    }
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailChangeCompletedProcessorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailChangeCompletedProcessorTests.cs
@@ -1,0 +1,182 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+using NSubstitute;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Services.Emails;
+
+public sealed class EmailChangeCompletedProcessorTests
+{
+    private const string PreviousEmail = "frodo@shire.me";
+    private const string NewEmail = "frodo@rivendell.example";
+
+    private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
+    private readonly IEmailChangeEmailSender _emailSender = Substitute.For<IEmailChangeEmailSender>();
+
+    [Fact]
+    public async Task ProcessAsync_UserNoLongerExists_SucceedsWithoutSending()
+    {
+        Guid userId = Guid.NewGuid();
+        _userManager.FindByIdAsync(userId.ToString()).Returns((ApplicationUser?)null);
+        EmailChangeCompletedProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeCompleted(userId, PreviousEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendChangedNoticeWithRevertAsync(default, default!, default!, default!, default, default);
+        await _emailSender.DidNotReceiveWithAnyArgs().SendChangedNoticeAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ChangeCompleted_SendsTheRevertOfferToThePreviousAddressAndANoticeToTheNewOne()
+    {
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GenerateUserTokenAsync(
+                user,
+                EmailChangeRevertTokenProvider.ProviderName,
+                EmailChangeRevertTokenProvider.PurposeFor(PreviousEmail, NewEmail))
+            .Returns("fresh-revert-token");
+        _emailSender.SendChangedNoticeWithRevertAsync(
+                user.Id, PreviousEmail, NewEmail, "fresh-revert-token", TimeSpan.FromDays(14), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _emailSender.SendChangedNoticeAsync(user.Id, NewEmail, PreviousEmail, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        EmailChangeCompletedProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeCompleted(user.Id, PreviousEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.Received(1).SendChangedNoticeWithRevertAsync(
+            user.Id, PreviousEmail, NewEmail, "fresh-revert-token", TimeSpan.FromDays(14), Arg.Any<CancellationToken>());
+        await _emailSender.Received(1)
+            .SendChangedNoticeAsync(user.Id, NewEmail, PreviousEmail, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RevertOfferFails_AsksForARetryAndDoesNotSendTheOtherNotice()
+    {
+        // The revert offer goes first on purpose. It is the one message that can still undo a takeover,
+        // so if only one of the two ever gets through it has to be that one.
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        Error smtpError = new("Email.SendFailed", "SMTP relay refused the message.");
+        _emailSender.SendChangedNoticeWithRevertAsync(
+                user.Id, PreviousEmail, NewEmail, Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(smtpError));
+        EmailChangeCompletedProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeCompleted(user.Id, PreviousEmail, NewEmail), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(smtpError);
+        await _emailSender.DidNotReceiveWithAnyArgs().SendChangedNoticeAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NoticeToTheNewAddressFails_AsksForARetry()
+    {
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        Error smtpError = new("Email.SendFailed", "SMTP relay refused the message.");
+        _emailSender.SendChangedNoticeWithRevertAsync(
+                user.Id, PreviousEmail, NewEmail, Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _emailSender.SendChangedNoticeAsync(user.Id, NewEmail, PreviousEmail, Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(smtpError));
+        EmailChangeCompletedProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeCompleted(user.Id, PreviousEmail, NewEmail), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(smtpError);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RunTwice_BuildsTheRevertTokenFromThePayloadBothTimes()
+    {
+        // The previous address is gone from the user row by now, so a processor that read it from
+        // there would build a different purpose on a redelivery and hand out a link that cannot work.
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _emailSender.SendChangedNoticeWithRevertAsync(
+                user.Id, PreviousEmail, NewEmail, Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _emailSender.SendChangedNoticeAsync(user.Id, NewEmail, PreviousEmail, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        EmailChangeCompletedProcessor sut = CreateSut();
+        EmailChangeCompleted message = new(user.Id, PreviousEmail, NewEmail);
+
+        Result first = await sut.ProcessAsync(message, CancellationToken.None);
+        Result second = await sut.ProcessAsync(message, CancellationToken.None);
+
+        first.IsSuccess.ShouldBeTrue();
+        second.IsSuccess.ShouldBeTrue();
+        await _userManager.Received(2).GenerateUserTokenAsync(
+            user,
+            EmailChangeRevertTokenProvider.ProviderName,
+            EmailChangeRevertTokenProvider.PurposeFor(PreviousEmail, NewEmail));
+    }
+
+    [Theory]
+    [InlineData("this is not json at all")]
+    [InlineData("{}")]
+    [InlineData("""{"IdentityUserId":"not-a-guid"}""")]
+    [InlineData("""{"IdentityUserId":"0195f0f6-0000-7000-8000-000000000000","PreviousEmail":"","NewEmail":"a@b.pl"}""")]
+    [InlineData("""{"IdentityUserId":"0195f0f6-0000-7000-8000-000000000000","PreviousEmail":"a@b.pl","NewEmail":"  "}""")]
+    public void TryDeserialize_PoisonPayload_ReturnsTheNullVerdict(string poisonPayload)
+    {
+        EmailChangeCompletedProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(System.Text.Encoding.UTF8.GetBytes(poisonPayload));
+
+        message.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_ValidPayload_ReturnsTheTypedMessage()
+    {
+        Guid userId = Guid.CreateVersion7();
+        EmailChangeCompletedProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(
+            System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(
+                new EmailChangeCompleted(userId, PreviousEmail, NewEmail)));
+
+        EmailChangeCompleted typed = message.ShouldBeOfType<EmailChangeCompleted>();
+        typed.IdentityUserId.ShouldBe(userId);
+        typed.PreviousEmail.ShouldBe(PreviousEmail);
+        typed.NewEmail.ShouldBe(NewEmail);
+    }
+
+    private static ApplicationUser CreateUser() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserName = "frodo",
+            Email = NewEmail
+        };
+
+    private EmailChangeCompletedProcessor CreateSut() =>
+        new(
+            _userManager,
+            _emailSender,
+            Microsoft.Extensions.Options.Options.Create(new EmailChangeRevertTokenProviderOptions()),
+            NullLogger<EmailChangeCompletedProcessor>.Instance);
+
+    private static UserManager<ApplicationUser> CreateUserManager() =>
+        Substitute.For<UserManager<ApplicationUser>>(
+            Substitute.For<IUserStore<ApplicationUser>>(),
+            null!, null!, null!, null!, null!, null!, null!, null!);
+}

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailChangeCompletedProcessorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailChangeCompletedProcessorTests.cs
@@ -19,6 +19,14 @@ public sealed class EmailChangeCompletedProcessorTests
     private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
     private readonly IEmailChangeEmailSender _emailSender = Substitute.For<IEmailChangeEmailSender>();
 
+    public EmailChangeCompletedProcessorTests()
+    {
+        // Without this the substitute answers null on both sides of every address comparison, and
+        // string.Equals(null, null) is true — so the arming check would silently pass in every test.
+        _userManager.NormalizeEmail(Arg.Any<string?>())
+            .Returns(callInfo => callInfo.Arg<string?>()?.ToUpperInvariant());
+    }
+
     [Fact]
     public async Task ProcessAsync_UserNoLongerExists_SucceedsWithoutSending()
     {
@@ -129,6 +137,67 @@ public sealed class EmailChangeCompletedProcessorTests
             EmailChangeRevertTokenProvider.PurposeFor(PreviousEmail, NewEmail));
     }
 
+    [Fact]
+    public async Task ProcessAsync_AnEarlierChangeAlreadyArmedTheUndo_SendsTheNoticeWithoutALink()
+    {
+        // The second hop of A -> B -> C. The armed target is still A, so this message must hand B
+        // nothing: B is whoever took the account over, and a link there undoes the owner's recovery.
+        ApplicationUser user = CreateUser();
+        user.EmailChangeRevertTo = "someone-else@shire.me";
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _emailSender.SendChangedNoticeAsync(user.Id, NewEmail, PreviousEmail, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        EmailChangeCompletedProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeCompleted(user.Id, PreviousEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendChangedNoticeWithRevertAsync(default, default!, default!, default!, default, default);
+        await _emailSender.Received(1)
+            .SendChangedNoticeAsync(user.Id, NewEmail, PreviousEmail, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NothingArmedAtAll_SendsTheNoticeWithoutALink()
+    {
+        ApplicationUser user = CreateUser();
+        user.EmailChangeRevertTo = null;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _emailSender.SendChangedNoticeAsync(user.Id, NewEmail, PreviousEmail, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        EmailChangeCompletedProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeCompleted(user.Id, PreviousEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendChangedNoticeWithRevertAsync(default, default!, default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ArmedTargetDiffersOnlyByCase_StillSendsTheLink()
+    {
+        ApplicationUser user = CreateUser();
+        user.EmailChangeRevertTo = PreviousEmail.ToUpperInvariant();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _emailSender.SendChangedNoticeWithRevertAsync(
+                user.Id, PreviousEmail, NewEmail, Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _emailSender.SendChangedNoticeAsync(user.Id, NewEmail, PreviousEmail, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        EmailChangeCompletedProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeCompleted(user.Id, PreviousEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.Received(1).SendChangedNoticeWithRevertAsync(
+            user.Id, PreviousEmail, NewEmail, Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
     [Theory]
     [InlineData("this is not json at all")]
     [InlineData("{}")]
@@ -165,7 +234,8 @@ public sealed class EmailChangeCompletedProcessorTests
         {
             Id = Guid.NewGuid(),
             UserName = "frodo",
-            Email = NewEmail
+            Email = NewEmail,
+            EmailChangeRevertTo = PreviousEmail
         };
 
     private EmailChangeCompletedProcessor CreateSut() =>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailChangeRequestProcessorTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Services/Emails/EmailChangeRequestProcessorTests.cs
@@ -1,0 +1,214 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using LotroKoniecDev.AuthSystem.API.Outbox;
+using LotroKoniecDev.AuthSystem.API.Services.Emails;
+using LotroKoniecDev.AuthSystem.Domain.Aggregates.ApplicationUsers.Entities;
+using LotroKoniecDev.AuthSystem.Persistence.Identity;
+using LotroKoniecDev.SharedKernel.BuildingBlocks;
+using LotroKoniecDev.SharedKernel.Monads;
+using NSubstitute;
+using Shouldly;
+
+namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Services.Emails;
+
+public sealed class EmailChangeRequestProcessorTests
+{
+    private const string CurrentEmail = "frodo@shire.me";
+    private const string NewEmail = "frodo@rivendell.example";
+
+    private readonly UserManager<ApplicationUser> _userManager = CreateUserManager();
+    private readonly IEmailChangeEmailSender _emailSender = Substitute.For<IEmailChangeEmailSender>();
+
+    public EmailChangeRequestProcessorTests()
+    {
+        _userManager.NormalizeEmail(Arg.Any<string?>())
+            .Returns(callInfo => callInfo.Arg<string?>()?.ToUpperInvariant());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_UserNoLongerExists_SucceedsWithoutSending()
+    {
+        Guid userId = Guid.NewGuid();
+        _userManager.FindByIdAsync(userId.ToString()).Returns((ApplicationUser?)null);
+        EmailChangeRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeRequested(userId, CurrentEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs().SendVerificationAsync(default, default!, default!, default);
+        await _emailSender.DidNotReceiveWithAnyArgs().SendChangeRequestedWarningAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_AddressAlreadyMovedOn_SendsNothing()
+    {
+        // A late or replayed delivery. Without this check the warning would be addressed to
+        // user.Email, which by now is the address the request was aiming at — so the "somebody wants
+        // to move your account" e-mail would land in the mailbox that asked for the move.
+        ApplicationUser user = CreateUser();
+        user.Email = NewEmail;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        EmailChangeRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeRequested(user.Id, CurrentEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs().SendVerificationAsync(default, default!, default!, default);
+        await _emailSender.DidNotReceiveWithAnyArgs().SendChangeRequestedWarningAsync(default, default!, default!, default);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ProcessAsync_UserHasNoEmailAddress_SucceedsWithoutSending(string? email)
+    {
+        ApplicationUser user = CreateUser();
+        user.Email = email;
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        EmailChangeRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeRequested(user.Id, CurrentEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.DidNotReceiveWithAnyArgs().SendVerificationAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_OpenRequest_SendsTheLinkToTheNewAddressAndTheWarningToTheOldOne()
+    {
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GenerateUserTokenAsync(
+                user,
+                EmailChangeTokenProvider.ProviderName,
+                EmailChangeTokenProvider.PurposeFor(NewEmail))
+            .Returns("fresh-change-token");
+        _emailSender.SendVerificationAsync(user.Id, NewEmail, "fresh-change-token", Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _emailSender.SendChangeRequestedWarningAsync(user.Id, CurrentEmail, NewEmail, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        EmailChangeRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeRequested(user.Id, CurrentEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.Received(1)
+            .SendVerificationAsync(user.Id, NewEmail, "fresh-change-token", Arg.Any<CancellationToken>());
+        await _emailSender.Received(1)
+            .SendChangeRequestedWarningAsync(user.Id, CurrentEmail, NewEmail, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_CurrentAddressDiffersOnlyByCase_StillTreatsTheRequestAsOpen()
+    {
+        ApplicationUser user = CreateUser();
+        user.Email = "Frodo@Shire.ME";
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _emailSender.SendVerificationAsync(user.Id, NewEmail, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _emailSender.SendChangeRequestedWarningAsync(
+                user.Id, CurrentEmail, NewEmail, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        EmailChangeRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeRequested(user.Id, CurrentEmail, NewEmail), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _emailSender.Received(1)
+            .SendVerificationAsync(user.Id, NewEmail, Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_VerificationSendFails_PropagatesTheFailureAndSkipsTheWarning()
+    {
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        Error smtpError = new("Email.SendFailed", "SMTP relay refused the message.");
+        _emailSender.SendVerificationAsync(user.Id, NewEmail, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(smtpError));
+        EmailChangeRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeRequested(user.Id, CurrentEmail, NewEmail), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(smtpError);
+        await _emailSender.DidNotReceiveWithAnyArgs()
+            .SendChangeRequestedWarningAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WarningSendFails_AsksForARetry()
+    {
+        // The warning is the message this flow cannot afford to lose, so a failure on it has to keep
+        // the message on the queue even though the verification link already went out.
+        ApplicationUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        Error smtpError = new("Email.SendFailed", "SMTP relay refused the message.");
+        _emailSender.SendVerificationAsync(user.Id, NewEmail, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _emailSender.SendChangeRequestedWarningAsync(
+                user.Id, CurrentEmail, NewEmail, Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(smtpError));
+        EmailChangeRequestProcessor sut = CreateSut();
+
+        Result result = await sut.ProcessAsync(
+            new EmailChangeRequested(user.Id, CurrentEmail, NewEmail), CancellationToken.None);
+
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(smtpError);
+    }
+
+    [Theory]
+    [InlineData("this is not json at all")]
+    [InlineData("{}")]
+    [InlineData("""{"IdentityUserId":"not-a-guid"}""")]
+    [InlineData("""{"IdentityUserId":"0195f0f6-0000-7000-8000-000000000000","CurrentEmail":"","NewEmail":"a@b.pl"}""")]
+    [InlineData("""{"IdentityUserId":"0195f0f6-0000-7000-8000-000000000000","CurrentEmail":"a@b.pl","NewEmail":"  "}""")]
+    public void TryDeserialize_PoisonPayload_ReturnsTheNullVerdict(string poisonPayload)
+    {
+        EmailChangeRequestProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(System.Text.Encoding.UTF8.GetBytes(poisonPayload));
+
+        message.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_ValidPayload_ReturnsTheTypedMessage()
+    {
+        Guid userId = Guid.CreateVersion7();
+        EmailChangeRequestProcessor sut = CreateSut();
+
+        object? message = sut.TryDeserialize(
+            System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(
+                new EmailChangeRequested(userId, CurrentEmail, NewEmail)));
+
+        EmailChangeRequested typed = message.ShouldBeOfType<EmailChangeRequested>();
+        typed.IdentityUserId.ShouldBe(userId);
+        typed.CurrentEmail.ShouldBe(CurrentEmail);
+        typed.NewEmail.ShouldBe(NewEmail);
+    }
+
+    private static ApplicationUser CreateUser() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserName = "frodo",
+            Email = CurrentEmail
+        };
+
+    private EmailChangeRequestProcessor CreateSut() =>
+        new(_userManager, _emailSender, NullLogger<EmailChangeRequestProcessor>.Instance);
+
+    private static UserManager<ApplicationUser> CreateUserManager() =>
+        Substitute.For<UserManager<ApplicationUser>>(
+            Substitute.For<IUserStore<ApplicationUser>>(),
+            null!, null!, null!, null!, null!, null!, null!, null!);
+}

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountLoaderTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountLoaderTests.cs
@@ -148,6 +148,26 @@ public sealed class AccountLoaderTests
         handler.LastRequestBody.ShouldContain("NewP@ss2");
     }
 
+    [Fact]
+    public async Task RequestEmailChangeAsync_PostsTheNewAddressAndThePasswordToTheGivenHref()
+    {
+        AccountLoader loader = CreateLoader(
+            StubHttpMessageHandler.RespondWith(HttpStatusCode.OK, string.Empty),
+            out StubHttpMessageHandler handler);
+
+        ApiResult result = await loader.RequestEmailChangeAsync(
+            "auth/account/change-email",
+            "frodo@rivendell.example",
+            "OldP@ss1");
+
+        result.IsSuccess.ShouldBeTrue();
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.ToString().ShouldBe($"{BaseUrl}auth/account/change-email");
+        handler.LastRequestBody.ShouldNotBeNull();
+        handler.LastRequestBody!.ShouldContain("frodo@rivendell.example");
+        handler.LastRequestBody.ShouldContain("OldP@ss1");
+    }
+
     private void StubDiscovery(List<LinkDto> links)
     {
         AuthDiscoveryResponse discovery = new("LotroKoniecDev.AuthSystem") { Links = links };

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountTests.cs
@@ -93,6 +93,22 @@ public sealed class AccountTests : BunitContext
     }
 
     [Fact]
+    public void Render_WhenEnvelopeAdvertisesChangeEmail_ShowsTheActionRowAndTheInlineLink()
+    {
+        StubExport(AccountLoaderTests.CreateEnvelope(links:
+        [
+            new LinkDto("auth/account/change-email", Rels.ChangeEmail, "POST")
+        ]));
+
+        IRenderedComponent<AccountComponent> component = Render<AccountComponent>();
+
+        component.Find("[data-testid=account-change-email]")
+            .GetAttribute("href").ShouldBe("/account/change-email");
+        component.Find("[data-testid=account-change-email-inline]")
+            .GetAttribute("href").ShouldBe("/account/change-email");
+    }
+
+    [Fact]
     public void Render_WhenEnvelopeAdvertisesNoActionRels_HidesTheGatedActionRows()
     {
         StubExport(AccountLoaderTests.CreateEnvelope(links: []));
@@ -100,6 +116,8 @@ public sealed class AccountTests : BunitContext
         IRenderedComponent<AccountComponent> component = Render<AccountComponent>();
 
         component.FindAll("[data-testid=account-change-password]").ShouldBeEmpty();
+        component.FindAll("[data-testid=account-change-email]").ShouldBeEmpty();
+        component.FindAll("[data-testid=account-change-email-inline]").ShouldBeEmpty();
         component.FindAll("[data-testid=account-delete]").ShouldBeEmpty();
         component.FindAll("[data-testid=account-export]").ShouldHaveSingleItem();
     }

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/ChangeEmailTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/ChangeEmailTests.cs
@@ -17,7 +17,11 @@ namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Account;
 /// Renders the <c>/account/change-email</c> page through bUnit over a stubbed auth client: the form
 /// appears only when the envelope advertises the <c>change-email</c> rel, and every input is named
 /// after the <c>[SupplyParameterFromForm]</c> model path so the posted fields actually bind (the M3-07
-/// SSR binding lesson). The submit path is exercised by the browser E2E.
+/// SSR binding lesson).
+/// The submit path is NOT covered here: bUnit's SubmitAsync fires only <c>@onsubmit</c> and does no
+/// SSR form-data binding, so a test that drove it would assert against fields the real request would
+/// have filled differently. The server side of the same flow is covered by the auth API's endpoint
+/// and page suites.
 /// </summary>
 public sealed class ChangeEmailTests : BunitContext
 {

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/ChangeEmailTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/ChangeEmailTests.cs
@@ -1,0 +1,105 @@
+using LotroKoniecDev.AuthSystem.Contracts.Features.Auth.Account;
+using LotroKoniecDev.AuthSystem.Contracts.Hateoas;
+using LotroKoniecDev.Frontend.Components.Pages.Account;
+using LotroKoniecDev.Frontend.Components.Shared;
+using LotroKoniecDev.Frontend.Infrastructure.Discovery;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients;
+using LotroKoniecDev.Frontend.Infrastructure.HttpClients.AuthSystemHttpClients;
+using LotroKoniecDev.Hateoas.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using AuthDiscoveryResponse = LotroKoniecDev.AuthSystem.Contracts.Discovery.DiscoveryResponse;
+using ChangeEmailComponent = LotroKoniecDev.Frontend.Components.Pages.Account.ChangeEmail;
+
+namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Pages.Account;
+
+/// <summary>
+/// Renders the <c>/account/change-email</c> page through bUnit over a stubbed auth client: the form
+/// appears only when the envelope advertises the <c>change-email</c> rel, and every input is named
+/// after the <c>[SupplyParameterFromForm]</c> model path so the posted fields actually bind (the M3-07
+/// SSR binding lesson). The submit path is exercised by the browser E2E.
+/// </summary>
+public sealed class ChangeEmailTests : BunitContext
+{
+    private readonly IDiscoveryCache _discoveryCache = Substitute.For<IDiscoveryCache>();
+    private readonly IAuthSystemClient _client = Substitute.For<IAuthSystemClient>();
+
+    public ChangeEmailTests()
+    {
+        Services.AddAntiforgery();
+        Services.AddSingleton(_discoveryCache);
+        Services.AddSingleton(_client);
+        Services.AddScoped<AccountLoader>();
+    }
+
+    [Fact]
+    public void Render_WhenChangeEmailRelAdvertised_ShowsTheFormWithModelBoundInputNames()
+    {
+        StubExport(AccountLoaderTests.CreateEnvelope(links:
+        [
+            new LinkDto("auth/account/change-email", Rels.ChangeEmail, "POST")
+        ]));
+
+        IRenderedComponent<ChangeEmailComponent> component = Render<ChangeEmailComponent>();
+
+        component.Find("#new-email").GetAttribute("name").ShouldBe("EmailInput.NewEmail");
+        component.Find("#repeat-email").GetAttribute("name").ShouldBe("EmailInput.RepeatEmail");
+        component.Find("#current-password").GetAttribute("name").ShouldBe("EmailInput.CurrentPassword");
+    }
+
+    [Fact]
+    public void Render_WhenChangeEmailRelAdvertised_SaysTheAddressIsAlsoTheLogin()
+    {
+        // The address is what LoginModel looks the user up by, so a page that does not say so leaves
+        // the user guessing why their next sign-in fails.
+        StubExport(AccountLoaderTests.CreateEnvelope(links:
+        [
+            new LinkDto("auth/account/change-email", Rels.ChangeEmail, "POST")
+        ]));
+
+        IRenderedComponent<ChangeEmailComponent> component = Render<ChangeEmailComponent>();
+
+        component.Markup.ShouldContain("loginem");
+    }
+
+    [Fact]
+    public void Render_WhenChangeEmailRelMissing_ShowsTheUnavailableNoticeAndNoForm()
+    {
+        StubExport(AccountLoaderTests.CreateEnvelope(links: []));
+
+        IRenderedComponent<ChangeEmailComponent> component = Render<ChangeEmailComponent>();
+
+        component.Markup.ShouldContain("niedostępna");
+        component.FindAll("input[type=email]").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_WhenTheLoadIsUnauthorized_RedirectsToLoginInsteadOfTheErrorPanel()
+    {
+        _discoveryCache.GetAuthSystemDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(new AuthDiscoveryResponse("LotroKoniecDev.AuthSystem")
+            {
+                Links = [new LinkDto("auth/account/data-export", Rels.ExportAccountData, "GET")]
+            }));
+        _client.GetApiResultAsync<AccountDataExportResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<AccountDataExportResponse>(
+                new Microsoft.AspNetCore.Mvc.ProblemDetails { Title = "Unauthorized", Status = 401 }));
+
+        IRenderedComponent<ChangeEmailComponent> component = Render<ChangeEmailComponent>();
+
+        component.FindComponents<RedirectToLogin>().ShouldHaveSingleItem();
+        component.FindAll(".error-message").ShouldBeEmpty();
+    }
+
+    private void StubExport(AccountDataExportResponse envelope)
+    {
+        AuthDiscoveryResponse discovery = new("LotroKoniecDev.AuthSystem")
+        {
+            Links = [new LinkDto("auth/account/data-export", Rels.ExportAccountData, "GET")]
+        };
+        _discoveryCache.GetAuthSystemDiscoveryAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(discovery));
+        _client.GetApiResultAsync<AccountDataExportResponse>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Success(envelope));
+    }
+}


### PR DESCRIPTION
Closes #671.

## What

A signed-in translator can change the e-mail address they log in with, from "Moje konto". The privacy policy §06 already promised rectification "w ustawieniach konta"; this makes that true.

```
REQUEST   POST auth/account/change-email     password + new address, 3/h per IP
          → warning        → OLD inbox (names the target)
          → verify link    → NEW inbox (24 h)

CONFIRM   /Account/ConfirmEmailChange        GET renders a form, POST applies
          address moves · EmailConfirmed · stamp rotated · sessions revoked
          → notice         → NEW inbox
          → notice + UNDO  → OLD inbox (14 days)

REVERT    /Account/RevertEmailChange         GET renders a form, POST reverts
          address restored · PasswordHash = null · deletion cancelled
          → password-reset flow
```

## Why it is shaped like this

The e-mail is the login identifier (`LoginModel` resolves users with `FindByEmailAsync`), so this changes a credential. Password-plus-a-click hands the account to anyone who steals the password, permanently — they move it to their own inbox and the owner can neither log in, nor reset, nor use the deletion-cancel path.

ADR-0048 answers that the way ADR-0031 answered it for deletion: don't block the action, give the mailbox the attacker doesn't control a way to undo it, and destroy the stolen credential on the way out. Gating the change on the old mailbox was rejected — losing that mailbox is *why* people change addresses.

Three rules make the undo actually hold, and **two earlier shapes were defeated in review before this one**:

1. Only the first change since the last revert arms an undo, at the address the chain started from. A second change carries no link — so after A→B→C there is nothing mailed to the attacker.
2. A revert restores the **armed** address, never the one its link names.
3. `EmailChangeRevertStamp` rotates on revert, retiring every issued token. Deliberately not the security stamp: a password change rotates that, and surviving a password change is the one thing this token must do.

ADR-0048 records both rejected shapes, because the next person to touch this will reach for one of them.

## Notes for review

- **One migration**, two nullable columns — additive, expand-only, N-1 safe per ADR-0023.
- Neither auth page mutates on `GET`. `CancelDeletion.cshtml.cs` spells out why: mail scanners open every link, and the revert link lands in a live inbox.
- The rate limit is keyed by IP, not user — `UseRateLimiter` runs before `UseAuthentication`, so the principal is anonymous at partition time.
- Both new e-mail types ride the outbox (ADR-0038); no SMTP on a request path.

## Tests

| Suite | |
|---|---|
| `AuthSystem.API.Tests.Unit` | 236 |
| `AuthSystem.API.Tests.Integration` | 375 |
| `Frontend.Tests.Unit` | 583 |
| `Tests.Unit` · `Architecture.Tests.Unit` | 4091 · 21 |

Build clean with zero warnings; SSR, hypermedia, migration-safety and Dockerfile restore-graph guards all pass.

The load-bearing ones: a `GET` of either link changes nothing; the revert survives a password change but not a revert-stamp rotation; and the attacker-clicks-first chain leaves the owner's link working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzACv65eo2tfNxTzQAaSRM