### PR TITLE
SEC-04/SEC-05: CodeQL cs/web/xss — carry returnUrl in a hidden field, not the form action

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,6 +462,18 @@ file_id||gossip_id||translated_text||args_order||args_id||approved||source_diges
   `scripts/tests/check-ssr-purity.tests.sh` proves the guard still fires. Deploy-time backstop: smoke
   leg 2 fails if a deployed page serves an inline script its own CSP blocks. Genuinely need
   interactivity, or an inline script? Both are ADR-first architecture changes.
+- **Auth Razor Pages: never put a caller-supplied value in an `asp-route-*` attribute (#681, #682).**
+  Razor writes a tag-helper attribute through `WriteLiteral` with the encoder switched off, and
+  `RazorPageBase.WriteLiteral` is the page-output sink CodeQL's `cs/web/xss` recognises — so
+  `asp-route-returnUrl="@Model.ReturnUrl"` raised two high alerts that sat open on `main` and blocked
+  every merge (`scripts/claude/work-ticket.sh` refuses a PR with open alerts). The tag helper encodes
+  the value before the browser sees it, so it was never exploitable — but "not exploitable" does not
+  clear an alert, and neither does a sanitizer that returns its input (the failed attempt in #536).
+  Use a plain attribute: `<input type="hidden" name="returnUrl" value="@Model.ReturnUrl" />` compiles
+  to `WriteAttributeValue`, is HTML-encoded, and is not a sink. A `<form>` with no `asp-*` attribute
+  still emits its antiforgery token and posts to the current URL, and handler binding reads the form
+  field before the query string. `LocalReturnUrl.Sanitize` only answers "is this target local"; the
+  encoding at each print site is what keeps these pages safe. (`Html.Raw` is a sink of its own.)
 - **No client hardcodes an API path — enforced, not just documented (#610 frontend, #611 CLI).**
   There is no gateway (ADR-0041), so every entry point is resolved by **rel name** — the Frontend
   through `IDiscoveryCache.ResolveTranslationSystemHrefAsync(Rels.<Name>)`, the CLI through

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Login.cshtml
@@ -553,7 +553,15 @@
                             <span class="panel-aside">E-mail + hasło</span>
                         </header>
 
-                        <form id="login-form" method="post" asp-route-returnUrl="@Model.ReturnUrl" class="auth-panel-body">
+                        @* The return target rides in a hidden field, not in the form action: an asp-route-*
+                           value is a raw write that CodeQL reads as an XSS sink (#681). The field is
+                           hand-rolled rather than asp-for because the handler sets ReturnUrl after checking
+                           it, so there is no bound property to render. *@
+                        <form id="login-form" method="post" class="auth-panel-body">
+                            @if (!string.IsNullOrEmpty(Model.ReturnUrl))
+                            {
+                                <input type="hidden" name="returnUrl" value="@Model.ReturnUrl" />
+                            }
                             @if (!string.IsNullOrEmpty(Model.ErrorMessage))
                             {
                                 <div class="auth-alert" role="alert" aria-live="assertive">

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/Register.cshtml
@@ -484,7 +484,15 @@
                             </h2>
                             <span class="panel-aside">Publiczna</span>
                         </header>
-                        <form class="auth-panel-body" method="post" asp-route-returnUrl="@Model.ReturnUrl">
+                        @* The return target rides in a hidden field, not in the form action: an asp-route-*
+                           value is a raw write that CodeQL reads as an XSS sink (#681). The field is
+                           hand-rolled rather than asp-for because the handler sets ReturnUrl after checking
+                           it, so there is no bound property to render. *@
+                        <form class="auth-panel-body" method="post">
+                            @if (!string.IsNullOrEmpty(Model.ReturnUrl))
+                            {
+                                <input type="hidden" name="returnUrl" value="@Model.ReturnUrl" />
+                            }
                             @if (!string.IsNullOrEmpty(Model.ErrorMessage))
                             {
                                 <div class="auth-alert" role="alert">

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/LoginPageTests.cs
@@ -223,6 +223,139 @@ public sealed partial class LoginPageTests : EndpointsTestBase
         response.Headers.Location!.OriginalString.ShouldBe(continuation);
     }
 
+    /// <summary>
+    /// The evidence for #681. A quote followed by an event handler is still a path that starts with one
+    /// <c>/</c>, so the local-target check keeps the value and the page prints it. What makes it harmless
+    /// is the encoding of the attribute, not the check, so the proof has to read the rendered body.
+    /// </summary>
+    [Theory]
+    [InlineData("""/x" onfocus="alert(1)""", "/x&quot; onfocus=&quot;alert(1)")]
+    [InlineData("/x<script>alert(1)</script>", "/x&lt;script&gt;alert(1)&lt;/script&gt;")]
+    public async Task LoginPage_ShouldEncodeTheReturnUrl_WhenALocalPathCarriesHtmlCharacters(
+        string returnUrl,
+        string expectedAttributeValue)
+    {
+        // Act
+        HttpResponseMessage response = await GetLoginPageAsync(returnUrl);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain($"""<input type="hidden" name="returnUrl" value="{expectedAttributeValue}" />""");
+        html.ShouldNotContain(returnUrl);
+    }
+
+    /// <summary>
+    /// Dropping the tag-helper route value also dropped the generated action attribute, and the form tag
+    /// helper decides on the antiforgery token from exactly that: it only leaves the token out when the
+    /// markup sets an action itself. Without the token every login POST would answer 400.
+    /// </summary>
+    [Fact]
+    public async Task LoginPage_ShouldStillEmitTheAntiforgeryToken_WhenTheFormCarriesNoAction()
+    {
+        // Act
+        HttpResponseMessage response = await GetLoginPageAsync("/connect/authorize?client_id=web");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        ExtractAntiForgeryToken(html).ShouldNotBeNullOrWhiteSpace();
+    }
+
+    /// <summary>
+    /// A target the check rejects must leave no trace in the page, so the field is rendered only when
+    /// there is something to continue to.
+    /// </summary>
+    [Theory]
+    [InlineData("//evil.example")]
+    [InlineData("/\t/evil.example")]
+    [InlineData("https://evil.example/harvest")]
+    public async Task LoginPage_ShouldNotRenderTheHiddenField_WhenReturnUrlIsNotLocal(string returnUrl)
+    {
+        // Act
+        HttpResponseMessage response = await GetLoginPageAsync(returnUrl);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldNotContain("name=\"returnUrl\"");
+    }
+
+    /// <summary>
+    /// Since #681 the form no longer puts the continuation into its action, so the hidden field is the
+    /// only part of the page that carries it. The POST goes to the bare page path, so a regression that
+    /// drops the field cannot hide behind the query string a browser would send as well.
+    /// </summary>
+    [Fact]
+    public async Task LoginPage_ShouldResumeTheContinuation_WhenOnlyTheRenderedFormCarriesIt()
+    {
+        // Arrange
+        const string continuation = "/connect/authorize?client_id=lotrokoniecdev-test&response_type=code";
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        using HttpClient browser = Factory.CreateClient(
+            new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        string renderedPage = await GetLoginPageBodyAsync(browser, continuation);
+
+        Match hiddenField = HiddenReturnUrlRegex().Match(renderedPage);
+        hiddenField.Success.ShouldBeTrue("The login form must carry the return target in a hidden field.");
+
+        // Act
+        HttpResponseMessage response = await PostLoginFormAsync(
+            browser,
+            renderedPage,
+            new Dictionary<string, string>
+            {
+                ["Email"] = request.Email,
+                ["Password"] = request.Password,
+                ["returnUrl"] = WebUtility.HtmlDecode(hiddenField.Groups[1].Value)
+            });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        response.Headers.Location.ShouldNotBeNull();
+        response.Headers.Location!.OriginalString.ShouldBe(continuation);
+    }
+
+    /// <summary>
+    /// The shape a browser really posts: the action-less form goes back to the address the page was loaded
+    /// from, so the query string arrives together with the hidden field. Model binding reads the form
+    /// before the query, and both carry the same target, so the continuation survives either way.
+    /// </summary>
+    [Fact]
+    public async Task LoginPage_ShouldResumeTheContinuation_WhenTheQueryAndTheFormBothCarryIt()
+    {
+        // Arrange
+        const string continuation = "/connect/authorize?client_id=lotrokoniecdev-test&response_type=code";
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy);
+
+        using HttpClient browser = Factory.CreateClient(
+            new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        string renderedPage = await GetLoginPageBodyAsync(browser, continuation);
+
+        Match hiddenField = HiddenReturnUrlRegex().Match(renderedPage);
+        hiddenField.Success.ShouldBeTrue("The login form must carry the return target in a hidden field.");
+
+        // Act
+        HttpResponseMessage response = await PostLoginFormAsync(
+            browser,
+            renderedPage,
+            new Dictionary<string, string>
+            {
+                ["Email"] = request.Email,
+                ["Password"] = request.Password,
+                ["returnUrl"] = WebUtility.HtmlDecode(hiddenField.Groups[1].Value)
+            },
+            $"/Account/Login?returnUrl={Uri.EscapeDataString(continuation)}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        response.Headers.Location.ShouldNotBeNull();
+        response.Headers.Location!.OriginalString.ShouldBe(continuation);
+    }
+
     private async Task LockOutAsync(string username)
     {
         await using AsyncServiceScope scope = Factory.Services.CreateAsyncScope();
@@ -282,6 +415,42 @@ public sealed partial class LoginPageTests : EndpointsTestBase
         return await browser.SendAsync(request);
     }
 
+    private async Task<HttpResponseMessage> GetLoginPageAsync(string returnUrl) =>
+        await ApiClient.Http.GetAsync(
+            new Uri($"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}", UriKind.Relative));
+
+    private static async Task<string> GetLoginPageBodyAsync(HttpClient browser, string returnUrl)
+    {
+        HttpResponseMessage pageResponse = await browser.GetAsync(
+            new Uri($"/Account/Login?returnUrl={Uri.EscapeDataString(returnUrl)}", UriKind.Relative));
+        pageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        return await pageResponse.Content.ReadAsStringAsync();
+    }
+
+    /// <summary>
+    /// Posts the given fields on the same client that rendered the page, so the antiforgery cookie and the
+    /// token in the body belong together. <paramref name="postUrl"/> defaults to the bare page path, which
+    /// is where a test sends the form when the hidden field alone has to carry the target.
+    /// </summary>
+    private static async Task<HttpResponseMessage> PostLoginFormAsync(
+        HttpClient browser,
+        string renderedPage,
+        Dictionary<string, string> formFields,
+        string postUrl = "/Account/Login")
+    {
+        if (ExtractAntiForgeryToken(renderedPage) is { } antiForgeryToken)
+        {
+            formFields["__RequestVerificationToken"] = antiForgeryToken;
+        }
+
+        using FormUrlEncodedContent content = new(formFields);
+        using HttpRequestMessage request = new(HttpMethod.Post, postUrl);
+        request.Content = content;
+
+        return await browser.SendAsync(request);
+    }
+
     private static string? ExtractAntiForgeryToken(string html)
     {
         Match match = AntiForgeryTokenRegex().Match(html);
@@ -290,6 +459,9 @@ public sealed partial class LoginPageTests : EndpointsTestBase
 
     [GeneratedRegex("""name="__RequestVerificationToken".*?value="([^"]+)""")]
     private static partial Regex AntiForgeryTokenRegex();
+
+    [GeneratedRegex("""name="returnUrl"[^>]*value="([^">]*)""")]
+    private static partial Regex HiddenReturnUrlRegex();
 
     [GeneratedRegex("""<span class="s">(.*?)</span>""", RegexOptions.Singleline)]
     private static partial Regex AlertMessageRegex();

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/RegisterPageTests.cs
@@ -166,6 +166,78 @@ public sealed partial class RegisterPageTests : EndpointsTestBase
         html.ShouldContain("Konto z tym adresem e-mail już istnieje");
     }
 
+    /// <summary>
+    /// The register half of #681. The target is a valid local path even with a quote in it, so the check
+    /// keeps it and the page prints it; the encoding of the attribute is what makes it harmless, which is
+    /// why the proof has to read the rendered body.
+    /// </summary>
+    [Theory]
+    [InlineData("""/x" onfocus="alert(1)""", "/x&quot; onfocus=&quot;alert(1)")]
+    [InlineData("/x<script>alert(1)</script>", "/x&lt;script&gt;alert(1)&lt;/script&gt;")]
+    public async Task RegisterPage_ShouldEncodeTheReturnUrl_WhenALocalPathCarriesHtmlCharacters(
+        string returnUrl,
+        string expectedAttributeValue)
+    {
+        // Act
+        HttpResponseMessage response = await GetRegisterPageAsync(returnUrl);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain($"""<input type="hidden" name="returnUrl" value="{expectedAttributeValue}" />""");
+        html.ShouldNotContain(returnUrl);
+    }
+
+    /// <summary>
+    /// Dropping the tag-helper route value also dropped the generated action attribute, and the form tag
+    /// helper decides on the antiforgery token from exactly that: it only leaves the token out when the
+    /// markup sets an action itself. Without the token every registration POST would answer 400.
+    /// </summary>
+    [Fact]
+    public async Task RegisterPage_ShouldStillEmitTheAntiforgeryToken_WhenTheFormCarriesNoAction()
+    {
+        // Act
+        HttpResponseMessage response = await GetRegisterPageAsync("/connect/authorize?client_id=web");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        ExtractAntiForgeryToken(html).ShouldNotBeNullOrWhiteSpace();
+    }
+
+    /// <summary>
+    /// Registration interrupts an authorization request, and the "log in" button on the success screen is
+    /// what resumes it. Since #681 only the hidden field carries that target across the POST, so the form
+    /// goes to the bare page path and the link is read back from the answer.
+    /// </summary>
+    [Fact]
+    public async Task RegisterPage_ShouldKeepTheContinuationOnTheLoginLink_WhenOnlyTheRenderedFormCarriesIt()
+    {
+        // Arrange
+        const string continuation = "/connect/authorize?client_id=lotrokoniecdev-test&response_type=code";
+        AccountConfirmationEmailSpy.Reset();
+        RegisterRequest request = UserFactory.GenerateRandomRegisterRequest(Faker);
+
+        HttpResponseMessage pageResponse = await GetRegisterPageAsync(continuation);
+        pageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string renderedPage = await pageResponse.Content.ReadAsStringAsync();
+
+        Match hiddenField = HiddenReturnUrlRegex().Match(renderedPage);
+        hiddenField.Success.ShouldBeTrue("The register form must carry the return target in a hidden field.");
+
+        Dictionary<string, string> formFields = BuildForm(request, request.Password);
+        formFields["returnUrl"] = WebUtility.HtmlDecode(hiddenField.Groups[1].Value);
+
+        // Act
+        HttpResponseMessage response = await PostRegisterFormAsync(pageResponse, renderedPage, formFields);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string html = await response.Content.ReadAsStringAsync();
+        html.ShouldContain("Konto zostało utworzone");
+        html.ShouldContain($"/Account/Login?returnUrl={Uri.EscapeDataString(continuation)}");
+    }
+
     private static Dictionary<string, string> BuildForm(
         RegisterRequest request,
         string confirmPassword,
@@ -210,6 +282,40 @@ public sealed partial class RegisterPageTests : EndpointsTestBase
         return await ApiClient.Http.SendAsync(request);
     }
 
+    private async Task<HttpResponseMessage> GetRegisterPageAsync(string returnUrl) =>
+        await ApiClient.Http.GetAsync(new Uri(
+            $"/Account/Register?returnUrl={Uri.EscapeDataString(returnUrl)}", UriKind.Relative));
+
+    /// <summary>
+    /// Posts the given fields to the bare page path, carrying the antiforgery cookie and token from the
+    /// page that rendered them. That path is where a test sends the form when the hidden field alone has
+    /// to carry the target: a browser would post to the current address and repeat the query string.
+    /// </summary>
+    private async Task<HttpResponseMessage> PostRegisterFormAsync(
+        HttpResponseMessage pageResponse,
+        string renderedPage,
+        Dictionary<string, string> formFields)
+    {
+        if (ExtractAntiForgeryToken(renderedPage) is { } antiForgeryToken)
+        {
+            formFields["__RequestVerificationToken"] = antiForgeryToken;
+        }
+
+        using FormUrlEncodedContent content = new(formFields);
+        using HttpRequestMessage request = new(HttpMethod.Post, "/Account/Register");
+        request.Content = content;
+
+        if (pageResponse.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
+        {
+            foreach (string cookie in cookies)
+            {
+                request.Headers.Add("Cookie", cookie.Split(';')[0]);
+            }
+        }
+
+        return await ApiClient.Http.SendAsync(request);
+    }
+
     private static string? ExtractAntiForgeryToken(string html)
     {
         Match match = AntiForgeryTokenRegex().Match(html);
@@ -218,4 +324,7 @@ public sealed partial class RegisterPageTests : EndpointsTestBase
 
     [GeneratedRegex("""name="__RequestVerificationToken".*?value="([^"]+)""")]
     private static partial Regex AntiForgeryTokenRegex();
+
+    [GeneratedRegex("""name="returnUrl"[^>]*value="([^">]*)""")]
+    private static partial Regex HiddenReturnUrlRegex();
 }

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Common/LocalReturnUrlTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Common/LocalReturnUrlTests.cs
@@ -36,6 +36,19 @@ public sealed class LocalReturnUrlTests
     }
 
     /// <summary>
+    /// A quote or an angle bracket inside a path is still a path, so the check keeps the value. It is not
+    /// an HTML escaper: the pages that print it HTML-encode it themselves (#681). Pinned here so nobody
+    /// reads this check as the escaping step and drops the encoding somewhere else.
+    /// </summary>
+    [Theory]
+    [InlineData("""/x" onfocus="alert(1)""")]
+    [InlineData("/x<script>alert(1)</script>")]
+    public void Sanitize_WhenALocalPathCarriesHtmlCharacters_KeepsItVerbatim(string returnUrl)
+    {
+        LocalReturnUrl.Sanitize(returnUrl).ShouldBe(returnUrl);
+    }
+
+    /// <summary>
     /// Browsers drop ASCII tab and newline before they parse a URL, so <c>/&lt;tab&gt;/evil.example</c>
     /// reads as <c>//evil.example</c> and must never end up in a link on the page. It arrives as
     /// <c>%09</c> in the query string, and model binding has already decoded it by the time the check

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Pages/Account/LoginModelTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Unit/Pages/Account/LoginModelTests.cs
@@ -9,7 +9,7 @@ using NSubstitute;
 namespace LotroKoniecDev.AuthSystem.API.Tests.Unit.Pages.Account;
 
 /// <summary>
-/// The login page puts <c>returnUrl</c> into its own form action and also uses it as the redirect target
+/// The login page puts <c>returnUrl</c> into a hidden field and also uses it as the redirect target
 /// after sign-in, so the value has to be checked on the way in and a raw query value must never reach
 /// the property. This pins the same wiring the register page already had.
 /// </summary>

--- a/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Security/LocalReturnUrlTests.cs
+++ b/tests/LotroKoniecDev.Frontend.Tests.Unit/Infrastructure/Security/LocalReturnUrlTests.cs
@@ -36,6 +36,19 @@ public sealed class LocalReturnUrlTests
     }
 
     /// <summary>
+    /// A quote or an angle bracket inside a path is still a path, so the check keeps the value. It only
+    /// decides whether a target is local, and this copy is only ever redirected to, never printed. Kept in
+    /// step with the twin (#681).
+    /// </summary>
+    [Theory]
+    [InlineData("""/x" onfocus="alert(1)""")]
+    [InlineData("/x<script>alert(1)</script>")]
+    public void Sanitize_WhenALocalPathCarriesHtmlCharacters_KeepsItVerbatim(string returnUrl)
+    {
+        LocalReturnUrl.Sanitize(returnUrl).ShouldBe(returnUrl);
+    }
+
+    /// <summary>
     /// Browsers drop ASCII tab and newline before they parse a URL, so
     /// <c>Location: /&lt;tab&gt;/evil.example</c> is followed as <c>//evil.example</c>. A check that only
     /// looked at the first characters would call that value local.


### PR DESCRIPTION
Closes #681
Closes #682

## What

Both auth forms carried the return target as a tag-helper route value:

```razor
<form ... method="post" asp-route-returnUrl="@Model.ReturnUrl">
```

They now carry it in a plain hidden field instead. `LocalReturnUrl` is untouched, so the two twins stay identical.

## Why

CodeQL alerts **#6** and **#7** (`cs/web/xss`, high) have been open on `main` since 2026-07-08. `scripts/claude/work-ticket.sh` refuses to merge a PR with open alerts, so every C#-touching PR inherited them.

**The finding is a real raw write, but never an exploitable XSS.** Evidence, verified rather than assumed:

1. **The generated Razor code.** `asp-route-returnUrl="@Model.ReturnUrl"` compiles to `BeginWriteTagHelperAttribute(); WriteLiteral(Model.ReturnUrl); EndWriteTagHelperAttribute();`. `BeginWriteTagHelperAttribute` swaps in `NullHtmlEncoder`, so it genuinely is an unencoded write — that is exactly the sink both alerts name.
2. **The new shape is not that sink.** The hidden field compiles to `BeginWriteAttribute(...)` / `WriteAttributeValue(..., isLiteral: false)`, which is HTML-encoded. The best proof it clears the rule is in this very file: `Login.cshtml:7`'s `<a href="@registerUrl">` writes the *same* tainted value through the *same* `WriteAttributeValue` call and has never been flagged by the same analysis.
3. **It was never exploitable.** The form tag helper URL-encodes the route value into the action and HTML-encodes the attribute. Nothing escaped — but "not exploitable" does not clear an alert.

### Why not the routes the ticket suggested

- *Make `Sanitize` return something CodeQL accepts as untainted* — not reachable. The rule's barriers are simple types, `Guid`, HTML encoders and `HttpUtility`/`WebUtility.UrlEncode`; none of them apply to a path we must hand on verbatim. A sanitizer that returns its input is what PR #536 already tried, and it left `fixed_at` null.
- *Dismiss the alert* — unnecessary once the sink itself is gone. Removing it is a real fix, not a suppression.
- The CodeQL config is untouched, so the next genuine `cs/web/xss` still fires.

## Behavior

Checked against the running app, not reasoned about:

- The form now renders with **no `action` attribute**, so a browser posts to the current address and repeats the query string.
- The **antiforgery token is still emitted** on both pages — the form tag helper only drops it when the markup sets an `action` itself. This has its own test, since removing the route value is precisely what decides it.
- Handler binding reads the **form field before the query string** (verified directly: form `/from-form` beat query `/from-query`).
- The posted value is re-checked by `OnPostAsync` whichever source wins.

## One amendment to the acceptance criteria

AC 3 on both tickets lists `/x" onfocus="alert(1)` as "still dropped by `LocalReturnUrl.Sanitize`". **It is not, and never was** — that is a valid local path, so the check keeps it. What makes it harmless is the encoding at each print site. `//evil.example` and `/%09/evil.example` *are* dropped, as before. Both `LocalReturnUrlTests` twins now pin this explicitly, so nobody reads the check as an escaper and drops the encoding somewhere else.

## Tests

- `LoginPageTests` / `RegisterPageTests` — the rendered body encodes a local path carrying `"` or `<script>`; the field is absent for a rejected target; the antiforgery token survives; the continuation resumes when only the rendered form carries it, and again in the shape a browser really posts.
- Both `LocalReturnUrlTests` twins gain the HTML-character rows.
- Removing the hidden field makes all four new login tests fail, so they are not vacuous.

Green: auth integration 387, auth unit 238, frontend unit 612, patcher unit 4091, architecture 21, and `Frontend.E2E.Tests` 14/14 — the Playwright suite drives register → confirm → login through the real OIDC challenge in Chromium against this exact form. Build is zero-warning. `code-reviewer` gate ran and its findings are applied.

**Before merge:** `gh api "repos/{owner}/{repo}/code-scanning/alerts?ref=refs/pull/<n>/merge&state=open"` must come back empty — that is what actually closes both tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HA7H4WeVuyyMmhnmgpCZKQ