### PR TITLE
Show "Szczegóły techniczne" only when the API message adds information (ADR-0044 §4 amendment)

### DIFF
--- a/docs/adr/0044-the-frontend-owns-polish-copy-and-translates-api-failures-by-default.md
+++ b/docs/adr/0044-the-frontend-owns-polish-copy-and-translates-api-failures-by-default.md
@@ -1,9 +1,9 @@
 # ADR-0044: The Frontend owns the Polish copy for API failures, and translates by default
 
-**Status:** Accepted
+**Status:** Accepted (amended 2026-08-21 — #703 narrows §4 to the codes whose API message adds information; see the in-body amendment)
 **Date:** 2026-08-06
 **Decision-makers:** Solo maintainer
-**Related:** #548 (the defect), #268 / #272 (the QA reports that found it), ADR-0041 (no gateway — the API is a shared contract surface), ADR-0040 (rel names are a frozen public contract), `ApiProblemCopy`, `HttpClientApiExtensions`
+**Related:** #548 (the defect), #268 / #272 (the QA reports that found it), #703 (the §4 amendment) / #669 (the QA report that found it), ADR-0041 (no gateway — the API is a shared contract surface), ADR-0040 (rel names are a frozen public contract), `ApiProblemCopy`, `HttpClientApiExtensions`
 
 ## Context
 
@@ -106,7 +106,7 @@ statystyk."` says only that something failed; `"Nie masz uprawnień do wykonania
 what to do about it. The call-site fallback stays for the one case nothing else covers — no problem
 object at all.
 
-### 4. The original English survives as collapsible technical detail
+### 4. The original English survives as collapsible technical detail *(narrowed — see the amendment below)*
 
 Some API messages carry numbers a static Polish string cannot reproduce: `Import.ParseFailed` names
 the first bad line, `Import.MassRemovalBlocked` names how many rows of how many would be removed.
@@ -121,6 +121,71 @@ The alternative of adding structured extensions to the API's import errors (`lin
 `removedCount`, …) so the Polish string could interpolate them was rejected as scope: it changes the
 API for one page's copy, and the nested parser messages inside `Import.ParseFailed` would stay
 English regardless.
+
+**Amendment (2026-08-21, #703) — the block is shown only where the API message adds information.**
+
+§4 was written from the import slice and then applied to every code. For most codes the English is a
+word-for-word restatement of the Polish headline, which adds nothing and reads like a leak — which is
+how QA reported it (#669 / TC-CP-06, filed as #703):
+
+```
+Aktualne hasło jest nieprawidłowe.
+▸ Szczegóły techniczne
+    Auth.InvalidCurrentPassword — The current password is incorrect.
+```
+
+There is also an audience split the original §4 never made: the data-carrying import codes only appear
+on `/import-export`, which is admin-only, while `/account/*` is used by every translator.
+
+**This is a trade, not a free win.** Four codes carry data no Polish string can reproduce, all in
+`ImportErrors.cs`: `Import.ParseFailed` (the first unparseable line number), `Import.InvalidRow` (the
+`(fileId, gossipId)` of the bad row), `Import.DuplicateFragmentKey` (the duplicate key) and
+`Import.MassRemovalBlocked` (the removal counters). Those keep the block. But they are not the only
+codes whose English is composed at runtime: the seven `Auth.*Failed` errors pass ASP.NET Identity's own
+descriptions straight through, and every `*.Validation` code carries the FluentValidation messages,
+which name the **rule** that failed. Hiding those is a real loss of information, and the ADR should
+not pretend otherwise.
+
+The loss is paid back in Polish, not bought back in English (§1 — the page is Polish). Concretely, the
+password rules now appear in the copy itself: `ApiProblemCopy.PasswordRules` spells out the 8-to-128
+length, case, digit and special character — the change-password hint renders the same constant, so the
+warning up front and the message after the fact cannot drift — and `ChangePassword.Validation`, `ResetPassword.Validation`,
+`RegisterUser.Validation`, `Auth.PasswordChangeFailed`, `Auth.PasswordResetFailed` and
+`Auth.RegistrationFailed` all end in it. Before #703 the drawer was the only place a user learned
+which rule they broke — and `/account/change-password`'s own hint did not even mention the special
+character both the validator and the Identity options require. **Adding a code to
+`CodesWhoseApiMessageCarriesData` is the wrong way to pay this debt**; better Polish copy is the right
+one, and a code whose English is a rule name is a copy gap, not a data carrier.
+
+So `BuildTechnicalDetail` returns `null` when the code **is mapped** and is **not** on
+`CodesWhoseApiMessageCarriesData`:
+
+| Case | Technical detail |
+|---|---|
+| Mapped code, not on the list | **hidden** — the Polish headline is the whole message |
+| Mapped code, on the list | shown, as before |
+| Unmapped code, or no code at all | shown, as before |
+
+The unmapped case stays because the user only sees the generic "Operacja nie powiodła się…" there,
+and the code plus the API's wording is the one thing that makes such a failure reportable. It is
+already logged as a warning (§3), so it is a known, temporary state by definition. The same PR closed
+the four `Auth.*EmailChange*` gaps that shipped uncovered with #683, so the map covers every code both
+APIs can produce again.
+
+**The no-code case stays for a narrower reason.** For a `UseStatusCodePages` body (§2 — 401, 403, 404,
+405, 415, 429) the drawer still shows the bare reason phrase next to the Polish, so
+`Nie masz uprawnień do wykonania tej operacji.` still carries `Szczegóły techniczne → Forbidden`. That
+is the same cosmetic blemish this amendment removes elsewhere, and it is kept deliberately: the rule
+here is "hide the English **when the Polish already says it**", and with no code there is nothing to
+look up, so the rule cannot be evaluated. Guessing from the status instead would re-introduce the
+absence-of-a-code discriminator §2 rejected. Revisit only with a real report; one English word with no
+code is a blemish, not the leak §2 exists to prevent.
+
+Nothing changes on the wire. `errorCode` is still stamped on every failure and is still a frozen
+contract token (§1); only the rendering changes. Both renderers follow the amendment, because both go
+through the same `BuildTechnicalDetail`: `ApiProblemAlert` emits no `<details>` element at all, and
+`Localize` omits the `technicalDetail` extension from the download routes' problem body. The `traceId`
+is untouched either way — that, not the English, is what links a support report to the server log.
 
 ### 5. One component, both existing shells
 

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/ChangePassword.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/ChangePassword.razor
@@ -100,7 +100,7 @@
                         </label>
                         <input id="new-password" name="PasswordInput.NewPassword" type="password"
                                autocomplete="new-password"/>
-                        <p class="field-hint">Co najmniej @PasswordMinLength znaków, w tym mała i wielka litera oraz cyfra.</p>
+                        <p class="field-hint">Wymagania: @ApiProblemCopy.PasswordRules</p>
                     </div>
                     <div class="field">
                         <label for="repeat-password">
@@ -122,8 +122,10 @@
 @code
 {
     /// <summary>
-    /// Repeats the auth API's <c>PasswordValidationRules</c> minimum of 8 as a hint for the user. The
-    /// server still decides; this is never enforced here beyond the hint text.
+    /// Repeats the auth API's <c>PasswordValidationRules</c> minimum of 8 for the panel heading. The
+    /// server still decides; this is never enforced here beyond the text. The full rule list under the
+    /// field comes from <see cref="ApiProblemCopy.PasswordRules"/>, so the hint and the failure message
+    /// cannot drift apart.
     /// </summary>
     private const int PasswordMinLength = 8;
 

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Shared/ApiProblemAlert.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Shared/ApiProblemAlert.razor
@@ -2,9 +2,10 @@
 @using LotroKoniecDev.Frontend.Infrastructure.Errors
 @inject ILogger<ApiProblemAlert> Logger
 
-@* The only way a page shows a failed call (ADR-0044): Polish text chosen by the API's errorCode, with
-   the API's own English wording one click away for a bug report. The caller provides the box
-   (`error-message` or `status-message status-error`) and this fills in its content. *@
+@* The only way a page shows a failed call (ADR-0044): Polish text chosen by the API's errorCode. The
+   API's English is one click away only where it adds information the Polish cannot carry, so for most
+   codes no details block is rendered at all (#703). The caller provides the box (`error-message` or
+   `status-message status-error`) and this fills in its content. *@
 
 <span class="problem-headline @HeadlineClass">@_view.Message</span>
 @if (_view.SecondaryMessage is not null)

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemCopy.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemCopy.cs
@@ -44,6 +44,20 @@ internal static class ApiProblemCopy
     internal const string GenericMessage = "Operacja nie powiodła się. Spróbuj ponownie za chwilę.";
 
     /// <summary>
+    /// The password rules, spelled out. Both layers that reject a password answer with a mapped code, so
+    /// since #703 hid the English drawer this sentence is the only place a user learns which rule they
+    /// broke. It must list <em>every</em> rule: a rule missing here is a rule the message silently
+    /// contradicts, which is the defect #703 exists to remove.
+    /// <para>
+    /// The wording is shared with the change-password hint, so the Frontend states the rules once. The
+    /// API states the same ones in <c>PasswordValidationRules</c> and in the Identity options; the
+    /// contexts share no code, so keep those in step by hand.
+    /// </para>
+    /// </summary>
+    internal const string PasswordRules =
+        "od 8 do 128 znaków, mała i wielka litera, cyfra oraz znak specjalny.";
+
+    /// <summary>
     /// The Polish text for each API error code. It covers every code <c>TranslationSystem.API</c> and
     /// <c>AuthSystem.API</c> can produce: the domain error lists, the per-slice validation errors and the
     /// shared exception handlers. A code that is missing here falls back to
@@ -134,17 +148,18 @@ internal static class ApiProblemCopy
             ["Auth.UserAlreadyExistsByUsername"] =
                 "Konto z tą nazwą użytkownika już istnieje.",
             ["Auth.RegistrationFailed"] =
-                "Nie udało się założyć konta. Sprawdź podane dane i spróbuj ponownie.",
+                "Nie udało się założyć konta. Sprawdź adres e-mail, nazwę użytkownika oraz wymagania hasła: "
+                + PasswordRules,
             ["Auth.UserNotFound"] =
                 "Nie znaleziono konta.",
             ["Auth.InvalidCurrentPassword"] =
                 "Aktualne hasło jest nieprawidłowe.",
             ["Auth.PasswordChangeFailed"] =
-                "Nie udało się zmienić hasła. Nowe hasło może nie spełniać wymagań.",
+                "Nie udało się zmienić hasła. Nowe hasło musi spełniać wymagania: " + PasswordRules,
             ["Auth.InvalidPasswordResetToken"] =
                 "Link do zmiany hasła jest nieprawidłowy lub wygasł. Poproś o nowy.",
             ["Auth.PasswordResetFailed"] =
-                "Nie udało się ustawić nowego hasła. Może ono nie spełniać wymagań.",
+                "Nie udało się ustawić nowego hasła. Musi ono spełniać wymagania: " + PasswordRules,
             ["Auth.InvalidEmailConfirmationToken"] =
                 "Link potwierdzający adres e-mail jest nieprawidłowy lub wygasł. Poproś o nowy.",
             ["Auth.EmailConfirmationFailed"] =
@@ -159,16 +174,26 @@ internal static class ApiProblemCopy
                 "Link anulujący usunięcie konta jest nieprawidłowy lub wygasł.",
             ["Auth.CancelDeletionFailed"] =
                 "Nie udało się anulować usunięcia konta. Spróbuj ponownie później.",
+            ["Auth.EmailChangeSameAddress"] =
+                "Podany adres e-mail jest taki sam jak obecny.",
+            ["Auth.InvalidEmailChangeToken"] =
+                "Link zmieniający adres e-mail jest nieprawidłowy lub wygasł. Poproś o nowy.",
+            ["Auth.EmailChangeFailed"] =
+                "Nie udało się zmienić adresu e-mail. Mógł on zostać w międzyczasie zajęty przez inne konto.",
 
             // ── Auth · per-slice request validation ────────────────────────────────────────────
+            // Registration and password reset live on the auth server's own Razor Pages, so these three
+            // entries are unreachable from the Frontend today. They stay for map completeness, and they
+            // name every rule their validator enforces in case those pages ever move here.
             ["RegisterUser.Validation"] =
-                "Formularz rejestracji zawiera nieprawidłowe dane.",
+                "Formularz rejestracji zawiera nieprawidłowe dane. Sprawdź adres e-mail, nazwę użytkownika "
+                + "i wymagane zgody, a hasło musi mieć " + PasswordRules,
             ["ChangePassword.Validation"] =
-                "Formularz zmiany hasła zawiera nieprawidłowe dane.",
+                "Nowe hasło nie spełnia wymagań: " + PasswordRules,
             ["ForgotPassword.Validation"] =
                 "Podany adres e-mail jest nieprawidłowy.",
             ["ResetPassword.Validation"] =
-                "Formularz zmiany hasła zawiera nieprawidłowe dane.",
+                "Nowe hasło nie spełnia wymagań: " + PasswordRules,
             ["ConfirmEmail.Validation"] =
                 "Link potwierdzający adres e-mail jest niekompletny lub nieprawidłowy.",
             ["ResendEmailConfirmation.Validation"] =
@@ -177,6 +202,8 @@ internal static class ApiProblemCopy
                 "Formularz usunięcia konta zawiera nieprawidłowe dane.",
             ["CancelAccountDeletion.Validation"] =
                 "Link anulujący usunięcie konta jest niekompletny lub nieprawidłowy.",
+            ["RequestEmailChange.Validation"] =
+                "Podany adres e-mail jest nieprawidłowy.",
 
             // ── Shared exception handlers (both APIs) ──────────────────────────────────────────
             ["Validation.FluentValidation"] =
@@ -192,6 +219,28 @@ internal static class ApiProblemCopy
             ["Internal.UnhandledException"] =
                 "Wystąpił nieoczekiwany błąd serwera. Spróbuj ponownie za chwilę."
         }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The mapped codes whose English message says something the Polish text cannot: a line number, a
+    /// row key, a duplicate fragment key, or the removal counters. Only for those is the API wording
+    /// worth showing (ADR-0044 §4, amended by #703). Everywhere else the English only restates the
+    /// Polish headline, which reads like a leak.
+    /// <para>
+    /// The list is short on purpose, and it is a trade, not a free win: a few other codes do carry a
+    /// runtime message (the Identity failures behind <c>Auth.*Failed</c>, the rule names behind
+    /// <c>*.Validation</c>). Hiding those is the accepted cost, paid back in Polish copy that says the
+    /// same thing — see <see cref="PasswordRules"/>. Adding a code here is the wrong way to pay it,
+    /// because the drawer is English on a Polish page.
+    /// </para>
+    /// </summary>
+    private static readonly FrozenSet<string> CodesWhoseApiMessageCarriesData =
+        FrozenSet.ToFrozenSet(
+        [
+            "Import.ParseFailed",
+            "Import.InvalidRow",
+            "Import.DuplicateFragmentKey",
+            "Import.MassRemovalBlocked"
+        ], StringComparer.Ordinal);
 
     /// <summary>
     /// The fallback for an API failure whose code has no text yet: say what the status means, in Polish,
@@ -377,17 +426,36 @@ internal static class ApiProblemCopy
     }
 
     /// <summary>
-    /// The code and the API's own wording, whichever of the two the problem carries. A problem with
-    /// neither, which is a status with no body, has nothing worth showing.
+    /// The code and the API's own wording, whichever of the two the problem carries — but only when
+    /// they add something. A problem with neither, which is a status with no body, has nothing worth
+    /// showing either.
     /// </summary>
     private static string? BuildTechnicalDetail(string? errorCode, ProblemDetails problem)
-        => (errorCode, FirstNonBlank(problem.Detail, problem.Title)) switch
+    {
+        if (errorCode is not null && AddsNothingToThePolishCopy(errorCode))
+        {
+            return null;
+        }
+
+        return (errorCode, FirstNonBlank(problem.Detail, problem.Title)) switch
         {
             (not null, { } apiMessage) => $"{errorCode} — {apiMessage}",
             (not null, null) => errorCode,
             (null, { } apiMessage) => apiMessage,
             _ => null
         };
+    }
+
+    /// <summary>
+    /// True when the Polish headline is already the whole message: the code has copy here, and its
+    /// English carries no data that copy is missing (#703).
+    /// <para>
+    /// An unmapped code is never hidden. The user only sees the generic sentence there, so the code and
+    /// the API's wording are the one thing that makes such a failure reportable.
+    /// </para>
+    /// </summary>
+    private static bool AddsNothingToThePolishCopy(string errorCode)
+        => PolishByErrorCode.ContainsKey(errorCode) && !CodesWhoseApiMessageCarriesData.Contains(errorCode);
 
     private static string? FirstNonBlank(params string?[] candidates)
         => Array.Find(candidates, candidate => !string.IsNullOrWhiteSpace(candidate));

--- a/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemView.cs
+++ b/src/Frontend/LotroKoniecDev.Frontend/Infrastructure/Errors/ApiProblemView.cs
@@ -11,7 +11,8 @@ namespace LotroKoniecDev.Frontend.Infrastructure.Errors;
 /// </param>
 /// <param name="TechnicalDetail">
 /// The API's error code and its own English wording, hidden behind a toggle so a bug report can quote
-/// it. Null for a problem the Frontend wrote, which has nothing to hide.
+/// it. Null far more often than not: a problem the Frontend wrote has nothing to hide, and a mapped
+/// code whose English only restates the Polish headline hides it too (#703).
 /// </param>
 /// <param name="UnmappedErrorCode">
 /// Set only when the API sent a code <see cref="ApiProblemCopy"/> has no text for, so the page can log

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/AccountEndpointsExtensionsTests.cs
@@ -285,8 +285,11 @@ public sealed class AccountEndpointsExtensionsTests
         ProblemHttpResult problem = result.ShouldBeOfType<ProblemHttpResult>();
         problem.ProblemDetails.Status.ShouldBe(404);
         problem.ProblemDetails.Title.ShouldBe("Nie znaleziono konta.");
-        problem.ProblemDetails.Extensions[ApiProblemCopy.TechnicalDetailExtensionKey]
-            .ShouldBe("Auth.UserNotFound — User not found.");
+        // The English only restates the Polish, so it is dropped here exactly as it is on a page (#703),
+        // which leaves the trace id as the only thing tying a user's report to the server log.
+        problem.ProblemDetails.Extensions.ShouldNotContainKey(ApiProblemCopy.TechnicalDetailExtensionKey);
+        // Read off the wire, so the value is a JsonElement rather than a string.
+        problem.ProblemDetails.Extensions[ApiProblemCopy.TraceIdExtensionKey]!.ToString().ShouldBe("00-abc-def-01");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/ChangePasswordTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/Account/ChangePasswordTests.cs
@@ -48,6 +48,27 @@ public sealed class ChangePasswordTests : BunitContext
     }
 
     [Fact]
+    public void Render_TheNewPasswordHint_NamesEveryRuleTheApiEnforces()
+    {
+        // The API rejects a weak password with a mapped code, and #703 stopped showing the English that
+        // used to name the broken rule. So the hint is now the user's only warning up front, and it has
+        // to match PasswordValidationRules — it used to omit the special character both it and the
+        // Identity options require, which turned a wrong password into a dead end.
+        StubExport(AccountLoaderTests.CreateEnvelope(links:
+        [
+            new LinkDto("auth/change-password", Rels.ChangePassword, "POST")
+        ]));
+
+        IRenderedComponent<ChangePasswordComponent> component = Render<ChangePasswordComponent>();
+
+        string hint = component.Find(".field-hint").TextContent;
+        hint.ShouldContain("od 8 do 128 znaków");
+        hint.ShouldContain("mała i wielka litera");
+        hint.ShouldContain("cyfra");
+        hint.ShouldContain("znak specjalny");
+    }
+
+    [Fact]
     public void Render_WhenChangePasswordRelMissing_ShowsTheUnavailableNoticeAndNoForm()
     {
         StubExport(AccountLoaderTests.CreateEnvelope(links: []));

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/GameVersions/GameVersionsTests.cs
@@ -183,9 +183,10 @@ public sealed class GameVersionsTests : BunitContext
         error.QuerySelector(".problem-headline")!.TextContent
             .ShouldBe("Tej wersji gry nie można usunąć, bo są z nią powiązane tłumaczenia.");
         error.QuerySelector(".problem-headline")!.TextContent.ShouldNotContain("Data Conflict");
-        // The API's own wording survives for a bug report, but only behind the technical-details block.
-        error.QuerySelector("details.problem-tech .problem-tech-body")!.TextContent
-            .ShouldContain("is referenced by one or more translations");
+        // The API's wording only restates the Polish here, so it is not rendered at all (#703). It is
+        // kept behind the technical-details block for the import codes whose English carries data.
+        error.QuerySelectorAll("details.problem-tech").ShouldBeEmpty();
+        error.TextContent.ShouldNotContain("is referenced by one or more translations");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportEndpointsExtensionsTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportEndpointsExtensionsTests.cs
@@ -84,8 +84,8 @@ public sealed class ImportExportEndpointsExtensionsTests
         problem.ProblemDetails.Status.ShouldBe(404);
         problem.ProblemDetails.Title.ShouldBe(
             "Plik z tłumaczeniami nie został jeszcze zbudowany. Zatwierdź przynajmniej jedno tłumaczenie i spróbuj ponownie.");
-        problem.ProblemDetails.Extensions[ApiProblemCopy.TechnicalDetailExtensionKey]
-            .ShouldBe("TranslationFiles.NotFound — No translation file has been built for 'pl' yet.");
+        // The English only restates the Polish, so it is dropped here exactly as it is on a page (#703).
+        problem.ProblemDetails.Extensions.ShouldNotContainKey(ApiProblemCopy.TechnicalDetailExtensionKey);
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Pages/ImportExport/ImportExportTests.cs
@@ -166,6 +166,29 @@ public sealed class ImportExportTests : BunitContext
         component.Find("a[download]").GetAttribute("href").ShouldBe("/download/polish.txt");
     }
 
+    [Fact]
+    public void Render_WhenTheVersionsLoadFailsWithAnUnmappedCode_StillOffersTheTechnicalDetails()
+    {
+        // #703 hides the drawer for mapped codes, and this page is the one that must never lose it: the
+        // import codes carry the line number and the removal counters. The exact import wording is
+        // pinned on the component (ApiProblemAlertTests), which is the seam this page renders through;
+        // this keeps a page-level pin that the block still reaches the screen at all.
+        AuthorizeAs("Frodo");
+        _client.GetApiResultAsync<CollectionResponse<GameVersionResponse>>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure<CollectionResponse<GameVersionResponse>>(new()
+            {
+                Title = "Data Conflict",
+                Detail = "Not your row.",
+                Status = 422,
+                Extensions = { ["errorCode"] = "Catalog.SomethingNobodyMappedYet" }
+            }));
+
+        IRenderedComponent<ImportExportComponent> component = RenderPage();
+
+        component.Find("details.problem-tech .problem-tech-body").TextContent
+            .ShouldBe("Catalog.SomethingNobodyMappedYet — Not your row.");
+    }
+
     private IRenderedComponent<ImportExportComponent> RenderPage() =>
         Render<ImportExportComponent>();
 

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Shared/ApiProblemAlertTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Components/Shared/ApiProblemAlertTests.cs
@@ -10,8 +10,9 @@ namespace LotroKoniecDev.Frontend.Tests.Unit.Components.Shared;
 
 /// <summary>
 /// The one component every page renders a failed call through (#548 / ADR-0044). These lock down what
-/// reaches the screen: Polish copy for an API failure, the API's English kept behind a collapsed
-/// <c>details</c>, and a logged warning when a code shipped without copy.
+/// reaches the screen: Polish copy for an API failure, the API's English behind a collapsed
+/// <c>details</c> only where it adds information (#703), and a logged warning when a code shipped
+/// without copy.
 /// </summary>
 public sealed class ApiProblemAlertTests : BunitContext
 {
@@ -55,7 +56,7 @@ public sealed class ApiProblemAlertTests : BunitContext
     }
 
     [Fact]
-    public void Render_ForAnApiFailure_KeepsTheCodeAndEnglishInACollapsedDetailsBlock()
+    public void Render_ForAnImportFailureWhoseEnglishCarriesData_KeepsTheCodeAndEnglishInACollapsedDetailsBlock()
     {
         ProblemDetails problem = ApiProblem(
             "Import.ParseFailed",
@@ -72,6 +73,42 @@ public sealed class ApiProblemAlertTests : BunitContext
         details.QuerySelector("summary")!.TextContent.ShouldBe("Szczegóły techniczne");
         details.QuerySelector(".problem-tech-body")!.TextContent
             .ShouldBe("Import.ParseFailed — The upload has 3 unparseable line(s); first failure — line 42: unexpected pipe.");
+    }
+
+    [Fact]
+    public void Render_ForAMappedFailureWhoseEnglishOnlyRestatesThePolish_RendersNoDetailsElementAtAll()
+    {
+        // The defect of #703, reported from /account/change-password: the drawer held
+        // "Auth.InvalidCurrentPassword — The current password is incorrect.", which is the headline
+        // again in English. Nothing to expand means nothing that reads like a leak.
+        ProblemDetails problem = ApiProblem(
+            "Auth.InvalidCurrentPassword",
+            400,
+            "Validation Error",
+            "The current password is incorrect.");
+
+        IRenderedComponent<ApiProblemAlert> component = Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Problem, problem)
+            .Add(alert => alert.Fallback, "Nie udało się zmienić hasła."));
+
+        component.Find(".problem-headline").TextContent.ShouldBe("Aktualne hasło jest nieprawidłowe.");
+        component.FindAll("details").ShouldBeEmpty();
+        component.Markup.ShouldNotContain("Szczegóły techniczne");
+    }
+
+    [Fact]
+    public void Render_ForAnUnmappedErrorCode_StillShowsTheCodeAndTheApiWording()
+    {
+        // Here the user only gets the generic status sentence, so the English is the one thing that
+        // makes the failure reportable. It stays until the code has Polish copy.
+        ProblemDetails problem = ApiProblem("Catalog.SomethingNobodyMappedYet", 403, "Forbidden", "Not your row.");
+
+        IRenderedComponent<ApiProblemAlert> component = Render<ApiProblemAlert>(parameters => parameters
+            .Add(alert => alert.Problem, problem)
+            .Add(alert => alert.Fallback, "Operacja nie powiodła się."));
+
+        component.Find("details.problem-tech .problem-tech-body").TextContent
+            .ShouldBe("Catalog.SomethingNobodyMappedYet — Not your row.");
     }
 
     [Fact]

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Errors/ApiProblemCopyTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Errors/ApiProblemCopyTests.cs
@@ -6,6 +6,7 @@ using LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.HttpClients;
 using LotroKoniecDev.Frontend.Tests.Unit.Shared;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace LotroKoniecDev.Frontend.Tests.Unit.Infrastructure.Errors;
 
@@ -148,43 +149,68 @@ public sealed class ApiProblemCopyTests
         view.UnmappedErrorCode.ShouldBeNull();
     }
 
-    [Fact]
-    public void Describe_WhenTheErrorCodeIsMapped_KeepsTheApiWordingAsTechnicalDetailOnly()
+    [Theory]
+    [InlineData("Import.ParseFailed", "The upload has 3 unparseable line(s); first failure — line 42: unexpected pipe.")]
+    [InlineData("Import.InvalidRow", "Row (620756992, 1001) is invalid: args_order must be NULL or dash-separated positions.")]
+    [InlineData("Import.DuplicateFragmentKey", "The upload contains more than one row for fragment (620756992, 1001).")]
+    [InlineData("Import.MassRemovalBlocked", "The upload would remove 812 of 1000 active row(s) (81%), exceeding the 30% safety threshold.")]
+    public void Describe_WhenTheMappedCodesApiMessageCarriesData_KeepsItAsTechnicalDetailOnly(
+        string errorCode,
+        string apiMessage)
     {
-        // The numbers an admin needs, such as line numbers and row counts, are in the API's own message,
-        // so we keep it one click away and never use it as the message itself.
-        ProblemDetails problem = ApiProblem(
-            "Import.MassRemovalBlocked",
-            422,
-            "Data Conflict",
-            "The upload would remove 812 of 1000 active row(s) (81%), exceeding the 30% safety threshold.");
+        // The numbers an admin needs, such as line numbers, row keys and removal counts, live only in the
+        // API's own message, so we keep it one click away and never use it as the message itself. These
+        // four codes are the whole reason ADR-0044 §4 exists.
+        ProblemDetails problem = ApiProblem(errorCode, 422, "Data Conflict", apiMessage);
 
         ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
 
-        view.Message.ShouldNotContain("The upload would remove");
-        view.TechnicalDetail.ShouldBe(
-            "Import.MassRemovalBlocked — The upload would remove 812 of 1000 active row(s) (81%), "
-            + "exceeding the 30% safety threshold.");
+        view.Message.ShouldNotContain(apiMessage);
+        view.TechnicalDetail.ShouldBe($"{errorCode} — {apiMessage}");
+        // Without this the theory would also pass if the code fell off PolishByErrorCode, because an
+        // unmapped code keeps its detail too. The set is only meaningful for codes that are mapped.
+        view.UnmappedErrorCode.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("Auth.InvalidCurrentPassword", 400, "The current password is incorrect.")]
+    [InlineData("Translations.Validation", 400, "'Translated Text' must not be empty.")]
+    [InlineData("GameVersionEntity.LotroNotationVersion.AlreadyTaken", 422, "The lotronotationversion value '48.0' is already taken.")]
+    [InlineData("Import.EmptyUpload", 422, "The upload contains no translatable rows.")]
+    [InlineData("Import.Validation", 400, "'File' must not be empty.")]
+    [InlineData("Internal.UnhandledException", 500, "An unexpected error occurred.")]
+    public void Describe_WhenTheMappedCodesApiMessageOnlyRestatesThePolish_HidesTheTechnicalDetail(
+        string errorCode,
+        int status,
+        string apiMessage)
+    {
+        // #703: the drawer repeated the headline in English and read like a leak. The Polish sentence is
+        // the whole message unless the API's wording carries data it cannot reproduce.
+        ProblemDetails problem = ApiProblem(errorCode, status, "Validation Error", apiMessage);
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.TechnicalDetail.ShouldBeNull();
     }
 
     [Fact]
-    public void Describe_WhenTheApiSendsNoDetail_FallsBackToTheApiTitleForTheTechnicalDetail()
+    public void Describe_WhenADataCarryingCodeSendsNoDetail_FallsBackToTheApiTitleForTheTechnicalDetail()
     {
-        ProblemDetails problem = ApiProblem("Internal.UnhandledException", 500, "Internal Server Error", detail: null);
+        ProblemDetails problem = ApiProblem("Import.ParseFailed", 422, "Data Conflict", detail: null);
 
         ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
 
-        view.TechnicalDetail.ShouldBe("Internal.UnhandledException — Internal Server Error");
+        view.TechnicalDetail.ShouldBe("Import.ParseFailed — Data Conflict");
     }
 
     [Fact]
-    public void Describe_WhenTheApiSendsNeitherTitleNorDetail_UsesTheBareCodeAsTechnicalDetail()
+    public void Describe_WhenADataCarryingCodeSendsNeitherTitleNorDetail_UsesTheBareCodeAsTechnicalDetail()
     {
-        ProblemDetails problem = ApiProblem("Internal.UnhandledException", 500, title: null, detail: null);
+        ProblemDetails problem = ApiProblem("Import.ParseFailed", 422, title: null, detail: null);
 
         ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
 
-        view.TechnicalDetail.ShouldBe("Internal.UnhandledException");
+        view.TechnicalDetail.ShouldBe("Import.ParseFailed");
     }
 
     [Theory]
@@ -360,7 +386,7 @@ public sealed class ApiProblemCopyTests
 
         result.IsFailure.ShouldBeTrue();
         view.Message.ShouldBe("Tłumaczenie nie może być puste i nie może przekraczać dozwolonej długości.");
-        view.TechnicalDetail.ShouldBe("Translations.Validation — 'Translated Text' must not be empty.");
+        view.TechnicalDetail.ShouldBeNull();
     }
 
     [Fact]
@@ -397,6 +423,86 @@ public sealed class ApiProblemCopyTests
             502);
 
         loggerProvider.Entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Localize_ForAMappedErrorCode_DropsTheEnglishButKeepsTheTraceId()
+    {
+        // The download routes answer with a raw body the browser shows as it is. Once #703 removes the
+        // English from it, the trace id is the only thing left that links a report to the server log.
+        ProblemDetails problem = ApiProblem("TranslationFiles.NotFound", 404, "Not Found", "No translation file yet.");
+        problem.Extensions[ApiProblemCopy.TraceIdExtensionKey] = "00-abc-def-01";
+        ProblemDetails localized = ApiProblemCopy.Localize(
+            NullLoggerFactory.Instance, problem, PageFallback, 502);
+
+        localized.Extensions.ShouldNotContainKey(ApiProblemCopy.TechnicalDetailExtensionKey);
+        localized.Extensions[ApiProblemCopy.TraceIdExtensionKey].ShouldBe("00-abc-def-01");
+    }
+
+    [Fact]
+    public void Describe_WhenTheCodeDiffersOnlyByCase_TreatsItAsUnmappedRatherThanHidingTheEnglish()
+    {
+        // Both lookups are Ordinal, so a mis-cased code is simply a code we do not know. It must keep
+        // its detail: hiding it would leave the user with a generic sentence and nothing to report.
+        ProblemDetails problem = ApiProblem("import.parsefailed", 422, "Data Conflict", "Line 42 is bad.");
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.UnmappedErrorCode.ShouldBe("import.parsefailed");
+        view.TechnicalDetail.ShouldBe("import.parsefailed — Line 42 is bad.");
+    }
+
+    [Fact]
+    public void Describe_WhenADataCarryingCodeSendsOnlyBlankText_UsesTheBareCodeAsTechnicalDetail()
+    {
+        ProblemDetails problem = ApiProblem("Import.ParseFailed", 422, "   ", "  ");
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.TechnicalDetail.ShouldBe("Import.ParseFailed");
+    }
+
+    [Theory]
+    [InlineData("ChangePassword.Validation", "Password must contain at least one special character.")]
+    [InlineData("ChangePassword.Validation", "Password must not exceed 128 characters.")]
+    [InlineData("ResetPassword.Validation", "Password must contain at least one special character.")]
+    [InlineData("RegisterUser.Validation", "Password must contain at least one special character.")]
+    [InlineData("Auth.PasswordChangeFailed", "Passwords must have at least one non alphanumeric character.")]
+    [InlineData("Auth.PasswordResetFailed", "Passwords must have at least one digit ('0'-'9').")]
+    [InlineData("Auth.RegistrationFailed", "Passwords must have at least one uppercase ('A'-'Z').")]
+    public void Describe_ForACodeThatRejectsAPassword_NamesEveryRuleInPolish(string errorCode, string apiMessage)
+    {
+        // #703 hid the English that used to name the broken rule, so the Polish has to name it instead.
+        // Every rule has to be listed, both bounds included: the special character is what the page hint
+        // used to omit, and a pasted 129-character passphrase satisfies every other rule on the list.
+        ProblemDetails problem = ApiProblem(errorCode, 400, "Validation Error", apiMessage);
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldContain("od 8 do 128 znaków");
+        view.Message.ShouldContain("mała i wielka litera");
+        view.Message.ShouldContain("cyfra");
+        view.Message.ShouldContain("znak specjalny");
+    }
+
+    [Theory]
+    [InlineData("Auth.EmailChangeSameAddress", 400, "Podany adres e-mail jest taki sam jak obecny.")]
+    [InlineData("Auth.InvalidEmailChangeToken", 400, "Link zmieniający adres e-mail jest nieprawidłowy lub wygasł. Poproś o nowy.")]
+    [InlineData("Auth.EmailChangeFailed", 500, "Nie udało się zmienić adresu e-mail. Mógł on zostać w międzyczasie zajęty przez inne konto.")]
+    [InlineData("RequestEmailChange.Validation", 400, "Podany adres e-mail jest nieprawidłowy.")]
+    public void Describe_ForAnEmailChangeCode_ShowsThePolishCopyInsteadOfDegrading(
+        string errorCode,
+        int status,
+        string expectedMessage)
+    {
+        // These four shipped with #683 and had no copy, so /account/change-email showed the generic
+        // sentence plus an English drawer. Hiding the drawer (#703) makes covering them mandatory.
+        ProblemDetails problem = ApiProblem(errorCode, status, "Validation Error", "English.");
+
+        ApiProblemView view = ApiProblemCopy.Describe(problem, PageFallback);
+
+        view.Message.ShouldBe(expectedMessage);
+        view.UnmappedErrorCode.ShouldBeNull();
     }
 
     private static ProblemDetails ApiProblem(string errorCode, int status, string? title, string? detail)


### PR DESCRIPTION
Closes #703

## What

`ApiProblemCopy.BuildTechnicalDetail` returns `null` when the error code **is mapped** and is **not** one of the four import codes whose English carries data the Polish cannot reproduce (`Import.ParseFailed`, `Import.InvalidRow`, `Import.DuplicateFragmentKey`, `Import.MassRemovalBlocked`).

| Case | Technical detail |
|---|---|
| Mapped code, not on the list | **hidden** — the Polish headline is the whole message |
| Mapped code, on the list | shown, as before |
| Unmapped code, or no code at all | shown, as before |

Both renderers follow it from the one guard: `ApiProblemAlert` emits no `<details>` element, and `Localize` omits the `technicalDetail` extension from the two download routes' problem body. `traceId` still travels — after this change it is the only thing linking a report to the server log, so both seams now assert it.

No API change. `errorCode` stays on the wire as a frozen contract token (ADR-0044 §1).

## Why the change grew past the guard

Hiding the English is a trade, not a free win, and two things had to land with it or `/account/change-password` would have got *worse* than before the ticket:

- **Password rules.** Both paths that reject a new password answer with a mapped code — `ChangePassword.Validation` (FluentValidation) and `Auth.PasswordChangeFailed` (Identity's own descriptions). Without the drawer both read "Formularz zawiera nieprawidłowe dane" and the user cannot learn which rule they broke. The page hint was wrong too: it listed length, case and digit but **not** the special character that `PasswordValidationRules` and `Identity.Password.RequireNonAlphanumeric` both require. `ApiProblemCopy.PasswordRules` now states every rule including the 128 upper bound, the six password-rejecting codes end in it, and the hint renders the same constant so the two cannot drift.
- **Four unmapped `Auth.*EmailChange*` codes** shipped without copy in #683. `/account/change-email` is translator-facing, so hiding the drawer would have left it with only the generic sentence. All 18 `Auth.*` codes and all 9 `{slice}.Validation` codes are mapped again.

This is what the ticket prescribes for validation codes — *"the fix is better Polish copy, not English in a drawer"* — so it is paid here rather than deferred.

Deliberately **not** done: no `maxlength` on the password inputs. The browser truncates a paste silently, so the user would set a password different from the one their manager stored; a clear message about the 128 limit is the safer failure.

## Acceptance criteria

- [x] A mapped code with no extra data renders the Polish headline and no "Szczegóły techniczne" element at all
- [x] `/import-export` still shows the line number and the removal counters for the four import codes
- [x] An unmapped code still shows the code and the API wording, and is still logged as a warning
- [x] ADR-0044 carries the amendment
- [ ] Re-run **QA-FE-22 (#669) / TC-CP-06** on staging after deploy

## Tests

`Frontend.Tests.Unit` 610 green (up from 594); every other unit suite green; build zero warnings; SSR-purity and hypermedia guards pass.

New coverage: the four data-carrying codes keep their drawer (theory) and are pinned as *mapped* so the set cannot go inert; six codes whose English only restates the Polish hide it; the six password codes name every rule including the 128 boundary; the four e-mail-change codes; a mis-cased code; blank-only Title+Detail; `traceId` survival at both download seams; the change-password hint lists every rule.

One gap stated plainly: there is no page-level pin driving a real import submit — that needs SSR form-data binding bUnit does not do (`SubmitAsync` fires only `@onsubmit`), so the exact import wording is pinned at the component seam every page renders through, with a page-level pin that the block still reaches the screen.

## Review

Two `code-reviewer` passes. The first found that hiding the drawer made a weak new password a dead end (fixed above) and that the ADR claimed the hidden English was redundant when seven `Auth.*Failed` codes carry runtime Identity text — the amendment now states the trade instead of denying it. The second found the 128-character bound missing from the new copy and approved once it was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmpv2VnTmzSYHJYGbzHmMM