### PR TITLE
SEC-08: An access token outlives the undo by up to 60 minutes

### DIFF
--- a/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
+++ b/docs/adr/0048-an-email-change-is-undone-from-the-old-mailbox-with-a-token-no-stamp-rotation-can-kill.md
@@ -131,6 +131,11 @@ revert token must do.
 - **The window is not a lock.** For up to 14 days the attacker really does control the account and
   can read and write translations. We accept it: the alternative locks out the users the feature
   exists for. Deletion could afford the lockout because the account was on its way out anyway.
+- **The undo does not stop a live access token straight away.** `IUserSessionRevoker` kills the
+  tokens in the database and the stamp rotation drops the auth cookie, but the TMS validates JWTs
+  on its own, so a token already in the attacker's hands keeps working until it expires. That
+  lifetime is **five minutes**, and this undo is the reason it is five and not sixty — ADR-0049,
+  #686. The ability to mint a *new* token dies immediately.
 - **A revert token outlives a password change by design.** That is the whole point, and it means
   the token cannot be cancelled by rotating the stamp — the usual lever in this codebase. Anyone
   touching `EmailChangeRevertTokenProvider` must understand that omitting the stamp is the

--- a/docs/adr/0049-the-revocation-window-is-the-access-token-lifetime-five-minutes-not-introspection.md
+++ b/docs/adr/0049-the-revocation-window-is-the-access-token-lifetime-five-minutes-not-introspection.md
@@ -1,0 +1,122 @@
+# ADR-0049: The revocation window is the access-token lifetime — five minutes, not introspection
+
+**Status:** Accepted
+**Date:** 2026-08-21
+**Decision-makers:** Solo maintainer
+**Related:** #686 (SEC-08, the defect), #701 (QA-FE-24 S03 TC06/TC07, where a tester hit it), ADR-0048 (the e-mail-change undo this protects), ADR-0041 (no API gateway), ADR-0031 (deletion grace period), `OpenIddictSettings`, `IUserSessionRevoker`, `SecurityStampCookieValidator`, `CookieTokenRefresher`, `DeadSessionRegistry`
+
+## Context
+
+Four flows end every session a user has: `RevertEmailChange`, `ConfirmEmailChange`, `ResetPassword`
+and `ChangePassword`. They all do the same two things — `IUserSessionRevoker.RevokeAllAsync` revokes
+the OpenIddict tokens and authorizations, and the rotated security stamp makes
+`SecurityStampCookieValidator` drop the auth-server cookie on its very next request.
+
+Both are correct, and neither reaches an access token that has already been handed out.
+
+The TMS validates access tokens on its own. `ApiDependencyInjection` registers a plain
+`AddJwtBearer()` against the authority's JWKS, so the only things checked are the signature, the
+issuer, the audience and `exp`. A revoked row in the auth database is invisible to it. And the
+frontend never notices either: `CookieTokenRefresher` only calls the token endpoint 60 seconds
+before the access token expires, so a page refresh checks nothing at all.
+
+So the revocation is real but **latent**. Nothing presents the revoked credential until the access
+token runs out. With the old 60-minute lifetime, someone who had taken an account over kept full API
+access for up to an hour *after* the owner clicked "to nie ja" — which is the one moment the undo
+exists for. A QA tester found it from the other side: they changed their address, were told every
+session was closed, and watched their other browser stay logged in.
+
+**The access-token lifetime is the fuse length on every revocation in this system.** That is the
+whole finding, and it reframes the setting: `AccessTokenLifetimeMinutes` is not a performance knob,
+it is a security parameter.
+
+One consequence is worth stating, because it changes what has to be built. Once the TMS refuses a
+token, the frontend needs no new code: the delegating handler already turns a `401` into a
+`DeadSessionRegistry` marker, and the next `OnValidatePrincipal` signs the user out cleanly with the
+session-expiry notice. The same happens when a refresh finally fails. The frontend half of this
+problem is already solved and waiting for a signal.
+
+## Decision
+
+**Cut `AccessTokenLifetimeMinutes` from 60 to 5, accept the residual five-minute window, and do not
+build introspection.**
+
+A five-minute JWT reaches the same end state as introspection. The attacker loses the API, and their
+failed refresh drives the existing dead-session path so their browser is signed out too. The only
+difference is *when*: about five minutes instead of about thirty seconds.
+
+The cost of the shorter lifetime is small and was measured rather than assumed. Reference refresh
+tokens write one row per refresh, so an active user produces twelve rows an hour and
+`OpenIddictPruneService` keeps fourteen days of them. A translator working two hours a day leaves
+roughly 340 rows inside the retention window. At fifty translators that is about 17 000 rows. This
+is not a load a small Postgres notices.
+
+### What the tests pin
+
+Two facts, both against real artefacts rather than against reasoning:
+
+1. A token minted by the real token endpoint reports a lifetime of five minutes
+   (`TokenEndpointTests.PasswordGrant_ShouldMintAnAccessTokenThatExpiresInFiveMinutes`). The test
+   host deliberately no longer pins its own lifetime, so it runs whatever ships in
+   `appsettings.json` — a test host cannot keep proving an old window after production moved.
+2. A session minted *after* an account was taken over cannot renew itself once the owner clicks the
+   undo (`EmailChangePageTests.RevertPage_Post_ShouldLeaveTheTakeoverSessionUnableToRenewItself`).
+
+Together they bound the takeover: the ability to mint a new token dies immediately, and the token
+already held dies within five minutes.
+
+### The pages stop over-promising
+
+Three screens told the user every session was closed, full stop. That was never true for an app
+session still inside its token's lifetime. `ConfirmEmailChange`, `ResetPassword` and the frontend's
+`DeleteAccount` now say the sessions were invalidated and that any other device is signed out within
+a few minutes. A security promise that is wrong for five minutes is worse than a smaller promise
+that is always right.
+
+## Rejected alternatives
+
+**Introspection on the TMS.** Swap `AddJwtBearer()` for OpenIddict validation with
+`UseIntrospection()`. It closes the window down to whatever the response cache allows, and it is the
+textbook answer. Rejected because it puts auth-api on the critical path of *every* TMS request to
+buy four and a half minutes. That is a real availability coupling — auth down means TMS answers 401
+— and it runs against ADR-0041's rule that nothing sits in the request path. At a few dozen
+translators the security gain does not pay for the coupling.
+
+**`EnableTokenEntryValidation` over a shared token table.** Have the TMS read the OpenIddict token
+entries directly, with no HTTP hop. Rejected on a fact rather than on taste: `lotro_auth` and
+`lotro_translation` are **separate databases**, so the TMS would need a second connection into the
+auth database and a hard dependency on the OpenIddict schema. That is the bounded-context isolation
+`Architecture.Tests.Unit` exists to protect.
+
+**A monotonic stamp claim checked by the TMS.** Put the security stamp in the access token and have
+the TMS reject any token carrying a stamp older than the newest it has seen. Rejected because the
+TMS only learns of a new stamp when a new token arrives, so the protection depends on the victim
+logging in promptly — security that waits for the person who was just attacked. A `Guid` stamp is
+also not ordered, so it would need a version counter, which is new state in the wrong context.
+
+**Redis plus a shared revocation cache.** Rejected as new infrastructure for one feature. There is
+no `IDistributedCache` anywhere in the stack today; both `HybridCache` registrations are in-memory.
+
+**Leaving the lifetime at 60 and documenting the window.** Rejected: the undo's entire purpose is to
+end a takeover now, and an hour is not now.
+
+## Consequences
+
+- **The window is five minutes and it is real.** Someone holding a live access token keeps API
+  access for up to five minutes after the owner revokes everything. This is accepted, not fixed.
+  It is written on the page the user reads, in this ADR, in ADR-0048's undo section and in the
+  runbook.
+- **The setting is now load-bearing.** Raising `AccessTokenLifetimeMinutes` lengthens the window on
+  every credential change, deletion and undo in the system. Nobody should raise it without reading
+  this ADR, which is why the property carries the reason in its doc comment.
+- **The test host follows production.** Token lifetimes were removed from
+  `AuthSystemApiFactory`'s in-memory configuration, so integration tests exercise the shipped value.
+- **More refresh traffic and more token rows.** Twelve refreshes an hour per active user instead of
+  one. `OpenIddictPruneService` already handles the rows; if the table ever becomes a problem, the
+  prune interval is the knob, not the lifetime.
+- **The frontend needed no change.** The `DeadSessionRegistry` path already converts a failed
+  refresh, or any 401, into a clean sign-out with the expiry notice.
+
+**Reopen this decision when:** five minutes is judged too long — most likely once there are real
+users and a real takeover — or a second consumer of user access tokens appears outside the frontend,
+which would make one shared introspection point cheaper than it is today.

--- a/docs/deployment/runbook.md
+++ b/docs/deployment/runbook.md
@@ -115,10 +115,12 @@ variable that does not appear there does nothing, whatever this table says.
   production-parity stack (`compose.prod.yaml`) wires the very same keys with `*.lotro.test`
   hostnames.
 
-Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:AccessTokenLifetimeMinutes`
-= 60, `OpenIddict:RefreshTokenLifetimeDays` = 14, `Import:*`, `TranslationFileRebuild:DebounceWindow`
+Purely optional tuning knobs with safe defaults are omitted (e.g.
+`OpenIddict:RefreshTokenLifetimeDays` = 14, `Import:*`, `TranslationFileRebuild:DebounceWindow`
 = 2 s (ADR-0021), `Email:TimeoutSeconds`/`MaxSendAttempts`, `RabbitMq:Port` = 5672,
-`RabbitMq:VirtualHost` = `/`, `AllowedHosts` = `*`).
+`RabbitMq:VirtualHost` = `/`, `AllowedHosts` = `*`). `OpenIddict:AccessTokenLifetimeMinutes` used to
+sit in that list at 60; it is listed in the table below instead, because it turned out to be the
+delay on every session revocation in the system rather than a tuning knob (ADR-0049, #686).
 
 > ⚠️ **Live prod domain is `lotro-translator.pl`** — auth → `https://auth.lotro-translator.pl`,
 > tms → `https://tms.lotro-translator.pl`, frontend → `https://lotro-translator.pl`. The three
@@ -134,6 +136,7 @@ Purely optional tuning knobs with safe defaults are omitted (e.g. `OpenIddict:Ac
 | `ConnectionStrings__AuthDatabase` | `…;Database=lotro_auth;…;Password=changeme` (appsettings.Development) | Neon: `Host=…;Database=lotro_auth;Username=…;Password=…;Ssl Mode=Require;Timeout=60` | ✅ all | **secret** | Carries the DB password. **Keyword format only** — Npgsql does not parse `postgres://` URIs. `Timeout=60` rides out Neon's ~31 s scale-to-zero resume. |
 | `OpenIddict__Issuer` | `https://localhost:5003` | `https://auth.lotro-translator.pl` | ✅ non-dev | plain | **THE token `iss`.** Absolute http(s), no `localhost`. Must equal tms `Auth__Issuer`. |
 | `OpenIddict__SigningKey__RsaPrivateKeyXml` | — (ephemeral) | base64 of RSA XML (≥2048-bit) | ✅ non-dev | **secret** | Generate with `gen-openiddict-keys`. |
+| `OpenIddict__AccessTokenLifetimeMinutes` | `5` (appsettings) | `5` (appsettings) | ❌ optional | plain | **A security parameter, not a tuning knob.** The TMS validates JWTs locally, so this is how long a revoked session keeps working after a password change, an e-mail-change undo or a scheduled deletion. Raising it lengthens that window everywhere — read ADR-0049 first. |
 | `OpenIddict__EncryptionKey__Key` | — (ephemeral) | base64 of a ≥32-byte key | ✅ non-dev | **secret** | Generate with `gen-openiddict-keys`. |
 | `OpenIddict__ApiClientSecret` | `dev-api-secret-min-32-characters-long` | ≥32-char random secret | ✅ non-dev | **secret** | Generate with `gen-openiddict-keys`. **Seeds a DB row** — rotating it needs the [reseed](#reseed-traps--the-auth-seeder-is-create-if-missing). Must equal that environment's `SMOKE_CLIENT_SECRET`. |
 | `OpenIddict__WebClient__RedirectUris__0` | `https://localhost:7017/callback` | `https://lotro-translator.pl/callback` | ✅ non-dev | plain | MUST equal the Frontend callback (its public origin + `AuthSystem__CallbackPath`). Written to the DB **only at client creation** — see the reseed traps. |

--- a/docs/tms-handbook.md
+++ b/docs/tms-handbook.md
@@ -700,8 +700,9 @@ The system uses the standard web login flow. In plain words:
 3. auth-api checks the password (with brute-force protections — Part 7.4), then redirects your
    browser back to the frontend with a short-lived, one-time **authorization code**.
 4. The frontend's server exchanges that code (plus the PKCE secret) at `/connect/token` for:
-   - an **access token** — a signed JWT, valid **60 minutes**; it carries `sub` (your account
-     ID), `name`, `email`, and `role`;
+   - an **access token** — a signed JWT, valid **5 minutes**; it carries `sub` (your account
+     ID), `name`, `email`, and `role`. It is short on purpose: the TMS validates it locally, so
+     this is also how long a revoked session keeps working (ADR-0049);
    - a **refresh token** — a *reference* token, valid **14 days**, stored server-side in the
      auth database, so it can be revoked; it is *rolling*: every use replaces it.
 5. The frontend stores the tokens **inside an encrypted cookie** (`.lotrokoniecdev.auth`,
@@ -991,9 +992,10 @@ consciously; Part 12, question 10.
 
 ### 7.2 Tokens, keys, sessions
 
-- **Access token**: signed JWT, 60 minutes, **signed but not encrypted** — a deliberate switch
+- **Access token**: signed JWT, 5 minutes, **signed but not encrypted** — a deliberate switch
   (`DisableAccessTokenEncryption`) so any standard JwtBearer middleware can validate it.
-  Tamper-proof (signature) but readable — never put secrets in claims.
+  Tamper-proof (signature) but readable — never put secrets in claims. Because nothing checks it
+  against the database, its lifetime is the delay on every session revocation — ADR-0049.
 - **Refresh token**: *reference* token — the client holds a random handle; the real state
   lives in the auth database. Revocable (logout revokes all of a user's tokens) and **rolling**
   (each use issues a replacement, so a stolen old one is useless).

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/DeleteAccount.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Features/Auth/DeleteAccount.cs
@@ -143,7 +143,8 @@ internal sealed partial class DeleteAccount : IApiEndpoint
         private async Task TryRevokeOpenIddictArtifactsAsync(ApplicationUser user, CancellationToken cancellationToken)
         {
             // Best effort. Refresh tokens are reference tokens, so revoking them stops them at once.
-            // Access tokens carry their own claims and simply expire within the hour.
+            // Access tokens carry their own claims, so one already issued keeps working until it
+            // expires. That is five minutes, and ADR-0049 is why.
             try
             {
                 string userId = user.Id.ToString();

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmailChange.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ConfirmEmailChange.cshtml
@@ -307,7 +307,7 @@
                                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
                                 <div>
                                     <span class="t">Adres e-mail Twojego konta został zmieniony</span>
-                                    <span class="s">Od teraz logujesz się adresem <strong>@Model.Email</strong>. Ze względów bezpieczeństwa zakończyliśmy wszystkie sesje — zaloguj się ponownie.</span>
+                                    <span class="s">Od teraz logujesz się adresem <strong>@Model.Email</strong>. Ze względów bezpieczeństwa unieważniliśmy wszystkie sesje — jeśli gdzieś jesteś jeszcze zalogowany, wylogujemy Cię w ciągu kilku minut.</span>
                                 </div>
                             </div>
                             <div class="auth-actions">

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Pages/Account/ResetPassword.cshtml
@@ -387,7 +387,7 @@
                                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
                                 <div>
                                     <span class="t">Hasło zmienione — zaloguj się</span>
-                                    <span class="s">Twoje nowe hasło jest aktywne. Ze względów bezpieczeństwa pozostałe sesje na innych urządzeniach zostały wylogowane.</span>
+                                    <span class="s">Twoje nowe hasło jest aktywne. Ze względów bezpieczeństwa unieważniliśmy pozostałe sesje — na innych urządzeniach wylogujemy Cię w ciągu kilku minut.</span>
                                 </div>
                             </div>
                             <div class="auth-actions">

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/OpenIddictSettings.cs
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/Settings/OpenIddictSettings.cs
@@ -13,7 +13,12 @@ internal sealed class OpenIddictSettings
     /// </summary>
     public string? InternalIssuer { get; init; }
 
-    public int AccessTokenLifetimeMinutes { get; init; } = 60;
+    /// <summary>
+    /// How long an access token stays valid. It is also how long any revocation takes to bite: the
+    /// TMS validates JWTs on its own, so a token keeps working until it expires even after
+    /// RevokeAllAsync has killed it in the database. Five minutes is the agreed window (ADR-0049).
+    /// </summary>
+    public int AccessTokenLifetimeMinutes { get; init; } = 5;
     public int RefreshTokenLifetimeDays { get; init; } = 14;
     public EncryptionKeySettings EncryptionKey { get; init; } = new();
     public SigningKeySettings SigningKey { get; init; } = new();

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.Development.json
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.Development.json
@@ -10,7 +10,7 @@
   },
   "OpenIddict": {
     "Issuer": "https://localhost:5003",
-    "AccessTokenLifetimeMinutes": 60,
+    "AccessTokenLifetimeMinutes": 5,
     "RefreshTokenLifetimeDays": 14,
     "EncryptionKey": {
       "Key": ""

--- a/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.json
+++ b/src/AuthSystem/LotroKoniecDev.AuthSystem.API/appsettings.json
@@ -11,7 +11,7 @@
   },
   "OpenIddict": {
     "Issuer": "",
-    "AccessTokenLifetimeMinutes": 60,
+    "AccessTokenLifetimeMinutes": 5,
     "RefreshTokenLifetimeDays": 14,
     "EncryptionKey": {
       "Key": ""

--- a/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/DeleteAccount.razor
+++ b/src/Frontend/LotroKoniecDev.Frontend/Components/Pages/Account/DeleteAccount.razor
@@ -93,7 +93,7 @@
             </header>
             <div class="panel-body">
                 <ul class="consequence-list">
-                    <li>Konto zostanie natychmiast zablokowane, a wszystkie sesje wylogowane.</li>
+                    <li>Konto zostanie natychmiast zablokowane, a wszystkie sesje unieważnione — na innych urządzeniach wylogujemy Cię w ciągu kilku minut.</li>
                     <li>Po 14 dniach dane konta zostaną trwale usunięte.</li>
                     <li>Anulować możesz wyłącznie linkiem wysłanym na Twój adres e-mail.</li>
                     <li>Po anulowaniu konieczne będzie ustawienie nowego hasła.</li>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/AuthSystemApiFactory.cs
@@ -48,8 +48,9 @@ public class AuthSystemApiFactory : WebApplicationFactory<Program>, IAsyncLifeti
             {
                 { "ConnectionStrings:AuthDatabase", _connectionString },
                 { "OpenIddict:Issuer", "https://localhost:5002" },
-                { "OpenIddict:AccessTokenLifetimeMinutes", "60" },
-                { "OpenIddict:RefreshTokenLifetimeDays", "14" },
+                // The token lifetimes are deliberately NOT pinned here. They come from the shipped
+                // appsettings.json, so a test host can never keep running an old window after
+                // production moved to a new one (#686).
                 { "OpenIddict:EncryptionKey:Key", "RGV2RW5jcnlwdGlvbktleTMyQnl0ZXNMb25nMTIzNDU=" },
                 { "OpenIddict:SigningKey:Key", "RGV2U2lnbmluZ0tleTMyQnl0ZXNMb25nRW5vdWdoMTI=" },
                 { "OpenIddict:ApiClientSecret", TestApiClientSecret },

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/EmailChangePageTests.cs
@@ -195,6 +195,41 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
     }
 
     [Fact]
+    public async Task RevertPage_Post_ShouldLeaveTheTakeoverSessionUnableToRenewItself()
+    {
+        // The undo exists to end a takeover. The session below is minted after the address already
+        // moved, so it belongs to whoever took the account over, and only the undo can end it.
+        (RegisterRequest user, string newEmail, Guid userId) = await CompleteChangeAsync();
+        string revertToken = EmailChangeEmailSpy.LastRevertToken!;
+        string takeoverRefreshToken = await GetRefreshTokenAsync(newEmail, Password);
+
+        HttpResponseMessage revertResponse = await PostToPageAsync(
+            "/Account/RevertEmailChange",
+            RevertUrl(userId, user.Email, newEmail, revertToken),
+            RevertForm(userId, user.Email, newEmail, revertToken));
+        revertResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Without this the test would also pass when the undo silently failed and the refresh was
+        // refused for some unrelated reason.
+        (await LoadUserByIdAsync(userId)).Email.ShouldBe(user.Email);
+
+        using FormUrlEncodedContent refreshRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = takeoverRefreshToken,
+            ["client_id"] = "lotrokoniecdev-test"
+        });
+
+        HttpResponseMessage response = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), refreshRequest);
+
+        // The access token they already hold still works until it expires, which is why that lifetime
+        // is five minutes (#686, ADR-0049). What must never survive the undo is the ability to mint a
+        // new one, because that would make the takeover permanent.
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task RevertPage_Post_ShouldStillWorkAfterThePasswordWasChanged()
     {
         // This is ADR-0048's whole reason for a hand-written token provider. Whoever took the account
@@ -464,6 +499,29 @@ public sealed partial class EmailChangePageTests : EndpointsTestBase
             });
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    /// <summary>
+    /// The base class helper does not ask for <c>offline_access</c>, so it never gets a refresh token.
+    /// </summary>
+    private async Task<string> GetRefreshTokenAsync(string email, string password)
+    {
+        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = email,
+            ["password"] = password,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api offline_access"
+        });
+
+        HttpResponseMessage tokenResponse = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), tokenRequest);
+        tokenResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string content = await tokenResponse.Content.ReadAsStringAsync();
+        using JsonDocument json = JsonDocument.Parse(content);
+        return json.RootElement.GetProperty("refresh_token").GetString()!;
     }
 
     private static Dictionary<string, string> RevertForm(Guid userId, string from, string to, string token) =>

--- a/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/TokenEndpointTests.cs
+++ b/tests/LotroKoniecDev.AuthSystem.API.Tests.Integration/Tests/Auth/TokenEndpointTests.cs
@@ -46,6 +46,46 @@ public sealed class TokenEndpointTests : EndpointsTestBase
     }
 
     [Fact]
+    public async Task PasswordGrant_ShouldMintAnAccessTokenThatExpiresInFiveMinutes()
+    {
+        // Arrange
+        // This number is a security contract, not a tuning knob. The TMS validates JWTs on its own, so
+        // a token that RevokeAllAsync already killed in the database keeps working until it expires.
+        // That makes this value the delay on every revocation in the system (#686, ADR-0049).
+        const int expectedLifetimeSeconds = 300;
+
+        // expires_in counts down from the moment the server stamped the token, so it can land a
+        // second short. The range is still nowhere near the hour this used to be.
+        const int shortestAcceptableLifetimeSeconds = 290;
+
+        const string password = "TestPass1!";
+        (RegisterRequest request, _) =
+            await UserFactory.RegisterRandomUserWithRequestAsync(ApiClient, Faker, AccountConfirmationEmailSpy, password);
+
+        using FormUrlEncodedContent tokenRequest = new(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = request.Email,
+            ["password"] = password,
+            ["client_id"] = "lotrokoniecdev-test",
+            ["scope"] = "email profile roles api offline_access"
+        });
+
+        // Act
+        HttpResponseMessage response = await ApiClient.Http.PostAsync(
+            new Uri("connect/token", UriKind.Relative), tokenRequest);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string content = await response.Content.ReadAsStringAsync();
+        using JsonDocument json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("expires_in").GetInt32()
+            .ShouldBeInRange(shortestAcceptableLifetimeSeconds, expectedLifetimeSeconds);
+    }
+
+    [Fact]
     public async Task PasswordGrant_ShouldReturnBadRequest_WhenPasswordIsInvalid()
     {
         // Arrange


### PR DESCRIPTION
Closes #686.

## What

The access-token lifetime drops from **60 minutes to 5**, and that number is now documented as what
it actually is: the delay on every session revocation in the system.

## Why

`RevokeAllAsync` and the security-stamp rotation are both correct, but nothing presents the revoked
credential until the access token runs out. The TMS validates JWTs locally (`AddJwtBearer()` against
JWKS), and `CookieTokenRefresher` only calls the token endpoint 60 seconds before expiry. So after
the owner clicked "to nie ja", whoever had taken the account over kept full API access for up to an
hour — during the one flow whose entire purpose is to end a takeover now.

A QA tester hit the same thing from the other side in #701 (S03 TC06/TC07): the address changed, the
page said every session was closed, and their other browser stayed logged in.

Introspection on the TMS would close the window completely. It is rejected in ADR-0049, with the
three other alternatives that were considered: a shared token table (`lotro_auth` and
`lotro_translation` are separate databases), a monotonic stamp claim (waits for the victim to log
in), and Redis (new infrastructure for one feature). A 5-minute JWT reaches the same end state as
introspection — the failed refresh drives the existing `DeadSessionRegistry` path, so the browser is
signed out too — about five minutes later instead of about thirty seconds, and without putting
auth-api on the critical path of every TMS request.

## Also in here

- **Three pages stopped over-promising.** `ConfirmEmailChange`, `ResetPassword` and the frontend's
  `DeleteAccount` said every session was closed, full stop. They now say the sessions were
  invalidated and any other device is signed out within a few minutes.
- **The test host no longer pins its own token lifetimes.** `AuthSystemApiFactory` hardcoded 60, so
  it would have kept proving an old window after production moved. It now runs the shipped value.
- **The stale "60 minutes" is gone** from `tms-handbook.md` and from `DeleteAccount`'s comment, and
  the runbook stops listing the setting as an optional tuning knob.

## Tests

- `TokenEndpointTests.PasswordGrant_ShouldMintAnAccessTokenThatExpiresInFiveMinutes` — a token from
  the real endpoint reports a five-minute lifetime, driven by the shipped configuration.
- `EmailChangePageTests.RevertPage_Post_ShouldLeaveTheTakeoverSessionUnableToRenewItself` — a
  session minted *after* the takeover cannot renew itself once the owner clicks the undo. It also
  asserts the address was really restored, so it cannot pass because the undo failed.

Green: build with zero warnings, all unit projects, AuthSystem integration (389) and TranslationSystem
integration (248). SSR-purity and hypermedia guards pass.

## Follow-up

Retest #701 S03 TC06 and TC07 on staging once this is deployed.
