### PR TITLE
QA: add a qa-blocked label so a stalled run is visible

### DIFF
--- a/.claude/commands/qa-ticket.md
+++ b/.claude/commands/qa-ticket.md
@@ -53,6 +53,8 @@ Watch specifically for the failure modes that already bit us:
   "optional": optional invites improvisation, and improvisation is what produced #602 and #604.
 - `**blocked: <what is missing>**` — the precondition does not exist yet (no sample `exported.txt`,
   no seeded NeedsReview row, no admin login handed over). Say what is missing and who provides it.
+  A ticket handed over with any blocked scenario also carries the **`qa-blocked`** label, so the gap
+  sits in `gh issue list --label qa-blocked` instead of hiding inside an open ticket.
 
 If more than half the ticket lands in owner-assisted/blocked, the ticket is not ready to hand over —
 say so and fix the precondition first (`scripts/qa/seed-staging.sql` exists for the data half).
@@ -75,9 +77,11 @@ Every QA ticket carries this at the very top, unchanged:
 > unless the owner runs them with you.
 >
 > **3. Do not improvise a missing precondition.** If a scenario needs data or a role you do not have
-> (a superseded row, an admin login, a sample `exported.txt`), leave the box unchecked and write
-> `blocked: <what is missing>` in your report. A guessed substitute produces a false bug, which costs
-> more than the untested scenario.
+> (a superseded row, an admin login, a sample `exported.txt`), leave the box unchecked, write
+> `blocked: <what is missing>` in your report, and **add the `qa-blocked` label to this ticket** so
+> the owner sees it is waiting on them. A guessed substitute produces a false bug, which costs more
+> than the untested scenario. A blocked scenario is the one case that keeps a finished run's ticket
+> open — a scenario that simply failed is a result, so it does not block anything.
 >
 > **4. Ask before filing a security or "this looks wrong" bug.** One comment on this ticket is
 > cheaper than a bug report that turns out to be by design. Vague auth messages and public download
@@ -93,7 +97,7 @@ Every QA ticket carries this at the very top, unchanged:
 Mirror the existing QA-FE tickets (`gh issue list --label qa`): read-first block → `## Context` →
 `### Environment & accounts (staging — browser only)` → `## Test scenarios` (checkboxes) →
 `## Acceptance criteria`. Title convention `QA-FE-{nn}: Area — what is covered`, labels `qa` + `test`
-+ a priority.
++ a priority, plus `qa-blocked` if any scenario ships blocked.
 
 State the concrete environment (`https://staging.lotro-translator.pl`) and exactly which account
 each leg needs. Where a scenario depends on a specific row, **name the FileId/GossipId** — do not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -718,10 +718,18 @@ with `/qa-ticket #<n>` before handing it over.**
   not exist yet and the QA ticket (or a follow-up run) stays open. `FAILED` = information obtained,
   work done; `blocked:` = work not done. Worked example: #262 closed at 6/7 with the failures carved
   out to #670 and #672.
+- **A blocked run is labelled `qa-blocked`, by the tester (owner rule, 2026-08-21).** An open QA
+  ticket does not say *why* it is open, so a run stalled on a missing precondition looks exactly like
+  one nobody has started. The tester applies the label themselves (they hold write access) and names
+  the missing precondition in a comment; `gh issue list --label qa-blocked` is then the owner's queue
+  of things only the owner can clear. The owner removes the label when the precondition lands — that
+  removal is the tester's signal to finish the run. The label tracks the *ticket*, so it comes off
+  once nothing on it is blocked any more, not once the first blocked scenario clears.
 - **Preconditions are the owner's job, not the tester's.** Non-default row states come from
   `scripts/qa/seed-staging.sql` (staging only; requires one approve in the UI afterwards to rebuild
   the artifact). Sample `exported.txt` files and the admin login are owner-provided — a scenario
-  without its precondition ships as `blocked:`, never as a hopeful checkbox.
+  without its precondition ships as `blocked:`, never as a hopeful checkbox, and the ticket is handed
+  over already carrying `qa-blocked` so the gap is on the owner's queue from day one.
 
 ### Loop mode — one ticket = one closed PR, in its own fresh headless process
 


### PR DESCRIPTION
## Why

An open QA ticket does not say **why** it is open. A run waiting on a precondition the owner never supplied (no sample `exported.txt`, no admin login, no seeded row) looks exactly like a run nobody has started — so the gap is only found by opening every ticket one by one.

The rule that makes this matter already exists in `CLAUDE.md`: a scenario that **failed** is a result and closes with the run, while a scenario that was **blocked** produced no information at all and keeps the ticket open. Nothing made that second state visible from the outside.

## What

- New repo label **`qa-blocked`** — "Manual QA: a scenario cannot run until the owner supplies a precondition" (already created).
- `CLAUDE.md`, Manual QA section: the tester applies the label themselves (they hold write access) and names the missing precondition in a comment. `gh issue list --label qa-blocked` becomes the owner's queue of things only the owner can clear. The owner removing the label is the tester's signal to finish the run. The label tracks the ticket, so it comes off when nothing on it is blocked any more.
- `.claude/commands/qa-ticket.md`: a ticket handed over with a known-blocked scenario ships already carrying the label, and the read-first block tells the tester to add it mid-run.

## Note

The read-first block is copied verbatim into each QA ticket, so the nine currently-open QA tickets still carry the previous wording. They pick up the new line the next time they are re-baselined with `/qa-ticket #<n>` — no back-fill needed.

Docs and command-file only: no code, no tests, no schema.